### PR TITLE
Add IQuantity.Value

### DIFF
--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -134,7 +134,7 @@ namespace UnitsNet
         /// </summary>
         public decimal Value => _value;
 
-        double IQuantity.Value => (double)_value;
+        double IQuantity.Value => (double) _value;
 
         /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -134,6 +134,8 @@ namespace UnitsNet
         /// </summary>
         public decimal Value => _value;
 
+        double IQuantity.Value => (double)_value;
+
         /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -131,6 +131,8 @@ namespace UnitsNet
         /// </summary>
         public decimal Value => _value;
 
+        double IQuantity.Value => (double)_value;
+
         /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -131,7 +131,7 @@ namespace UnitsNet
         /// </summary>
         public decimal Value => _value;
 
-        double IQuantity.Value => (double)_value;
+        double IQuantity.Value => (double) _value;
 
         /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;

--- a/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
@@ -131,6 +131,8 @@ namespace UnitsNet
         /// </summary>
         public decimal Value => _value;
 
+        double IQuantity.Value => (double) _value;
+
         /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -58,6 +58,9 @@ namespace UnitsNet
         /// </summary>
         Enum Unit { get; }
 
+        /// <summary>
+        ///     The value this quantity was constructed with. Should be seen in combination with <see cref="Unit"/>.
+        /// </summary>
         double Value { get; }
 
         /// <summary>

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -28,7 +28,7 @@ namespace UnitsNet
     /// <summary>
     ///     Represents a quantity.
     /// </summary>
-    public partial interface IQuantity
+    public interface IQuantity
     {
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
@@ -57,6 +57,8 @@ namespace UnitsNet
         ///     The unit this quantity was constructed with or the BaseUnit if the default constructor was used.
         /// </summary>
         Enum Unit { get; }
+
+        double Value { get; }
 
         /// <summary>
         ///     Change the default unit representation of the quantity, which affects things like <see cref="IQuantity.ToString(System.IFormatProvider)"/>.

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -348,8 +348,8 @@ function GenerateProperties([GeneratorArgs]$genArgs)
 {
   $quantityName = $genArgs.Quantity.Name
   $unitEnumName = $genArgs.UnitEnumName
-  $baseUnitSingularName = $genArgs.BaseUnit.SingularName
   $valueType = $genArgs.Quantity.BaseType
+  [bool]$isDoubleValueType = $valueType -eq "double"
 @"
 
         #region Properties
@@ -359,6 +359,10 @@ function GenerateProperties([GeneratorArgs]$genArgs)
         /// </summary>
         public $valueType Value => _value;
 
+"@; if (-not $isDoubleValueType) { @"
+        double IQuantity.Value => (double) _value;
+
+"@; } @"
         /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 


### PR DESCRIPTION
Using value type double since that is the standard conversion property getters, until we add support for different value types. Those handful few quantities that use decimal internally for precision reasons explicitly implement the interface with a cast to double.