### PR TITLE
Static properties should be read-only properties with inline initiali…

### DIFF
--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Acceleration.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Acceleration.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Acceleration, which is MeterPerSecondSquared. All conversions go via this value.
         /// </summary>
-        public static AccelerationUnit BaseUnit => AccelerationUnit.MeterPerSecondSquared;
+        public static AccelerationUnit BaseUnit { get; } = AccelerationUnit.MeterPerSecondSquared;
 
         /// <summary>
         /// Represents the largest possible value of Acceleration
         /// </summary>
-        public static Acceleration MaxValue => new Acceleration(double.MaxValue, BaseUnit);
+        public static Acceleration MaxValue { get; } = new Acceleration(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Acceleration
         /// </summary>
-        public static Acceleration MinValue => new Acceleration(double.MinValue, BaseUnit);
+        public static Acceleration MinValue { get; } = new Acceleration(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Acceleration;
+        public static QuantityType QuantityType { get; } = QuantityType.Acceleration;
 
         /// <summary>
         ///     All units of measurement for the Acceleration quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MeterPerSecondSquared.
         /// </summary>
-        public static Acceleration Zero => new Acceleration(0, BaseUnit);
+        public static Acceleration Zero { get; } = new Acceleration(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmountOfSubstance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmountOfSubstance.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AmountOfSubstance, which is Mole. All conversions go via this value.
         /// </summary>
-        public static AmountOfSubstanceUnit BaseUnit => AmountOfSubstanceUnit.Mole;
+        public static AmountOfSubstanceUnit BaseUnit { get; } = AmountOfSubstanceUnit.Mole;
 
         /// <summary>
         /// Represents the largest possible value of AmountOfSubstance
         /// </summary>
-        public static AmountOfSubstance MaxValue => new AmountOfSubstance(double.MaxValue, BaseUnit);
+        public static AmountOfSubstance MaxValue { get; } = new AmountOfSubstance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AmountOfSubstance
         /// </summary>
-        public static AmountOfSubstance MinValue => new AmountOfSubstance(double.MinValue, BaseUnit);
+        public static AmountOfSubstance MinValue { get; } = new AmountOfSubstance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AmountOfSubstance;
+        public static QuantityType QuantityType { get; } = QuantityType.AmountOfSubstance;
 
         /// <summary>
         ///     All units of measurement for the AmountOfSubstance quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Mole.
         /// </summary>
-        public static AmountOfSubstance Zero => new AmountOfSubstance(0, BaseUnit);
+        public static AmountOfSubstance Zero { get; } = new AmountOfSubstance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmplitudeRatio.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmplitudeRatio.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AmplitudeRatio, which is DecibelVolt. All conversions go via this value.
         /// </summary>
-        public static AmplitudeRatioUnit BaseUnit => AmplitudeRatioUnit.DecibelVolt;
+        public static AmplitudeRatioUnit BaseUnit { get; } = AmplitudeRatioUnit.DecibelVolt;
 
         /// <summary>
         /// Represents the largest possible value of AmplitudeRatio
         /// </summary>
-        public static AmplitudeRatio MaxValue => new AmplitudeRatio(double.MaxValue, BaseUnit);
+        public static AmplitudeRatio MaxValue { get; } = new AmplitudeRatio(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AmplitudeRatio
         /// </summary>
-        public static AmplitudeRatio MinValue => new AmplitudeRatio(double.MinValue, BaseUnit);
+        public static AmplitudeRatio MinValue { get; } = new AmplitudeRatio(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AmplitudeRatio;
+        public static QuantityType QuantityType { get; } = QuantityType.AmplitudeRatio;
 
         /// <summary>
         ///     All units of measurement for the AmplitudeRatio quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DecibelVolt.
         /// </summary>
-        public static AmplitudeRatio Zero => new AmplitudeRatio(0, BaseUnit);
+        public static AmplitudeRatio Zero { get; } = new AmplitudeRatio(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Angle.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Angle.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Angle, which is Degree. All conversions go via this value.
         /// </summary>
-        public static AngleUnit BaseUnit => AngleUnit.Degree;
+        public static AngleUnit BaseUnit { get; } = AngleUnit.Degree;
 
         /// <summary>
         /// Represents the largest possible value of Angle
         /// </summary>
-        public static Angle MaxValue => new Angle(double.MaxValue, BaseUnit);
+        public static Angle MaxValue { get; } = new Angle(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Angle
         /// </summary>
-        public static Angle MinValue => new Angle(double.MinValue, BaseUnit);
+        public static Angle MinValue { get; } = new Angle(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Angle;
+        public static QuantityType QuantityType { get; } = QuantityType.Angle;
 
         /// <summary>
         ///     All units of measurement for the Angle quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Degree.
         /// </summary>
-        public static Angle Zero => new Angle(0, BaseUnit);
+        public static Angle Zero { get; } = new Angle(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentEnergy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ApparentEnergy, which is VoltampereHour. All conversions go via this value.
         /// </summary>
-        public static ApparentEnergyUnit BaseUnit => ApparentEnergyUnit.VoltampereHour;
+        public static ApparentEnergyUnit BaseUnit { get; } = ApparentEnergyUnit.VoltampereHour;
 
         /// <summary>
         /// Represents the largest possible value of ApparentEnergy
         /// </summary>
-        public static ApparentEnergy MaxValue => new ApparentEnergy(double.MaxValue, BaseUnit);
+        public static ApparentEnergy MaxValue { get; } = new ApparentEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ApparentEnergy
         /// </summary>
-        public static ApparentEnergy MinValue => new ApparentEnergy(double.MinValue, BaseUnit);
+        public static ApparentEnergy MinValue { get; } = new ApparentEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ApparentEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.ApparentEnergy;
 
         /// <summary>
         ///     All units of measurement for the ApparentEnergy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereHour.
         /// </summary>
-        public static ApparentEnergy Zero => new ApparentEnergy(0, BaseUnit);
+        public static ApparentEnergy Zero { get; } = new ApparentEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentPower.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentPower.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ApparentPower, which is Voltampere. All conversions go via this value.
         /// </summary>
-        public static ApparentPowerUnit BaseUnit => ApparentPowerUnit.Voltampere;
+        public static ApparentPowerUnit BaseUnit { get; } = ApparentPowerUnit.Voltampere;
 
         /// <summary>
         /// Represents the largest possible value of ApparentPower
         /// </summary>
-        public static ApparentPower MaxValue => new ApparentPower(double.MaxValue, BaseUnit);
+        public static ApparentPower MaxValue { get; } = new ApparentPower(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ApparentPower
         /// </summary>
-        public static ApparentPower MinValue => new ApparentPower(double.MinValue, BaseUnit);
+        public static ApparentPower MinValue { get; } = new ApparentPower(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ApparentPower;
+        public static QuantityType QuantityType { get; } = QuantityType.ApparentPower;
 
         /// <summary>
         ///     All units of measurement for the ApparentPower quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Voltampere.
         /// </summary>
-        public static ApparentPower Zero => new ApparentPower(0, BaseUnit);
+        public static ApparentPower Zero { get; } = new ApparentPower(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Area, which is SquareMeter. All conversions go via this value.
         /// </summary>
-        public static AreaUnit BaseUnit => AreaUnit.SquareMeter;
+        public static AreaUnit BaseUnit { get; } = AreaUnit.SquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of Area
         /// </summary>
-        public static Area MaxValue => new Area(double.MaxValue, BaseUnit);
+        public static Area MaxValue { get; } = new Area(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Area
         /// </summary>
-        public static Area MinValue => new Area(double.MinValue, BaseUnit);
+        public static Area MinValue { get; } = new Area(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Area;
+        public static QuantityType QuantityType { get; } = QuantityType.Area;
 
         /// <summary>
         ///     All units of measurement for the Area quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeter.
         /// </summary>
-        public static Area Zero => new Area(0, BaseUnit);
+        public static Area Zero { get; } = new Area(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaDensity.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AreaDensity, which is KilogramPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static AreaDensityUnit BaseUnit => AreaDensityUnit.KilogramPerSquareMeter;
+        public static AreaDensityUnit BaseUnit { get; } = AreaDensityUnit.KilogramPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of AreaDensity
         /// </summary>
-        public static AreaDensity MaxValue => new AreaDensity(double.MaxValue, BaseUnit);
+        public static AreaDensity MaxValue { get; } = new AreaDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AreaDensity
         /// </summary>
-        public static AreaDensity MinValue => new AreaDensity(double.MinValue, BaseUnit);
+        public static AreaDensity MinValue { get; } = new AreaDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AreaDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.AreaDensity;
 
         /// <summary>
         ///     All units of measurement for the AreaDensity quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerSquareMeter.
         /// </summary>
-        public static AreaDensity Zero => new AreaDensity(0, BaseUnit);
+        public static AreaDensity Zero { get; } = new AreaDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaMomentOfInertia.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaMomentOfInertia.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AreaMomentOfInertia, which is MeterToTheFourth. All conversions go via this value.
         /// </summary>
-        public static AreaMomentOfInertiaUnit BaseUnit => AreaMomentOfInertiaUnit.MeterToTheFourth;
+        public static AreaMomentOfInertiaUnit BaseUnit { get; } = AreaMomentOfInertiaUnit.MeterToTheFourth;
 
         /// <summary>
         /// Represents the largest possible value of AreaMomentOfInertia
         /// </summary>
-        public static AreaMomentOfInertia MaxValue => new AreaMomentOfInertia(double.MaxValue, BaseUnit);
+        public static AreaMomentOfInertia MaxValue { get; } = new AreaMomentOfInertia(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AreaMomentOfInertia
         /// </summary>
-        public static AreaMomentOfInertia MinValue => new AreaMomentOfInertia(double.MinValue, BaseUnit);
+        public static AreaMomentOfInertia MinValue { get; } = new AreaMomentOfInertia(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AreaMomentOfInertia;
+        public static QuantityType QuantityType { get; } = QuantityType.AreaMomentOfInertia;
 
         /// <summary>
         ///     All units of measurement for the AreaMomentOfInertia quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MeterToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia Zero => new AreaMomentOfInertia(0, BaseUnit);
+        public static AreaMomentOfInertia Zero { get; } = new AreaMomentOfInertia(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BitRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BitRate.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of BitRate, which is BitPerSecond. All conversions go via this value.
         /// </summary>
-        public static BitRateUnit BaseUnit => BitRateUnit.BitPerSecond;
+        public static BitRateUnit BaseUnit { get; } = BitRateUnit.BitPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of BitRate
         /// </summary>
-        public static BitRate MaxValue => new BitRate(decimal.MaxValue, BaseUnit);
+        public static BitRate MaxValue { get; } = new BitRate(decimal.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of BitRate
         /// </summary>
-        public static BitRate MinValue => new BitRate(decimal.MinValue, BaseUnit);
+        public static BitRate MinValue { get; } = new BitRate(decimal.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.BitRate;
+        public static QuantityType QuantityType { get; } = QuantityType.BitRate;
 
         /// <summary>
         ///     All units of measurement for the BitRate quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit BitPerSecond.
         /// </summary>
-        public static BitRate Zero => new BitRate(0, BaseUnit);
+        public static BitRate Zero { get; } = new BitRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of BrakeSpecificFuelConsumption, which is KilogramPerJoule. All conversions go via this value.
         /// </summary>
-        public static BrakeSpecificFuelConsumptionUnit BaseUnit => BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
+        public static BrakeSpecificFuelConsumptionUnit BaseUnit { get; } = BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
 
         /// <summary>
         /// Represents the largest possible value of BrakeSpecificFuelConsumption
         /// </summary>
-        public static BrakeSpecificFuelConsumption MaxValue => new BrakeSpecificFuelConsumption(double.MaxValue, BaseUnit);
+        public static BrakeSpecificFuelConsumption MaxValue { get; } = new BrakeSpecificFuelConsumption(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of BrakeSpecificFuelConsumption
         /// </summary>
-        public static BrakeSpecificFuelConsumption MinValue => new BrakeSpecificFuelConsumption(double.MinValue, BaseUnit);
+        public static BrakeSpecificFuelConsumption MinValue { get; } = new BrakeSpecificFuelConsumption(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.BrakeSpecificFuelConsumption;
+        public static QuantityType QuantityType { get; } = QuantityType.BrakeSpecificFuelConsumption;
 
         /// <summary>
         ///     All units of measurement for the BrakeSpecificFuelConsumption quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerJoule.
         /// </summary>
-        public static BrakeSpecificFuelConsumption Zero => new BrakeSpecificFuelConsumption(0, BaseUnit);
+        public static BrakeSpecificFuelConsumption Zero { get; } = new BrakeSpecificFuelConsumption(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Capacitance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Capacitance.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Capacitance, which is Farad. All conversions go via this value.
         /// </summary>
-        public static CapacitanceUnit BaseUnit => CapacitanceUnit.Farad;
+        public static CapacitanceUnit BaseUnit { get; } = CapacitanceUnit.Farad;
 
         /// <summary>
         /// Represents the largest possible value of Capacitance
         /// </summary>
-        public static Capacitance MaxValue => new Capacitance(double.MaxValue, BaseUnit);
+        public static Capacitance MaxValue { get; } = new Capacitance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Capacitance
         /// </summary>
-        public static Capacitance MinValue => new Capacitance(double.MinValue, BaseUnit);
+        public static Capacitance MinValue { get; } = new Capacitance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Capacitance;
+        public static QuantityType QuantityType { get; } = QuantityType.Capacitance;
 
         /// <summary>
         ///     All units of measurement for the Capacitance quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Farad.
         /// </summary>
-        public static Capacitance Zero => new Capacitance(0, BaseUnit);
+        public static Capacitance Zero { get; } = new Capacitance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/CoefficientOfThermalExpansion.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/CoefficientOfThermalExpansion.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of CoefficientOfThermalExpansion, which is InverseKelvin. All conversions go via this value.
         /// </summary>
-        public static CoefficientOfThermalExpansionUnit BaseUnit => CoefficientOfThermalExpansionUnit.InverseKelvin;
+        public static CoefficientOfThermalExpansionUnit BaseUnit { get; } = CoefficientOfThermalExpansionUnit.InverseKelvin;
 
         /// <summary>
         /// Represents the largest possible value of CoefficientOfThermalExpansion
         /// </summary>
-        public static CoefficientOfThermalExpansion MaxValue => new CoefficientOfThermalExpansion(double.MaxValue, BaseUnit);
+        public static CoefficientOfThermalExpansion MaxValue { get; } = new CoefficientOfThermalExpansion(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of CoefficientOfThermalExpansion
         /// </summary>
-        public static CoefficientOfThermalExpansion MinValue => new CoefficientOfThermalExpansion(double.MinValue, BaseUnit);
+        public static CoefficientOfThermalExpansion MinValue { get; } = new CoefficientOfThermalExpansion(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.CoefficientOfThermalExpansion;
+        public static QuantityType QuantityType { get; } = QuantityType.CoefficientOfThermalExpansion;
 
         /// <summary>
         ///     All units of measurement for the CoefficientOfThermalExpansion quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit InverseKelvin.
         /// </summary>
-        public static CoefficientOfThermalExpansion Zero => new CoefficientOfThermalExpansion(0, BaseUnit);
+        public static CoefficientOfThermalExpansion Zero { get; } = new CoefficientOfThermalExpansion(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Density.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Density.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Density, which is KilogramPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static DensityUnit BaseUnit => DensityUnit.KilogramPerCubicMeter;
+        public static DensityUnit BaseUnit { get; } = DensityUnit.KilogramPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of Density
         /// </summary>
-        public static Density MaxValue => new Density(double.MaxValue, BaseUnit);
+        public static Density MaxValue { get; } = new Density(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Density
         /// </summary>
-        public static Density MinValue => new Density(double.MinValue, BaseUnit);
+        public static Density MinValue { get; } = new Density(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Density;
+        public static QuantityType QuantityType { get; } = QuantityType.Density;
 
         /// <summary>
         ///     All units of measurement for the Density quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerCubicMeter.
         /// </summary>
-        public static Density Zero => new Density(0, BaseUnit);
+        public static Density Zero { get; } = new Density(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Duration.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Duration.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Duration, which is Second. All conversions go via this value.
         /// </summary>
-        public static DurationUnit BaseUnit => DurationUnit.Second;
+        public static DurationUnit BaseUnit { get; } = DurationUnit.Second;
 
         /// <summary>
         /// Represents the largest possible value of Duration
         /// </summary>
-        public static Duration MaxValue => new Duration(double.MaxValue, BaseUnit);
+        public static Duration MaxValue { get; } = new Duration(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Duration
         /// </summary>
-        public static Duration MinValue => new Duration(double.MinValue, BaseUnit);
+        public static Duration MinValue { get; } = new Duration(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Duration;
+        public static QuantityType QuantityType { get; } = QuantityType.Duration;
 
         /// <summary>
         ///     All units of measurement for the Duration quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Second.
         /// </summary>
-        public static Duration Zero => new Duration(0, BaseUnit);
+        public static Duration Zero { get; } = new Duration(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of DynamicViscosity, which is NewtonSecondPerMeterSquared. All conversions go via this value.
         /// </summary>
-        public static DynamicViscosityUnit BaseUnit => DynamicViscosityUnit.NewtonSecondPerMeterSquared;
+        public static DynamicViscosityUnit BaseUnit { get; } = DynamicViscosityUnit.NewtonSecondPerMeterSquared;
 
         /// <summary>
         /// Represents the largest possible value of DynamicViscosity
         /// </summary>
-        public static DynamicViscosity MaxValue => new DynamicViscosity(double.MaxValue, BaseUnit);
+        public static DynamicViscosity MaxValue { get; } = new DynamicViscosity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of DynamicViscosity
         /// </summary>
-        public static DynamicViscosity MinValue => new DynamicViscosity(double.MinValue, BaseUnit);
+        public static DynamicViscosity MinValue { get; } = new DynamicViscosity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.DynamicViscosity;
+        public static QuantityType QuantityType { get; } = QuantityType.DynamicViscosity;
 
         /// <summary>
         ///     All units of measurement for the DynamicViscosity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonSecondPerMeterSquared.
         /// </summary>
-        public static DynamicViscosity Zero => new DynamicViscosity(0, BaseUnit);
+        public static DynamicViscosity Zero { get; } = new DynamicViscosity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricAdmittance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricAdmittance.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricAdmittance, which is Siemens. All conversions go via this value.
         /// </summary>
-        public static ElectricAdmittanceUnit BaseUnit => ElectricAdmittanceUnit.Siemens;
+        public static ElectricAdmittanceUnit BaseUnit { get; } = ElectricAdmittanceUnit.Siemens;
 
         /// <summary>
         /// Represents the largest possible value of ElectricAdmittance
         /// </summary>
-        public static ElectricAdmittance MaxValue => new ElectricAdmittance(double.MaxValue, BaseUnit);
+        public static ElectricAdmittance MaxValue { get; } = new ElectricAdmittance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricAdmittance
         /// </summary>
-        public static ElectricAdmittance MinValue => new ElectricAdmittance(double.MinValue, BaseUnit);
+        public static ElectricAdmittance MinValue { get; } = new ElectricAdmittance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricAdmittance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricAdmittance;
 
         /// <summary>
         ///     All units of measurement for the ElectricAdmittance quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Siemens.
         /// </summary>
-        public static ElectricAdmittance Zero => new ElectricAdmittance(0, BaseUnit);
+        public static ElectricAdmittance Zero { get; } = new ElectricAdmittance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCharge.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCharge.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCharge, which is Coulomb. All conversions go via this value.
         /// </summary>
-        public static ElectricChargeUnit BaseUnit => ElectricChargeUnit.Coulomb;
+        public static ElectricChargeUnit BaseUnit { get; } = ElectricChargeUnit.Coulomb;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCharge
         /// </summary>
-        public static ElectricCharge MaxValue => new ElectricCharge(double.MaxValue, BaseUnit);
+        public static ElectricCharge MaxValue { get; } = new ElectricCharge(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCharge
         /// </summary>
-        public static ElectricCharge MinValue => new ElectricCharge(double.MinValue, BaseUnit);
+        public static ElectricCharge MinValue { get; } = new ElectricCharge(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCharge;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCharge;
 
         /// <summary>
         ///     All units of measurement for the ElectricCharge quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Coulomb.
         /// </summary>
-        public static ElectricCharge Zero => new ElectricCharge(0, BaseUnit);
+        public static ElectricCharge Zero { get; } = new ElectricCharge(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricChargeDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricChargeDensity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricChargeDensity, which is CoulombPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricChargeDensityUnit BaseUnit => ElectricChargeDensityUnit.CoulombPerCubicMeter;
+        public static ElectricChargeDensityUnit BaseUnit { get; } = ElectricChargeDensityUnit.CoulombPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricChargeDensity
         /// </summary>
-        public static ElectricChargeDensity MaxValue => new ElectricChargeDensity(double.MaxValue, BaseUnit);
+        public static ElectricChargeDensity MaxValue { get; } = new ElectricChargeDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricChargeDensity
         /// </summary>
-        public static ElectricChargeDensity MinValue => new ElectricChargeDensity(double.MinValue, BaseUnit);
+        public static ElectricChargeDensity MinValue { get; } = new ElectricChargeDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricChargeDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricChargeDensity;
 
         /// <summary>
         ///     All units of measurement for the ElectricChargeDensity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CoulombPerCubicMeter.
         /// </summary>
-        public static ElectricChargeDensity Zero => new ElectricChargeDensity(0, BaseUnit);
+        public static ElectricChargeDensity Zero { get; } = new ElectricChargeDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductance.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricConductance, which is Siemens. All conversions go via this value.
         /// </summary>
-        public static ElectricConductanceUnit BaseUnit => ElectricConductanceUnit.Siemens;
+        public static ElectricConductanceUnit BaseUnit { get; } = ElectricConductanceUnit.Siemens;
 
         /// <summary>
         /// Represents the largest possible value of ElectricConductance
         /// </summary>
-        public static ElectricConductance MaxValue => new ElectricConductance(double.MaxValue, BaseUnit);
+        public static ElectricConductance MaxValue { get; } = new ElectricConductance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricConductance
         /// </summary>
-        public static ElectricConductance MinValue => new ElectricConductance(double.MinValue, BaseUnit);
+        public static ElectricConductance MinValue { get; } = new ElectricConductance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricConductance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricConductance;
 
         /// <summary>
         ///     All units of measurement for the ElectricConductance quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Siemens.
         /// </summary>
-        public static ElectricConductance Zero => new ElectricConductance(0, BaseUnit);
+        public static ElectricConductance Zero { get; } = new ElectricConductance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricConductivity, which is SiemensPerMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricConductivityUnit BaseUnit => ElectricConductivityUnit.SiemensPerMeter;
+        public static ElectricConductivityUnit BaseUnit { get; } = ElectricConductivityUnit.SiemensPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricConductivity
         /// </summary>
-        public static ElectricConductivity MaxValue => new ElectricConductivity(double.MaxValue, BaseUnit);
+        public static ElectricConductivity MaxValue { get; } = new ElectricConductivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricConductivity
         /// </summary>
-        public static ElectricConductivity MinValue => new ElectricConductivity(double.MinValue, BaseUnit);
+        public static ElectricConductivity MinValue { get; } = new ElectricConductivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricConductivity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricConductivity;
 
         /// <summary>
         ///     All units of measurement for the ElectricConductivity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SiemensPerMeter.
         /// </summary>
-        public static ElectricConductivity Zero => new ElectricConductivity(0, BaseUnit);
+        public static ElectricConductivity Zero { get; } = new ElectricConductivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrent.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrent.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCurrent, which is Ampere. All conversions go via this value.
         /// </summary>
-        public static ElectricCurrentUnit BaseUnit => ElectricCurrentUnit.Ampere;
+        public static ElectricCurrentUnit BaseUnit { get; } = ElectricCurrentUnit.Ampere;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCurrent
         /// </summary>
-        public static ElectricCurrent MaxValue => new ElectricCurrent(double.MaxValue, BaseUnit);
+        public static ElectricCurrent MaxValue { get; } = new ElectricCurrent(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCurrent
         /// </summary>
-        public static ElectricCurrent MinValue => new ElectricCurrent(double.MinValue, BaseUnit);
+        public static ElectricCurrent MinValue { get; } = new ElectricCurrent(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCurrent;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCurrent;
 
         /// <summary>
         ///     All units of measurement for the ElectricCurrent quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Ampere.
         /// </summary>
-        public static ElectricCurrent Zero => new ElectricCurrent(0, BaseUnit);
+        public static ElectricCurrent Zero { get; } = new ElectricCurrent(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentDensity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCurrentDensity, which is AmperePerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricCurrentDensityUnit BaseUnit => ElectricCurrentDensityUnit.AmperePerSquareMeter;
+        public static ElectricCurrentDensityUnit BaseUnit { get; } = ElectricCurrentDensityUnit.AmperePerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCurrentDensity
         /// </summary>
-        public static ElectricCurrentDensity MaxValue => new ElectricCurrentDensity(double.MaxValue, BaseUnit);
+        public static ElectricCurrentDensity MaxValue { get; } = new ElectricCurrentDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCurrentDensity
         /// </summary>
-        public static ElectricCurrentDensity MinValue => new ElectricCurrentDensity(double.MinValue, BaseUnit);
+        public static ElectricCurrentDensity MinValue { get; } = new ElectricCurrentDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCurrentDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCurrentDensity;
 
         /// <summary>
         ///     All units of measurement for the ElectricCurrentDensity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerSquareMeter.
         /// </summary>
-        public static ElectricCurrentDensity Zero => new ElectricCurrentDensity(0, BaseUnit);
+        public static ElectricCurrentDensity Zero { get; } = new ElectricCurrentDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentGradient.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentGradient.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCurrentGradient, which is AmperePerSecond. All conversions go via this value.
         /// </summary>
-        public static ElectricCurrentGradientUnit BaseUnit => ElectricCurrentGradientUnit.AmperePerSecond;
+        public static ElectricCurrentGradientUnit BaseUnit { get; } = ElectricCurrentGradientUnit.AmperePerSecond;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCurrentGradient
         /// </summary>
-        public static ElectricCurrentGradient MaxValue => new ElectricCurrentGradient(double.MaxValue, BaseUnit);
+        public static ElectricCurrentGradient MaxValue { get; } = new ElectricCurrentGradient(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCurrentGradient
         /// </summary>
-        public static ElectricCurrentGradient MinValue => new ElectricCurrentGradient(double.MinValue, BaseUnit);
+        public static ElectricCurrentGradient MinValue { get; } = new ElectricCurrentGradient(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCurrentGradient;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCurrentGradient;
 
         /// <summary>
         ///     All units of measurement for the ElectricCurrentGradient quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerSecond.
         /// </summary>
-        public static ElectricCurrentGradient Zero => new ElectricCurrentGradient(0, BaseUnit);
+        public static ElectricCurrentGradient Zero { get; } = new ElectricCurrentGradient(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricField.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricField.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricField, which is VoltPerMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricFieldUnit BaseUnit => ElectricFieldUnit.VoltPerMeter;
+        public static ElectricFieldUnit BaseUnit { get; } = ElectricFieldUnit.VoltPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricField
         /// </summary>
-        public static ElectricField MaxValue => new ElectricField(double.MaxValue, BaseUnit);
+        public static ElectricField MaxValue { get; } = new ElectricField(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricField
         /// </summary>
-        public static ElectricField MinValue => new ElectricField(double.MinValue, BaseUnit);
+        public static ElectricField MinValue { get; } = new ElectricField(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricField;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricField;
 
         /// <summary>
         ///     All units of measurement for the ElectricField quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltPerMeter.
         /// </summary>
-        public static ElectricField Zero => new ElectricField(0, BaseUnit);
+        public static ElectricField Zero { get; } = new ElectricField(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricInductance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricInductance.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricInductance, which is Henry. All conversions go via this value.
         /// </summary>
-        public static ElectricInductanceUnit BaseUnit => ElectricInductanceUnit.Henry;
+        public static ElectricInductanceUnit BaseUnit { get; } = ElectricInductanceUnit.Henry;
 
         /// <summary>
         /// Represents the largest possible value of ElectricInductance
         /// </summary>
-        public static ElectricInductance MaxValue => new ElectricInductance(double.MaxValue, BaseUnit);
+        public static ElectricInductance MaxValue { get; } = new ElectricInductance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricInductance
         /// </summary>
-        public static ElectricInductance MinValue => new ElectricInductance(double.MinValue, BaseUnit);
+        public static ElectricInductance MinValue { get; } = new ElectricInductance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricInductance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricInductance;
 
         /// <summary>
         ///     All units of measurement for the ElectricInductance quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Henry.
         /// </summary>
-        public static ElectricInductance Zero => new ElectricInductance(0, BaseUnit);
+        public static ElectricInductance Zero { get; } = new ElectricInductance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotential.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotential.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricPotential, which is Volt. All conversions go via this value.
         /// </summary>
-        public static ElectricPotentialUnit BaseUnit => ElectricPotentialUnit.Volt;
+        public static ElectricPotentialUnit BaseUnit { get; } = ElectricPotentialUnit.Volt;
 
         /// <summary>
         /// Represents the largest possible value of ElectricPotential
         /// </summary>
-        public static ElectricPotential MaxValue => new ElectricPotential(double.MaxValue, BaseUnit);
+        public static ElectricPotential MaxValue { get; } = new ElectricPotential(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricPotential
         /// </summary>
-        public static ElectricPotential MinValue => new ElectricPotential(double.MinValue, BaseUnit);
+        public static ElectricPotential MinValue { get; } = new ElectricPotential(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricPotential;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricPotential;
 
         /// <summary>
         ///     All units of measurement for the ElectricPotential quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Volt.
         /// </summary>
-        public static ElectricPotential Zero => new ElectricPotential(0, BaseUnit);
+        public static ElectricPotential Zero { get; } = new ElectricPotential(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialAc.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialAc.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricPotentialAc, which is VoltAc. All conversions go via this value.
         /// </summary>
-        public static ElectricPotentialAcUnit BaseUnit => ElectricPotentialAcUnit.VoltAc;
+        public static ElectricPotentialAcUnit BaseUnit { get; } = ElectricPotentialAcUnit.VoltAc;
 
         /// <summary>
         /// Represents the largest possible value of ElectricPotentialAc
         /// </summary>
-        public static ElectricPotentialAc MaxValue => new ElectricPotentialAc(double.MaxValue, BaseUnit);
+        public static ElectricPotentialAc MaxValue { get; } = new ElectricPotentialAc(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricPotentialAc
         /// </summary>
-        public static ElectricPotentialAc MinValue => new ElectricPotentialAc(double.MinValue, BaseUnit);
+        public static ElectricPotentialAc MinValue { get; } = new ElectricPotentialAc(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricPotentialAc;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricPotentialAc;
 
         /// <summary>
         ///     All units of measurement for the ElectricPotentialAc quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltAc.
         /// </summary>
-        public static ElectricPotentialAc Zero => new ElectricPotentialAc(0, BaseUnit);
+        public static ElectricPotentialAc Zero { get; } = new ElectricPotentialAc(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialDc.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialDc.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricPotentialDc, which is VoltDc. All conversions go via this value.
         /// </summary>
-        public static ElectricPotentialDcUnit BaseUnit => ElectricPotentialDcUnit.VoltDc;
+        public static ElectricPotentialDcUnit BaseUnit { get; } = ElectricPotentialDcUnit.VoltDc;
 
         /// <summary>
         /// Represents the largest possible value of ElectricPotentialDc
         /// </summary>
-        public static ElectricPotentialDc MaxValue => new ElectricPotentialDc(double.MaxValue, BaseUnit);
+        public static ElectricPotentialDc MaxValue { get; } = new ElectricPotentialDc(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricPotentialDc
         /// </summary>
-        public static ElectricPotentialDc MinValue => new ElectricPotentialDc(double.MinValue, BaseUnit);
+        public static ElectricPotentialDc MinValue { get; } = new ElectricPotentialDc(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricPotentialDc;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricPotentialDc;
 
         /// <summary>
         ///     All units of measurement for the ElectricPotentialDc quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltDc.
         /// </summary>
-        public static ElectricPotentialDc Zero => new ElectricPotentialDc(0, BaseUnit);
+        public static ElectricPotentialDc Zero { get; } = new ElectricPotentialDc(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistance.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricResistance, which is Ohm. All conversions go via this value.
         /// </summary>
-        public static ElectricResistanceUnit BaseUnit => ElectricResistanceUnit.Ohm;
+        public static ElectricResistanceUnit BaseUnit { get; } = ElectricResistanceUnit.Ohm;
 
         /// <summary>
         /// Represents the largest possible value of ElectricResistance
         /// </summary>
-        public static ElectricResistance MaxValue => new ElectricResistance(double.MaxValue, BaseUnit);
+        public static ElectricResistance MaxValue { get; } = new ElectricResistance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricResistance
         /// </summary>
-        public static ElectricResistance MinValue => new ElectricResistance(double.MinValue, BaseUnit);
+        public static ElectricResistance MinValue { get; } = new ElectricResistance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricResistance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricResistance;
 
         /// <summary>
         ///     All units of measurement for the ElectricResistance quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Ohm.
         /// </summary>
-        public static ElectricResistance Zero => new ElectricResistance(0, BaseUnit);
+        public static ElectricResistance Zero { get; } = new ElectricResistance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistivity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricResistivity, which is OhmMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricResistivityUnit BaseUnit => ElectricResistivityUnit.OhmMeter;
+        public static ElectricResistivityUnit BaseUnit { get; } = ElectricResistivityUnit.OhmMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricResistivity
         /// </summary>
-        public static ElectricResistivity MaxValue => new ElectricResistivity(double.MaxValue, BaseUnit);
+        public static ElectricResistivity MaxValue { get; } = new ElectricResistivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricResistivity
         /// </summary>
-        public static ElectricResistivity MinValue => new ElectricResistivity(double.MinValue, BaseUnit);
+        public static ElectricResistivity MinValue { get; } = new ElectricResistivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricResistivity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricResistivity;
 
         /// <summary>
         ///     All units of measurement for the ElectricResistivity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit OhmMeter.
         /// </summary>
-        public static ElectricResistivity Zero => new ElectricResistivity(0, BaseUnit);
+        public static ElectricResistivity Zero { get; } = new ElectricResistivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Energy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Energy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Energy, which is Joule. All conversions go via this value.
         /// </summary>
-        public static EnergyUnit BaseUnit => EnergyUnit.Joule;
+        public static EnergyUnit BaseUnit { get; } = EnergyUnit.Joule;
 
         /// <summary>
         /// Represents the largest possible value of Energy
         /// </summary>
-        public static Energy MaxValue => new Energy(double.MaxValue, BaseUnit);
+        public static Energy MaxValue { get; } = new Energy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Energy
         /// </summary>
-        public static Energy MinValue => new Energy(double.MinValue, BaseUnit);
+        public static Energy MinValue { get; } = new Energy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Energy;
+        public static QuantityType QuantityType { get; } = QuantityType.Energy;
 
         /// <summary>
         ///     All units of measurement for the Energy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Joule.
         /// </summary>
-        public static Energy Zero => new Energy(0, BaseUnit);
+        public static Energy Zero { get; } = new Energy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Entropy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Entropy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Entropy, which is JoulePerKelvin. All conversions go via this value.
         /// </summary>
-        public static EntropyUnit BaseUnit => EntropyUnit.JoulePerKelvin;
+        public static EntropyUnit BaseUnit { get; } = EntropyUnit.JoulePerKelvin;
 
         /// <summary>
         /// Represents the largest possible value of Entropy
         /// </summary>
-        public static Entropy MaxValue => new Entropy(double.MaxValue, BaseUnit);
+        public static Entropy MaxValue { get; } = new Entropy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Entropy
         /// </summary>
-        public static Entropy MinValue => new Entropy(double.MinValue, BaseUnit);
+        public static Entropy MinValue { get; } = new Entropy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Entropy;
+        public static QuantityType QuantityType { get; } = QuantityType.Entropy;
 
         /// <summary>
         ///     All units of measurement for the Entropy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKelvin.
         /// </summary>
-        public static Entropy Zero => new Entropy(0, BaseUnit);
+        public static Entropy Zero { get; } = new Entropy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Force, which is Newton. All conversions go via this value.
         /// </summary>
-        public static ForceUnit BaseUnit => ForceUnit.Newton;
+        public static ForceUnit BaseUnit { get; } = ForceUnit.Newton;
 
         /// <summary>
         /// Represents the largest possible value of Force
         /// </summary>
-        public static Force MaxValue => new Force(double.MaxValue, BaseUnit);
+        public static Force MaxValue { get; } = new Force(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Force
         /// </summary>
-        public static Force MinValue => new Force(double.MinValue, BaseUnit);
+        public static Force MinValue { get; } = new Force(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Force;
+        public static QuantityType QuantityType { get; } = QuantityType.Force;
 
         /// <summary>
         ///     All units of measurement for the Force quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Newton.
         /// </summary>
-        public static Force Zero => new Force(0, BaseUnit);
+        public static Force Zero { get; } = new Force(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForceChangeRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForceChangeRate.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ForceChangeRate, which is NewtonPerSecond. All conversions go via this value.
         /// </summary>
-        public static ForceChangeRateUnit BaseUnit => ForceChangeRateUnit.NewtonPerSecond;
+        public static ForceChangeRateUnit BaseUnit { get; } = ForceChangeRateUnit.NewtonPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of ForceChangeRate
         /// </summary>
-        public static ForceChangeRate MaxValue => new ForceChangeRate(double.MaxValue, BaseUnit);
+        public static ForceChangeRate MaxValue { get; } = new ForceChangeRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ForceChangeRate
         /// </summary>
-        public static ForceChangeRate MinValue => new ForceChangeRate(double.MinValue, BaseUnit);
+        public static ForceChangeRate MinValue { get; } = new ForceChangeRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ForceChangeRate;
+        public static QuantityType QuantityType { get; } = QuantityType.ForceChangeRate;
 
         /// <summary>
         ///     All units of measurement for the ForceChangeRate quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerSecond.
         /// </summary>
-        public static ForceChangeRate Zero => new ForceChangeRate(0, BaseUnit);
+        public static ForceChangeRate Zero { get; } = new ForceChangeRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForcePerLength.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForcePerLength.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ForcePerLength, which is NewtonPerMeter. All conversions go via this value.
         /// </summary>
-        public static ForcePerLengthUnit BaseUnit => ForcePerLengthUnit.NewtonPerMeter;
+        public static ForcePerLengthUnit BaseUnit { get; } = ForcePerLengthUnit.NewtonPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of ForcePerLength
         /// </summary>
-        public static ForcePerLength MaxValue => new ForcePerLength(double.MaxValue, BaseUnit);
+        public static ForcePerLength MaxValue { get; } = new ForcePerLength(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ForcePerLength
         /// </summary>
-        public static ForcePerLength MinValue => new ForcePerLength(double.MinValue, BaseUnit);
+        public static ForcePerLength MinValue { get; } = new ForcePerLength(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ForcePerLength;
+        public static QuantityType QuantityType { get; } = QuantityType.ForcePerLength;
 
         /// <summary>
         ///     All units of measurement for the ForcePerLength quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerMeter.
         /// </summary>
-        public static ForcePerLength Zero => new ForcePerLength(0, BaseUnit);
+        public static ForcePerLength Zero { get; } = new ForcePerLength(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Frequency, which is Hertz. All conversions go via this value.
         /// </summary>
-        public static FrequencyUnit BaseUnit => FrequencyUnit.Hertz;
+        public static FrequencyUnit BaseUnit { get; } = FrequencyUnit.Hertz;
 
         /// <summary>
         /// Represents the largest possible value of Frequency
         /// </summary>
-        public static Frequency MaxValue => new Frequency(double.MaxValue, BaseUnit);
+        public static Frequency MaxValue { get; } = new Frequency(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Frequency
         /// </summary>
-        public static Frequency MinValue => new Frequency(double.MinValue, BaseUnit);
+        public static Frequency MinValue { get; } = new Frequency(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Frequency;
+        public static QuantityType QuantityType { get; } = QuantityType.Frequency;
 
         /// <summary>
         ///     All units of measurement for the Frequency quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Hertz.
         /// </summary>
-        public static Frequency Zero => new Frequency(0, BaseUnit);
+        public static Frequency Zero { get; } = new Frequency(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatFlux.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of HeatFlux, which is WattPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static HeatFluxUnit BaseUnit => HeatFluxUnit.WattPerSquareMeter;
+        public static HeatFluxUnit BaseUnit { get; } = HeatFluxUnit.WattPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of HeatFlux
         /// </summary>
-        public static HeatFlux MaxValue => new HeatFlux(double.MaxValue, BaseUnit);
+        public static HeatFlux MaxValue { get; } = new HeatFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of HeatFlux
         /// </summary>
-        public static HeatFlux MinValue => new HeatFlux(double.MinValue, BaseUnit);
+        public static HeatFlux MinValue { get; } = new HeatFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.HeatFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.HeatFlux;
 
         /// <summary>
         ///     All units of measurement for the HeatFlux quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeter.
         /// </summary>
-        public static HeatFlux Zero => new HeatFlux(0, BaseUnit);
+        public static HeatFlux Zero { get; } = new HeatFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatTransferCoefficient.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatTransferCoefficient.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of HeatTransferCoefficient, which is WattPerSquareMeterKelvin. All conversions go via this value.
         /// </summary>
-        public static HeatTransferCoefficientUnit BaseUnit => HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
+        public static HeatTransferCoefficientUnit BaseUnit { get; } = HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
 
         /// <summary>
         /// Represents the largest possible value of HeatTransferCoefficient
         /// </summary>
-        public static HeatTransferCoefficient MaxValue => new HeatTransferCoefficient(double.MaxValue, BaseUnit);
+        public static HeatTransferCoefficient MaxValue { get; } = new HeatTransferCoefficient(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of HeatTransferCoefficient
         /// </summary>
-        public static HeatTransferCoefficient MinValue => new HeatTransferCoefficient(double.MinValue, BaseUnit);
+        public static HeatTransferCoefficient MinValue { get; } = new HeatTransferCoefficient(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.HeatTransferCoefficient;
+        public static QuantityType QuantityType { get; } = QuantityType.HeatTransferCoefficient;
 
         /// <summary>
         ///     All units of measurement for the HeatTransferCoefficient quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeterKelvin.
         /// </summary>
-        public static HeatTransferCoefficient Zero => new HeatTransferCoefficient(0, BaseUnit);
+        public static HeatTransferCoefficient Zero { get; } = new HeatTransferCoefficient(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Illuminance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Illuminance.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Illuminance, which is Lux. All conversions go via this value.
         /// </summary>
-        public static IlluminanceUnit BaseUnit => IlluminanceUnit.Lux;
+        public static IlluminanceUnit BaseUnit { get; } = IlluminanceUnit.Lux;
 
         /// <summary>
         /// Represents the largest possible value of Illuminance
         /// </summary>
-        public static Illuminance MaxValue => new Illuminance(double.MaxValue, BaseUnit);
+        public static Illuminance MaxValue { get; } = new Illuminance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Illuminance
         /// </summary>
-        public static Illuminance MinValue => new Illuminance(double.MinValue, BaseUnit);
+        public static Illuminance MinValue { get; } = new Illuminance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Illuminance;
+        public static QuantityType QuantityType { get; } = QuantityType.Illuminance;
 
         /// <summary>
         ///     All units of measurement for the Illuminance quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Lux.
         /// </summary>
-        public static Illuminance Zero => new Illuminance(0, BaseUnit);
+        public static Illuminance Zero { get; } = new Illuminance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Information, which is Bit. All conversions go via this value.
         /// </summary>
-        public static InformationUnit BaseUnit => InformationUnit.Bit;
+        public static InformationUnit BaseUnit { get; } = InformationUnit.Bit;
 
         /// <summary>
         /// Represents the largest possible value of Information
         /// </summary>
-        public static Information MaxValue => new Information(decimal.MaxValue, BaseUnit);
+        public static Information MaxValue { get; } = new Information(decimal.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Information
         /// </summary>
-        public static Information MinValue => new Information(decimal.MinValue, BaseUnit);
+        public static Information MinValue { get; } = new Information(decimal.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Information;
+        public static QuantityType QuantityType { get; } = QuantityType.Information;
 
         /// <summary>
         ///     All units of measurement for the Information quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Bit.
         /// </summary>
-        public static Information Zero => new Information(0, BaseUnit);
+        public static Information Zero { get; } = new Information(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiance.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Irradiance, which is WattPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static IrradianceUnit BaseUnit => IrradianceUnit.WattPerSquareMeter;
+        public static IrradianceUnit BaseUnit { get; } = IrradianceUnit.WattPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of Irradiance
         /// </summary>
-        public static Irradiance MaxValue => new Irradiance(double.MaxValue, BaseUnit);
+        public static Irradiance MaxValue { get; } = new Irradiance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Irradiance
         /// </summary>
-        public static Irradiance MinValue => new Irradiance(double.MinValue, BaseUnit);
+        public static Irradiance MinValue { get; } = new Irradiance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Irradiance;
+        public static QuantityType QuantityType { get; } = QuantityType.Irradiance;
 
         /// <summary>
         ///     All units of measurement for the Irradiance quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeter.
         /// </summary>
-        public static Irradiance Zero => new Irradiance(0, BaseUnit);
+        public static Irradiance Zero { get; } = new Irradiance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiation.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiation.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Irradiation, which is JoulePerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static IrradiationUnit BaseUnit => IrradiationUnit.JoulePerSquareMeter;
+        public static IrradiationUnit BaseUnit { get; } = IrradiationUnit.JoulePerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of Irradiation
         /// </summary>
-        public static Irradiation MaxValue => new Irradiation(double.MaxValue, BaseUnit);
+        public static Irradiation MaxValue { get; } = new Irradiation(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Irradiation
         /// </summary>
-        public static Irradiation MinValue => new Irradiation(double.MinValue, BaseUnit);
+        public static Irradiation MinValue { get; } = new Irradiation(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Irradiation;
+        public static QuantityType QuantityType { get; } = QuantityType.Irradiation;
 
         /// <summary>
         ///     All units of measurement for the Irradiation quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerSquareMeter.
         /// </summary>
-        public static Irradiation Zero => new Irradiation(0, BaseUnit);
+        public static Irradiation Zero { get; } = new Irradiation(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/KinematicViscosity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/KinematicViscosity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of KinematicViscosity, which is SquareMeterPerSecond. All conversions go via this value.
         /// </summary>
-        public static KinematicViscosityUnit BaseUnit => KinematicViscosityUnit.SquareMeterPerSecond;
+        public static KinematicViscosityUnit BaseUnit { get; } = KinematicViscosityUnit.SquareMeterPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of KinematicViscosity
         /// </summary>
-        public static KinematicViscosity MaxValue => new KinematicViscosity(double.MaxValue, BaseUnit);
+        public static KinematicViscosity MaxValue { get; } = new KinematicViscosity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of KinematicViscosity
         /// </summary>
-        public static KinematicViscosity MinValue => new KinematicViscosity(double.MinValue, BaseUnit);
+        public static KinematicViscosity MinValue { get; } = new KinematicViscosity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.KinematicViscosity;
+        public static QuantityType QuantityType { get; } = QuantityType.KinematicViscosity;
 
         /// <summary>
         ///     All units of measurement for the KinematicViscosity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeterPerSecond.
         /// </summary>
-        public static KinematicViscosity Zero => new KinematicViscosity(0, BaseUnit);
+        public static KinematicViscosity Zero { get; } = new KinematicViscosity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LapseRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LapseRate.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LapseRate, which is DegreeCelsiusPerKilometer. All conversions go via this value.
         /// </summary>
-        public static LapseRateUnit BaseUnit => LapseRateUnit.DegreeCelsiusPerKilometer;
+        public static LapseRateUnit BaseUnit { get; } = LapseRateUnit.DegreeCelsiusPerKilometer;
 
         /// <summary>
         /// Represents the largest possible value of LapseRate
         /// </summary>
-        public static LapseRate MaxValue => new LapseRate(double.MaxValue, BaseUnit);
+        public static LapseRate MaxValue { get; } = new LapseRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LapseRate
         /// </summary>
-        public static LapseRate MinValue => new LapseRate(double.MinValue, BaseUnit);
+        public static LapseRate MinValue { get; } = new LapseRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LapseRate;
+        public static QuantityType QuantityType { get; } = QuantityType.LapseRate;
 
         /// <summary>
         ///     All units of measurement for the LapseRate quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DegreeCelsiusPerKilometer.
         /// </summary>
-        public static LapseRate Zero => new LapseRate(0, BaseUnit);
+        public static LapseRate Zero { get; } = new LapseRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Length, which is Meter. All conversions go via this value.
         /// </summary>
-        public static LengthUnit BaseUnit => LengthUnit.Meter;
+        public static LengthUnit BaseUnit { get; } = LengthUnit.Meter;
 
         /// <summary>
         /// Represents the largest possible value of Length
         /// </summary>
-        public static Length MaxValue => new Length(double.MaxValue, BaseUnit);
+        public static Length MaxValue { get; } = new Length(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Length
         /// </summary>
-        public static Length MinValue => new Length(double.MinValue, BaseUnit);
+        public static Length MinValue { get; } = new Length(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Length;
+        public static QuantityType QuantityType { get; } = QuantityType.Length;
 
         /// <summary>
         ///     All units of measurement for the Length quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Meter.
         /// </summary>
-        public static Length Zero => new Length(0, BaseUnit);
+        public static Length Zero { get; } = new Length(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Level.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Level, which is Decibel. All conversions go via this value.
         /// </summary>
-        public static LevelUnit BaseUnit => LevelUnit.Decibel;
+        public static LevelUnit BaseUnit { get; } = LevelUnit.Decibel;
 
         /// <summary>
         /// Represents the largest possible value of Level
         /// </summary>
-        public static Level MaxValue => new Level(double.MaxValue, BaseUnit);
+        public static Level MaxValue { get; } = new Level(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Level
         /// </summary>
-        public static Level MinValue => new Level(double.MinValue, BaseUnit);
+        public static Level MinValue { get; } = new Level(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Level;
+        public static QuantityType QuantityType { get; } = QuantityType.Level;
 
         /// <summary>
         ///     All units of measurement for the Level quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Decibel.
         /// </summary>
-        public static Level Zero => new Level(0, BaseUnit);
+        public static Level Zero { get; } = new Level(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearDensity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LinearDensity, which is KilogramPerMeter. All conversions go via this value.
         /// </summary>
-        public static LinearDensityUnit BaseUnit => LinearDensityUnit.KilogramPerMeter;
+        public static LinearDensityUnit BaseUnit { get; } = LinearDensityUnit.KilogramPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of LinearDensity
         /// </summary>
-        public static LinearDensity MaxValue => new LinearDensity(double.MaxValue, BaseUnit);
+        public static LinearDensity MaxValue { get; } = new LinearDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LinearDensity
         /// </summary>
-        public static LinearDensity MinValue => new LinearDensity(double.MinValue, BaseUnit);
+        public static LinearDensity MinValue { get; } = new LinearDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LinearDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.LinearDensity;
 
         /// <summary>
         ///     All units of measurement for the LinearDensity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerMeter.
         /// </summary>
-        public static LinearDensity Zero => new LinearDensity(0, BaseUnit);
+        public static LinearDensity Zero { get; } = new LinearDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousFlux.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LuminousFlux, which is Lumen. All conversions go via this value.
         /// </summary>
-        public static LuminousFluxUnit BaseUnit => LuminousFluxUnit.Lumen;
+        public static LuminousFluxUnit BaseUnit { get; } = LuminousFluxUnit.Lumen;
 
         /// <summary>
         /// Represents the largest possible value of LuminousFlux
         /// </summary>
-        public static LuminousFlux MaxValue => new LuminousFlux(double.MaxValue, BaseUnit);
+        public static LuminousFlux MaxValue { get; } = new LuminousFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LuminousFlux
         /// </summary>
-        public static LuminousFlux MinValue => new LuminousFlux(double.MinValue, BaseUnit);
+        public static LuminousFlux MinValue { get; } = new LuminousFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LuminousFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.LuminousFlux;
 
         /// <summary>
         ///     All units of measurement for the LuminousFlux quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Lumen.
         /// </summary>
-        public static LuminousFlux Zero => new LuminousFlux(0, BaseUnit);
+        public static LuminousFlux Zero { get; } = new LuminousFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousIntensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousIntensity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LuminousIntensity, which is Candela. All conversions go via this value.
         /// </summary>
-        public static LuminousIntensityUnit BaseUnit => LuminousIntensityUnit.Candela;
+        public static LuminousIntensityUnit BaseUnit { get; } = LuminousIntensityUnit.Candela;
 
         /// <summary>
         /// Represents the largest possible value of LuminousIntensity
         /// </summary>
-        public static LuminousIntensity MaxValue => new LuminousIntensity(double.MaxValue, BaseUnit);
+        public static LuminousIntensity MaxValue { get; } = new LuminousIntensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LuminousIntensity
         /// </summary>
-        public static LuminousIntensity MinValue => new LuminousIntensity(double.MinValue, BaseUnit);
+        public static LuminousIntensity MinValue { get; } = new LuminousIntensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LuminousIntensity;
+        public static QuantityType QuantityType { get; } = QuantityType.LuminousIntensity;
 
         /// <summary>
         ///     All units of measurement for the LuminousIntensity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Candela.
         /// </summary>
-        public static LuminousIntensity Zero => new LuminousIntensity(0, BaseUnit);
+        public static LuminousIntensity Zero { get; } = new LuminousIntensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticField.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticField.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MagneticField, which is Tesla. All conversions go via this value.
         /// </summary>
-        public static MagneticFieldUnit BaseUnit => MagneticFieldUnit.Tesla;
+        public static MagneticFieldUnit BaseUnit { get; } = MagneticFieldUnit.Tesla;
 
         /// <summary>
         /// Represents the largest possible value of MagneticField
         /// </summary>
-        public static MagneticField MaxValue => new MagneticField(double.MaxValue, BaseUnit);
+        public static MagneticField MaxValue { get; } = new MagneticField(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MagneticField
         /// </summary>
-        public static MagneticField MinValue => new MagneticField(double.MinValue, BaseUnit);
+        public static MagneticField MinValue { get; } = new MagneticField(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MagneticField;
+        public static QuantityType QuantityType { get; } = QuantityType.MagneticField;
 
         /// <summary>
         ///     All units of measurement for the MagneticField quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Tesla.
         /// </summary>
-        public static MagneticField Zero => new MagneticField(0, BaseUnit);
+        public static MagneticField Zero { get; } = new MagneticField(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticFlux.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MagneticFlux, which is Weber. All conversions go via this value.
         /// </summary>
-        public static MagneticFluxUnit BaseUnit => MagneticFluxUnit.Weber;
+        public static MagneticFluxUnit BaseUnit { get; } = MagneticFluxUnit.Weber;
 
         /// <summary>
         /// Represents the largest possible value of MagneticFlux
         /// </summary>
-        public static MagneticFlux MaxValue => new MagneticFlux(double.MaxValue, BaseUnit);
+        public static MagneticFlux MaxValue { get; } = new MagneticFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MagneticFlux
         /// </summary>
-        public static MagneticFlux MinValue => new MagneticFlux(double.MinValue, BaseUnit);
+        public static MagneticFlux MinValue { get; } = new MagneticFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MagneticFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.MagneticFlux;
 
         /// <summary>
         ///     All units of measurement for the MagneticFlux quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Weber.
         /// </summary>
-        public static MagneticFlux Zero => new MagneticFlux(0, BaseUnit);
+        public static MagneticFlux Zero { get; } = new MagneticFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Magnetization.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Magnetization.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Magnetization, which is AmperePerMeter. All conversions go via this value.
         /// </summary>
-        public static MagnetizationUnit BaseUnit => MagnetizationUnit.AmperePerMeter;
+        public static MagnetizationUnit BaseUnit { get; } = MagnetizationUnit.AmperePerMeter;
 
         /// <summary>
         /// Represents the largest possible value of Magnetization
         /// </summary>
-        public static Magnetization MaxValue => new Magnetization(double.MaxValue, BaseUnit);
+        public static Magnetization MaxValue { get; } = new Magnetization(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Magnetization
         /// </summary>
-        public static Magnetization MinValue => new Magnetization(double.MinValue, BaseUnit);
+        public static Magnetization MinValue { get; } = new Magnetization(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Magnetization;
+        public static QuantityType QuantityType { get; } = QuantityType.Magnetization;
 
         /// <summary>
         ///     All units of measurement for the Magnetization quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerMeter.
         /// </summary>
-        public static Magnetization Zero => new Magnetization(0, BaseUnit);
+        public static Magnetization Zero { get; } = new Magnetization(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Mass.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Mass.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Mass, which is Kilogram. All conversions go via this value.
         /// </summary>
-        public static MassUnit BaseUnit => MassUnit.Kilogram;
+        public static MassUnit BaseUnit { get; } = MassUnit.Kilogram;
 
         /// <summary>
         /// Represents the largest possible value of Mass
         /// </summary>
-        public static Mass MaxValue => new Mass(double.MaxValue, BaseUnit);
+        public static Mass MaxValue { get; } = new Mass(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Mass
         /// </summary>
-        public static Mass MinValue => new Mass(double.MinValue, BaseUnit);
+        public static Mass MinValue { get; } = new Mass(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Mass;
+        public static QuantityType QuantityType { get; } = QuantityType.Mass;
 
         /// <summary>
         ///     All units of measurement for the Mass quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Kilogram.
         /// </summary>
-        public static Mass Zero => new Mass(0, BaseUnit);
+        public static Mass Zero { get; } = new Mass(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlow.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlow.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MassFlow, which is GramPerSecond. All conversions go via this value.
         /// </summary>
-        public static MassFlowUnit BaseUnit => MassFlowUnit.GramPerSecond;
+        public static MassFlowUnit BaseUnit { get; } = MassFlowUnit.GramPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of MassFlow
         /// </summary>
-        public static MassFlow MaxValue => new MassFlow(double.MaxValue, BaseUnit);
+        public static MassFlow MaxValue { get; } = new MassFlow(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MassFlow
         /// </summary>
-        public static MassFlow MinValue => new MassFlow(double.MinValue, BaseUnit);
+        public static MassFlow MinValue { get; } = new MassFlow(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MassFlow;
+        public static QuantityType QuantityType { get; } = QuantityType.MassFlow;
 
         /// <summary>
         ///     All units of measurement for the MassFlow quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit GramPerSecond.
         /// </summary>
-        public static MassFlow Zero => new MassFlow(0, BaseUnit);
+        public static MassFlow Zero { get; } = new MassFlow(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlux.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlux.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MassFlux, which is KilogramPerSecondPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static MassFluxUnit BaseUnit => MassFluxUnit.KilogramPerSecondPerSquareMeter;
+        public static MassFluxUnit BaseUnit { get; } = MassFluxUnit.KilogramPerSecondPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of MassFlux
         /// </summary>
-        public static MassFlux MaxValue => new MassFlux(double.MaxValue, BaseUnit);
+        public static MassFlux MaxValue { get; } = new MassFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MassFlux
         /// </summary>
-        public static MassFlux MinValue => new MassFlux(double.MinValue, BaseUnit);
+        public static MassFlux MinValue { get; } = new MassFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MassFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.MassFlux;
 
         /// <summary>
         ///     All units of measurement for the MassFlux quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerSecondPerSquareMeter.
         /// </summary>
-        public static MassFlux Zero => new MassFlux(0, BaseUnit);
+        public static MassFlux Zero { get; } = new MassFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassMomentOfInertia.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassMomentOfInertia.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MassMomentOfInertia, which is KilogramSquareMeter. All conversions go via this value.
         /// </summary>
-        public static MassMomentOfInertiaUnit BaseUnit => MassMomentOfInertiaUnit.KilogramSquareMeter;
+        public static MassMomentOfInertiaUnit BaseUnit { get; } = MassMomentOfInertiaUnit.KilogramSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of MassMomentOfInertia
         /// </summary>
-        public static MassMomentOfInertia MaxValue => new MassMomentOfInertia(double.MaxValue, BaseUnit);
+        public static MassMomentOfInertia MaxValue { get; } = new MassMomentOfInertia(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MassMomentOfInertia
         /// </summary>
-        public static MassMomentOfInertia MinValue => new MassMomentOfInertia(double.MinValue, BaseUnit);
+        public static MassMomentOfInertia MinValue { get; } = new MassMomentOfInertia(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MassMomentOfInertia;
+        public static QuantityType QuantityType { get; } = QuantityType.MassMomentOfInertia;
 
         /// <summary>
         ///     All units of measurement for the MassMomentOfInertia quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramSquareMeter.
         /// </summary>
-        public static MassMomentOfInertia Zero => new MassMomentOfInertia(0, BaseUnit);
+        public static MassMomentOfInertia Zero { get; } = new MassMomentOfInertia(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEnergy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MolarEnergy, which is JoulePerMole. All conversions go via this value.
         /// </summary>
-        public static MolarEnergyUnit BaseUnit => MolarEnergyUnit.JoulePerMole;
+        public static MolarEnergyUnit BaseUnit { get; } = MolarEnergyUnit.JoulePerMole;
 
         /// <summary>
         /// Represents the largest possible value of MolarEnergy
         /// </summary>
-        public static MolarEnergy MaxValue => new MolarEnergy(double.MaxValue, BaseUnit);
+        public static MolarEnergy MaxValue { get; } = new MolarEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MolarEnergy
         /// </summary>
-        public static MolarEnergy MinValue => new MolarEnergy(double.MinValue, BaseUnit);
+        public static MolarEnergy MinValue { get; } = new MolarEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MolarEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.MolarEnergy;
 
         /// <summary>
         ///     All units of measurement for the MolarEnergy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerMole.
         /// </summary>
-        public static MolarEnergy Zero => new MolarEnergy(0, BaseUnit);
+        public static MolarEnergy Zero { get; } = new MolarEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEntropy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEntropy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MolarEntropy, which is JoulePerMoleKelvin. All conversions go via this value.
         /// </summary>
-        public static MolarEntropyUnit BaseUnit => MolarEntropyUnit.JoulePerMoleKelvin;
+        public static MolarEntropyUnit BaseUnit { get; } = MolarEntropyUnit.JoulePerMoleKelvin;
 
         /// <summary>
         /// Represents the largest possible value of MolarEntropy
         /// </summary>
-        public static MolarEntropy MaxValue => new MolarEntropy(double.MaxValue, BaseUnit);
+        public static MolarEntropy MaxValue { get; } = new MolarEntropy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MolarEntropy
         /// </summary>
-        public static MolarEntropy MinValue => new MolarEntropy(double.MinValue, BaseUnit);
+        public static MolarEntropy MinValue { get; } = new MolarEntropy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MolarEntropy;
+        public static QuantityType QuantityType { get; } = QuantityType.MolarEntropy;
 
         /// <summary>
         ///     All units of measurement for the MolarEntropy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerMoleKelvin.
         /// </summary>
-        public static MolarEntropy Zero => new MolarEntropy(0, BaseUnit);
+        public static MolarEntropy Zero { get; } = new MolarEntropy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarMass.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarMass.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MolarMass, which is KilogramPerMole. All conversions go via this value.
         /// </summary>
-        public static MolarMassUnit BaseUnit => MolarMassUnit.KilogramPerMole;
+        public static MolarMassUnit BaseUnit { get; } = MolarMassUnit.KilogramPerMole;
 
         /// <summary>
         /// Represents the largest possible value of MolarMass
         /// </summary>
-        public static MolarMass MaxValue => new MolarMass(double.MaxValue, BaseUnit);
+        public static MolarMass MaxValue { get; } = new MolarMass(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MolarMass
         /// </summary>
-        public static MolarMass MinValue => new MolarMass(double.MinValue, BaseUnit);
+        public static MolarMass MinValue { get; } = new MolarMass(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MolarMass;
+        public static QuantityType QuantityType { get; } = QuantityType.MolarMass;
 
         /// <summary>
         ///     All units of measurement for the MolarMass quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerMole.
         /// </summary>
-        public static MolarMass Zero => new MolarMass(0, BaseUnit);
+        public static MolarMass Zero { get; } = new MolarMass(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Molarity, which is MolesPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static MolarityUnit BaseUnit => MolarityUnit.MolesPerCubicMeter;
+        public static MolarityUnit BaseUnit { get; } = MolarityUnit.MolesPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of Molarity
         /// </summary>
-        public static Molarity MaxValue => new Molarity(double.MaxValue, BaseUnit);
+        public static Molarity MaxValue { get; } = new Molarity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Molarity
         /// </summary>
-        public static Molarity MinValue => new Molarity(double.MinValue, BaseUnit);
+        public static Molarity MinValue { get; } = new Molarity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Molarity;
+        public static QuantityType QuantityType { get; } = QuantityType.Molarity;
 
         /// <summary>
         ///     All units of measurement for the Molarity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MolesPerCubicMeter.
         /// </summary>
-        public static Molarity Zero => new Molarity(0, BaseUnit);
+        public static Molarity Zero { get; } = new Molarity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permeability.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permeability.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Permeability, which is HenryPerMeter. All conversions go via this value.
         /// </summary>
-        public static PermeabilityUnit BaseUnit => PermeabilityUnit.HenryPerMeter;
+        public static PermeabilityUnit BaseUnit { get; } = PermeabilityUnit.HenryPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of Permeability
         /// </summary>
-        public static Permeability MaxValue => new Permeability(double.MaxValue, BaseUnit);
+        public static Permeability MaxValue { get; } = new Permeability(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Permeability
         /// </summary>
-        public static Permeability MinValue => new Permeability(double.MinValue, BaseUnit);
+        public static Permeability MinValue { get; } = new Permeability(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Permeability;
+        public static QuantityType QuantityType { get; } = QuantityType.Permeability;
 
         /// <summary>
         ///     All units of measurement for the Permeability quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit HenryPerMeter.
         /// </summary>
-        public static Permeability Zero => new Permeability(0, BaseUnit);
+        public static Permeability Zero { get; } = new Permeability(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permittivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permittivity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Permittivity, which is FaradPerMeter. All conversions go via this value.
         /// </summary>
-        public static PermittivityUnit BaseUnit => PermittivityUnit.FaradPerMeter;
+        public static PermittivityUnit BaseUnit { get; } = PermittivityUnit.FaradPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of Permittivity
         /// </summary>
-        public static Permittivity MaxValue => new Permittivity(double.MaxValue, BaseUnit);
+        public static Permittivity MaxValue { get; } = new Permittivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Permittivity
         /// </summary>
-        public static Permittivity MinValue => new Permittivity(double.MinValue, BaseUnit);
+        public static Permittivity MinValue { get; } = new Permittivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Permittivity;
+        public static QuantityType QuantityType { get; } = QuantityType.Permittivity;
 
         /// <summary>
         ///     All units of measurement for the Permittivity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit FaradPerMeter.
         /// </summary>
-        public static Permittivity Zero => new Permittivity(0, BaseUnit);
+        public static Permittivity Zero { get; } = new Permittivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Power.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Power.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Power, which is Watt. All conversions go via this value.
         /// </summary>
-        public static PowerUnit BaseUnit => PowerUnit.Watt;
+        public static PowerUnit BaseUnit { get; } = PowerUnit.Watt;
 
         /// <summary>
         /// Represents the largest possible value of Power
         /// </summary>
-        public static Power MaxValue => new Power(decimal.MaxValue, BaseUnit);
+        public static Power MaxValue { get; } = new Power(decimal.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Power
         /// </summary>
-        public static Power MinValue => new Power(decimal.MinValue, BaseUnit);
+        public static Power MinValue { get; } = new Power(decimal.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Power;
+        public static QuantityType QuantityType { get; } = QuantityType.Power;
 
         /// <summary>
         ///     All units of measurement for the Power quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Watt.
         /// </summary>
-        public static Power Zero => new Power(0, BaseUnit);
+        public static Power Zero { get; } = new Power(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerDensity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerDensity.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of PowerDensity, which is WattPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static PowerDensityUnit BaseUnit => PowerDensityUnit.WattPerCubicMeter;
+        public static PowerDensityUnit BaseUnit { get; } = PowerDensityUnit.WattPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of PowerDensity
         /// </summary>
-        public static PowerDensity MaxValue => new PowerDensity(double.MaxValue, BaseUnit);
+        public static PowerDensity MaxValue { get; } = new PowerDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of PowerDensity
         /// </summary>
-        public static PowerDensity MinValue => new PowerDensity(double.MinValue, BaseUnit);
+        public static PowerDensity MinValue { get; } = new PowerDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.PowerDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.PowerDensity;
 
         /// <summary>
         ///     All units of measurement for the PowerDensity quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerCubicMeter.
         /// </summary>
-        public static PowerDensity Zero => new PowerDensity(0, BaseUnit);
+        public static PowerDensity Zero { get; } = new PowerDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerRatio.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerRatio.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of PowerRatio, which is DecibelWatt. All conversions go via this value.
         /// </summary>
-        public static PowerRatioUnit BaseUnit => PowerRatioUnit.DecibelWatt;
+        public static PowerRatioUnit BaseUnit { get; } = PowerRatioUnit.DecibelWatt;
 
         /// <summary>
         /// Represents the largest possible value of PowerRatio
         /// </summary>
-        public static PowerRatio MaxValue => new PowerRatio(double.MaxValue, BaseUnit);
+        public static PowerRatio MaxValue { get; } = new PowerRatio(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of PowerRatio
         /// </summary>
-        public static PowerRatio MinValue => new PowerRatio(double.MinValue, BaseUnit);
+        public static PowerRatio MinValue { get; } = new PowerRatio(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.PowerRatio;
+        public static QuantityType QuantityType { get; } = QuantityType.PowerRatio;
 
         /// <summary>
         ///     All units of measurement for the PowerRatio quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DecibelWatt.
         /// </summary>
-        public static PowerRatio Zero => new PowerRatio(0, BaseUnit);
+        public static PowerRatio Zero { get; } = new PowerRatio(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Pressure.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Pressure.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Pressure, which is Pascal. All conversions go via this value.
         /// </summary>
-        public static PressureUnit BaseUnit => PressureUnit.Pascal;
+        public static PressureUnit BaseUnit { get; } = PressureUnit.Pascal;
 
         /// <summary>
         /// Represents the largest possible value of Pressure
         /// </summary>
-        public static Pressure MaxValue => new Pressure(double.MaxValue, BaseUnit);
+        public static Pressure MaxValue { get; } = new Pressure(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Pressure
         /// </summary>
-        public static Pressure MinValue => new Pressure(double.MinValue, BaseUnit);
+        public static Pressure MinValue { get; } = new Pressure(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Pressure;
+        public static QuantityType QuantityType { get; } = QuantityType.Pressure;
 
         /// <summary>
         ///     All units of measurement for the Pressure quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Pascal.
         /// </summary>
-        public static Pressure Zero => new Pressure(0, BaseUnit);
+        public static Pressure Zero { get; } = new Pressure(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PressureChangeRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PressureChangeRate.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of PressureChangeRate, which is PascalPerSecond. All conversions go via this value.
         /// </summary>
-        public static PressureChangeRateUnit BaseUnit => PressureChangeRateUnit.PascalPerSecond;
+        public static PressureChangeRateUnit BaseUnit { get; } = PressureChangeRateUnit.PascalPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of PressureChangeRate
         /// </summary>
-        public static PressureChangeRate MaxValue => new PressureChangeRate(double.MaxValue, BaseUnit);
+        public static PressureChangeRate MaxValue { get; } = new PressureChangeRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of PressureChangeRate
         /// </summary>
-        public static PressureChangeRate MinValue => new PressureChangeRate(double.MinValue, BaseUnit);
+        public static PressureChangeRate MinValue { get; } = new PressureChangeRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.PressureChangeRate;
+        public static QuantityType QuantityType { get; } = QuantityType.PressureChangeRate;
 
         /// <summary>
         ///     All units of measurement for the PressureChangeRate quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit PascalPerSecond.
         /// </summary>
-        public static PressureChangeRate Zero => new PressureChangeRate(0, BaseUnit);
+        public static PressureChangeRate Zero { get; } = new PressureChangeRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Ratio.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Ratio.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Ratio, which is DecimalFraction. All conversions go via this value.
         /// </summary>
-        public static RatioUnit BaseUnit => RatioUnit.DecimalFraction;
+        public static RatioUnit BaseUnit { get; } = RatioUnit.DecimalFraction;
 
         /// <summary>
         /// Represents the largest possible value of Ratio
         /// </summary>
-        public static Ratio MaxValue => new Ratio(double.MaxValue, BaseUnit);
+        public static Ratio MaxValue { get; } = new Ratio(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Ratio
         /// </summary>
-        public static Ratio MinValue => new Ratio(double.MinValue, BaseUnit);
+        public static Ratio MinValue { get; } = new Ratio(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Ratio;
+        public static QuantityType QuantityType { get; } = QuantityType.Ratio;
 
         /// <summary>
         ///     All units of measurement for the Ratio quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DecimalFraction.
         /// </summary>
-        public static Ratio Zero => new Ratio(0, BaseUnit);
+        public static Ratio Zero { get; } = new Ratio(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactiveEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactiveEnergy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ReactiveEnergy, which is VoltampereReactiveHour. All conversions go via this value.
         /// </summary>
-        public static ReactiveEnergyUnit BaseUnit => ReactiveEnergyUnit.VoltampereReactiveHour;
+        public static ReactiveEnergyUnit BaseUnit { get; } = ReactiveEnergyUnit.VoltampereReactiveHour;
 
         /// <summary>
         /// Represents the largest possible value of ReactiveEnergy
         /// </summary>
-        public static ReactiveEnergy MaxValue => new ReactiveEnergy(double.MaxValue, BaseUnit);
+        public static ReactiveEnergy MaxValue { get; } = new ReactiveEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ReactiveEnergy
         /// </summary>
-        public static ReactiveEnergy MinValue => new ReactiveEnergy(double.MinValue, BaseUnit);
+        public static ReactiveEnergy MinValue { get; } = new ReactiveEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ReactiveEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.ReactiveEnergy;
 
         /// <summary>
         ///     All units of measurement for the ReactiveEnergy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereReactiveHour.
         /// </summary>
-        public static ReactiveEnergy Zero => new ReactiveEnergy(0, BaseUnit);
+        public static ReactiveEnergy Zero { get; } = new ReactiveEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactivePower.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactivePower.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ReactivePower, which is VoltampereReactive. All conversions go via this value.
         /// </summary>
-        public static ReactivePowerUnit BaseUnit => ReactivePowerUnit.VoltampereReactive;
+        public static ReactivePowerUnit BaseUnit { get; } = ReactivePowerUnit.VoltampereReactive;
 
         /// <summary>
         /// Represents the largest possible value of ReactivePower
         /// </summary>
-        public static ReactivePower MaxValue => new ReactivePower(double.MaxValue, BaseUnit);
+        public static ReactivePower MaxValue { get; } = new ReactivePower(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ReactivePower
         /// </summary>
-        public static ReactivePower MinValue => new ReactivePower(double.MinValue, BaseUnit);
+        public static ReactivePower MinValue { get; } = new ReactivePower(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ReactivePower;
+        public static QuantityType QuantityType { get; } = QuantityType.ReactivePower;
 
         /// <summary>
         ///     All units of measurement for the ReactivePower quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereReactive.
         /// </summary>
-        public static ReactivePower Zero => new ReactivePower(0, BaseUnit);
+        public static ReactivePower Zero { get; } = new ReactivePower(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalAcceleration, which is RadianPerSecondSquared. All conversions go via this value.
         /// </summary>
-        public static RotationalAccelerationUnit BaseUnit => RotationalAccelerationUnit.RadianPerSecondSquared;
+        public static RotationalAccelerationUnit BaseUnit { get; } = RotationalAccelerationUnit.RadianPerSecondSquared;
 
         /// <summary>
         /// Represents the largest possible value of RotationalAcceleration
         /// </summary>
-        public static RotationalAcceleration MaxValue => new RotationalAcceleration(double.MaxValue, BaseUnit);
+        public static RotationalAcceleration MaxValue { get; } = new RotationalAcceleration(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalAcceleration
         /// </summary>
-        public static RotationalAcceleration MinValue => new RotationalAcceleration(double.MinValue, BaseUnit);
+        public static RotationalAcceleration MinValue { get; } = new RotationalAcceleration(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalAcceleration;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalAcceleration;
 
         /// <summary>
         ///     All units of measurement for the RotationalAcceleration quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit RadianPerSecondSquared.
         /// </summary>
-        public static RotationalAcceleration Zero => new RotationalAcceleration(0, BaseUnit);
+        public static RotationalAcceleration Zero { get; } = new RotationalAcceleration(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalSpeed.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalSpeed.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalSpeed, which is RadianPerSecond. All conversions go via this value.
         /// </summary>
-        public static RotationalSpeedUnit BaseUnit => RotationalSpeedUnit.RadianPerSecond;
+        public static RotationalSpeedUnit BaseUnit { get; } = RotationalSpeedUnit.RadianPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of RotationalSpeed
         /// </summary>
-        public static RotationalSpeed MaxValue => new RotationalSpeed(double.MaxValue, BaseUnit);
+        public static RotationalSpeed MaxValue { get; } = new RotationalSpeed(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalSpeed
         /// </summary>
-        public static RotationalSpeed MinValue => new RotationalSpeed(double.MinValue, BaseUnit);
+        public static RotationalSpeed MinValue { get; } = new RotationalSpeed(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalSpeed;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalSpeed;
 
         /// <summary>
         ///     All units of measurement for the RotationalSpeed quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit RadianPerSecond.
         /// </summary>
-        public static RotationalSpeed Zero => new RotationalSpeed(0, BaseUnit);
+        public static RotationalSpeed Zero { get; } = new RotationalSpeed(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffness.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffness.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalStiffness, which is NewtonMeterPerRadian. All conversions go via this value.
         /// </summary>
-        public static RotationalStiffnessUnit BaseUnit => RotationalStiffnessUnit.NewtonMeterPerRadian;
+        public static RotationalStiffnessUnit BaseUnit { get; } = RotationalStiffnessUnit.NewtonMeterPerRadian;
 
         /// <summary>
         /// Represents the largest possible value of RotationalStiffness
         /// </summary>
-        public static RotationalStiffness MaxValue => new RotationalStiffness(double.MaxValue, BaseUnit);
+        public static RotationalStiffness MaxValue { get; } = new RotationalStiffness(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalStiffness
         /// </summary>
-        public static RotationalStiffness MinValue => new RotationalStiffness(double.MinValue, BaseUnit);
+        public static RotationalStiffness MinValue { get; } = new RotationalStiffness(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalStiffness;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalStiffness;
 
         /// <summary>
         ///     All units of measurement for the RotationalStiffness quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeterPerRadian.
         /// </summary>
-        public static RotationalStiffness Zero => new RotationalStiffness(0, BaseUnit);
+        public static RotationalStiffness Zero { get; } = new RotationalStiffness(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffnessPerLength.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffnessPerLength.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalStiffnessPerLength, which is NewtonMeterPerRadianPerMeter. All conversions go via this value.
         /// </summary>
-        public static RotationalStiffnessPerLengthUnit BaseUnit => RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
+        public static RotationalStiffnessPerLengthUnit BaseUnit { get; } = RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of RotationalStiffnessPerLength
         /// </summary>
-        public static RotationalStiffnessPerLength MaxValue => new RotationalStiffnessPerLength(double.MaxValue, BaseUnit);
+        public static RotationalStiffnessPerLength MaxValue { get; } = new RotationalStiffnessPerLength(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalStiffnessPerLength
         /// </summary>
-        public static RotationalStiffnessPerLength MinValue => new RotationalStiffnessPerLength(double.MinValue, BaseUnit);
+        public static RotationalStiffnessPerLength MinValue { get; } = new RotationalStiffnessPerLength(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalStiffnessPerLength;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalStiffnessPerLength;
 
         /// <summary>
         ///     All units of measurement for the RotationalStiffnessPerLength quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeterPerRadianPerMeter.
         /// </summary>
-        public static RotationalStiffnessPerLength Zero => new RotationalStiffnessPerLength(0, BaseUnit);
+        public static RotationalStiffnessPerLength Zero { get; } = new RotationalStiffnessPerLength(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SolidAngle.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SolidAngle.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SolidAngle, which is Steradian. All conversions go via this value.
         /// </summary>
-        public static SolidAngleUnit BaseUnit => SolidAngleUnit.Steradian;
+        public static SolidAngleUnit BaseUnit { get; } = SolidAngleUnit.Steradian;
 
         /// <summary>
         /// Represents the largest possible value of SolidAngle
         /// </summary>
-        public static SolidAngle MaxValue => new SolidAngle(double.MaxValue, BaseUnit);
+        public static SolidAngle MaxValue { get; } = new SolidAngle(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SolidAngle
         /// </summary>
-        public static SolidAngle MinValue => new SolidAngle(double.MinValue, BaseUnit);
+        public static SolidAngle MinValue { get; } = new SolidAngle(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SolidAngle;
+        public static QuantityType QuantityType { get; } = QuantityType.SolidAngle;
 
         /// <summary>
         ///     All units of measurement for the SolidAngle quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Steradian.
         /// </summary>
-        public static SolidAngle Zero => new SolidAngle(0, BaseUnit);
+        public static SolidAngle Zero { get; } = new SolidAngle(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEnergy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEnergy.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificEnergy, which is JoulePerKilogram. All conversions go via this value.
         /// </summary>
-        public static SpecificEnergyUnit BaseUnit => SpecificEnergyUnit.JoulePerKilogram;
+        public static SpecificEnergyUnit BaseUnit { get; } = SpecificEnergyUnit.JoulePerKilogram;
 
         /// <summary>
         /// Represents the largest possible value of SpecificEnergy
         /// </summary>
-        public static SpecificEnergy MaxValue => new SpecificEnergy(double.MaxValue, BaseUnit);
+        public static SpecificEnergy MaxValue { get; } = new SpecificEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificEnergy
         /// </summary>
-        public static SpecificEnergy MinValue => new SpecificEnergy(double.MinValue, BaseUnit);
+        public static SpecificEnergy MinValue { get; } = new SpecificEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificEnergy;
 
         /// <summary>
         ///     All units of measurement for the SpecificEnergy quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKilogram.
         /// </summary>
-        public static SpecificEnergy Zero => new SpecificEnergy(0, BaseUnit);
+        public static SpecificEnergy Zero { get; } = new SpecificEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEntropy.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEntropy.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificEntropy, which is JoulePerKilogramKelvin. All conversions go via this value.
         /// </summary>
-        public static SpecificEntropyUnit BaseUnit => SpecificEntropyUnit.JoulePerKilogramKelvin;
+        public static SpecificEntropyUnit BaseUnit { get; } = SpecificEntropyUnit.JoulePerKilogramKelvin;
 
         /// <summary>
         /// Represents the largest possible value of SpecificEntropy
         /// </summary>
-        public static SpecificEntropy MaxValue => new SpecificEntropy(double.MaxValue, BaseUnit);
+        public static SpecificEntropy MaxValue { get; } = new SpecificEntropy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificEntropy
         /// </summary>
-        public static SpecificEntropy MinValue => new SpecificEntropy(double.MinValue, BaseUnit);
+        public static SpecificEntropy MinValue { get; } = new SpecificEntropy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificEntropy;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificEntropy;
 
         /// <summary>
         ///     All units of measurement for the SpecificEntropy quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKilogramKelvin.
         /// </summary>
-        public static SpecificEntropy Zero => new SpecificEntropy(0, BaseUnit);
+        public static SpecificEntropy Zero { get; } = new SpecificEntropy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificVolume.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificVolume.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificVolume, which is CubicMeterPerKilogram. All conversions go via this value.
         /// </summary>
-        public static SpecificVolumeUnit BaseUnit => SpecificVolumeUnit.CubicMeterPerKilogram;
+        public static SpecificVolumeUnit BaseUnit { get; } = SpecificVolumeUnit.CubicMeterPerKilogram;
 
         /// <summary>
         /// Represents the largest possible value of SpecificVolume
         /// </summary>
-        public static SpecificVolume MaxValue => new SpecificVolume(double.MaxValue, BaseUnit);
+        public static SpecificVolume MaxValue { get; } = new SpecificVolume(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificVolume
         /// </summary>
-        public static SpecificVolume MinValue => new SpecificVolume(double.MinValue, BaseUnit);
+        public static SpecificVolume MinValue { get; } = new SpecificVolume(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificVolume;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificVolume;
 
         /// <summary>
         ///     All units of measurement for the SpecificVolume quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerKilogram.
         /// </summary>
-        public static SpecificVolume Zero => new SpecificVolume(0, BaseUnit);
+        public static SpecificVolume Zero { get; } = new SpecificVolume(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificWeight.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificWeight.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificWeight, which is NewtonPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static SpecificWeightUnit BaseUnit => SpecificWeightUnit.NewtonPerCubicMeter;
+        public static SpecificWeightUnit BaseUnit { get; } = SpecificWeightUnit.NewtonPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of SpecificWeight
         /// </summary>
-        public static SpecificWeight MaxValue => new SpecificWeight(double.MaxValue, BaseUnit);
+        public static SpecificWeight MaxValue { get; } = new SpecificWeight(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificWeight
         /// </summary>
-        public static SpecificWeight MinValue => new SpecificWeight(double.MinValue, BaseUnit);
+        public static SpecificWeight MinValue { get; } = new SpecificWeight(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificWeight;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificWeight;
 
         /// <summary>
         ///     All units of measurement for the SpecificWeight quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerCubicMeter.
         /// </summary>
-        public static SpecificWeight Zero => new SpecificWeight(0, BaseUnit);
+        public static SpecificWeight Zero { get; } = new SpecificWeight(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Speed.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Speed.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Speed, which is MeterPerSecond. All conversions go via this value.
         /// </summary>
-        public static SpeedUnit BaseUnit => SpeedUnit.MeterPerSecond;
+        public static SpeedUnit BaseUnit { get; } = SpeedUnit.MeterPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of Speed
         /// </summary>
-        public static Speed MaxValue => new Speed(double.MaxValue, BaseUnit);
+        public static Speed MaxValue { get; } = new Speed(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Speed
         /// </summary>
-        public static Speed MinValue => new Speed(double.MinValue, BaseUnit);
+        public static Speed MinValue { get; } = new Speed(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Speed;
+        public static QuantityType QuantityType { get; } = QuantityType.Speed;
 
         /// <summary>
         ///     All units of measurement for the Speed quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MeterPerSecond.
         /// </summary>
-        public static Speed Zero => new Speed(0, BaseUnit);
+        public static Speed Zero { get; } = new Speed(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Temperature.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Temperature.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Temperature, which is Kelvin. All conversions go via this value.
         /// </summary>
-        public static TemperatureUnit BaseUnit => TemperatureUnit.Kelvin;
+        public static TemperatureUnit BaseUnit { get; } = TemperatureUnit.Kelvin;
 
         /// <summary>
         /// Represents the largest possible value of Temperature
         /// </summary>
-        public static Temperature MaxValue => new Temperature(double.MaxValue, BaseUnit);
+        public static Temperature MaxValue { get; } = new Temperature(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Temperature
         /// </summary>
-        public static Temperature MinValue => new Temperature(double.MinValue, BaseUnit);
+        public static Temperature MinValue { get; } = new Temperature(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Temperature;
+        public static QuantityType QuantityType { get; } = QuantityType.Temperature;
 
         /// <summary>
         ///     All units of measurement for the Temperature quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Kelvin.
         /// </summary>
-        public static Temperature Zero => new Temperature(0, BaseUnit);
+        public static Temperature Zero { get; } = new Temperature(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureChangeRate.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureChangeRate.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of TemperatureChangeRate, which is DegreeCelsiusPerSecond. All conversions go via this value.
         /// </summary>
-        public static TemperatureChangeRateUnit BaseUnit => TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
+        public static TemperatureChangeRateUnit BaseUnit { get; } = TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of TemperatureChangeRate
         /// </summary>
-        public static TemperatureChangeRate MaxValue => new TemperatureChangeRate(double.MaxValue, BaseUnit);
+        public static TemperatureChangeRate MaxValue { get; } = new TemperatureChangeRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of TemperatureChangeRate
         /// </summary>
-        public static TemperatureChangeRate MinValue => new TemperatureChangeRate(double.MinValue, BaseUnit);
+        public static TemperatureChangeRate MinValue { get; } = new TemperatureChangeRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.TemperatureChangeRate;
+        public static QuantityType QuantityType { get; } = QuantityType.TemperatureChangeRate;
 
         /// <summary>
         ///     All units of measurement for the TemperatureChangeRate quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DegreeCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate Zero => new TemperatureChangeRate(0, BaseUnit);
+        public static TemperatureChangeRate Zero { get; } = new TemperatureChangeRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureDelta.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureDelta.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of TemperatureDelta, which is Kelvin. All conversions go via this value.
         /// </summary>
-        public static TemperatureDeltaUnit BaseUnit => TemperatureDeltaUnit.Kelvin;
+        public static TemperatureDeltaUnit BaseUnit { get; } = TemperatureDeltaUnit.Kelvin;
 
         /// <summary>
         /// Represents the largest possible value of TemperatureDelta
         /// </summary>
-        public static TemperatureDelta MaxValue => new TemperatureDelta(double.MaxValue, BaseUnit);
+        public static TemperatureDelta MaxValue { get; } = new TemperatureDelta(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of TemperatureDelta
         /// </summary>
-        public static TemperatureDelta MinValue => new TemperatureDelta(double.MinValue, BaseUnit);
+        public static TemperatureDelta MinValue { get; } = new TemperatureDelta(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.TemperatureDelta;
+        public static QuantityType QuantityType { get; } = QuantityType.TemperatureDelta;
 
         /// <summary>
         ///     All units of measurement for the TemperatureDelta quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Kelvin.
         /// </summary>
-        public static TemperatureDelta Zero => new TemperatureDelta(0, BaseUnit);
+        public static TemperatureDelta Zero { get; } = new TemperatureDelta(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalConductivity.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalConductivity.WindowsRuntimeComponent.g.cs
@@ -109,22 +109,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ThermalConductivity, which is WattPerMeterKelvin. All conversions go via this value.
         /// </summary>
-        public static ThermalConductivityUnit BaseUnit => ThermalConductivityUnit.WattPerMeterKelvin;
+        public static ThermalConductivityUnit BaseUnit { get; } = ThermalConductivityUnit.WattPerMeterKelvin;
 
         /// <summary>
         /// Represents the largest possible value of ThermalConductivity
         /// </summary>
-        public static ThermalConductivity MaxValue => new ThermalConductivity(double.MaxValue, BaseUnit);
+        public static ThermalConductivity MaxValue { get; } = new ThermalConductivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ThermalConductivity
         /// </summary>
-        public static ThermalConductivity MinValue => new ThermalConductivity(double.MinValue, BaseUnit);
+        public static ThermalConductivity MinValue { get; } = new ThermalConductivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ThermalConductivity;
+        public static QuantityType QuantityType { get; } = QuantityType.ThermalConductivity;
 
         /// <summary>
         ///     All units of measurement for the ThermalConductivity quantity.
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerMeterKelvin.
         /// </summary>
-        public static ThermalConductivity Zero => new ThermalConductivity(0, BaseUnit);
+        public static ThermalConductivity Zero { get; } = new ThermalConductivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ThermalResistance, which is SquareMeterKelvinPerKilowatt. All conversions go via this value.
         /// </summary>
-        public static ThermalResistanceUnit BaseUnit => ThermalResistanceUnit.SquareMeterKelvinPerKilowatt;
+        public static ThermalResistanceUnit BaseUnit { get; } = ThermalResistanceUnit.SquareMeterKelvinPerKilowatt;
 
         /// <summary>
         /// Represents the largest possible value of ThermalResistance
         /// </summary>
-        public static ThermalResistance MaxValue => new ThermalResistance(double.MaxValue, BaseUnit);
+        public static ThermalResistance MaxValue { get; } = new ThermalResistance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ThermalResistance
         /// </summary>
-        public static ThermalResistance MinValue => new ThermalResistance(double.MinValue, BaseUnit);
+        public static ThermalResistance MinValue { get; } = new ThermalResistance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ThermalResistance;
+        public static QuantityType QuantityType { get; } = QuantityType.ThermalResistance;
 
         /// <summary>
         ///     All units of measurement for the ThermalResistance quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeterKelvinPerKilowatt.
         /// </summary>
-        public static ThermalResistance Zero => new ThermalResistance(0, BaseUnit);
+        public static ThermalResistance Zero { get; } = new ThermalResistance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Torque.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Torque.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Torque, which is NewtonMeter. All conversions go via this value.
         /// </summary>
-        public static TorqueUnit BaseUnit => TorqueUnit.NewtonMeter;
+        public static TorqueUnit BaseUnit { get; } = TorqueUnit.NewtonMeter;
 
         /// <summary>
         /// Represents the largest possible value of Torque
         /// </summary>
-        public static Torque MaxValue => new Torque(double.MaxValue, BaseUnit);
+        public static Torque MaxValue { get; } = new Torque(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Torque
         /// </summary>
-        public static Torque MinValue => new Torque(double.MinValue, BaseUnit);
+        public static Torque MinValue { get; } = new Torque(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Torque;
+        public static QuantityType QuantityType { get; } = QuantityType.Torque;
 
         /// <summary>
         ///     All units of measurement for the Torque quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeter.
         /// </summary>
-        public static Torque Zero => new Torque(0, BaseUnit);
+        public static Torque Zero { get; } = new Torque(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VitaminA.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VitaminA.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of VitaminA, which is InternationalUnit. All conversions go via this value.
         /// </summary>
-        public static VitaminAUnit BaseUnit => VitaminAUnit.InternationalUnit;
+        public static VitaminAUnit BaseUnit { get; } = VitaminAUnit.InternationalUnit;
 
         /// <summary>
         /// Represents the largest possible value of VitaminA
         /// </summary>
-        public static VitaminA MaxValue => new VitaminA(double.MaxValue, BaseUnit);
+        public static VitaminA MaxValue { get; } = new VitaminA(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of VitaminA
         /// </summary>
-        public static VitaminA MinValue => new VitaminA(double.MinValue, BaseUnit);
+        public static VitaminA MinValue { get; } = new VitaminA(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.VitaminA;
+        public static QuantityType QuantityType { get; } = QuantityType.VitaminA;
 
         /// <summary>
         ///     All units of measurement for the VitaminA quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit InternationalUnit.
         /// </summary>
-        public static VitaminA Zero => new VitaminA(0, BaseUnit);
+        public static VitaminA Zero { get; } = new VitaminA(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Volume.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Volume.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Volume, which is CubicMeter. All conversions go via this value.
         /// </summary>
-        public static VolumeUnit BaseUnit => VolumeUnit.CubicMeter;
+        public static VolumeUnit BaseUnit { get; } = VolumeUnit.CubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of Volume
         /// </summary>
-        public static Volume MaxValue => new Volume(double.MaxValue, BaseUnit);
+        public static Volume MaxValue { get; } = new Volume(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Volume
         /// </summary>
-        public static Volume MinValue => new Volume(double.MinValue, BaseUnit);
+        public static Volume MinValue { get; } = new Volume(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Volume;
+        public static QuantityType QuantityType { get; } = QuantityType.Volume;
 
         /// <summary>
         ///     All units of measurement for the Volume quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeter.
         /// </summary>
-        public static Volume Zero => new Volume(0, BaseUnit);
+        public static Volume Zero { get; } = new Volume(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumeFlow.WindowsRuntimeComponent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumeFlow.WindowsRuntimeComponent.g.cs
@@ -106,22 +106,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of VolumeFlow, which is CubicMeterPerSecond. All conversions go via this value.
         /// </summary>
-        public static VolumeFlowUnit BaseUnit => VolumeFlowUnit.CubicMeterPerSecond;
+        public static VolumeFlowUnit BaseUnit { get; } = VolumeFlowUnit.CubicMeterPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of VolumeFlow
         /// </summary>
-        public static VolumeFlow MaxValue => new VolumeFlow(double.MaxValue, BaseUnit);
+        public static VolumeFlow MaxValue { get; } = new VolumeFlow(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of VolumeFlow
         /// </summary>
-        public static VolumeFlow MinValue => new VolumeFlow(double.MinValue, BaseUnit);
+        public static VolumeFlow MinValue { get; } = new VolumeFlow(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.VolumeFlow;
+        public static QuantityType QuantityType { get; } = QuantityType.VolumeFlow;
 
         /// <summary>
         ///     All units of measurement for the VolumeFlow quantity.
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerSecond.
         /// </summary>
-        public static VolumeFlow Zero => new VolumeFlow(0, BaseUnit);
+        public static VolumeFlow Zero { get; } = new VolumeFlow(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Acceleration, which is MeterPerSecondSquared. All conversions go via this value.
         /// </summary>
-        public static AccelerationUnit BaseUnit => AccelerationUnit.MeterPerSecondSquared;
+        public static AccelerationUnit BaseUnit { get; } = AccelerationUnit.MeterPerSecondSquared;
 
         /// <summary>
         /// Represents the largest possible value of Acceleration
         /// </summary>
-        public static Acceleration MaxValue => new Acceleration(double.MaxValue, BaseUnit);
+        public static Acceleration MaxValue { get; } = new Acceleration(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Acceleration
         /// </summary>
-        public static Acceleration MinValue => new Acceleration(double.MinValue, BaseUnit);
+        public static Acceleration MinValue { get; } = new Acceleration(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Acceleration;
+        public static QuantityType QuantityType { get; } = QuantityType.Acceleration;
 
         /// <summary>
         ///     All units of measurement for the Acceleration quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MeterPerSecondSquared.
         /// </summary>
-        public static Acceleration Zero => new Acceleration(0, BaseUnit);
+        public static Acceleration Zero { get; } = new Acceleration(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AmountOfSubstance, which is Mole. All conversions go via this value.
         /// </summary>
-        public static AmountOfSubstanceUnit BaseUnit => AmountOfSubstanceUnit.Mole;
+        public static AmountOfSubstanceUnit BaseUnit { get; } = AmountOfSubstanceUnit.Mole;
 
         /// <summary>
         /// Represents the largest possible value of AmountOfSubstance
         /// </summary>
-        public static AmountOfSubstance MaxValue => new AmountOfSubstance(double.MaxValue, BaseUnit);
+        public static AmountOfSubstance MaxValue { get; } = new AmountOfSubstance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AmountOfSubstance
         /// </summary>
-        public static AmountOfSubstance MinValue => new AmountOfSubstance(double.MinValue, BaseUnit);
+        public static AmountOfSubstance MinValue { get; } = new AmountOfSubstance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AmountOfSubstance;
+        public static QuantityType QuantityType { get; } = QuantityType.AmountOfSubstance;
 
         /// <summary>
         ///     All units of measurement for the AmountOfSubstance quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Mole.
         /// </summary>
-        public static AmountOfSubstance Zero => new AmountOfSubstance(0, BaseUnit);
+        public static AmountOfSubstance Zero { get; } = new AmountOfSubstance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AmplitudeRatio, which is DecibelVolt. All conversions go via this value.
         /// </summary>
-        public static AmplitudeRatioUnit BaseUnit => AmplitudeRatioUnit.DecibelVolt;
+        public static AmplitudeRatioUnit BaseUnit { get; } = AmplitudeRatioUnit.DecibelVolt;
 
         /// <summary>
         /// Represents the largest possible value of AmplitudeRatio
         /// </summary>
-        public static AmplitudeRatio MaxValue => new AmplitudeRatio(double.MaxValue, BaseUnit);
+        public static AmplitudeRatio MaxValue { get; } = new AmplitudeRatio(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AmplitudeRatio
         /// </summary>
-        public static AmplitudeRatio MinValue => new AmplitudeRatio(double.MinValue, BaseUnit);
+        public static AmplitudeRatio MinValue { get; } = new AmplitudeRatio(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AmplitudeRatio;
+        public static QuantityType QuantityType { get; } = QuantityType.AmplitudeRatio;
 
         /// <summary>
         ///     All units of measurement for the AmplitudeRatio quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DecibelVolt.
         /// </summary>
-        public static AmplitudeRatio Zero => new AmplitudeRatio(0, BaseUnit);
+        public static AmplitudeRatio Zero { get; } = new AmplitudeRatio(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Angle, which is Degree. All conversions go via this value.
         /// </summary>
-        public static AngleUnit BaseUnit => AngleUnit.Degree;
+        public static AngleUnit BaseUnit { get; } = AngleUnit.Degree;
 
         /// <summary>
         /// Represents the largest possible value of Angle
         /// </summary>
-        public static Angle MaxValue => new Angle(double.MaxValue, BaseUnit);
+        public static Angle MaxValue { get; } = new Angle(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Angle
         /// </summary>
-        public static Angle MinValue => new Angle(double.MinValue, BaseUnit);
+        public static Angle MinValue { get; } = new Angle(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Angle;
+        public static QuantityType QuantityType { get; } = QuantityType.Angle;
 
         /// <summary>
         ///     All units of measurement for the Angle quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Degree.
         /// </summary>
-        public static Angle Zero => new Angle(0, BaseUnit);
+        public static Angle Zero { get; } = new Angle(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ApparentEnergy, which is VoltampereHour. All conversions go via this value.
         /// </summary>
-        public static ApparentEnergyUnit BaseUnit => ApparentEnergyUnit.VoltampereHour;
+        public static ApparentEnergyUnit BaseUnit { get; } = ApparentEnergyUnit.VoltampereHour;
 
         /// <summary>
         /// Represents the largest possible value of ApparentEnergy
         /// </summary>
-        public static ApparentEnergy MaxValue => new ApparentEnergy(double.MaxValue, BaseUnit);
+        public static ApparentEnergy MaxValue { get; } = new ApparentEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ApparentEnergy
         /// </summary>
-        public static ApparentEnergy MinValue => new ApparentEnergy(double.MinValue, BaseUnit);
+        public static ApparentEnergy MinValue { get; } = new ApparentEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ApparentEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.ApparentEnergy;
 
         /// <summary>
         ///     All units of measurement for the ApparentEnergy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereHour.
         /// </summary>
-        public static ApparentEnergy Zero => new ApparentEnergy(0, BaseUnit);
+        public static ApparentEnergy Zero { get; } = new ApparentEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ApparentPower, which is Voltampere. All conversions go via this value.
         /// </summary>
-        public static ApparentPowerUnit BaseUnit => ApparentPowerUnit.Voltampere;
+        public static ApparentPowerUnit BaseUnit { get; } = ApparentPowerUnit.Voltampere;
 
         /// <summary>
         /// Represents the largest possible value of ApparentPower
         /// </summary>
-        public static ApparentPower MaxValue => new ApparentPower(double.MaxValue, BaseUnit);
+        public static ApparentPower MaxValue { get; } = new ApparentPower(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ApparentPower
         /// </summary>
-        public static ApparentPower MinValue => new ApparentPower(double.MinValue, BaseUnit);
+        public static ApparentPower MinValue { get; } = new ApparentPower(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ApparentPower;
+        public static QuantityType QuantityType { get; } = QuantityType.ApparentPower;
 
         /// <summary>
         ///     All units of measurement for the ApparentPower quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Voltampere.
         /// </summary>
-        public static ApparentPower Zero => new ApparentPower(0, BaseUnit);
+        public static ApparentPower Zero { get; } = new ApparentPower(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Area, which is SquareMeter. All conversions go via this value.
         /// </summary>
-        public static AreaUnit BaseUnit => AreaUnit.SquareMeter;
+        public static AreaUnit BaseUnit { get; } = AreaUnit.SquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of Area
         /// </summary>
-        public static Area MaxValue => new Area(double.MaxValue, BaseUnit);
+        public static Area MaxValue { get; } = new Area(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Area
         /// </summary>
-        public static Area MinValue => new Area(double.MinValue, BaseUnit);
+        public static Area MinValue { get; } = new Area(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Area;
+        public static QuantityType QuantityType { get; } = QuantityType.Area;
 
         /// <summary>
         ///     All units of measurement for the Area quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeter.
         /// </summary>
-        public static Area Zero => new Area(0, BaseUnit);
+        public static Area Zero { get; } = new Area(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AreaDensity, which is KilogramPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static AreaDensityUnit BaseUnit => AreaDensityUnit.KilogramPerSquareMeter;
+        public static AreaDensityUnit BaseUnit { get; } = AreaDensityUnit.KilogramPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of AreaDensity
         /// </summary>
-        public static AreaDensity MaxValue => new AreaDensity(double.MaxValue, BaseUnit);
+        public static AreaDensity MaxValue { get; } = new AreaDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AreaDensity
         /// </summary>
-        public static AreaDensity MinValue => new AreaDensity(double.MinValue, BaseUnit);
+        public static AreaDensity MinValue { get; } = new AreaDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AreaDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.AreaDensity;
 
         /// <summary>
         ///     All units of measurement for the AreaDensity quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerSquareMeter.
         /// </summary>
-        public static AreaDensity Zero => new AreaDensity(0, BaseUnit);
+        public static AreaDensity Zero { get; } = new AreaDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of AreaMomentOfInertia, which is MeterToTheFourth. All conversions go via this value.
         /// </summary>
-        public static AreaMomentOfInertiaUnit BaseUnit => AreaMomentOfInertiaUnit.MeterToTheFourth;
+        public static AreaMomentOfInertiaUnit BaseUnit { get; } = AreaMomentOfInertiaUnit.MeterToTheFourth;
 
         /// <summary>
         /// Represents the largest possible value of AreaMomentOfInertia
         /// </summary>
-        public static AreaMomentOfInertia MaxValue => new AreaMomentOfInertia(double.MaxValue, BaseUnit);
+        public static AreaMomentOfInertia MaxValue { get; } = new AreaMomentOfInertia(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of AreaMomentOfInertia
         /// </summary>
-        public static AreaMomentOfInertia MinValue => new AreaMomentOfInertia(double.MinValue, BaseUnit);
+        public static AreaMomentOfInertia MinValue { get; } = new AreaMomentOfInertia(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.AreaMomentOfInertia;
+        public static QuantityType QuantityType { get; } = QuantityType.AreaMomentOfInertia;
 
         /// <summary>
         ///     All units of measurement for the AreaMomentOfInertia quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MeterToTheFourth.
         /// </summary>
-        public static AreaMomentOfInertia Zero => new AreaMomentOfInertia(0, BaseUnit);
+        public static AreaMomentOfInertia Zero { get; } = new AreaMomentOfInertia(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of BitRate, which is BitPerSecond. All conversions go via this value.
         /// </summary>
-        public static BitRateUnit BaseUnit => BitRateUnit.BitPerSecond;
+        public static BitRateUnit BaseUnit { get; } = BitRateUnit.BitPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of BitRate
         /// </summary>
-        public static BitRate MaxValue => new BitRate(decimal.MaxValue, BaseUnit);
+        public static BitRate MaxValue { get; } = new BitRate(decimal.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of BitRate
         /// </summary>
-        public static BitRate MinValue => new BitRate(decimal.MinValue, BaseUnit);
+        public static BitRate MinValue { get; } = new BitRate(decimal.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.BitRate;
+        public static QuantityType QuantityType { get; } = QuantityType.BitRate;
 
         /// <summary>
         ///     All units of measurement for the BitRate quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit BitPerSecond.
         /// </summary>
-        public static BitRate Zero => new BitRate(0, BaseUnit);
+        public static BitRate Zero { get; } = new BitRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of BrakeSpecificFuelConsumption, which is KilogramPerJoule. All conversions go via this value.
         /// </summary>
-        public static BrakeSpecificFuelConsumptionUnit BaseUnit => BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
+        public static BrakeSpecificFuelConsumptionUnit BaseUnit { get; } = BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
 
         /// <summary>
         /// Represents the largest possible value of BrakeSpecificFuelConsumption
         /// </summary>
-        public static BrakeSpecificFuelConsumption MaxValue => new BrakeSpecificFuelConsumption(double.MaxValue, BaseUnit);
+        public static BrakeSpecificFuelConsumption MaxValue { get; } = new BrakeSpecificFuelConsumption(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of BrakeSpecificFuelConsumption
         /// </summary>
-        public static BrakeSpecificFuelConsumption MinValue => new BrakeSpecificFuelConsumption(double.MinValue, BaseUnit);
+        public static BrakeSpecificFuelConsumption MinValue { get; } = new BrakeSpecificFuelConsumption(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.BrakeSpecificFuelConsumption;
+        public static QuantityType QuantityType { get; } = QuantityType.BrakeSpecificFuelConsumption;
 
         /// <summary>
         ///     All units of measurement for the BrakeSpecificFuelConsumption quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerJoule.
         /// </summary>
-        public static BrakeSpecificFuelConsumption Zero => new BrakeSpecificFuelConsumption(0, BaseUnit);
+        public static BrakeSpecificFuelConsumption Zero { get; } = new BrakeSpecificFuelConsumption(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Capacitance, which is Farad. All conversions go via this value.
         /// </summary>
-        public static CapacitanceUnit BaseUnit => CapacitanceUnit.Farad;
+        public static CapacitanceUnit BaseUnit { get; } = CapacitanceUnit.Farad;
 
         /// <summary>
         /// Represents the largest possible value of Capacitance
         /// </summary>
-        public static Capacitance MaxValue => new Capacitance(double.MaxValue, BaseUnit);
+        public static Capacitance MaxValue { get; } = new Capacitance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Capacitance
         /// </summary>
-        public static Capacitance MinValue => new Capacitance(double.MinValue, BaseUnit);
+        public static Capacitance MinValue { get; } = new Capacitance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Capacitance;
+        public static QuantityType QuantityType { get; } = QuantityType.Capacitance;
 
         /// <summary>
         ///     All units of measurement for the Capacitance quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Farad.
         /// </summary>
-        public static Capacitance Zero => new Capacitance(0, BaseUnit);
+        public static Capacitance Zero { get; } = new Capacitance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of CoefficientOfThermalExpansion, which is InverseKelvin. All conversions go via this value.
         /// </summary>
-        public static CoefficientOfThermalExpansionUnit BaseUnit => CoefficientOfThermalExpansionUnit.InverseKelvin;
+        public static CoefficientOfThermalExpansionUnit BaseUnit { get; } = CoefficientOfThermalExpansionUnit.InverseKelvin;
 
         /// <summary>
         /// Represents the largest possible value of CoefficientOfThermalExpansion
         /// </summary>
-        public static CoefficientOfThermalExpansion MaxValue => new CoefficientOfThermalExpansion(double.MaxValue, BaseUnit);
+        public static CoefficientOfThermalExpansion MaxValue { get; } = new CoefficientOfThermalExpansion(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of CoefficientOfThermalExpansion
         /// </summary>
-        public static CoefficientOfThermalExpansion MinValue => new CoefficientOfThermalExpansion(double.MinValue, BaseUnit);
+        public static CoefficientOfThermalExpansion MinValue { get; } = new CoefficientOfThermalExpansion(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.CoefficientOfThermalExpansion;
+        public static QuantityType QuantityType { get; } = QuantityType.CoefficientOfThermalExpansion;
 
         /// <summary>
         ///     All units of measurement for the CoefficientOfThermalExpansion quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit InverseKelvin.
         /// </summary>
-        public static CoefficientOfThermalExpansion Zero => new CoefficientOfThermalExpansion(0, BaseUnit);
+        public static CoefficientOfThermalExpansion Zero { get; } = new CoefficientOfThermalExpansion(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Density, which is KilogramPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static DensityUnit BaseUnit => DensityUnit.KilogramPerCubicMeter;
+        public static DensityUnit BaseUnit { get; } = DensityUnit.KilogramPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of Density
         /// </summary>
-        public static Density MaxValue => new Density(double.MaxValue, BaseUnit);
+        public static Density MaxValue { get; } = new Density(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Density
         /// </summary>
-        public static Density MinValue => new Density(double.MinValue, BaseUnit);
+        public static Density MinValue { get; } = new Density(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Density;
+        public static QuantityType QuantityType { get; } = QuantityType.Density;
 
         /// <summary>
         ///     All units of measurement for the Density quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerCubicMeter.
         /// </summary>
-        public static Density Zero => new Density(0, BaseUnit);
+        public static Density Zero { get; } = new Density(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Duration, which is Second. All conversions go via this value.
         /// </summary>
-        public static DurationUnit BaseUnit => DurationUnit.Second;
+        public static DurationUnit BaseUnit { get; } = DurationUnit.Second;
 
         /// <summary>
         /// Represents the largest possible value of Duration
         /// </summary>
-        public static Duration MaxValue => new Duration(double.MaxValue, BaseUnit);
+        public static Duration MaxValue { get; } = new Duration(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Duration
         /// </summary>
-        public static Duration MinValue => new Duration(double.MinValue, BaseUnit);
+        public static Duration MinValue { get; } = new Duration(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Duration;
+        public static QuantityType QuantityType { get; } = QuantityType.Duration;
 
         /// <summary>
         ///     All units of measurement for the Duration quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Second.
         /// </summary>
-        public static Duration Zero => new Duration(0, BaseUnit);
+        public static Duration Zero { get; } = new Duration(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of DynamicViscosity, which is NewtonSecondPerMeterSquared. All conversions go via this value.
         /// </summary>
-        public static DynamicViscosityUnit BaseUnit => DynamicViscosityUnit.NewtonSecondPerMeterSquared;
+        public static DynamicViscosityUnit BaseUnit { get; } = DynamicViscosityUnit.NewtonSecondPerMeterSquared;
 
         /// <summary>
         /// Represents the largest possible value of DynamicViscosity
         /// </summary>
-        public static DynamicViscosity MaxValue => new DynamicViscosity(double.MaxValue, BaseUnit);
+        public static DynamicViscosity MaxValue { get; } = new DynamicViscosity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of DynamicViscosity
         /// </summary>
-        public static DynamicViscosity MinValue => new DynamicViscosity(double.MinValue, BaseUnit);
+        public static DynamicViscosity MinValue { get; } = new DynamicViscosity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.DynamicViscosity;
+        public static QuantityType QuantityType { get; } = QuantityType.DynamicViscosity;
 
         /// <summary>
         ///     All units of measurement for the DynamicViscosity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonSecondPerMeterSquared.
         /// </summary>
-        public static DynamicViscosity Zero => new DynamicViscosity(0, BaseUnit);
+        public static DynamicViscosity Zero { get; } = new DynamicViscosity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricAdmittance, which is Siemens. All conversions go via this value.
         /// </summary>
-        public static ElectricAdmittanceUnit BaseUnit => ElectricAdmittanceUnit.Siemens;
+        public static ElectricAdmittanceUnit BaseUnit { get; } = ElectricAdmittanceUnit.Siemens;
 
         /// <summary>
         /// Represents the largest possible value of ElectricAdmittance
         /// </summary>
-        public static ElectricAdmittance MaxValue => new ElectricAdmittance(double.MaxValue, BaseUnit);
+        public static ElectricAdmittance MaxValue { get; } = new ElectricAdmittance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricAdmittance
         /// </summary>
-        public static ElectricAdmittance MinValue => new ElectricAdmittance(double.MinValue, BaseUnit);
+        public static ElectricAdmittance MinValue { get; } = new ElectricAdmittance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricAdmittance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricAdmittance;
 
         /// <summary>
         ///     All units of measurement for the ElectricAdmittance quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Siemens.
         /// </summary>
-        public static ElectricAdmittance Zero => new ElectricAdmittance(0, BaseUnit);
+        public static ElectricAdmittance Zero { get; } = new ElectricAdmittance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCharge, which is Coulomb. All conversions go via this value.
         /// </summary>
-        public static ElectricChargeUnit BaseUnit => ElectricChargeUnit.Coulomb;
+        public static ElectricChargeUnit BaseUnit { get; } = ElectricChargeUnit.Coulomb;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCharge
         /// </summary>
-        public static ElectricCharge MaxValue => new ElectricCharge(double.MaxValue, BaseUnit);
+        public static ElectricCharge MaxValue { get; } = new ElectricCharge(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCharge
         /// </summary>
-        public static ElectricCharge MinValue => new ElectricCharge(double.MinValue, BaseUnit);
+        public static ElectricCharge MinValue { get; } = new ElectricCharge(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCharge;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCharge;
 
         /// <summary>
         ///     All units of measurement for the ElectricCharge quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Coulomb.
         /// </summary>
-        public static ElectricCharge Zero => new ElectricCharge(0, BaseUnit);
+        public static ElectricCharge Zero { get; } = new ElectricCharge(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricChargeDensity, which is CoulombPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricChargeDensityUnit BaseUnit => ElectricChargeDensityUnit.CoulombPerCubicMeter;
+        public static ElectricChargeDensityUnit BaseUnit { get; } = ElectricChargeDensityUnit.CoulombPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricChargeDensity
         /// </summary>
-        public static ElectricChargeDensity MaxValue => new ElectricChargeDensity(double.MaxValue, BaseUnit);
+        public static ElectricChargeDensity MaxValue { get; } = new ElectricChargeDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricChargeDensity
         /// </summary>
-        public static ElectricChargeDensity MinValue => new ElectricChargeDensity(double.MinValue, BaseUnit);
+        public static ElectricChargeDensity MinValue { get; } = new ElectricChargeDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricChargeDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricChargeDensity;
 
         /// <summary>
         ///     All units of measurement for the ElectricChargeDensity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CoulombPerCubicMeter.
         /// </summary>
-        public static ElectricChargeDensity Zero => new ElectricChargeDensity(0, BaseUnit);
+        public static ElectricChargeDensity Zero { get; } = new ElectricChargeDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricConductance, which is Siemens. All conversions go via this value.
         /// </summary>
-        public static ElectricConductanceUnit BaseUnit => ElectricConductanceUnit.Siemens;
+        public static ElectricConductanceUnit BaseUnit { get; } = ElectricConductanceUnit.Siemens;
 
         /// <summary>
         /// Represents the largest possible value of ElectricConductance
         /// </summary>
-        public static ElectricConductance MaxValue => new ElectricConductance(double.MaxValue, BaseUnit);
+        public static ElectricConductance MaxValue { get; } = new ElectricConductance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricConductance
         /// </summary>
-        public static ElectricConductance MinValue => new ElectricConductance(double.MinValue, BaseUnit);
+        public static ElectricConductance MinValue { get; } = new ElectricConductance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricConductance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricConductance;
 
         /// <summary>
         ///     All units of measurement for the ElectricConductance quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Siemens.
         /// </summary>
-        public static ElectricConductance Zero => new ElectricConductance(0, BaseUnit);
+        public static ElectricConductance Zero { get; } = new ElectricConductance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricConductivity, which is SiemensPerMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricConductivityUnit BaseUnit => ElectricConductivityUnit.SiemensPerMeter;
+        public static ElectricConductivityUnit BaseUnit { get; } = ElectricConductivityUnit.SiemensPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricConductivity
         /// </summary>
-        public static ElectricConductivity MaxValue => new ElectricConductivity(double.MaxValue, BaseUnit);
+        public static ElectricConductivity MaxValue { get; } = new ElectricConductivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricConductivity
         /// </summary>
-        public static ElectricConductivity MinValue => new ElectricConductivity(double.MinValue, BaseUnit);
+        public static ElectricConductivity MinValue { get; } = new ElectricConductivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricConductivity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricConductivity;
 
         /// <summary>
         ///     All units of measurement for the ElectricConductivity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SiemensPerMeter.
         /// </summary>
-        public static ElectricConductivity Zero => new ElectricConductivity(0, BaseUnit);
+        public static ElectricConductivity Zero { get; } = new ElectricConductivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCurrent, which is Ampere. All conversions go via this value.
         /// </summary>
-        public static ElectricCurrentUnit BaseUnit => ElectricCurrentUnit.Ampere;
+        public static ElectricCurrentUnit BaseUnit { get; } = ElectricCurrentUnit.Ampere;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCurrent
         /// </summary>
-        public static ElectricCurrent MaxValue => new ElectricCurrent(double.MaxValue, BaseUnit);
+        public static ElectricCurrent MaxValue { get; } = new ElectricCurrent(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCurrent
         /// </summary>
-        public static ElectricCurrent MinValue => new ElectricCurrent(double.MinValue, BaseUnit);
+        public static ElectricCurrent MinValue { get; } = new ElectricCurrent(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCurrent;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCurrent;
 
         /// <summary>
         ///     All units of measurement for the ElectricCurrent quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Ampere.
         /// </summary>
-        public static ElectricCurrent Zero => new ElectricCurrent(0, BaseUnit);
+        public static ElectricCurrent Zero { get; } = new ElectricCurrent(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCurrentDensity, which is AmperePerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricCurrentDensityUnit BaseUnit => ElectricCurrentDensityUnit.AmperePerSquareMeter;
+        public static ElectricCurrentDensityUnit BaseUnit { get; } = ElectricCurrentDensityUnit.AmperePerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCurrentDensity
         /// </summary>
-        public static ElectricCurrentDensity MaxValue => new ElectricCurrentDensity(double.MaxValue, BaseUnit);
+        public static ElectricCurrentDensity MaxValue { get; } = new ElectricCurrentDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCurrentDensity
         /// </summary>
-        public static ElectricCurrentDensity MinValue => new ElectricCurrentDensity(double.MinValue, BaseUnit);
+        public static ElectricCurrentDensity MinValue { get; } = new ElectricCurrentDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCurrentDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCurrentDensity;
 
         /// <summary>
         ///     All units of measurement for the ElectricCurrentDensity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerSquareMeter.
         /// </summary>
-        public static ElectricCurrentDensity Zero => new ElectricCurrentDensity(0, BaseUnit);
+        public static ElectricCurrentDensity Zero { get; } = new ElectricCurrentDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricCurrentGradient, which is AmperePerSecond. All conversions go via this value.
         /// </summary>
-        public static ElectricCurrentGradientUnit BaseUnit => ElectricCurrentGradientUnit.AmperePerSecond;
+        public static ElectricCurrentGradientUnit BaseUnit { get; } = ElectricCurrentGradientUnit.AmperePerSecond;
 
         /// <summary>
         /// Represents the largest possible value of ElectricCurrentGradient
         /// </summary>
-        public static ElectricCurrentGradient MaxValue => new ElectricCurrentGradient(double.MaxValue, BaseUnit);
+        public static ElectricCurrentGradient MaxValue { get; } = new ElectricCurrentGradient(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricCurrentGradient
         /// </summary>
-        public static ElectricCurrentGradient MinValue => new ElectricCurrentGradient(double.MinValue, BaseUnit);
+        public static ElectricCurrentGradient MinValue { get; } = new ElectricCurrentGradient(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricCurrentGradient;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricCurrentGradient;
 
         /// <summary>
         ///     All units of measurement for the ElectricCurrentGradient quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerSecond.
         /// </summary>
-        public static ElectricCurrentGradient Zero => new ElectricCurrentGradient(0, BaseUnit);
+        public static ElectricCurrentGradient Zero { get; } = new ElectricCurrentGradient(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricField, which is VoltPerMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricFieldUnit BaseUnit => ElectricFieldUnit.VoltPerMeter;
+        public static ElectricFieldUnit BaseUnit { get; } = ElectricFieldUnit.VoltPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricField
         /// </summary>
-        public static ElectricField MaxValue => new ElectricField(double.MaxValue, BaseUnit);
+        public static ElectricField MaxValue { get; } = new ElectricField(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricField
         /// </summary>
-        public static ElectricField MinValue => new ElectricField(double.MinValue, BaseUnit);
+        public static ElectricField MinValue { get; } = new ElectricField(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricField;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricField;
 
         /// <summary>
         ///     All units of measurement for the ElectricField quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltPerMeter.
         /// </summary>
-        public static ElectricField Zero => new ElectricField(0, BaseUnit);
+        public static ElectricField Zero { get; } = new ElectricField(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricInductance, which is Henry. All conversions go via this value.
         /// </summary>
-        public static ElectricInductanceUnit BaseUnit => ElectricInductanceUnit.Henry;
+        public static ElectricInductanceUnit BaseUnit { get; } = ElectricInductanceUnit.Henry;
 
         /// <summary>
         /// Represents the largest possible value of ElectricInductance
         /// </summary>
-        public static ElectricInductance MaxValue => new ElectricInductance(double.MaxValue, BaseUnit);
+        public static ElectricInductance MaxValue { get; } = new ElectricInductance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricInductance
         /// </summary>
-        public static ElectricInductance MinValue => new ElectricInductance(double.MinValue, BaseUnit);
+        public static ElectricInductance MinValue { get; } = new ElectricInductance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricInductance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricInductance;
 
         /// <summary>
         ///     All units of measurement for the ElectricInductance quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Henry.
         /// </summary>
-        public static ElectricInductance Zero => new ElectricInductance(0, BaseUnit);
+        public static ElectricInductance Zero { get; } = new ElectricInductance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricPotential, which is Volt. All conversions go via this value.
         /// </summary>
-        public static ElectricPotentialUnit BaseUnit => ElectricPotentialUnit.Volt;
+        public static ElectricPotentialUnit BaseUnit { get; } = ElectricPotentialUnit.Volt;
 
         /// <summary>
         /// Represents the largest possible value of ElectricPotential
         /// </summary>
-        public static ElectricPotential MaxValue => new ElectricPotential(double.MaxValue, BaseUnit);
+        public static ElectricPotential MaxValue { get; } = new ElectricPotential(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricPotential
         /// </summary>
-        public static ElectricPotential MinValue => new ElectricPotential(double.MinValue, BaseUnit);
+        public static ElectricPotential MinValue { get; } = new ElectricPotential(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricPotential;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricPotential;
 
         /// <summary>
         ///     All units of measurement for the ElectricPotential quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Volt.
         /// </summary>
-        public static ElectricPotential Zero => new ElectricPotential(0, BaseUnit);
+        public static ElectricPotential Zero { get; } = new ElectricPotential(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricPotentialAc, which is VoltAc. All conversions go via this value.
         /// </summary>
-        public static ElectricPotentialAcUnit BaseUnit => ElectricPotentialAcUnit.VoltAc;
+        public static ElectricPotentialAcUnit BaseUnit { get; } = ElectricPotentialAcUnit.VoltAc;
 
         /// <summary>
         /// Represents the largest possible value of ElectricPotentialAc
         /// </summary>
-        public static ElectricPotentialAc MaxValue => new ElectricPotentialAc(double.MaxValue, BaseUnit);
+        public static ElectricPotentialAc MaxValue { get; } = new ElectricPotentialAc(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricPotentialAc
         /// </summary>
-        public static ElectricPotentialAc MinValue => new ElectricPotentialAc(double.MinValue, BaseUnit);
+        public static ElectricPotentialAc MinValue { get; } = new ElectricPotentialAc(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricPotentialAc;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricPotentialAc;
 
         /// <summary>
         ///     All units of measurement for the ElectricPotentialAc quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltAc.
         /// </summary>
-        public static ElectricPotentialAc Zero => new ElectricPotentialAc(0, BaseUnit);
+        public static ElectricPotentialAc Zero { get; } = new ElectricPotentialAc(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricPotentialDc, which is VoltDc. All conversions go via this value.
         /// </summary>
-        public static ElectricPotentialDcUnit BaseUnit => ElectricPotentialDcUnit.VoltDc;
+        public static ElectricPotentialDcUnit BaseUnit { get; } = ElectricPotentialDcUnit.VoltDc;
 
         /// <summary>
         /// Represents the largest possible value of ElectricPotentialDc
         /// </summary>
-        public static ElectricPotentialDc MaxValue => new ElectricPotentialDc(double.MaxValue, BaseUnit);
+        public static ElectricPotentialDc MaxValue { get; } = new ElectricPotentialDc(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricPotentialDc
         /// </summary>
-        public static ElectricPotentialDc MinValue => new ElectricPotentialDc(double.MinValue, BaseUnit);
+        public static ElectricPotentialDc MinValue { get; } = new ElectricPotentialDc(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricPotentialDc;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricPotentialDc;
 
         /// <summary>
         ///     All units of measurement for the ElectricPotentialDc quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltDc.
         /// </summary>
-        public static ElectricPotentialDc Zero => new ElectricPotentialDc(0, BaseUnit);
+        public static ElectricPotentialDc Zero { get; } = new ElectricPotentialDc(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricResistance, which is Ohm. All conversions go via this value.
         /// </summary>
-        public static ElectricResistanceUnit BaseUnit => ElectricResistanceUnit.Ohm;
+        public static ElectricResistanceUnit BaseUnit { get; } = ElectricResistanceUnit.Ohm;
 
         /// <summary>
         /// Represents the largest possible value of ElectricResistance
         /// </summary>
-        public static ElectricResistance MaxValue => new ElectricResistance(double.MaxValue, BaseUnit);
+        public static ElectricResistance MaxValue { get; } = new ElectricResistance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricResistance
         /// </summary>
-        public static ElectricResistance MinValue => new ElectricResistance(double.MinValue, BaseUnit);
+        public static ElectricResistance MinValue { get; } = new ElectricResistance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricResistance;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricResistance;
 
         /// <summary>
         ///     All units of measurement for the ElectricResistance quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Ohm.
         /// </summary>
-        public static ElectricResistance Zero => new ElectricResistance(0, BaseUnit);
+        public static ElectricResistance Zero { get; } = new ElectricResistance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ElectricResistivity, which is OhmMeter. All conversions go via this value.
         /// </summary>
-        public static ElectricResistivityUnit BaseUnit => ElectricResistivityUnit.OhmMeter;
+        public static ElectricResistivityUnit BaseUnit { get; } = ElectricResistivityUnit.OhmMeter;
 
         /// <summary>
         /// Represents the largest possible value of ElectricResistivity
         /// </summary>
-        public static ElectricResistivity MaxValue => new ElectricResistivity(double.MaxValue, BaseUnit);
+        public static ElectricResistivity MaxValue { get; } = new ElectricResistivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ElectricResistivity
         /// </summary>
-        public static ElectricResistivity MinValue => new ElectricResistivity(double.MinValue, BaseUnit);
+        public static ElectricResistivity MinValue { get; } = new ElectricResistivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ElectricResistivity;
+        public static QuantityType QuantityType { get; } = QuantityType.ElectricResistivity;
 
         /// <summary>
         ///     All units of measurement for the ElectricResistivity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit OhmMeter.
         /// </summary>
-        public static ElectricResistivity Zero => new ElectricResistivity(0, BaseUnit);
+        public static ElectricResistivity Zero { get; } = new ElectricResistivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Energy, which is Joule. All conversions go via this value.
         /// </summary>
-        public static EnergyUnit BaseUnit => EnergyUnit.Joule;
+        public static EnergyUnit BaseUnit { get; } = EnergyUnit.Joule;
 
         /// <summary>
         /// Represents the largest possible value of Energy
         /// </summary>
-        public static Energy MaxValue => new Energy(double.MaxValue, BaseUnit);
+        public static Energy MaxValue { get; } = new Energy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Energy
         /// </summary>
-        public static Energy MinValue => new Energy(double.MinValue, BaseUnit);
+        public static Energy MinValue { get; } = new Energy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Energy;
+        public static QuantityType QuantityType { get; } = QuantityType.Energy;
 
         /// <summary>
         ///     All units of measurement for the Energy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Joule.
         /// </summary>
-        public static Energy Zero => new Energy(0, BaseUnit);
+        public static Energy Zero { get; } = new Energy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Entropy, which is JoulePerKelvin. All conversions go via this value.
         /// </summary>
-        public static EntropyUnit BaseUnit => EntropyUnit.JoulePerKelvin;
+        public static EntropyUnit BaseUnit { get; } = EntropyUnit.JoulePerKelvin;
 
         /// <summary>
         /// Represents the largest possible value of Entropy
         /// </summary>
-        public static Entropy MaxValue => new Entropy(double.MaxValue, BaseUnit);
+        public static Entropy MaxValue { get; } = new Entropy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Entropy
         /// </summary>
-        public static Entropy MinValue => new Entropy(double.MinValue, BaseUnit);
+        public static Entropy MinValue { get; } = new Entropy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Entropy;
+        public static QuantityType QuantityType { get; } = QuantityType.Entropy;
 
         /// <summary>
         ///     All units of measurement for the Entropy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKelvin.
         /// </summary>
-        public static Entropy Zero => new Entropy(0, BaseUnit);
+        public static Entropy Zero { get; } = new Entropy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Force, which is Newton. All conversions go via this value.
         /// </summary>
-        public static ForceUnit BaseUnit => ForceUnit.Newton;
+        public static ForceUnit BaseUnit { get; } = ForceUnit.Newton;
 
         /// <summary>
         /// Represents the largest possible value of Force
         /// </summary>
-        public static Force MaxValue => new Force(double.MaxValue, BaseUnit);
+        public static Force MaxValue { get; } = new Force(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Force
         /// </summary>
-        public static Force MinValue => new Force(double.MinValue, BaseUnit);
+        public static Force MinValue { get; } = new Force(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Force;
+        public static QuantityType QuantityType { get; } = QuantityType.Force;
 
         /// <summary>
         ///     All units of measurement for the Force quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Newton.
         /// </summary>
-        public static Force Zero => new Force(0, BaseUnit);
+        public static Force Zero { get; } = new Force(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ForceChangeRate, which is NewtonPerSecond. All conversions go via this value.
         /// </summary>
-        public static ForceChangeRateUnit BaseUnit => ForceChangeRateUnit.NewtonPerSecond;
+        public static ForceChangeRateUnit BaseUnit { get; } = ForceChangeRateUnit.NewtonPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of ForceChangeRate
         /// </summary>
-        public static ForceChangeRate MaxValue => new ForceChangeRate(double.MaxValue, BaseUnit);
+        public static ForceChangeRate MaxValue { get; } = new ForceChangeRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ForceChangeRate
         /// </summary>
-        public static ForceChangeRate MinValue => new ForceChangeRate(double.MinValue, BaseUnit);
+        public static ForceChangeRate MinValue { get; } = new ForceChangeRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ForceChangeRate;
+        public static QuantityType QuantityType { get; } = QuantityType.ForceChangeRate;
 
         /// <summary>
         ///     All units of measurement for the ForceChangeRate quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerSecond.
         /// </summary>
-        public static ForceChangeRate Zero => new ForceChangeRate(0, BaseUnit);
+        public static ForceChangeRate Zero { get; } = new ForceChangeRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ForcePerLength, which is NewtonPerMeter. All conversions go via this value.
         /// </summary>
-        public static ForcePerLengthUnit BaseUnit => ForcePerLengthUnit.NewtonPerMeter;
+        public static ForcePerLengthUnit BaseUnit { get; } = ForcePerLengthUnit.NewtonPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of ForcePerLength
         /// </summary>
-        public static ForcePerLength MaxValue => new ForcePerLength(double.MaxValue, BaseUnit);
+        public static ForcePerLength MaxValue { get; } = new ForcePerLength(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ForcePerLength
         /// </summary>
-        public static ForcePerLength MinValue => new ForcePerLength(double.MinValue, BaseUnit);
+        public static ForcePerLength MinValue { get; } = new ForcePerLength(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ForcePerLength;
+        public static QuantityType QuantityType { get; } = QuantityType.ForcePerLength;
 
         /// <summary>
         ///     All units of measurement for the ForcePerLength quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerMeter.
         /// </summary>
-        public static ForcePerLength Zero => new ForcePerLength(0, BaseUnit);
+        public static ForcePerLength Zero { get; } = new ForcePerLength(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Frequency, which is Hertz. All conversions go via this value.
         /// </summary>
-        public static FrequencyUnit BaseUnit => FrequencyUnit.Hertz;
+        public static FrequencyUnit BaseUnit { get; } = FrequencyUnit.Hertz;
 
         /// <summary>
         /// Represents the largest possible value of Frequency
         /// </summary>
-        public static Frequency MaxValue => new Frequency(double.MaxValue, BaseUnit);
+        public static Frequency MaxValue { get; } = new Frequency(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Frequency
         /// </summary>
-        public static Frequency MinValue => new Frequency(double.MinValue, BaseUnit);
+        public static Frequency MinValue { get; } = new Frequency(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Frequency;
+        public static QuantityType QuantityType { get; } = QuantityType.Frequency;
 
         /// <summary>
         ///     All units of measurement for the Frequency quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Hertz.
         /// </summary>
-        public static Frequency Zero => new Frequency(0, BaseUnit);
+        public static Frequency Zero { get; } = new Frequency(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of HeatFlux, which is WattPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static HeatFluxUnit BaseUnit => HeatFluxUnit.WattPerSquareMeter;
+        public static HeatFluxUnit BaseUnit { get; } = HeatFluxUnit.WattPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of HeatFlux
         /// </summary>
-        public static HeatFlux MaxValue => new HeatFlux(double.MaxValue, BaseUnit);
+        public static HeatFlux MaxValue { get; } = new HeatFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of HeatFlux
         /// </summary>
-        public static HeatFlux MinValue => new HeatFlux(double.MinValue, BaseUnit);
+        public static HeatFlux MinValue { get; } = new HeatFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.HeatFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.HeatFlux;
 
         /// <summary>
         ///     All units of measurement for the HeatFlux quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeter.
         /// </summary>
-        public static HeatFlux Zero => new HeatFlux(0, BaseUnit);
+        public static HeatFlux Zero { get; } = new HeatFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of HeatTransferCoefficient, which is WattPerSquareMeterKelvin. All conversions go via this value.
         /// </summary>
-        public static HeatTransferCoefficientUnit BaseUnit => HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
+        public static HeatTransferCoefficientUnit BaseUnit { get; } = HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
 
         /// <summary>
         /// Represents the largest possible value of HeatTransferCoefficient
         /// </summary>
-        public static HeatTransferCoefficient MaxValue => new HeatTransferCoefficient(double.MaxValue, BaseUnit);
+        public static HeatTransferCoefficient MaxValue { get; } = new HeatTransferCoefficient(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of HeatTransferCoefficient
         /// </summary>
-        public static HeatTransferCoefficient MinValue => new HeatTransferCoefficient(double.MinValue, BaseUnit);
+        public static HeatTransferCoefficient MinValue { get; } = new HeatTransferCoefficient(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.HeatTransferCoefficient;
+        public static QuantityType QuantityType { get; } = QuantityType.HeatTransferCoefficient;
 
         /// <summary>
         ///     All units of measurement for the HeatTransferCoefficient quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeterKelvin.
         /// </summary>
-        public static HeatTransferCoefficient Zero => new HeatTransferCoefficient(0, BaseUnit);
+        public static HeatTransferCoefficient Zero { get; } = new HeatTransferCoefficient(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Illuminance, which is Lux. All conversions go via this value.
         /// </summary>
-        public static IlluminanceUnit BaseUnit => IlluminanceUnit.Lux;
+        public static IlluminanceUnit BaseUnit { get; } = IlluminanceUnit.Lux;
 
         /// <summary>
         /// Represents the largest possible value of Illuminance
         /// </summary>
-        public static Illuminance MaxValue => new Illuminance(double.MaxValue, BaseUnit);
+        public static Illuminance MaxValue { get; } = new Illuminance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Illuminance
         /// </summary>
-        public static Illuminance MinValue => new Illuminance(double.MinValue, BaseUnit);
+        public static Illuminance MinValue { get; } = new Illuminance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Illuminance;
+        public static QuantityType QuantityType { get; } = QuantityType.Illuminance;
 
         /// <summary>
         ///     All units of measurement for the Illuminance quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Lux.
         /// </summary>
-        public static Illuminance Zero => new Illuminance(0, BaseUnit);
+        public static Illuminance Zero { get; } = new Illuminance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Information, which is Bit. All conversions go via this value.
         /// </summary>
-        public static InformationUnit BaseUnit => InformationUnit.Bit;
+        public static InformationUnit BaseUnit { get; } = InformationUnit.Bit;
 
         /// <summary>
         /// Represents the largest possible value of Information
         /// </summary>
-        public static Information MaxValue => new Information(decimal.MaxValue, BaseUnit);
+        public static Information MaxValue { get; } = new Information(decimal.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Information
         /// </summary>
-        public static Information MinValue => new Information(decimal.MinValue, BaseUnit);
+        public static Information MinValue { get; } = new Information(decimal.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Information;
+        public static QuantityType QuantityType { get; } = QuantityType.Information;
 
         /// <summary>
         ///     All units of measurement for the Information quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Bit.
         /// </summary>
-        public static Information Zero => new Information(0, BaseUnit);
+        public static Information Zero { get; } = new Information(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Irradiance, which is WattPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static IrradianceUnit BaseUnit => IrradianceUnit.WattPerSquareMeter;
+        public static IrradianceUnit BaseUnit { get; } = IrradianceUnit.WattPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of Irradiance
         /// </summary>
-        public static Irradiance MaxValue => new Irradiance(double.MaxValue, BaseUnit);
+        public static Irradiance MaxValue { get; } = new Irradiance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Irradiance
         /// </summary>
-        public static Irradiance MinValue => new Irradiance(double.MinValue, BaseUnit);
+        public static Irradiance MinValue { get; } = new Irradiance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Irradiance;
+        public static QuantityType QuantityType { get; } = QuantityType.Irradiance;
 
         /// <summary>
         ///     All units of measurement for the Irradiance quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerSquareMeter.
         /// </summary>
-        public static Irradiance Zero => new Irradiance(0, BaseUnit);
+        public static Irradiance Zero { get; } = new Irradiance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Irradiation, which is JoulePerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static IrradiationUnit BaseUnit => IrradiationUnit.JoulePerSquareMeter;
+        public static IrradiationUnit BaseUnit { get; } = IrradiationUnit.JoulePerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of Irradiation
         /// </summary>
-        public static Irradiation MaxValue => new Irradiation(double.MaxValue, BaseUnit);
+        public static Irradiation MaxValue { get; } = new Irradiation(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Irradiation
         /// </summary>
-        public static Irradiation MinValue => new Irradiation(double.MinValue, BaseUnit);
+        public static Irradiation MinValue { get; } = new Irradiation(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Irradiation;
+        public static QuantityType QuantityType { get; } = QuantityType.Irradiation;
 
         /// <summary>
         ///     All units of measurement for the Irradiation quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerSquareMeter.
         /// </summary>
-        public static Irradiation Zero => new Irradiation(0, BaseUnit);
+        public static Irradiation Zero { get; } = new Irradiation(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of KinematicViscosity, which is SquareMeterPerSecond. All conversions go via this value.
         /// </summary>
-        public static KinematicViscosityUnit BaseUnit => KinematicViscosityUnit.SquareMeterPerSecond;
+        public static KinematicViscosityUnit BaseUnit { get; } = KinematicViscosityUnit.SquareMeterPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of KinematicViscosity
         /// </summary>
-        public static KinematicViscosity MaxValue => new KinematicViscosity(double.MaxValue, BaseUnit);
+        public static KinematicViscosity MaxValue { get; } = new KinematicViscosity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of KinematicViscosity
         /// </summary>
-        public static KinematicViscosity MinValue => new KinematicViscosity(double.MinValue, BaseUnit);
+        public static KinematicViscosity MinValue { get; } = new KinematicViscosity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.KinematicViscosity;
+        public static QuantityType QuantityType { get; } = QuantityType.KinematicViscosity;
 
         /// <summary>
         ///     All units of measurement for the KinematicViscosity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeterPerSecond.
         /// </summary>
-        public static KinematicViscosity Zero => new KinematicViscosity(0, BaseUnit);
+        public static KinematicViscosity Zero { get; } = new KinematicViscosity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LapseRate, which is DegreeCelsiusPerKilometer. All conversions go via this value.
         /// </summary>
-        public static LapseRateUnit BaseUnit => LapseRateUnit.DegreeCelsiusPerKilometer;
+        public static LapseRateUnit BaseUnit { get; } = LapseRateUnit.DegreeCelsiusPerKilometer;
 
         /// <summary>
         /// Represents the largest possible value of LapseRate
         /// </summary>
-        public static LapseRate MaxValue => new LapseRate(double.MaxValue, BaseUnit);
+        public static LapseRate MaxValue { get; } = new LapseRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LapseRate
         /// </summary>
-        public static LapseRate MinValue => new LapseRate(double.MinValue, BaseUnit);
+        public static LapseRate MinValue { get; } = new LapseRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LapseRate;
+        public static QuantityType QuantityType { get; } = QuantityType.LapseRate;
 
         /// <summary>
         ///     All units of measurement for the LapseRate quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DegreeCelsiusPerKilometer.
         /// </summary>
-        public static LapseRate Zero => new LapseRate(0, BaseUnit);
+        public static LapseRate Zero { get; } = new LapseRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Length, which is Meter. All conversions go via this value.
         /// </summary>
-        public static LengthUnit BaseUnit => LengthUnit.Meter;
+        public static LengthUnit BaseUnit { get; } = LengthUnit.Meter;
 
         /// <summary>
         /// Represents the largest possible value of Length
         /// </summary>
-        public static Length MaxValue => new Length(double.MaxValue, BaseUnit);
+        public static Length MaxValue { get; } = new Length(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Length
         /// </summary>
-        public static Length MinValue => new Length(double.MinValue, BaseUnit);
+        public static Length MinValue { get; } = new Length(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Length;
+        public static QuantityType QuantityType { get; } = QuantityType.Length;
 
         /// <summary>
         ///     All units of measurement for the Length quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Meter.
         /// </summary>
-        public static Length Zero => new Length(0, BaseUnit);
+        public static Length Zero { get; } = new Length(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Level, which is Decibel. All conversions go via this value.
         /// </summary>
-        public static LevelUnit BaseUnit => LevelUnit.Decibel;
+        public static LevelUnit BaseUnit { get; } = LevelUnit.Decibel;
 
         /// <summary>
         /// Represents the largest possible value of Level
         /// </summary>
-        public static Level MaxValue => new Level(double.MaxValue, BaseUnit);
+        public static Level MaxValue { get; } = new Level(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Level
         /// </summary>
-        public static Level MinValue => new Level(double.MinValue, BaseUnit);
+        public static Level MinValue { get; } = new Level(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Level;
+        public static QuantityType QuantityType { get; } = QuantityType.Level;
 
         /// <summary>
         ///     All units of measurement for the Level quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Decibel.
         /// </summary>
-        public static Level Zero => new Level(0, BaseUnit);
+        public static Level Zero { get; } = new Level(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LinearDensity, which is KilogramPerMeter. All conversions go via this value.
         /// </summary>
-        public static LinearDensityUnit BaseUnit => LinearDensityUnit.KilogramPerMeter;
+        public static LinearDensityUnit BaseUnit { get; } = LinearDensityUnit.KilogramPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of LinearDensity
         /// </summary>
-        public static LinearDensity MaxValue => new LinearDensity(double.MaxValue, BaseUnit);
+        public static LinearDensity MaxValue { get; } = new LinearDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LinearDensity
         /// </summary>
-        public static LinearDensity MinValue => new LinearDensity(double.MinValue, BaseUnit);
+        public static LinearDensity MinValue { get; } = new LinearDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LinearDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.LinearDensity;
 
         /// <summary>
         ///     All units of measurement for the LinearDensity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerMeter.
         /// </summary>
-        public static LinearDensity Zero => new LinearDensity(0, BaseUnit);
+        public static LinearDensity Zero { get; } = new LinearDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LuminousFlux, which is Lumen. All conversions go via this value.
         /// </summary>
-        public static LuminousFluxUnit BaseUnit => LuminousFluxUnit.Lumen;
+        public static LuminousFluxUnit BaseUnit { get; } = LuminousFluxUnit.Lumen;
 
         /// <summary>
         /// Represents the largest possible value of LuminousFlux
         /// </summary>
-        public static LuminousFlux MaxValue => new LuminousFlux(double.MaxValue, BaseUnit);
+        public static LuminousFlux MaxValue { get; } = new LuminousFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LuminousFlux
         /// </summary>
-        public static LuminousFlux MinValue => new LuminousFlux(double.MinValue, BaseUnit);
+        public static LuminousFlux MinValue { get; } = new LuminousFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LuminousFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.LuminousFlux;
 
         /// <summary>
         ///     All units of measurement for the LuminousFlux quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Lumen.
         /// </summary>
-        public static LuminousFlux Zero => new LuminousFlux(0, BaseUnit);
+        public static LuminousFlux Zero { get; } = new LuminousFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of LuminousIntensity, which is Candela. All conversions go via this value.
         /// </summary>
-        public static LuminousIntensityUnit BaseUnit => LuminousIntensityUnit.Candela;
+        public static LuminousIntensityUnit BaseUnit { get; } = LuminousIntensityUnit.Candela;
 
         /// <summary>
         /// Represents the largest possible value of LuminousIntensity
         /// </summary>
-        public static LuminousIntensity MaxValue => new LuminousIntensity(double.MaxValue, BaseUnit);
+        public static LuminousIntensity MaxValue { get; } = new LuminousIntensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of LuminousIntensity
         /// </summary>
-        public static LuminousIntensity MinValue => new LuminousIntensity(double.MinValue, BaseUnit);
+        public static LuminousIntensity MinValue { get; } = new LuminousIntensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.LuminousIntensity;
+        public static QuantityType QuantityType { get; } = QuantityType.LuminousIntensity;
 
         /// <summary>
         ///     All units of measurement for the LuminousIntensity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Candela.
         /// </summary>
-        public static LuminousIntensity Zero => new LuminousIntensity(0, BaseUnit);
+        public static LuminousIntensity Zero { get; } = new LuminousIntensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MagneticField, which is Tesla. All conversions go via this value.
         /// </summary>
-        public static MagneticFieldUnit BaseUnit => MagneticFieldUnit.Tesla;
+        public static MagneticFieldUnit BaseUnit { get; } = MagneticFieldUnit.Tesla;
 
         /// <summary>
         /// Represents the largest possible value of MagneticField
         /// </summary>
-        public static MagneticField MaxValue => new MagneticField(double.MaxValue, BaseUnit);
+        public static MagneticField MaxValue { get; } = new MagneticField(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MagneticField
         /// </summary>
-        public static MagneticField MinValue => new MagneticField(double.MinValue, BaseUnit);
+        public static MagneticField MinValue { get; } = new MagneticField(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MagneticField;
+        public static QuantityType QuantityType { get; } = QuantityType.MagneticField;
 
         /// <summary>
         ///     All units of measurement for the MagneticField quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Tesla.
         /// </summary>
-        public static MagneticField Zero => new MagneticField(0, BaseUnit);
+        public static MagneticField Zero { get; } = new MagneticField(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MagneticFlux, which is Weber. All conversions go via this value.
         /// </summary>
-        public static MagneticFluxUnit BaseUnit => MagneticFluxUnit.Weber;
+        public static MagneticFluxUnit BaseUnit { get; } = MagneticFluxUnit.Weber;
 
         /// <summary>
         /// Represents the largest possible value of MagneticFlux
         /// </summary>
-        public static MagneticFlux MaxValue => new MagneticFlux(double.MaxValue, BaseUnit);
+        public static MagneticFlux MaxValue { get; } = new MagneticFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MagneticFlux
         /// </summary>
-        public static MagneticFlux MinValue => new MagneticFlux(double.MinValue, BaseUnit);
+        public static MagneticFlux MinValue { get; } = new MagneticFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MagneticFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.MagneticFlux;
 
         /// <summary>
         ///     All units of measurement for the MagneticFlux quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Weber.
         /// </summary>
-        public static MagneticFlux Zero => new MagneticFlux(0, BaseUnit);
+        public static MagneticFlux Zero { get; } = new MagneticFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Magnetization, which is AmperePerMeter. All conversions go via this value.
         /// </summary>
-        public static MagnetizationUnit BaseUnit => MagnetizationUnit.AmperePerMeter;
+        public static MagnetizationUnit BaseUnit { get; } = MagnetizationUnit.AmperePerMeter;
 
         /// <summary>
         /// Represents the largest possible value of Magnetization
         /// </summary>
-        public static Magnetization MaxValue => new Magnetization(double.MaxValue, BaseUnit);
+        public static Magnetization MaxValue { get; } = new Magnetization(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Magnetization
         /// </summary>
-        public static Magnetization MinValue => new Magnetization(double.MinValue, BaseUnit);
+        public static Magnetization MinValue { get; } = new Magnetization(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Magnetization;
+        public static QuantityType QuantityType { get; } = QuantityType.Magnetization;
 
         /// <summary>
         ///     All units of measurement for the Magnetization quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit AmperePerMeter.
         /// </summary>
-        public static Magnetization Zero => new Magnetization(0, BaseUnit);
+        public static Magnetization Zero { get; } = new Magnetization(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Mass, which is Kilogram. All conversions go via this value.
         /// </summary>
-        public static MassUnit BaseUnit => MassUnit.Kilogram;
+        public static MassUnit BaseUnit { get; } = MassUnit.Kilogram;
 
         /// <summary>
         /// Represents the largest possible value of Mass
         /// </summary>
-        public static Mass MaxValue => new Mass(double.MaxValue, BaseUnit);
+        public static Mass MaxValue { get; } = new Mass(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Mass
         /// </summary>
-        public static Mass MinValue => new Mass(double.MinValue, BaseUnit);
+        public static Mass MinValue { get; } = new Mass(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Mass;
+        public static QuantityType QuantityType { get; } = QuantityType.Mass;
 
         /// <summary>
         ///     All units of measurement for the Mass quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Kilogram.
         /// </summary>
-        public static Mass Zero => new Mass(0, BaseUnit);
+        public static Mass Zero { get; } = new Mass(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MassFlow, which is GramPerSecond. All conversions go via this value.
         /// </summary>
-        public static MassFlowUnit BaseUnit => MassFlowUnit.GramPerSecond;
+        public static MassFlowUnit BaseUnit { get; } = MassFlowUnit.GramPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of MassFlow
         /// </summary>
-        public static MassFlow MaxValue => new MassFlow(double.MaxValue, BaseUnit);
+        public static MassFlow MaxValue { get; } = new MassFlow(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MassFlow
         /// </summary>
-        public static MassFlow MinValue => new MassFlow(double.MinValue, BaseUnit);
+        public static MassFlow MinValue { get; } = new MassFlow(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MassFlow;
+        public static QuantityType QuantityType { get; } = QuantityType.MassFlow;
 
         /// <summary>
         ///     All units of measurement for the MassFlow quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit GramPerSecond.
         /// </summary>
-        public static MassFlow Zero => new MassFlow(0, BaseUnit);
+        public static MassFlow Zero { get; } = new MassFlow(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MassFlux, which is KilogramPerSecondPerSquareMeter. All conversions go via this value.
         /// </summary>
-        public static MassFluxUnit BaseUnit => MassFluxUnit.KilogramPerSecondPerSquareMeter;
+        public static MassFluxUnit BaseUnit { get; } = MassFluxUnit.KilogramPerSecondPerSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of MassFlux
         /// </summary>
-        public static MassFlux MaxValue => new MassFlux(double.MaxValue, BaseUnit);
+        public static MassFlux MaxValue { get; } = new MassFlux(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MassFlux
         /// </summary>
-        public static MassFlux MinValue => new MassFlux(double.MinValue, BaseUnit);
+        public static MassFlux MinValue { get; } = new MassFlux(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MassFlux;
+        public static QuantityType QuantityType { get; } = QuantityType.MassFlux;
 
         /// <summary>
         ///     All units of measurement for the MassFlux quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerSecondPerSquareMeter.
         /// </summary>
-        public static MassFlux Zero => new MassFlux(0, BaseUnit);
+        public static MassFlux Zero { get; } = new MassFlux(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MassMomentOfInertia, which is KilogramSquareMeter. All conversions go via this value.
         /// </summary>
-        public static MassMomentOfInertiaUnit BaseUnit => MassMomentOfInertiaUnit.KilogramSquareMeter;
+        public static MassMomentOfInertiaUnit BaseUnit { get; } = MassMomentOfInertiaUnit.KilogramSquareMeter;
 
         /// <summary>
         /// Represents the largest possible value of MassMomentOfInertia
         /// </summary>
-        public static MassMomentOfInertia MaxValue => new MassMomentOfInertia(double.MaxValue, BaseUnit);
+        public static MassMomentOfInertia MaxValue { get; } = new MassMomentOfInertia(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MassMomentOfInertia
         /// </summary>
-        public static MassMomentOfInertia MinValue => new MassMomentOfInertia(double.MinValue, BaseUnit);
+        public static MassMomentOfInertia MinValue { get; } = new MassMomentOfInertia(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MassMomentOfInertia;
+        public static QuantityType QuantityType { get; } = QuantityType.MassMomentOfInertia;
 
         /// <summary>
         ///     All units of measurement for the MassMomentOfInertia quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramSquareMeter.
         /// </summary>
-        public static MassMomentOfInertia Zero => new MassMomentOfInertia(0, BaseUnit);
+        public static MassMomentOfInertia Zero { get; } = new MassMomentOfInertia(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MolarEnergy, which is JoulePerMole. All conversions go via this value.
         /// </summary>
-        public static MolarEnergyUnit BaseUnit => MolarEnergyUnit.JoulePerMole;
+        public static MolarEnergyUnit BaseUnit { get; } = MolarEnergyUnit.JoulePerMole;
 
         /// <summary>
         /// Represents the largest possible value of MolarEnergy
         /// </summary>
-        public static MolarEnergy MaxValue => new MolarEnergy(double.MaxValue, BaseUnit);
+        public static MolarEnergy MaxValue { get; } = new MolarEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MolarEnergy
         /// </summary>
-        public static MolarEnergy MinValue => new MolarEnergy(double.MinValue, BaseUnit);
+        public static MolarEnergy MinValue { get; } = new MolarEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MolarEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.MolarEnergy;
 
         /// <summary>
         ///     All units of measurement for the MolarEnergy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerMole.
         /// </summary>
-        public static MolarEnergy Zero => new MolarEnergy(0, BaseUnit);
+        public static MolarEnergy Zero { get; } = new MolarEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MolarEntropy, which is JoulePerMoleKelvin. All conversions go via this value.
         /// </summary>
-        public static MolarEntropyUnit BaseUnit => MolarEntropyUnit.JoulePerMoleKelvin;
+        public static MolarEntropyUnit BaseUnit { get; } = MolarEntropyUnit.JoulePerMoleKelvin;
 
         /// <summary>
         /// Represents the largest possible value of MolarEntropy
         /// </summary>
-        public static MolarEntropy MaxValue => new MolarEntropy(double.MaxValue, BaseUnit);
+        public static MolarEntropy MaxValue { get; } = new MolarEntropy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MolarEntropy
         /// </summary>
-        public static MolarEntropy MinValue => new MolarEntropy(double.MinValue, BaseUnit);
+        public static MolarEntropy MinValue { get; } = new MolarEntropy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MolarEntropy;
+        public static QuantityType QuantityType { get; } = QuantityType.MolarEntropy;
 
         /// <summary>
         ///     All units of measurement for the MolarEntropy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerMoleKelvin.
         /// </summary>
-        public static MolarEntropy Zero => new MolarEntropy(0, BaseUnit);
+        public static MolarEntropy Zero { get; } = new MolarEntropy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of MolarMass, which is KilogramPerMole. All conversions go via this value.
         /// </summary>
-        public static MolarMassUnit BaseUnit => MolarMassUnit.KilogramPerMole;
+        public static MolarMassUnit BaseUnit { get; } = MolarMassUnit.KilogramPerMole;
 
         /// <summary>
         /// Represents the largest possible value of MolarMass
         /// </summary>
-        public static MolarMass MaxValue => new MolarMass(double.MaxValue, BaseUnit);
+        public static MolarMass MaxValue { get; } = new MolarMass(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of MolarMass
         /// </summary>
-        public static MolarMass MinValue => new MolarMass(double.MinValue, BaseUnit);
+        public static MolarMass MinValue { get; } = new MolarMass(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.MolarMass;
+        public static QuantityType QuantityType { get; } = QuantityType.MolarMass;
 
         /// <summary>
         ///     All units of measurement for the MolarMass quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit KilogramPerMole.
         /// </summary>
-        public static MolarMass Zero => new MolarMass(0, BaseUnit);
+        public static MolarMass Zero { get; } = new MolarMass(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Molarity, which is MolesPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static MolarityUnit BaseUnit => MolarityUnit.MolesPerCubicMeter;
+        public static MolarityUnit BaseUnit { get; } = MolarityUnit.MolesPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of Molarity
         /// </summary>
-        public static Molarity MaxValue => new Molarity(double.MaxValue, BaseUnit);
+        public static Molarity MaxValue { get; } = new Molarity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Molarity
         /// </summary>
-        public static Molarity MinValue => new Molarity(double.MinValue, BaseUnit);
+        public static Molarity MinValue { get; } = new Molarity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Molarity;
+        public static QuantityType QuantityType { get; } = QuantityType.Molarity;
 
         /// <summary>
         ///     All units of measurement for the Molarity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MolesPerCubicMeter.
         /// </summary>
-        public static Molarity Zero => new Molarity(0, BaseUnit);
+        public static Molarity Zero { get; } = new Molarity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Permeability, which is HenryPerMeter. All conversions go via this value.
         /// </summary>
-        public static PermeabilityUnit BaseUnit => PermeabilityUnit.HenryPerMeter;
+        public static PermeabilityUnit BaseUnit { get; } = PermeabilityUnit.HenryPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of Permeability
         /// </summary>
-        public static Permeability MaxValue => new Permeability(double.MaxValue, BaseUnit);
+        public static Permeability MaxValue { get; } = new Permeability(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Permeability
         /// </summary>
-        public static Permeability MinValue => new Permeability(double.MinValue, BaseUnit);
+        public static Permeability MinValue { get; } = new Permeability(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Permeability;
+        public static QuantityType QuantityType { get; } = QuantityType.Permeability;
 
         /// <summary>
         ///     All units of measurement for the Permeability quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit HenryPerMeter.
         /// </summary>
-        public static Permeability Zero => new Permeability(0, BaseUnit);
+        public static Permeability Zero { get; } = new Permeability(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Permittivity, which is FaradPerMeter. All conversions go via this value.
         /// </summary>
-        public static PermittivityUnit BaseUnit => PermittivityUnit.FaradPerMeter;
+        public static PermittivityUnit BaseUnit { get; } = PermittivityUnit.FaradPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of Permittivity
         /// </summary>
-        public static Permittivity MaxValue => new Permittivity(double.MaxValue, BaseUnit);
+        public static Permittivity MaxValue { get; } = new Permittivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Permittivity
         /// </summary>
-        public static Permittivity MinValue => new Permittivity(double.MinValue, BaseUnit);
+        public static Permittivity MinValue { get; } = new Permittivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Permittivity;
+        public static QuantityType QuantityType { get; } = QuantityType.Permittivity;
 
         /// <summary>
         ///     All units of measurement for the Permittivity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit FaradPerMeter.
         /// </summary>
-        public static Permittivity Zero => new Permittivity(0, BaseUnit);
+        public static Permittivity Zero { get; } = new Permittivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Power, which is Watt. All conversions go via this value.
         /// </summary>
-        public static PowerUnit BaseUnit => PowerUnit.Watt;
+        public static PowerUnit BaseUnit { get; } = PowerUnit.Watt;
 
         /// <summary>
         /// Represents the largest possible value of Power
         /// </summary>
-        public static Power MaxValue => new Power(decimal.MaxValue, BaseUnit);
+        public static Power MaxValue { get; } = new Power(decimal.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Power
         /// </summary>
-        public static Power MinValue => new Power(decimal.MinValue, BaseUnit);
+        public static Power MinValue { get; } = new Power(decimal.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Power;
+        public static QuantityType QuantityType { get; } = QuantityType.Power;
 
         /// <summary>
         ///     All units of measurement for the Power quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Watt.
         /// </summary>
-        public static Power Zero => new Power(0, BaseUnit);
+        public static Power Zero { get; } = new Power(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of PowerDensity, which is WattPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static PowerDensityUnit BaseUnit => PowerDensityUnit.WattPerCubicMeter;
+        public static PowerDensityUnit BaseUnit { get; } = PowerDensityUnit.WattPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of PowerDensity
         /// </summary>
-        public static PowerDensity MaxValue => new PowerDensity(double.MaxValue, BaseUnit);
+        public static PowerDensity MaxValue { get; } = new PowerDensity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of PowerDensity
         /// </summary>
-        public static PowerDensity MinValue => new PowerDensity(double.MinValue, BaseUnit);
+        public static PowerDensity MinValue { get; } = new PowerDensity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.PowerDensity;
+        public static QuantityType QuantityType { get; } = QuantityType.PowerDensity;
 
         /// <summary>
         ///     All units of measurement for the PowerDensity quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerCubicMeter.
         /// </summary>
-        public static PowerDensity Zero => new PowerDensity(0, BaseUnit);
+        public static PowerDensity Zero { get; } = new PowerDensity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of PowerRatio, which is DecibelWatt. All conversions go via this value.
         /// </summary>
-        public static PowerRatioUnit BaseUnit => PowerRatioUnit.DecibelWatt;
+        public static PowerRatioUnit BaseUnit { get; } = PowerRatioUnit.DecibelWatt;
 
         /// <summary>
         /// Represents the largest possible value of PowerRatio
         /// </summary>
-        public static PowerRatio MaxValue => new PowerRatio(double.MaxValue, BaseUnit);
+        public static PowerRatio MaxValue { get; } = new PowerRatio(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of PowerRatio
         /// </summary>
-        public static PowerRatio MinValue => new PowerRatio(double.MinValue, BaseUnit);
+        public static PowerRatio MinValue { get; } = new PowerRatio(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.PowerRatio;
+        public static QuantityType QuantityType { get; } = QuantityType.PowerRatio;
 
         /// <summary>
         ///     All units of measurement for the PowerRatio quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DecibelWatt.
         /// </summary>
-        public static PowerRatio Zero => new PowerRatio(0, BaseUnit);
+        public static PowerRatio Zero { get; } = new PowerRatio(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Pressure, which is Pascal. All conversions go via this value.
         /// </summary>
-        public static PressureUnit BaseUnit => PressureUnit.Pascal;
+        public static PressureUnit BaseUnit { get; } = PressureUnit.Pascal;
 
         /// <summary>
         /// Represents the largest possible value of Pressure
         /// </summary>
-        public static Pressure MaxValue => new Pressure(double.MaxValue, BaseUnit);
+        public static Pressure MaxValue { get; } = new Pressure(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Pressure
         /// </summary>
-        public static Pressure MinValue => new Pressure(double.MinValue, BaseUnit);
+        public static Pressure MinValue { get; } = new Pressure(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Pressure;
+        public static QuantityType QuantityType { get; } = QuantityType.Pressure;
 
         /// <summary>
         ///     All units of measurement for the Pressure quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Pascal.
         /// </summary>
-        public static Pressure Zero => new Pressure(0, BaseUnit);
+        public static Pressure Zero { get; } = new Pressure(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of PressureChangeRate, which is PascalPerSecond. All conversions go via this value.
         /// </summary>
-        public static PressureChangeRateUnit BaseUnit => PressureChangeRateUnit.PascalPerSecond;
+        public static PressureChangeRateUnit BaseUnit { get; } = PressureChangeRateUnit.PascalPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of PressureChangeRate
         /// </summary>
-        public static PressureChangeRate MaxValue => new PressureChangeRate(double.MaxValue, BaseUnit);
+        public static PressureChangeRate MaxValue { get; } = new PressureChangeRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of PressureChangeRate
         /// </summary>
-        public static PressureChangeRate MinValue => new PressureChangeRate(double.MinValue, BaseUnit);
+        public static PressureChangeRate MinValue { get; } = new PressureChangeRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.PressureChangeRate;
+        public static QuantityType QuantityType { get; } = QuantityType.PressureChangeRate;
 
         /// <summary>
         ///     All units of measurement for the PressureChangeRate quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit PascalPerSecond.
         /// </summary>
-        public static PressureChangeRate Zero => new PressureChangeRate(0, BaseUnit);
+        public static PressureChangeRate Zero { get; } = new PressureChangeRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Ratio, which is DecimalFraction. All conversions go via this value.
         /// </summary>
-        public static RatioUnit BaseUnit => RatioUnit.DecimalFraction;
+        public static RatioUnit BaseUnit { get; } = RatioUnit.DecimalFraction;
 
         /// <summary>
         /// Represents the largest possible value of Ratio
         /// </summary>
-        public static Ratio MaxValue => new Ratio(double.MaxValue, BaseUnit);
+        public static Ratio MaxValue { get; } = new Ratio(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Ratio
         /// </summary>
-        public static Ratio MinValue => new Ratio(double.MinValue, BaseUnit);
+        public static Ratio MinValue { get; } = new Ratio(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Ratio;
+        public static QuantityType QuantityType { get; } = QuantityType.Ratio;
 
         /// <summary>
         ///     All units of measurement for the Ratio quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DecimalFraction.
         /// </summary>
-        public static Ratio Zero => new Ratio(0, BaseUnit);
+        public static Ratio Zero { get; } = new Ratio(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ReactiveEnergy, which is VoltampereReactiveHour. All conversions go via this value.
         /// </summary>
-        public static ReactiveEnergyUnit BaseUnit => ReactiveEnergyUnit.VoltampereReactiveHour;
+        public static ReactiveEnergyUnit BaseUnit { get; } = ReactiveEnergyUnit.VoltampereReactiveHour;
 
         /// <summary>
         /// Represents the largest possible value of ReactiveEnergy
         /// </summary>
-        public static ReactiveEnergy MaxValue => new ReactiveEnergy(double.MaxValue, BaseUnit);
+        public static ReactiveEnergy MaxValue { get; } = new ReactiveEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ReactiveEnergy
         /// </summary>
-        public static ReactiveEnergy MinValue => new ReactiveEnergy(double.MinValue, BaseUnit);
+        public static ReactiveEnergy MinValue { get; } = new ReactiveEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ReactiveEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.ReactiveEnergy;
 
         /// <summary>
         ///     All units of measurement for the ReactiveEnergy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereReactiveHour.
         /// </summary>
-        public static ReactiveEnergy Zero => new ReactiveEnergy(0, BaseUnit);
+        public static ReactiveEnergy Zero { get; } = new ReactiveEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ReactivePower, which is VoltampereReactive. All conversions go via this value.
         /// </summary>
-        public static ReactivePowerUnit BaseUnit => ReactivePowerUnit.VoltampereReactive;
+        public static ReactivePowerUnit BaseUnit { get; } = ReactivePowerUnit.VoltampereReactive;
 
         /// <summary>
         /// Represents the largest possible value of ReactivePower
         /// </summary>
-        public static ReactivePower MaxValue => new ReactivePower(double.MaxValue, BaseUnit);
+        public static ReactivePower MaxValue { get; } = new ReactivePower(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ReactivePower
         /// </summary>
-        public static ReactivePower MinValue => new ReactivePower(double.MinValue, BaseUnit);
+        public static ReactivePower MinValue { get; } = new ReactivePower(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ReactivePower;
+        public static QuantityType QuantityType { get; } = QuantityType.ReactivePower;
 
         /// <summary>
         ///     All units of measurement for the ReactivePower quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit VoltampereReactive.
         /// </summary>
-        public static ReactivePower Zero => new ReactivePower(0, BaseUnit);
+        public static ReactivePower Zero { get; } = new ReactivePower(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalAcceleration, which is RadianPerSecondSquared. All conversions go via this value.
         /// </summary>
-        public static RotationalAccelerationUnit BaseUnit => RotationalAccelerationUnit.RadianPerSecondSquared;
+        public static RotationalAccelerationUnit BaseUnit { get; } = RotationalAccelerationUnit.RadianPerSecondSquared;
 
         /// <summary>
         /// Represents the largest possible value of RotationalAcceleration
         /// </summary>
-        public static RotationalAcceleration MaxValue => new RotationalAcceleration(double.MaxValue, BaseUnit);
+        public static RotationalAcceleration MaxValue { get; } = new RotationalAcceleration(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalAcceleration
         /// </summary>
-        public static RotationalAcceleration MinValue => new RotationalAcceleration(double.MinValue, BaseUnit);
+        public static RotationalAcceleration MinValue { get; } = new RotationalAcceleration(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalAcceleration;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalAcceleration;
 
         /// <summary>
         ///     All units of measurement for the RotationalAcceleration quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit RadianPerSecondSquared.
         /// </summary>
-        public static RotationalAcceleration Zero => new RotationalAcceleration(0, BaseUnit);
+        public static RotationalAcceleration Zero { get; } = new RotationalAcceleration(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalSpeed, which is RadianPerSecond. All conversions go via this value.
         /// </summary>
-        public static RotationalSpeedUnit BaseUnit => RotationalSpeedUnit.RadianPerSecond;
+        public static RotationalSpeedUnit BaseUnit { get; } = RotationalSpeedUnit.RadianPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of RotationalSpeed
         /// </summary>
-        public static RotationalSpeed MaxValue => new RotationalSpeed(double.MaxValue, BaseUnit);
+        public static RotationalSpeed MaxValue { get; } = new RotationalSpeed(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalSpeed
         /// </summary>
-        public static RotationalSpeed MinValue => new RotationalSpeed(double.MinValue, BaseUnit);
+        public static RotationalSpeed MinValue { get; } = new RotationalSpeed(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalSpeed;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalSpeed;
 
         /// <summary>
         ///     All units of measurement for the RotationalSpeed quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit RadianPerSecond.
         /// </summary>
-        public static RotationalSpeed Zero => new RotationalSpeed(0, BaseUnit);
+        public static RotationalSpeed Zero { get; } = new RotationalSpeed(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalStiffness, which is NewtonMeterPerRadian. All conversions go via this value.
         /// </summary>
-        public static RotationalStiffnessUnit BaseUnit => RotationalStiffnessUnit.NewtonMeterPerRadian;
+        public static RotationalStiffnessUnit BaseUnit { get; } = RotationalStiffnessUnit.NewtonMeterPerRadian;
 
         /// <summary>
         /// Represents the largest possible value of RotationalStiffness
         /// </summary>
-        public static RotationalStiffness MaxValue => new RotationalStiffness(double.MaxValue, BaseUnit);
+        public static RotationalStiffness MaxValue { get; } = new RotationalStiffness(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalStiffness
         /// </summary>
-        public static RotationalStiffness MinValue => new RotationalStiffness(double.MinValue, BaseUnit);
+        public static RotationalStiffness MinValue { get; } = new RotationalStiffness(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalStiffness;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalStiffness;
 
         /// <summary>
         ///     All units of measurement for the RotationalStiffness quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeterPerRadian.
         /// </summary>
-        public static RotationalStiffness Zero => new RotationalStiffness(0, BaseUnit);
+        public static RotationalStiffness Zero { get; } = new RotationalStiffness(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RotationalStiffnessPerLength, which is NewtonMeterPerRadianPerMeter. All conversions go via this value.
         /// </summary>
-        public static RotationalStiffnessPerLengthUnit BaseUnit => RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
+        public static RotationalStiffnessPerLengthUnit BaseUnit { get; } = RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
 
         /// <summary>
         /// Represents the largest possible value of RotationalStiffnessPerLength
         /// </summary>
-        public static RotationalStiffnessPerLength MaxValue => new RotationalStiffnessPerLength(double.MaxValue, BaseUnit);
+        public static RotationalStiffnessPerLength MaxValue { get; } = new RotationalStiffnessPerLength(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of RotationalStiffnessPerLength
         /// </summary>
-        public static RotationalStiffnessPerLength MinValue => new RotationalStiffnessPerLength(double.MinValue, BaseUnit);
+        public static RotationalStiffnessPerLength MinValue { get; } = new RotationalStiffnessPerLength(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.RotationalStiffnessPerLength;
+        public static QuantityType QuantityType { get; } = QuantityType.RotationalStiffnessPerLength;
 
         /// <summary>
         ///     All units of measurement for the RotationalStiffnessPerLength quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeterPerRadianPerMeter.
         /// </summary>
-        public static RotationalStiffnessPerLength Zero => new RotationalStiffnessPerLength(0, BaseUnit);
+        public static RotationalStiffnessPerLength Zero { get; } = new RotationalStiffnessPerLength(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SolidAngle, which is Steradian. All conversions go via this value.
         /// </summary>
-        public static SolidAngleUnit BaseUnit => SolidAngleUnit.Steradian;
+        public static SolidAngleUnit BaseUnit { get; } = SolidAngleUnit.Steradian;
 
         /// <summary>
         /// Represents the largest possible value of SolidAngle
         /// </summary>
-        public static SolidAngle MaxValue => new SolidAngle(double.MaxValue, BaseUnit);
+        public static SolidAngle MaxValue { get; } = new SolidAngle(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SolidAngle
         /// </summary>
-        public static SolidAngle MinValue => new SolidAngle(double.MinValue, BaseUnit);
+        public static SolidAngle MinValue { get; } = new SolidAngle(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SolidAngle;
+        public static QuantityType QuantityType { get; } = QuantityType.SolidAngle;
 
         /// <summary>
         ///     All units of measurement for the SolidAngle quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Steradian.
         /// </summary>
-        public static SolidAngle Zero => new SolidAngle(0, BaseUnit);
+        public static SolidAngle Zero { get; } = new SolidAngle(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificEnergy, which is JoulePerKilogram. All conversions go via this value.
         /// </summary>
-        public static SpecificEnergyUnit BaseUnit => SpecificEnergyUnit.JoulePerKilogram;
+        public static SpecificEnergyUnit BaseUnit { get; } = SpecificEnergyUnit.JoulePerKilogram;
 
         /// <summary>
         /// Represents the largest possible value of SpecificEnergy
         /// </summary>
-        public static SpecificEnergy MaxValue => new SpecificEnergy(double.MaxValue, BaseUnit);
+        public static SpecificEnergy MaxValue { get; } = new SpecificEnergy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificEnergy
         /// </summary>
-        public static SpecificEnergy MinValue => new SpecificEnergy(double.MinValue, BaseUnit);
+        public static SpecificEnergy MinValue { get; } = new SpecificEnergy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificEnergy;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificEnergy;
 
         /// <summary>
         ///     All units of measurement for the SpecificEnergy quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKilogram.
         /// </summary>
-        public static SpecificEnergy Zero => new SpecificEnergy(0, BaseUnit);
+        public static SpecificEnergy Zero { get; } = new SpecificEnergy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificEntropy, which is JoulePerKilogramKelvin. All conversions go via this value.
         /// </summary>
-        public static SpecificEntropyUnit BaseUnit => SpecificEntropyUnit.JoulePerKilogramKelvin;
+        public static SpecificEntropyUnit BaseUnit { get; } = SpecificEntropyUnit.JoulePerKilogramKelvin;
 
         /// <summary>
         /// Represents the largest possible value of SpecificEntropy
         /// </summary>
-        public static SpecificEntropy MaxValue => new SpecificEntropy(double.MaxValue, BaseUnit);
+        public static SpecificEntropy MaxValue { get; } = new SpecificEntropy(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificEntropy
         /// </summary>
-        public static SpecificEntropy MinValue => new SpecificEntropy(double.MinValue, BaseUnit);
+        public static SpecificEntropy MinValue { get; } = new SpecificEntropy(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificEntropy;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificEntropy;
 
         /// <summary>
         ///     All units of measurement for the SpecificEntropy quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit JoulePerKilogramKelvin.
         /// </summary>
-        public static SpecificEntropy Zero => new SpecificEntropy(0, BaseUnit);
+        public static SpecificEntropy Zero { get; } = new SpecificEntropy(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificVolume, which is CubicMeterPerKilogram. All conversions go via this value.
         /// </summary>
-        public static SpecificVolumeUnit BaseUnit => SpecificVolumeUnit.CubicMeterPerKilogram;
+        public static SpecificVolumeUnit BaseUnit { get; } = SpecificVolumeUnit.CubicMeterPerKilogram;
 
         /// <summary>
         /// Represents the largest possible value of SpecificVolume
         /// </summary>
-        public static SpecificVolume MaxValue => new SpecificVolume(double.MaxValue, BaseUnit);
+        public static SpecificVolume MaxValue { get; } = new SpecificVolume(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificVolume
         /// </summary>
-        public static SpecificVolume MinValue => new SpecificVolume(double.MinValue, BaseUnit);
+        public static SpecificVolume MinValue { get; } = new SpecificVolume(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificVolume;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificVolume;
 
         /// <summary>
         ///     All units of measurement for the SpecificVolume quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerKilogram.
         /// </summary>
-        public static SpecificVolume Zero => new SpecificVolume(0, BaseUnit);
+        public static SpecificVolume Zero { get; } = new SpecificVolume(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of SpecificWeight, which is NewtonPerCubicMeter. All conversions go via this value.
         /// </summary>
-        public static SpecificWeightUnit BaseUnit => SpecificWeightUnit.NewtonPerCubicMeter;
+        public static SpecificWeightUnit BaseUnit { get; } = SpecificWeightUnit.NewtonPerCubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of SpecificWeight
         /// </summary>
-        public static SpecificWeight MaxValue => new SpecificWeight(double.MaxValue, BaseUnit);
+        public static SpecificWeight MaxValue { get; } = new SpecificWeight(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of SpecificWeight
         /// </summary>
-        public static SpecificWeight MinValue => new SpecificWeight(double.MinValue, BaseUnit);
+        public static SpecificWeight MinValue { get; } = new SpecificWeight(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.SpecificWeight;
+        public static QuantityType QuantityType { get; } = QuantityType.SpecificWeight;
 
         /// <summary>
         ///     All units of measurement for the SpecificWeight quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonPerCubicMeter.
         /// </summary>
-        public static SpecificWeight Zero => new SpecificWeight(0, BaseUnit);
+        public static SpecificWeight Zero { get; } = new SpecificWeight(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Speed, which is MeterPerSecond. All conversions go via this value.
         /// </summary>
-        public static SpeedUnit BaseUnit => SpeedUnit.MeterPerSecond;
+        public static SpeedUnit BaseUnit { get; } = SpeedUnit.MeterPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of Speed
         /// </summary>
-        public static Speed MaxValue => new Speed(double.MaxValue, BaseUnit);
+        public static Speed MaxValue { get; } = new Speed(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Speed
         /// </summary>
-        public static Speed MinValue => new Speed(double.MinValue, BaseUnit);
+        public static Speed MinValue { get; } = new Speed(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Speed;
+        public static QuantityType QuantityType { get; } = QuantityType.Speed;
 
         /// <summary>
         ///     All units of measurement for the Speed quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit MeterPerSecond.
         /// </summary>
-        public static Speed Zero => new Speed(0, BaseUnit);
+        public static Speed Zero { get; } = new Speed(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Temperature, which is Kelvin. All conversions go via this value.
         /// </summary>
-        public static TemperatureUnit BaseUnit => TemperatureUnit.Kelvin;
+        public static TemperatureUnit BaseUnit { get; } = TemperatureUnit.Kelvin;
 
         /// <summary>
         /// Represents the largest possible value of Temperature
         /// </summary>
-        public static Temperature MaxValue => new Temperature(double.MaxValue, BaseUnit);
+        public static Temperature MaxValue { get; } = new Temperature(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Temperature
         /// </summary>
-        public static Temperature MinValue => new Temperature(double.MinValue, BaseUnit);
+        public static Temperature MinValue { get; } = new Temperature(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Temperature;
+        public static QuantityType QuantityType { get; } = QuantityType.Temperature;
 
         /// <summary>
         ///     All units of measurement for the Temperature quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Kelvin.
         /// </summary>
-        public static Temperature Zero => new Temperature(0, BaseUnit);
+        public static Temperature Zero { get; } = new Temperature(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of TemperatureChangeRate, which is DegreeCelsiusPerSecond. All conversions go via this value.
         /// </summary>
-        public static TemperatureChangeRateUnit BaseUnit => TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
+        public static TemperatureChangeRateUnit BaseUnit { get; } = TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of TemperatureChangeRate
         /// </summary>
-        public static TemperatureChangeRate MaxValue => new TemperatureChangeRate(double.MaxValue, BaseUnit);
+        public static TemperatureChangeRate MaxValue { get; } = new TemperatureChangeRate(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of TemperatureChangeRate
         /// </summary>
-        public static TemperatureChangeRate MinValue => new TemperatureChangeRate(double.MinValue, BaseUnit);
+        public static TemperatureChangeRate MinValue { get; } = new TemperatureChangeRate(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.TemperatureChangeRate;
+        public static QuantityType QuantityType { get; } = QuantityType.TemperatureChangeRate;
 
         /// <summary>
         ///     All units of measurement for the TemperatureChangeRate quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit DegreeCelsiusPerSecond.
         /// </summary>
-        public static TemperatureChangeRate Zero => new TemperatureChangeRate(0, BaseUnit);
+        public static TemperatureChangeRate Zero { get; } = new TemperatureChangeRate(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of TemperatureDelta, which is Kelvin. All conversions go via this value.
         /// </summary>
-        public static TemperatureDeltaUnit BaseUnit => TemperatureDeltaUnit.Kelvin;
+        public static TemperatureDeltaUnit BaseUnit { get; } = TemperatureDeltaUnit.Kelvin;
 
         /// <summary>
         /// Represents the largest possible value of TemperatureDelta
         /// </summary>
-        public static TemperatureDelta MaxValue => new TemperatureDelta(double.MaxValue, BaseUnit);
+        public static TemperatureDelta MaxValue { get; } = new TemperatureDelta(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of TemperatureDelta
         /// </summary>
-        public static TemperatureDelta MinValue => new TemperatureDelta(double.MinValue, BaseUnit);
+        public static TemperatureDelta MinValue { get; } = new TemperatureDelta(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.TemperatureDelta;
+        public static QuantityType QuantityType { get; } = QuantityType.TemperatureDelta;
 
         /// <summary>
         ///     All units of measurement for the TemperatureDelta quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit Kelvin.
         /// </summary>
-        public static TemperatureDelta Zero => new TemperatureDelta(0, BaseUnit);
+        public static TemperatureDelta Zero { get; } = new TemperatureDelta(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
@@ -95,22 +95,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ThermalConductivity, which is WattPerMeterKelvin. All conversions go via this value.
         /// </summary>
-        public static ThermalConductivityUnit BaseUnit => ThermalConductivityUnit.WattPerMeterKelvin;
+        public static ThermalConductivityUnit BaseUnit { get; } = ThermalConductivityUnit.WattPerMeterKelvin;
 
         /// <summary>
         /// Represents the largest possible value of ThermalConductivity
         /// </summary>
-        public static ThermalConductivity MaxValue => new ThermalConductivity(double.MaxValue, BaseUnit);
+        public static ThermalConductivity MaxValue { get; } = new ThermalConductivity(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ThermalConductivity
         /// </summary>
-        public static ThermalConductivity MinValue => new ThermalConductivity(double.MinValue, BaseUnit);
+        public static ThermalConductivity MinValue { get; } = new ThermalConductivity(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ThermalConductivity;
+        public static QuantityType QuantityType { get; } = QuantityType.ThermalConductivity;
 
         /// <summary>
         ///     All units of measurement for the ThermalConductivity quantity.
@@ -120,7 +120,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit WattPerMeterKelvin.
         /// </summary>
-        public static ThermalConductivity Zero => new ThermalConductivity(0, BaseUnit);
+        public static ThermalConductivity Zero { get; } = new ThermalConductivity(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of ThermalResistance, which is SquareMeterKelvinPerKilowatt. All conversions go via this value.
         /// </summary>
-        public static ThermalResistanceUnit BaseUnit => ThermalResistanceUnit.SquareMeterKelvinPerKilowatt;
+        public static ThermalResistanceUnit BaseUnit { get; } = ThermalResistanceUnit.SquareMeterKelvinPerKilowatt;
 
         /// <summary>
         /// Represents the largest possible value of ThermalResistance
         /// </summary>
-        public static ThermalResistance MaxValue => new ThermalResistance(double.MaxValue, BaseUnit);
+        public static ThermalResistance MaxValue { get; } = new ThermalResistance(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of ThermalResistance
         /// </summary>
-        public static ThermalResistance MinValue => new ThermalResistance(double.MinValue, BaseUnit);
+        public static ThermalResistance MinValue { get; } = new ThermalResistance(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.ThermalResistance;
+        public static QuantityType QuantityType { get; } = QuantityType.ThermalResistance;
 
         /// <summary>
         ///     All units of measurement for the ThermalResistance quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit SquareMeterKelvinPerKilowatt.
         /// </summary>
-        public static ThermalResistance Zero => new ThermalResistance(0, BaseUnit);
+        public static ThermalResistance Zero { get; } = new ThermalResistance(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Torque, which is NewtonMeter. All conversions go via this value.
         /// </summary>
-        public static TorqueUnit BaseUnit => TorqueUnit.NewtonMeter;
+        public static TorqueUnit BaseUnit { get; } = TorqueUnit.NewtonMeter;
 
         /// <summary>
         /// Represents the largest possible value of Torque
         /// </summary>
-        public static Torque MaxValue => new Torque(double.MaxValue, BaseUnit);
+        public static Torque MaxValue { get; } = new Torque(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Torque
         /// </summary>
-        public static Torque MinValue => new Torque(double.MinValue, BaseUnit);
+        public static Torque MinValue { get; } = new Torque(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Torque;
+        public static QuantityType QuantityType { get; } = QuantityType.Torque;
 
         /// <summary>
         ///     All units of measurement for the Torque quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit NewtonMeter.
         /// </summary>
-        public static Torque Zero => new Torque(0, BaseUnit);
+        public static Torque Zero { get; } = new Torque(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of VitaminA, which is InternationalUnit. All conversions go via this value.
         /// </summary>
-        public static VitaminAUnit BaseUnit => VitaminAUnit.InternationalUnit;
+        public static VitaminAUnit BaseUnit { get; } = VitaminAUnit.InternationalUnit;
 
         /// <summary>
         /// Represents the largest possible value of VitaminA
         /// </summary>
-        public static VitaminA MaxValue => new VitaminA(double.MaxValue, BaseUnit);
+        public static VitaminA MaxValue { get; } = new VitaminA(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of VitaminA
         /// </summary>
-        public static VitaminA MinValue => new VitaminA(double.MinValue, BaseUnit);
+        public static VitaminA MinValue { get; } = new VitaminA(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.VitaminA;
+        public static QuantityType QuantityType { get; } = QuantityType.VitaminA;
 
         /// <summary>
         ///     All units of measurement for the VitaminA quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit InternationalUnit.
         /// </summary>
-        public static VitaminA Zero => new VitaminA(0, BaseUnit);
+        public static VitaminA Zero { get; } = new VitaminA(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Volume, which is CubicMeter. All conversions go via this value.
         /// </summary>
-        public static VolumeUnit BaseUnit => VolumeUnit.CubicMeter;
+        public static VolumeUnit BaseUnit { get; } = VolumeUnit.CubicMeter;
 
         /// <summary>
         /// Represents the largest possible value of Volume
         /// </summary>
-        public static Volume MaxValue => new Volume(double.MaxValue, BaseUnit);
+        public static Volume MaxValue { get; } = new Volume(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Volume
         /// </summary>
-        public static Volume MinValue => new Volume(double.MinValue, BaseUnit);
+        public static Volume MinValue { get; } = new Volume(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.Volume;
+        public static QuantityType QuantityType { get; } = QuantityType.Volume;
 
         /// <summary>
         ///     All units of measurement for the Volume quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeter.
         /// </summary>
-        public static Volume Zero => new Volume(0, BaseUnit);
+        public static Volume Zero { get; } = new Volume(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
@@ -92,22 +92,22 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of VolumeFlow, which is CubicMeterPerSecond. All conversions go via this value.
         /// </summary>
-        public static VolumeFlowUnit BaseUnit => VolumeFlowUnit.CubicMeterPerSecond;
+        public static VolumeFlowUnit BaseUnit { get; } = VolumeFlowUnit.CubicMeterPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of VolumeFlow
         /// </summary>
-        public static VolumeFlow MaxValue => new VolumeFlow(double.MaxValue, BaseUnit);
+        public static VolumeFlow MaxValue { get; } = new VolumeFlow(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of VolumeFlow
         /// </summary>
-        public static VolumeFlow MinValue => new VolumeFlow(double.MinValue, BaseUnit);
+        public static VolumeFlow MinValue { get; } = new VolumeFlow(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.VolumeFlow;
+        public static QuantityType QuantityType { get; } = QuantityType.VolumeFlow;
 
         /// <summary>
         ///     All units of measurement for the VolumeFlow quantity.
@@ -117,7 +117,7 @@ namespace UnitsNet
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit CubicMeterPerSecond.
         /// </summary>
-        public static VolumeFlow Zero => new VolumeFlow(0, BaseUnit);
+        public static VolumeFlow Zero { get; } = new VolumeFlow(0, BaseUnit);
 
         #endregion
 

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCodeNetFramework.ps1
@@ -279,22 +279,22 @@ function GenerateStaticProperties([GeneratorArgs]$genArgs)
         /// <summary>
         ///     The base unit of $quantityName, which is $baseUnitSingularName. All conversions go via this value.
         /// </summary>
-        public static $unitEnumName BaseUnit => $unitEnumName.$baseUnitSingularName;
+        public static $unitEnumName BaseUnit { get; } = $unitEnumName.$baseUnitSingularName;
 
         /// <summary>
         /// Represents the largest possible value of $quantityName
         /// </summary>
-        public static $quantityName MaxValue => new $quantityName($valueType.MaxValue, BaseUnit);
+        public static $quantityName MaxValue { get; } = new $quantityName($valueType.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of $quantityName
         /// </summary>
-        public static $quantityName MinValue => new $quantityName($valueType.MinValue, BaseUnit);
+        public static $quantityName MinValue { get; } = new $quantityName($valueType.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
-        public static QuantityType QuantityType => QuantityType.$quantityName;
+        public static QuantityType QuantityType { get; } = QuantityType.$quantityName;
 
         /// <summary>
         ///     All units of measurement for the $quantityName quantity.
@@ -304,7 +304,7 @@ function GenerateStaticProperties([GeneratorArgs]$genArgs)
         /// <summary>
         ///     Gets an instance of this quantity with a value of 0 in the base unit $baseUnitSingularName.
         /// </summary>
-        public static $quantityName Zero => new $quantityName(0, BaseUnit);
+        public static $quantityName Zero { get; } = new $quantityName(0, BaseUnit);
 
         #endregion
 "@;


### PR DESCRIPTION
Static properties should be read-only properties with inline initialization rather than lambdas.

For example, using a lambda for the Zero property would create a new Acceleration(0, BaseUnit) every time it's called, rather than just initializing it once.

A quick test of calling these properties 100,000,000 times showed the lambdas were roughly 10x slower. Not a huge deal but, thought I'd fix it 😃  