### PR TITLE
Use formatprovider in StonePounds.ToString()

### DIFF
--- a/UnitsNet.Tests/CustomCode/StonePoundsTests.cs
+++ b/UnitsNet.Tests/CustomCode/StonePoundsTests.cs
@@ -1,16 +1,16 @@
 ﻿// Copyright (c) 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).
 // https://github.com/angularsen/UnitsNet
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -19,6 +19,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using System.Globalization;
 using Xunit;
 
 namespace UnitsNet.Tests.CustomCode
@@ -45,6 +46,29 @@ namespace UnitsNet.Tests.CustomCode
             StonePounds stonePounds = m.StonePounds;
             AssertEx.EqualTolerance(2, stonePounds.Stone, StoneTolerance);
             AssertEx.EqualTolerance(3, stonePounds.Pounds, PoundsTolerance);
+        }
+
+        [Fact]
+        public void StonePoundsToString_FormatsNumberInDefaultCulture()
+        {
+            Mass m = Mass.FromStonePounds(3500, 1);
+            StonePounds stonePounds = m.StonePounds;
+            string numberInCurrentCulture =  3500.ToString("n0", GlobalConfiguration.DefaultCulture); // Varies between machines, can't hard code it
+
+            Assert.Equal($"{numberInCurrentCulture} st 1 lb", stonePounds.ToString());
+        }
+
+        // These cultures use a thin space in digit grouping
+        [Theory]
+        [InlineData("nn-NO")]
+        [InlineData("fr-FR")]
+        public void StonePoundsToString_GivenCultureWithThinSpaceDigitGroup_ReturnsNumberWithThinSpaceDigitGroup(string cultureName)
+        {
+            var formatProvider = new CultureInfo(cultureName);
+            Mass m = Mass.FromStonePounds(3500, 1);
+            StonePounds stonePounds = m.StonePounds;
+
+            Assert.Equal("3 500 st 1 lb", stonePounds.ToString(formatProvider));
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -193,8 +193,8 @@ namespace UnitsNet
         {
             cultureInfo = cultureInfo ?? GlobalConfiguration.DefaultCulture;
 
-            var footUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Foot);
-            var inchUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Inch);
+            var footUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Foot, cultureInfo);
+            var inchUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Inch, cultureInfo);
 
             // Note that it isn't customary to use fractions - one wouldn't say "I am 5 feet and 4.5 inches".
             // So inches are rounded when converting from base units to feet/inches.

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -191,13 +191,14 @@ namespace UnitsNet
 
         public string ToString([CanBeNull] IFormatProvider cultureInfo)
         {
-            // Note that it isn't customary to use fractions - one wouldn't say "I am 5 feet and 4.5 inches".
-            // So inches are rounded when converting from base units to feet/inches.
+            cultureInfo = cultureInfo ?? GlobalConfiguration.DefaultCulture;
+
             var footUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Foot);
             var inchUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Inch);
 
-            return string.Format(GlobalConfiguration.DefaultCulture, "{0:n0} {1} {2:n0} {3}", Feet, footUnit, Math.Round(Inches),
-                inchUnit);
+            // Note that it isn't customary to use fractions - one wouldn't say "I am 5 feet and 4.5 inches".
+            // So inches are rounded when converting from base units to feet/inches.
+            return string.Format(cultureInfo, "{0:n0} {1} {2:n0} {3}", Feet, footUnit, Math.Round(Inches), inchUnit);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Mass.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Mass.extra.cs
@@ -111,15 +111,14 @@ namespace UnitsNet
 
         public string ToString([CanBeNull] IFormatProvider cultureInfo)
         {
-            // Note that it isn't customary to use fractions - one wouldn't say "I am 11 stone and 4.5 pounds".
-            // So pounds are rounded here.
-
             cultureInfo = cultureInfo ?? GlobalConfiguration.DefaultCulture;
+
             var stoneUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Stone, cultureInfo);
             var poundUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Pound, cultureInfo);
 
-            return string.Format(cultureInfo, "{0:n0} {1} {2:n0} {3}",
-                Stone, stoneUnit, Math.Round(Pounds), poundUnit);
+            // Note that it isn't customary to use fractions - one wouldn't say "I am 11 stone and 4.5 pounds".
+            // So pounds are rounded here.
+            return string.Format(cultureInfo, "{0:n0} {1} {2:n0} {3}", Stone, stoneUnit, Math.Round(Pounds), poundUnit);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Mass.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Mass.extra.cs
@@ -114,10 +114,11 @@ namespace UnitsNet
             // Note that it isn't customary to use fractions - one wouldn't say "I am 11 stone and 4.5 pounds".
             // So pounds are rounded here.
 
-            var stoneUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Stone);
-            var poundUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Pound);
+            cultureInfo = cultureInfo ?? GlobalConfiguration.DefaultCulture;
+            var stoneUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Stone, cultureInfo);
+            var poundUnit = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Pound, cultureInfo);
 
-            return string.Format(GlobalConfiguration.DefaultCulture, "{0:n0} {1} {2:n0} {3}",
+            return string.Format(cultureInfo, "{0:n0} {1} {2:n0} {3}",
                 Stone, stoneUnit, Math.Round(Pounds), poundUnit);
         }
     }


### PR DESCRIPTION
Stumbled upon this when refactoring WRC. Culture param was never used.