### PR TITLE
Fix msbuild warnings, re-enable and treat all as errors

### DIFF
--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Serialization.JsonNet.CompatibilityTests</RootNamespace>
     <LangVersion>7.3</LangVersion>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Serialization.JsonNet.Tests</RootNamespace>
     <LangVersion>7.3</LangVersion>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -22,6 +22,7 @@
     <LangVersion>7.3</LangVersion>
     <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- SourceLink -->

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -20,7 +20,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion> <!-- Should reflect major part of Version -->
     <LangVersion>7.3</LangVersion>
-    <NoWarn>CS1701;CS1702;CS1705;CS0618</NoWarn>
     <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>

--- a/UnitsNet.Tests/CustomCode/MolarityTests.cs
+++ b/UnitsNet.Tests/CustomCode/MolarityTests.cs
@@ -42,7 +42,7 @@ namespace UnitsNet.Tests.CustomCode
         {
             var density = Density.FromKilogramsPerCubicMeter(60.02);
             var mw = Mass.FromGrams(58.443);
-            var molarity = Molarity.FromDensity(density, mw).MolesPerCubicMeter;
+            var molarity = (density / mw).MolesPerCubicMeter;
             AssertEx.EqualTolerance(1026.98355, molarity, MolesPerCubicMeterTolerance);
         }
 

--- a/UnitsNet.Tests/QuantityInfoTest.cs
+++ b/UnitsNet.Tests/QuantityInfoTest.cs
@@ -24,9 +24,12 @@ namespace UnitsNet.Tests
 
             Assert.Equal(expectedZero, info.Zero);
             Assert.Equal("Length", info.Name);
+            // Obsolete members
+#pragma warning disable 618
             Assert.Equal(expectedUnits, info.Units);
             Assert.Equal(expectedBaseUnit, info.BaseUnit);
             Assert.Equal(new[]{"Centimeter", "Kilometer"}, info.UnitNames);
+#pragma warning restore 618
             Assert.Equal(expectedQuantityType, info.QuantityType);
             Assert.Equal(expectedBaseDimensions, info.BaseDimensions);
         }
@@ -44,9 +47,12 @@ namespace UnitsNet.Tests
 
             Assert.Equal(expectedZero, info.Zero);
             Assert.Equal("Length", info.Name);
+            // Obsolete members
+#pragma warning disable 618
             Assert.Equal(expectedUnits, info.Units);
             Assert.Equal(expectedBaseUnit, info.BaseUnit);
             Assert.Equal(new[]{"Centimeter", "Kilometer"}, info.UnitNames);
+#pragma warning restore 618
             Assert.Equal(expectedQuantityType, info.QuantityType);
             Assert.Equal(expectedBaseDimensions, info.BaseDimensions);
         }

--- a/UnitsNet.Tests/QuantityTest.cs
+++ b/UnitsNet.Tests/QuantityTest.cs
@@ -52,10 +52,13 @@ namespace UnitsNet.Tests
 
             Assert.Equal("Length", quantityInfo.Name);
             Assert.Equal(QuantityType.Length, quantityInfo.QuantityType);
+            // Obsolete members
+#pragma warning disable 618
             Assert.Superset(knownLengthUnitNames.ToHashSet(), quantityInfo.UnitNames.ToHashSet());
             Assert.Superset(knownLengthUnits.ToHashSet(), quantityInfo.Units.ToHashSet());
             Assert.Equal(lengthUnitCount, quantityInfo.UnitNames.Length);
             Assert.Equal(lengthUnitCount, quantityInfo.Units.Length);
+#pragma warning restore 618
             Assert.Equal(typeof(LengthUnit), quantityInfo.UnitType);
             Assert.Equal(typeof(Length), quantityInfo.ValueType);
             Assert.Equal(Length.Zero, quantityInfo.Zero);
@@ -72,10 +75,13 @@ namespace UnitsNet.Tests
 
             Assert.Equal("Mass", quantityInfo.Name);
             Assert.Equal(QuantityType.Mass, quantityInfo.QuantityType);
+            // Obsolete members
+#pragma warning disable 618
             Assert.Superset(knownMassUnitNames.ToHashSet(), quantityInfo.UnitNames.ToHashSet());
             Assert.Superset(knownMassUnits.ToHashSet(), quantityInfo.Units.ToHashSet());
             Assert.Equal(massUnitCount, quantityInfo.UnitNames.Length);
             Assert.Equal(massUnitCount, quantityInfo.Units.Length);
+#pragma warning restore 618
             Assert.Equal(typeof(MassUnit), quantityInfo.UnitType);
             Assert.Equal(typeof(Mass), quantityInfo.ValueType);
             Assert.Equal(Mass.Zero, quantityInfo.Zero);

--- a/UnitsNet.Tests/QuantityTests.cs
+++ b/UnitsNet.Tests/QuantityTests.cs
@@ -40,13 +40,16 @@ namespace UnitsNet.Tests
         {
             Assert.Equal(Length.Zero, quantityInfo.Zero);
             Assert.Equal("Length", quantityInfo.Name);
-
-            var lengthUnits = EnumUtils.GetEnumValues<LengthUnit>().Except(new[] {LengthUnit.Undefined}).ToArray();
-            Assert.Equal(lengthUnits, quantityInfo.Units);
             Assert.Equal(QuantityType.Length, quantityInfo.QuantityType);
 
+            var lengthUnits = EnumUtils.GetEnumValues<LengthUnit>().Except(new[] {LengthUnit.Undefined}).ToArray();
             var lengthUnitNames = lengthUnits.Select(x => x.ToString());
+
+            // Obsolete members
+#pragma warning disable 618
+            Assert.Equal(lengthUnits, quantityInfo.Units);
             Assert.Equal(lengthUnitNames, quantityInfo.UnitNames);
+#pragma warning restore 618
         }
     }
 }

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Tests</RootNamespace>
-    <NoWarn>CS1701;CS1702;CS1705;CS0618</NoWarn>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Tests</RootNamespace>
     <LangVersion>7.3</LangVersion>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.csproj
+++ b/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.csproj
@@ -18,7 +18,6 @@
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <AllowCrossPlatformRetargeting>false</AllowCrossPlatformRetargeting>
     <OutputPath>..\Artifacts\UnitsNet.WindowsRuntimeComponent</OutputPath>
-    <NoWarn>CS1701;CS1702;CS1705;CS0618;CS0809;CS1591</NoWarn>
     <LangVersion>7.3</LangVersion>
 
     <!-- SourceLink -->

--- a/UnitsNet.sln.DotSettings
+++ b/UnitsNet.sln.DotSettings
@@ -16,4 +16,5 @@
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
-	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Gullberg/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/UnitsNet/BaseUnits.cs
+++ b/UnitsNet/BaseUnits.cs
@@ -7,13 +7,12 @@ using UnitsNet.Units;
 
 namespace UnitsNet
 {
-    public sealed partial class BaseUnits : IEquatable<BaseUnits> { }
-
+    /// <inheritdoc />
     /// <summary>
     ///     Represents the base units for a quantity. All quantities, both base and derived, can be
     ///     represented by a combination of these seven base units.
     /// </summary>
-    public sealed partial class BaseUnits
+    public sealed class BaseUnits: IEquatable<BaseUnits>
     {
         /// <summary>
         /// Creates an instance of if the base units class that represents the base units for a quantity.

--- a/UnitsNet/CustomCode/GlobalConfiguration.cs
+++ b/UnitsNet/CustomCode/GlobalConfiguration.cs
@@ -7,7 +7,11 @@ using System.Globalization;
 // ReSharper disable once CheckNamespace
 namespace UnitsNet
 {
-    public sealed class GlobalConfiguration
+    /// <summary>
+    ///     Global configuration for culture, used as default culture in methods like <see cref="Length.ToString()" /> and
+    ///     <see cref="Length.Parse(string)" />.
+    /// </summary>
+    public static class GlobalConfiguration
     {
         /// <summary>
         ///     Defaults to <see cref="CultureInfo.CurrentUICulture" /> when creating an instance with no culture provided.

--- a/UnitsNet/CustomCode/Quantities/Angle.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Angle.extra.cs
@@ -7,11 +7,13 @@ namespace UnitsNet
 {
     public partial struct Angle
     {
+        /// <summary>Get <see cref="RotationalSpeed"/> from <see cref="Angle"/> delta over time delta.</summary>
         public static RotationalSpeed operator /(Angle angle, TimeSpan timeSpan)
         {
             return RotationalSpeed.FromRadiansPerSecond(angle.Radians / timeSpan.TotalSeconds);
         }
 
+        /// <inheritdoc cref="op_Division(UnitsNet.Angle,System.TimeSpan)" />
         public static RotationalSpeed operator /(Angle angle, Duration duration)
         {
             return RotationalSpeed.FromRadiansPerSecond(angle.Radians / duration.Seconds);

--- a/UnitsNet/CustomCode/Quantities/Area.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Area.extra.cs
@@ -9,12 +9,14 @@ namespace UnitsNet
     {
         #region Static Methods
 
+        /// <summary>Get circle area from a diameter.</summary>
         public static Area FromCircleDiameter(Length diameter)
         {
             var radius = Length.FromMeters(diameter.Meters / 2d);
             return FromCircleRadius(radius);
         }
 
+        /// <summary>Get circle area from a radius.</summary>
         public static Area FromCircleRadius(Length radius)
         {
             return FromSquareMeters(Math.PI * radius.Meters * radius.Meters);
@@ -22,16 +24,19 @@ namespace UnitsNet
 
         #endregion
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Area"/> divided by <see cref="Length"/>.</summary>
         public static Length operator /(Area area, Length length)
         {
             return Length.FromMeters(area.SquareMeters / length.Meters);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="Area"/> times <see cref="MassFlux"/>.</summary>
         public static MassFlow operator *(Area area, MassFlux massFlux)
         {
             return MassFlow.FromGramsPerSecond(area.SquareMeters * massFlux.GramsPerSecondPerSquareMeter);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from <see cref="Area"/> times <see cref="Speed"/>.</summary>
         public static VolumeFlow operator *(Area area, Speed speed)
         {
             return VolumeFlow.FromCubicMetersPerSecond(area.SquareMeters * speed.MetersPerSecond);

--- a/UnitsNet/CustomCode/Quantities/BrakeSpecificFuelConsumption.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/BrakeSpecificFuelConsumption.extra.cs
@@ -5,16 +5,19 @@ namespace UnitsNet
 {
     public partial struct BrakeSpecificFuelConsumption
     {
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="BrakeSpecificFuelConsumption"/> times <see cref="Power"/>.</summary>
         public static MassFlow operator *(BrakeSpecificFuelConsumption bsfc, Power power)
         {
             return MassFlow.FromKilogramsPerSecond(bsfc.KilogramsPerJoule*power.Watts);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from <paramref name="value"/> divided by <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static SpecificEnergy operator /(double value, BrakeSpecificFuelConsumption bsfc)
         {
             return SpecificEnergy.FromJoulesPerKilogram(value/bsfc.KilogramsPerJoule);
         }
 
+        /// <summary>Get constant from <see cref="BrakeSpecificFuelConsumption"/> times <see cref="SpecificEnergy"/>.</summary>
         public static double operator *(BrakeSpecificFuelConsumption bsfc, SpecificEnergy specificEnergy)
         {
             return specificEnergy.JoulesPerKilogram*bsfc.KilogramsPerJoule;

--- a/UnitsNet/CustomCode/Quantities/Density.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Density.extra.cs
@@ -21,8 +21,6 @@ namespace UnitsNet
         /// <summary>
         ///     Get <see cref="Density" /> from <see cref="Molarity" />.
         /// </summary>
-        /// <param name="molarity"></param>
-        /// <param name="molecularWeight"></param>
         public static Density FromMolarity(Molarity molarity, Mass molecularWeight)
         {
             return new Density(molarity.MolesPerCubicMeter * molecularWeight.Kilograms, DensityUnit.KilogramPerCubicMeter);
@@ -30,29 +28,40 @@ namespace UnitsNet
 
         #endregion
 
+        /// <summary>Get <see cref="Mass"/> from <see cref="Density"/> times <see cref="Volume"/>.</summary>
         public static Mass operator *(Density density, Volume volume)
         {
             return Mass.FromKilograms(density.KilogramsPerCubicMeter * volume.CubicMeters);
         }
 
+        /// <summary>Get <see cref="Mass"/> from <see cref="Volume"/> times <see cref="Density"/>.</summary>
         public static Mass operator *(Volume volume, Density density)
         {
             return Mass.FromKilograms(density.KilogramsPerCubicMeter * volume.CubicMeters);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from <see cref="Density"/> times <see cref="KinematicViscosity"/>.</summary>
         public static DynamicViscosity operator *(Density density, KinematicViscosity kinematicViscosity)
         {
             return DynamicViscosity.FromNewtonSecondsPerMeterSquared(kinematicViscosity.SquareMetersPerSecond * density.KilogramsPerCubicMeter);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> <see cref="Density"/> times <see cref="Speed"/>.</summary>
         public static MassFlux operator *(Density density, Speed speed)
         {
             return MassFlux.FromKilogramsPerSecondPerSquareMeter(density.KilogramsPerCubicMeter * speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from <see cref="Density"/> times <see cref="Acceleration"/>.</summary>
         public static SpecificWeight operator *(Density density, Acceleration acceleration)
         {
             return new SpecificWeight(density.KilogramsPerCubicMeter * acceleration.MetersPerSecondSquared, SpecificWeightUnit.NewtonPerCubicMeter);
+        }
+
+        /// <summary>Get <see cref="Molarity"/> from <see cref="Density"/> divided by <see cref="Mass"/>.</summary>
+        public static Molarity operator /(Density density, Mass molecularWeight)
+        {
+            return new Molarity(density.KilogramsPerCubicMeter / molecularWeight.Kilograms, MolarityUnit.MolesPerCubicMeter);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Duration.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Duration.extra.cs
@@ -20,66 +20,79 @@ namespace UnitsNet
             return TimeSpan.FromSeconds( Seconds );
         }
 
+        /// <summary>Get <see cref="DateTime"/> from <see cref="DateTime"/> plus <see cref="Duration"/>.</summary>
         public static DateTime operator +(DateTime time, Duration duration)
         {
             return time.AddSeconds(duration.Seconds);
         }
 
+        /// <summary>Get <see cref="DateTime"/> from <see cref="DateTime"/> minus <see cref="Duration"/>.</summary>
         public static DateTime operator -(DateTime time, Duration duration)
         {
             return time.AddSeconds(-duration.Seconds);
         }
 
+        /// <summary>Explicitly cast <see cref="Duration"/> to <see cref="TimeSpan"/>.</summary>
         public static explicit operator TimeSpan(Duration duration)
         {
             return duration.ToTimeSpan();
         }
 
+        /// <summary>Explicitly cast <see cref="TimeSpan"/> to <see cref="Duration"/>.</summary>
         public static explicit operator Duration(TimeSpan duration)
         {
             return FromSeconds(duration.TotalSeconds);
         }
 
+        /// <summary>True if <see cref="Duration"/> is less than <see cref="TimeSpan"/>.</summary>
         public static bool operator <(Duration duration, TimeSpan timeSpan)
         {
             return duration.Seconds < timeSpan.TotalSeconds;
         }
 
+        /// <summary>True if <see cref="Duration"/> is greater than <see cref="TimeSpan"/>.</summary>
         public static bool operator >(Duration duration, TimeSpan timeSpan)
         {
             return duration.Seconds > timeSpan.TotalSeconds;
         }
 
+        /// <summary>True if <see cref="Duration"/> is less than or equal to <see cref="TimeSpan"/>.</summary>
         public static bool operator <=(Duration duration, TimeSpan timeSpan)
         {
             return duration.Seconds <= timeSpan.TotalSeconds;
         }
 
+        /// <summary>True if <see cref="Duration"/> is greater than or equal to <see cref="TimeSpan"/>.</summary>
         public static bool operator >=(Duration duration, TimeSpan timeSpan)
         {
             return duration.Seconds >= timeSpan.TotalSeconds;
         }
 
+        /// <summary>True if <see cref="TimeSpan"/> is less than <see cref="Duration"/>.</summary>
         public static bool operator <(TimeSpan timeSpan, Duration duration)
         {
             return timeSpan.TotalSeconds < duration.Seconds;
         }
 
+        /// <summary>True if <see cref="TimeSpan"/> is greater than <see cref="Duration"/>.</summary>
         public static bool operator >(TimeSpan timeSpan, Duration duration)
         {
             return timeSpan.TotalSeconds > duration.Seconds;
         }
 
+        /// <summary>True if <see cref="TimeSpan"/> is less than or equal to <see cref="Duration"/>.</summary>
         public static bool operator <=(TimeSpan timeSpan, Duration duration)
         {
             return timeSpan.TotalSeconds <= duration.Seconds;
         }
 
+        /// <summary>True if <see cref="TimeSpan"/> is greater than or equal to <see cref="Duration"/>.</summary>
         public static bool operator >=(TimeSpan timeSpan, Duration duration)
         {
             return timeSpan.TotalSeconds >= duration.Seconds;
         }
 
+        /// <summary>Get <see cref="Volume"/> from <see cref="Duration"/> times <see cref="VolumeFlow"/>.</summary>
         public static Volume operator *(Duration duration, VolumeFlow volumeFlow)
         {
             return Volume.FromCubicMeters(volumeFlow.CubicMetersPerSecond * duration.Seconds);

--- a/UnitsNet/CustomCode/Quantities/DynamicViscosity.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/DynamicViscosity.extra.cs
@@ -5,6 +5,7 @@ namespace UnitsNet
 {
     public partial struct DynamicViscosity
     {
+        /// <summary>Get <see cref="KinematicViscosity"/> from <see cref="DynamicViscosity"/> divided by <see cref="Density"/>.</summary>
         public static KinematicViscosity operator /(DynamicViscosity dynamicViscosity, Density density)
         {
             return KinematicViscosity.FromSquareMetersPerSecond(dynamicViscosity.NewtonSecondsPerMeterSquared / density.KilogramsPerCubicMeter);

--- a/UnitsNet/CustomCode/Quantities/Force.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Force.extra.cs
@@ -7,42 +7,50 @@ namespace UnitsNet
 {
     public partial struct Force
     {
+        /// <summary>Get <see cref="Force"/> from <see cref="Pressure"/> divided by <see cref="Area"/>.</summary>
         public static Force FromPressureByArea(Pressure p, Area area)
         {
             double newtons = p.Pascals * area.SquareMeters;
             return new Force(newtons, ForceUnit.Newton);
         }
 
+        /// <summary>Get <see cref="Force"/> from <see cref="Mass"/> times <see cref="Acceleration"/>.</summary>
         public static Force FromMassByAcceleration(Mass mass, Acceleration acceleration)
         {
             return new Force(mass.Kilograms * acceleration.MetersPerSecondSquared, ForceUnit.Newton);
         }
 
+        /// <summary>Get <see cref="Power"/> from <see cref="Force"/> times <see cref="Speed"/>.</summary>
         public static Power operator *(Force force, Speed speed)
         {
             return Power.FromWatts(force.Newtons * speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="Power"/> from <see cref="Speed"/> times <see cref="Force"/>.</summary>
         public static Power operator *(Speed speed, Force force)
         {
             return Power.FromWatts(force.Newtons * speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from <see cref="Force"/> divided by <see cref="Mass"/>.</summary>
         public static Acceleration operator /(Force force, Mass mass)
         {
             return Acceleration.FromMetersPerSecondSquared(force.Newtons / mass.Kilograms);
         }
 
-        public static Mass operator /(Force force, Acceleration mass)
+        /// <summary>Get <see cref="Mass"/> from <see cref="Force"/> divided by <see cref="Acceleration"/>.</summary>
+        public static Mass operator /(Force force, Acceleration acceleration)
         {
-            return Mass.FromKilograms(force.Newtons / mass.MetersPerSecondSquared);
+            return Mass.FromKilograms(force.Newtons / acceleration.MetersPerSecondSquared);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from <see cref="Force"/> divided by <see cref="Area"/>.</summary>
         public static Pressure operator /(Force force, Area area)
         {
             return Pressure.FromPascals(force.Newtons / area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="ForcePerLength"/> from <see cref="Force"/> divided by <see cref="Length"/>.</summary>
         public static ForcePerLength operator /(Force force, Length length)
         {
             return ForcePerLength.FromNewtonsPerMeter(force.Newtons / length.Meters);

--- a/UnitsNet/CustomCode/Quantities/ForcePerLength.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/ForcePerLength.extra.cs
@@ -5,16 +5,19 @@ namespace UnitsNet
 {
     public partial struct ForcePerLength
     {
+        /// <summary>Get <see cref="Force"/> from <see cref="ForcePerLength"/> divided by <see cref="Length"/>.</summary>
         public static Force operator *(ForcePerLength forcePerLength, Length length)
         {
             return Force.FromNewtons(forcePerLength.NewtonsPerMeter * length.Meters);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Force"/> divided by <see cref="ForcePerLength"/>.</summary>
         public static Length operator /(Force force, ForcePerLength forcePerLength)
         {
             return Length.FromMeters(force.Newtons / forcePerLength.NewtonsPerMeter);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from <see cref="ForcePerLength"/> divided by <see cref="Length"/>.</summary>
         public static Pressure operator /(ForcePerLength forcePerLength, Length length)
         {
             return Pressure.FromNewtonsPerSquareMeter(forcePerLength.NewtonsPerMeter / length.Meters);

--- a/UnitsNet/CustomCode/Quantities/HeatFlux.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/HeatFlux.extra.cs
@@ -5,6 +5,7 @@ namespace UnitsNet
 {
     public partial struct HeatFlux
     {
+        /// <summary>Get <see cref="Power"/> from <see cref="HeatFlux"/> times <see cref="Area"/>.</summary>
         public static Power operator *(HeatFlux heatFlux, Area area)
         {
             return Power.FromWatts(heatFlux.WattsPerSquareMeter * area.SquareMeters);

--- a/UnitsNet/CustomCode/Quantities/KinematicViscosity.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/KinematicViscosity.extra.cs
@@ -7,31 +7,37 @@ namespace UnitsNet
 {
     public partial struct KinematicViscosity
     {
+        /// <summary>Get <see cref="Speed"/> from <see cref="KinematicViscosity"/> divided by <see cref="Length"/>.</summary>
         public static Speed operator /(KinematicViscosity kinematicViscosity, Length length)
         {
             return Speed.FromMetersPerSecond(kinematicViscosity.SquareMetersPerSecond / length.Meters);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="KinematicViscosity"/> times <see cref="TimeSpan"/>.</summary>
         public static Area operator *(KinematicViscosity kinematicViscosity, TimeSpan timeSpan)
         {
             return Area.FromSquareMeters(kinematicViscosity.SquareMetersPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="TimeSpan"/> times <see cref="KinematicViscosity"/>.</summary>
         public static Area operator *(TimeSpan timeSpan, KinematicViscosity kinematicViscosity)
         {
             return Area.FromSquareMeters(kinematicViscosity.SquareMetersPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="KinematicViscosity"/> times <see cref="Duration"/>.</summary>
         public static Area operator *(KinematicViscosity kinematicViscosity, Duration duration)
         {
             return Area.FromSquareMeters(kinematicViscosity.SquareMetersPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="Duration"/> times <see cref="KinematicViscosity"/>.</summary>
         public static Area operator *(Duration duration, KinematicViscosity kinematicViscosity)
         {
             return Area.FromSquareMeters(kinematicViscosity.SquareMetersPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from <see cref="KinematicViscosity"/> times <see cref="Density"/>.</summary>
         public static DynamicViscosity operator *(KinematicViscosity kinematicViscosity, Density density)
         {
             return DynamicViscosity.FromNewtonSecondsPerMeterSquared(kinematicViscosity.SquareMetersPerSecond * density.KilogramsPerCubicMeter);

--- a/UnitsNet/CustomCode/Quantities/LapseRate.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/LapseRate.extra.cs
@@ -5,13 +5,16 @@ namespace UnitsNet
 {
     public partial struct LapseRate
     {
+        /// <summary>Get <see cref="Length"/> from <see cref="TemperatureDelta"/> divided by <see cref="LapseRate"/>.</summary>
         public static Length operator /(TemperatureDelta left, LapseRate right)
         {
             return Length.FromKilometers(left.Kelvins / right.DegreesCelciusPerKilometer);
         }
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from <see cref="Length"/> times <see cref="LapseRate"/>.</summary>
         public static TemperatureDelta operator *(Length left, LapseRate right) => right * left;
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from <see cref="LapseRate"/> times <see cref="Length"/>.</summary>
         public static TemperatureDelta operator *(LapseRate left, Length right)
         {
             return TemperatureDelta.FromDegreesCelsius(left.DegreesCelciusPerKilometer * right.Kilometers);

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Text.RegularExpressions;
+using System.Threading;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -104,73 +105,106 @@ namespace UnitsNet
             return false;
         }
 
+        /// <summary>Get <see cref="Speed"/> from <see cref="Length"/> divided by <see cref="TimeSpan"/>.</summary>
         public static Speed operator /(Length length, TimeSpan timeSpan)
         {
             return Speed.FromMetersPerSecond(length.Meters/timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Speed"/> from <see cref="Length"/> divided by <see cref="Duration"/>.</summary>
         public static Speed operator /(Length length, Duration duration)
         {
             return Speed.FromMetersPerSecond(length.Meters/duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Duration"/> from <see cref="Length"/> divided by <see cref="Speed"/>.</summary>
         public static Duration operator /(Length length, Speed speed)
         {
             return Duration.FromSeconds(length.Meters/speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="Length"/> times <see cref="Length"/>.</summary>
         public static Area operator *(Length length1, Length length2)
         {
             return Area.FromSquareMeters(length1.Meters*length2.Meters);
         }
 
+        /// <summary>Get <see cref="Volume"/> from <see cref="Area"/> times <see cref="Length"/>.</summary>
         public static Volume operator *(Area area, Length length)
         {
             return Volume.FromCubicMeters(area.SquareMeters*length.Meters);
         }
 
+        /// <summary>Get <see cref="Volume"/> from <see cref="Length"/> times <see cref="Area"/>.</summary>
         public static Volume operator *(Length length, Area area)
         {
             return Volume.FromCubicMeters(area.SquareMeters*length.Meters);
         }
 
+        /// <summary>Get <see cref="Torque"/> from <see cref="Force"/> times <see cref="Length"/>.</summary>
         public static Torque operator *(Force force, Length length)
         {
             return Torque.FromNewtonMeters(force.Newtons*length.Meters);
         }
 
+        /// <summary>Get <see cref="Torque"/> from <see cref="Length"/> times <see cref="Force"/>.</summary>
         public static Torque operator *(Length length, Force force)
         {
             return Torque.FromNewtonMeters(force.Newtons*length.Meters);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from <see cref="Length"/> times <see cref="Speed"/>.</summary>
         public static KinematicViscosity operator *(Length length, Speed speed)
         {
             return KinematicViscosity.FromSquareMetersPerSecond(length.Meters*speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from <see cref="Length"/> times <see cref="SpecificWeight"/>.</summary>
         public static Pressure operator *(Length length, SpecificWeight specificWeight)
         {
             return new Pressure(length.Meters * specificWeight.NewtonsPerCubicMeter, PressureUnit.Pascal);
         }
     }
 
+    /// <summary>
+    ///     Representation of feet and inches, used to preserve the original values when constructing <see cref="Length"/> by
+    ///     <see cref="Length.FromFeetInches"/> and later output them unaltered with <see cref="ToString()"/>.
+    /// </summary>
     public sealed class FeetInches
     {
+        /// <summary>
+        ///     Construct from feet and inches.
+        /// </summary>
         public FeetInches(double feet, double inches)
         {
             Feet = feet;
             Inches = inches;
         }
 
+        /// <summary>
+        ///     The feet value it was constructed with.
+        /// </summary>
         public double Feet { get; }
+
+        /// <summary>
+        ///     The inches value it was constructed with.
+        /// </summary>
         public double Inches { get; }
 
+        /// <inheritdoc cref="ToString(IFormatProvider)"/>
         public override string ToString()
         {
             return ToString(null);
         }
 
+        /// <summary>
+        ///     Outputs feet and inches on the format: {feetValue} {feetUnit} {inchesValue} {inchesUnit}
+        /// </summary>
+        /// <example>Length.FromFeetInches(3,2).FeetInches.ToString() outputs: "3 ft 2 in"</example>
+        /// <param name="cultureInfo">
+        ///     Optional culture to format number and localize unit abbreviations.
+        ///     If null, defaults to <see cref="Thread.CurrentUICulture"/>.
+        /// </param>
         public string ToString([CanBeNull] IFormatProvider cultureInfo)
         {
             cultureInfo = cultureInfo ?? GlobalConfiguration.DefaultCulture;

--- a/UnitsNet/CustomCode/Quantities/Mass.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Mass.extra.cs
@@ -2,6 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using System.Threading;
 using JetBrains.Annotations;
 using UnitsNet.Units;
 
@@ -9,6 +10,7 @@ namespace UnitsNet
 {
     public partial struct Mass
     {
+        /// <summary>Get <see cref="Mass"/> from <see cref="Force"/> of gravity.</summary>
         public static Mass FromGravitationalForce(Force f)
         {
             return new Mass(f.KilogramsForce, MassUnit.Kilogram);
@@ -44,53 +46,82 @@ namespace UnitsNet
             return FromPounds(StonesInOnePound*stone + pounds);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="Mass"/> divided by <see cref="TimeSpan"/>.</summary>
         public static MassFlow operator /(Mass mass, TimeSpan timeSpan)
         {
             return MassFlow.FromKilogramsPerSecond(mass.Kilograms/timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="Mass"/> divided by <see cref="Duration"/>.</summary>
         public static MassFlow operator /(Mass mass, Duration duration)
         {
             return MassFlow.FromKilogramsPerSecond(mass.Kilograms/duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Density"/> from <see cref="MassFlow"/> divided by <see cref="Volume"/>.</summary>
         public static Density operator /(Mass mass, Volume volume)
         {
             return Density.FromKilogramsPerCubicMeter(mass.Kilograms/volume.CubicMeters);
         }
 
+        /// <summary>Get <see cref="Volume"/> from <see cref="Mass"/> divided by <see cref="Density"/>.</summary>
         public static Volume operator /(Mass mass, Density density)
         {
             return Volume.FromCubicMeters(mass.Kilograms / density.KilogramsPerCubicMeter);
         }
 
+        /// <summary>Get <see cref="Force"/> from <see cref="Mass"/> times <see cref="Acceleration"/>.</summary>
         public static Force operator *(Mass mass, Acceleration acceleration)
         {
             return Force.FromNewtons(mass.Kilograms*acceleration.MetersPerSecondSquared);
         }
 
+        /// <summary>Get <see cref="Force"/> from <see cref="Acceleration"/> times <see cref="Mass"/>.</summary>
         public static Force operator *(Acceleration acceleration, Mass mass)
         {
             return Force.FromNewtons(mass.Kilograms*acceleration.MetersPerSecondSquared);
         }
     }
 
+    /// <summary>
+    ///     Representation of stone and pounds, used to preserve the original values when constructing <see cref="Mass"/> by
+    ///     <see cref="Mass.FromStonePounds"/> and later output them unaltered with <see cref="ToString()"/>.
+    /// </summary>
     public sealed class StonePounds
     {
+        /// <summary>
+        ///     Construct from stone and pounds.
+        /// </summary>
         public StonePounds(double stone, double pounds)
         {
             Stone = stone;
             Pounds = pounds;
         }
 
+        /// <summary>
+        ///     The stone value it was created with.
+        /// </summary>
         public double Stone { get; }
+
+        /// <summary>
+        ///     The pounds value it was created with.
+        /// </summary>
         public double Pounds { get; }
 
+        /// <inheritdoc cref="ToString(IFormatProvider)"/>
         public override string ToString()
         {
             return ToString(null);
         }
 
+        /// <summary>
+        ///     Outputs stone and pounds on the format: {stoneValue} {stoneUnit} {poundsValue} {poundsUnit}
+        /// </summary>
+        /// <example>Mass.FromStonePounds(3,2).StonePounds.ToString() outputs: "3 st 2 lb"</example>
+        /// <param name="cultureInfo">
+        ///     Optional culture to format number and localize unit abbreviations.
+        ///     If null, defaults to <see cref="Thread.CurrentUICulture"/>.
+        /// </param>
         public string ToString([CanBeNull] IFormatProvider cultureInfo)
         {
             cultureInfo = cultureInfo ?? GlobalConfiguration.DefaultCulture;

--- a/UnitsNet/CustomCode/Quantities/MassFlow.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/MassFlow.extra.cs
@@ -7,56 +7,67 @@ namespace UnitsNet
 {
     public partial struct MassFlow
     {
+        /// <summary>Get <see cref="Mass"/> from <see cref="MassFlow"/> times <see cref="TimeSpan"/>.</summary>
         public static Mass operator *(MassFlow massFlow, TimeSpan time)
         {
             return Mass.FromKilograms(massFlow.KilogramsPerSecond * time.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Mass"/> from <see cref="TimeSpan"/> times <see cref="MassFlow"/>.</summary>
         public static Mass operator *(TimeSpan time, MassFlow massFlow)
         {
             return Mass.FromKilograms(massFlow.KilogramsPerSecond * time.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Mass"/> from <see cref="MassFlow"/> times <see cref="Duration"/>.</summary>
         public static Mass operator *(MassFlow massFlow, Duration duration)
         {
             return Mass.FromKilograms(massFlow.KilogramsPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Mass"/> from <see cref="Duration"/> times <see cref="MassFlow"/>.</summary>
         public static Mass operator *(Duration duration, MassFlow massFlow)
         {
             return Mass.FromKilograms(massFlow.KilogramsPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Power"/> from <see cref="MassFlow"/> divided by <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static Power operator /(MassFlow massFlow, BrakeSpecificFuelConsumption bsfc)
         {
             return Power.FromWatts(massFlow.KilogramsPerSecond / bsfc.KilogramsPerJoule);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from <see cref="MassFlow"/> divided by <see cref="Power"/>.</summary>
         public static BrakeSpecificFuelConsumption operator /(MassFlow massFlow, Power power)
         {
             return BrakeSpecificFuelConsumption.FromKilogramsPerJoule(massFlow.KilogramsPerSecond / power.Watts);
         }
 
+        /// <summary>Get <see cref="Power"/> from <see cref="MassFlow"/> times <see cref="SpecificEnergy"/>.</summary>
         public static Power operator *(MassFlow massFlow, SpecificEnergy specificEnergy)
         {
             return Power.FromWatts(massFlow.KilogramsPerSecond * specificEnergy.JoulesPerKilogram);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from <see cref="MassFlow"/> divided by <see cref="Area"/>.</summary>
         public static MassFlux operator /(MassFlow massFlow, Area area)
         {
             return MassFlux.FromKilogramsPerSecondPerSquareMeter(massFlow.KilogramsPerSecond / area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="MassFlow"/> divided by <see cref="MassFlux"/>.</summary>
         public static Area operator /(MassFlow massFlow, MassFlux massFlux)
         {
             return Area.FromSquareMeters(massFlow.KilogramsPerSecond / massFlux.KilogramsPerSecondPerSquareMeter);
         }
 
+        /// <summary>Get <see cref="Density"/> from <see cref="MassFlow"/> divided by <see cref="VolumeFlow"/>.</summary>
         public static Density operator /(MassFlow massFlow, VolumeFlow volumeFlow)
         {
             return Density.FromKilogramsPerCubicMeter(massFlow.KilogramsPerSecond / volumeFlow.CubicMetersPerSecond);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from <see cref="MassFlow"/> divided by <see cref="Density"/>.</summary>
         public static VolumeFlow operator /(MassFlow massFlow, Density density)
         {
             return VolumeFlow.FromCubicMetersPerSecond(massFlow.KilogramsPerSecond / density.KilogramsPerCubicMeter);

--- a/UnitsNet/CustomCode/Quantities/MassFlux.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/MassFlux.extra.cs
@@ -5,14 +5,19 @@ namespace UnitsNet
 {
     public partial struct MassFlux
     {
+        /// <summary>Get <see cref="Density"/> from <see cref="MassFlux"/> divided by <see cref="Speed"/>.</summary>
         public static Density operator /(MassFlux massFlux, Speed speed)
         {
             return Density.FromKilogramsPerCubicMeter(massFlux.KilogramsPerSecondPerSquareMeter / speed.MetersPerSecond);
         }
+
+        /// <summary>Get <see cref="Speed"/> from <see cref="MassFlux"/> divided by <see cref="Density"/>.</summary>
         public static Speed operator /(MassFlux massFlux, Density density)
         {
             return Speed.FromMetersPerSecond(massFlux.KilogramsPerSecondPerSquareMeter / density.KilogramsPerCubicMeter);
         }
+
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="MassFlux"/> times <see cref="Area"/>.</summary>
         public static MassFlow operator *(MassFlux massFlux, Area area)
         {
             return MassFlow.FromGramsPerSecond(massFlux.GramsPerSecondPerSquareMeter * area.SquareMeters);

--- a/UnitsNet/CustomCode/Quantities/Molarity.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Molarity.extra.cs
@@ -1,9 +1,15 @@
-﻿using UnitsNet.Units;
+﻿using System;
+using UnitsNet.Units;
 
 namespace UnitsNet
 {
     public partial struct Molarity
     {
+        /// <summary>
+        ///     Construct from <see cref="Density"/> divided by <see cref="Mass"/>.
+        /// </summary>
+        /// <seealso cref="Density.op_Division(UnitsNet.Density,UnitsNet.Mass)"/>
+        [Obsolete("This constructor will be removed in favor of operator overload Density.op_Division(UnitsNet.Density,UnitsNet.Mass).")]
         public Molarity(Density density, Mass molecularWeight)
             : this()
         {

--- a/UnitsNet/CustomCode/Quantities/Molarity.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Molarity.extra.cs
@@ -27,9 +27,10 @@ namespace UnitsNet
         /// </summary>
         /// <param name="density"></param>
         /// <param name="molecularWeight"></param>
+        [Obsolete("Use Density / Mass operator overload instead.")]
         public static Molarity FromDensity(Density density, Mass molecularWeight)
         {
-            return new Molarity(density, molecularWeight);
+            return density / molecularWeight;
         }
 
         #endregion

--- a/UnitsNet/CustomCode/Quantities/Power.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Power.extra.cs
@@ -21,61 +21,73 @@ namespace UnitsNet
             return PowerRatio.FromPower(this);
         }
 
+        /// <summary>Get <see cref="Energy"/> from <see cref="Power"/> times <see cref="TimeSpan"/>.</summary>
         public static Energy operator *(Power power, TimeSpan time)
         {
             return Energy.FromJoules(power.Watts * time.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Energy"/> from <see cref="TimeSpan"/> times <see cref="Power"/>.</summary>
         public static Energy operator *(TimeSpan time, Power power)
         {
             return Energy.FromJoules(power.Watts * time.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Energy"/> from <see cref="Power"/> times <see cref="Duration"/>.</summary>
         public static Energy operator *(Power power, Duration duration)
         {
             return Energy.FromJoules(power.Watts * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Energy"/> from <see cref="Duration"/> times <see cref="Power"/>.</summary>
         public static Energy operator *(Duration duration, Power power)
         {
             return Energy.FromJoules(power.Watts * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Force"/> from <see cref="Power"/> divided by <see cref="Speed"/>.</summary>
         public static Force operator /(Power power, Speed speed)
         {
             return Force.FromNewtons(power.Watts / speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="Torque"/> from <see cref="Power"/> divided by <see cref="RotationalSpeed"/>.</summary>
         public static Torque operator /(Power power, RotationalSpeed rotationalSpeed)
         {
             return Torque.FromNewtonMeters(power.Watts / rotationalSpeed.RadiansPerSecond);
         }
 
+        /// <summary>Get <see cref="RotationalSpeed"/> from <see cref="Power"/> divided by <see cref="Torque"/>.</summary>
         public static RotationalSpeed operator /(Power power, Torque torque)
         {
             return RotationalSpeed.FromRadiansPerSecond(power.Watts / torque.NewtonMeters);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="Power"/> times <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static MassFlow operator *(Power power, BrakeSpecificFuelConsumption bsfc)
         {
             return MassFlow.FromKilogramsPerSecond(bsfc.KilogramsPerJoule * power.Watts);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from <see cref="Power"/> divided by <see cref="MassFlow"/>.</summary>
         public static SpecificEnergy operator /(Power power, MassFlow massFlow)
         {
             return SpecificEnergy.FromJoulesPerKilogram(power.Watts / massFlow.KilogramsPerSecond);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="Power"/> divided by <see cref="SpecificEnergy"/>.</summary>
         public static MassFlow operator /(Power power, SpecificEnergy specificEnergy)
         {
             return MassFlow.FromKilogramsPerSecond(power.Watts / specificEnergy.JoulesPerKilogram);
         }
 
+        /// <summary>Get <see cref="HeatFlux"/> from <see cref="Power"/> divided by <see cref="Area"/>.</summary>
         public static HeatFlux operator /(Power power, Area area)
         {
             return HeatFlux.FromWattsPerSquareMeter(power.Watts / area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="Power"/> divided by <see cref="HeatFlux"/>.</summary>
         public static Area operator /(Power power, HeatFlux heatFlux)
         {
             return Area.FromSquareMeters( power.Watts / heatFlux.WattsPerSquareMeter );

--- a/UnitsNet/CustomCode/Quantities/Pressure.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Pressure.extra.cs
@@ -5,21 +5,25 @@ namespace UnitsNet
 {
     public partial struct Pressure
     {
+        /// <summary>Get <see cref="Force"/> from <see cref="Pressure"/> times <see cref="Area"/>.</summary>
         public static Force operator *(Pressure pressure, Area area)
         {
             return Force.FromNewtons(pressure.Pascals * area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="Force"/> from <see cref="Area"/> times <see cref="Pressure"/>.</summary>
         public static Force operator *(Area area, Pressure pressure)
         {
             return Force.FromNewtons(pressure.Pascals * area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Pressure"/> divided by <see cref="SpecificWeight"/>.</summary>
         public static Length operator /(Pressure pressure, SpecificWeight specificWeight)
         {
             return new Length(pressure.Pascals / specificWeight.NewtonsPerCubicMeter, UnitsNet.Units.LengthUnit.Meter);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from <see cref="Pressure"/> divided by <see cref="Length"/>.</summary>
         public static SpecificWeight operator /(Pressure pressure, Length length)
         {
             return new SpecificWeight(pressure.Pascals / length.Meters, UnitsNet.Units.SpecificWeightUnit.NewtonPerCubicMeter);

--- a/UnitsNet/CustomCode/Quantities/RotationalSpeed.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/RotationalSpeed.extra.cs
@@ -7,21 +7,25 @@ namespace UnitsNet
 {
     public partial struct RotationalSpeed
     {
+        /// <summary>Get <see cref="Angle"/> from <see cref="RotationalSpeed"/> times <see cref="TimeSpan"/>.</summary>
         public static Angle operator *(RotationalSpeed rotationalSpeed, TimeSpan timeSpan)
         {
             return Angle.FromRadians(rotationalSpeed.RadiansPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Angle"/> from <see cref="TimeSpan"/> times <see cref="RotationalSpeed"/>.</summary>
         public static Angle operator *(TimeSpan timeSpan, RotationalSpeed rotationalSpeed)
         {
             return Angle.FromRadians(rotationalSpeed.RadiansPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Angle"/> from <see cref="RotationalSpeed"/> times <see cref="Duration"/>.</summary>
         public static Angle operator *(RotationalSpeed rotationalSpeed, Duration duration)
         {
             return Angle.FromRadians(rotationalSpeed.RadiansPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Angle"/> from <see cref="Duration"/> times <see cref="RotationalSpeed"/>.</summary>
         public static Angle operator *(Duration duration, RotationalSpeed rotationalSpeed)
         {
             return Angle.FromRadians(rotationalSpeed.RadiansPerSecond * duration.Seconds);

--- a/UnitsNet/CustomCode/Quantities/RotationalStiffness.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/RotationalStiffness.extra.cs
@@ -5,16 +5,19 @@ namespace UnitsNet
 {
     public partial struct RotationalStiffness
     {
+        /// <summary>Get <see cref="Torque"/> from <see cref="RotationalStiffness"/> times <see cref="Angle"/>.</summary>
         public static Torque operator *(RotationalStiffness rotationalStiffness, Angle angle)
         {
             return Torque.FromNewtonMeters(rotationalStiffness.NewtonMetersPerRadian * angle.Radians);
         }
 
+        /// <summary>Get <see cref="RotationalStiffnessPerLength"/> from <see cref="RotationalStiffness"/> divided by <see cref="Length"/>.</summary>
         public static RotationalStiffnessPerLength operator /(RotationalStiffness rotationalStiffness, Length length)
         {
             return RotationalStiffnessPerLength.FromNewtonMetersPerRadianPerMeter(rotationalStiffness.NewtonMetersPerRadian / length.Meters);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="RotationalStiffness"/> divided by <see cref="RotationalStiffnessPerLength"/>.</summary>
         public static Length operator /(RotationalStiffness rotationalStiffness, RotationalStiffnessPerLength rotationalStiffnessPerLength)
         {
             return Length.FromMeters(rotationalStiffness.NewtonMetersPerRadian / rotationalStiffnessPerLength.NewtonMetersPerRadianPerMeter);

--- a/UnitsNet/CustomCode/Quantities/RotationalStiffnessPerLength.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/RotationalStiffnessPerLength.extra.cs
@@ -6,6 +6,7 @@ namespace UnitsNet
 {
     public partial struct RotationalStiffnessPerLength
     {
+        /// <summary>Get <see cref="RotationalStiffness"/> from <see cref="RotationalStiffnessPerLength"/> times <see cref="Length"/>.</summary>
         public static RotationalStiffness operator *(RotationalStiffnessPerLength rotationalStiffness, Length length)
         {
             return RotationalStiffness.FromNewtonMetersPerRadian(rotationalStiffness.NewtonMetersPerRadianPerMeter * length.Meters);

--- a/UnitsNet/CustomCode/Quantities/SpecificEnergy.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/SpecificEnergy.extra.cs
@@ -5,26 +5,31 @@ namespace UnitsNet
 {
     public partial struct SpecificEnergy
     {
+        /// <summary>Get <see cref="Energy"/> from <see cref="SpecificEnergy"/> times <see cref="Mass"/>.</summary>
         public static Energy operator *(SpecificEnergy specificEnergy, Mass mass)
         {
             return Energy.FromJoules(specificEnergy.JoulesPerKilogram * mass.Kilograms);
         }
 
+        /// <summary>Get <see cref="Energy"/> from <see cref="Mass"/> times <see cref="SpecificEnergy"/>.</summary>
         public static Energy operator *(Mass mass, SpecificEnergy specificEnergy)
         {
             return Energy.FromJoules(specificEnergy.JoulesPerKilogram * mass.Kilograms);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from <see cref="double"/> divided by <see cref="SpecificEnergy"/>.</summary>
         public static BrakeSpecificFuelConsumption operator /(double value, SpecificEnergy specificEnergy)
         {
             return BrakeSpecificFuelConsumption.FromKilogramsPerJoule(value / specificEnergy.JoulesPerKilogram);
         }
 
+        /// <summary>Get <see cref="double"/> from <see cref="SpecificEnergy"/> times <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static double operator *(SpecificEnergy specificEnergy, BrakeSpecificFuelConsumption bsfc)
         {
             return specificEnergy.JoulesPerKilogram * bsfc.KilogramsPerJoule;
         }
 
+        /// <summary>Get <see cref="Power"/> from <see cref="SpecificEnergy"/> times <see cref="MassFlow"/>.</summary>
         public static Power operator *(SpecificEnergy specificEnergy, MassFlow massFlow)
         {
             return Power.FromWatts(massFlow.KilogramsPerSecond * specificEnergy.JoulesPerKilogram);

--- a/UnitsNet/CustomCode/Quantities/SpecificVolume.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/SpecificVolume.extra.cs
@@ -5,11 +5,13 @@ namespace UnitsNet
 {
     public partial struct SpecificVolume
     {
+        /// <summary>Get <see cref="Density"/> from <see cref="double"/> divided by <see cref="SpecificVolume"/>.</summary>
         public static Density operator /(double constant, SpecificVolume volume)
         {
             return Density.FromKilogramsPerCubicMeter(constant / volume.CubicMetersPerKilogram);
         }
 
+        /// <summary>Get <see cref="Volume"/> from <see cref="SpecificVolume"/> times <see cref="Mass"/>.</summary>
         public static Volume operator *(SpecificVolume volume, Mass mass)
         {
             return Volume.FromCubicMeters(volume.CubicMetersPerKilogram * mass.Kilograms);

--- a/UnitsNet/CustomCode/Quantities/SpecificWeight.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/SpecificWeight.extra.cs
@@ -5,16 +5,19 @@ namespace UnitsNet
 {
     public partial struct SpecificWeight
     {
+        /// <summary>Get <see cref="Pressure"/> from <see cref="SpecificWeight"/> times <see cref="Length"/>.</summary>
         public static Pressure operator *(SpecificWeight specificWeight, Length length)
         {
             return new Pressure(specificWeight.NewtonsPerCubicMeter * length.Meters, UnitsNet.Units.PressureUnit.Pascal);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from <see cref="SpecificWeight"/> divided by <see cref="Density"/>.</summary>
         public static Acceleration operator /(SpecificWeight specificWeight, Density density)
         {
             return new Acceleration(specificWeight.NewtonsPerCubicMeter / density.KilogramsPerCubicMeter, UnitsNet.Units.AccelerationUnit.MeterPerSecondSquared);
         }
 
+        /// <summary>Get <see cref="Density"/> from <see cref="SpecificWeight"/> divided by <see cref="Acceleration"/>.</summary>
         public static Density operator /(SpecificWeight specific, Acceleration acceleration)
         {
             return new Density(specific.NewtonsPerCubicMeter / acceleration.MetersPerSecondSquared, UnitsNet.Units.DensityUnit.KilogramPerCubicMeter);

--- a/UnitsNet/CustomCode/Quantities/Speed.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Speed.extra.cs
@@ -7,51 +7,61 @@ namespace UnitsNet
 {
     public partial struct Speed
     {
+        /// <summary>Get <see cref="Acceleration"/> from <see cref="Speed"/> divided by <see cref="TimeSpan"/>.</summary>
         public static Acceleration operator /(Speed speed, TimeSpan timeSpan)
         {
             return Acceleration.FromMetersPerSecondSquared(speed.MetersPerSecond / timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Speed"/> times <see cref="TimeSpan"/>.</summary>
         public static Length operator *(Speed speed, TimeSpan timeSpan)
         {
             return Length.FromMeters(speed.MetersPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="TimeSpan"/> times <see cref="Speed"/>.</summary>
         public static Length operator *(TimeSpan timeSpan, Speed speed)
         {
             return Length.FromMeters(speed.MetersPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from <see cref="Speed"/> divided by <see cref="Duration"/>.</summary>
         public static Acceleration operator /(Speed speed, Duration duration)
         {
             return Acceleration.FromMetersPerSecondSquared(speed.MetersPerSecond / duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Speed"/> times <see cref="Duration"/>.</summary>
         public static Length operator *(Speed speed, Duration duration)
         {
             return Length.FromMeters(speed.MetersPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Duration"/> times <see cref="Speed"/>.</summary>
         public static Length operator *(Duration duration, Speed speed)
         {
             return Length.FromMeters(speed.MetersPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from <see cref="Speed"/> times <see cref="Length"/>.</summary>
         public static KinematicViscosity operator *(Speed speed, Length length)
         {
             return KinematicViscosity.FromSquareMetersPerSecond(length.Meters * speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from <see cref="Speed"/> times <see cref="Speed"/>.</summary>
         public static SpecificEnergy operator *(Speed left, Speed right)
         {
             return SpecificEnergy.FromJoulesPerKilogram(left.MetersPerSecond * right.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from <see cref="Speed"/> times <see cref="Density"/>.</summary>
         public static MassFlux operator *(Speed speed, Density density)
         {
             return MassFlux.FromKilogramsPerSecondPerSquareMeter(speed.MetersPerSecond * density.KilogramsPerCubicMeter);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from <see cref="Speed"/> times <see cref="Area"/>.</summary>
         public static VolumeFlow operator *(Speed speed, Area area)
         {
             return VolumeFlow.FromCubicMetersPerSecond(speed.MetersPerSecond * area.SquareMeters);

--- a/UnitsNet/CustomCode/Quantities/TemperatureDelta.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/TemperatureDelta.extra.cs
@@ -5,16 +5,19 @@ namespace UnitsNet
 {
     public partial struct TemperatureDelta
     {
+        /// <summary>Get <see cref="LapseRate"/> from <see cref="TemperatureDelta"/> divided by <see cref="Length"/>.</summary>
         public static LapseRate operator /(TemperatureDelta left, Length right)
         {
             return LapseRate.FromDegreesCelciusPerKilometer(left.DegreesCelsius / right.Kilometers);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from <see cref="SpecificEntropy"/> times <see cref="TemperatureDelta"/>.</summary>
         public static SpecificEnergy operator *(SpecificEntropy specificEntropy, TemperatureDelta temperatureDelta)
         {
             return SpecificEnergy.FromJoulesPerKilogram(specificEntropy.JoulesPerKilogramKelvin * temperatureDelta.Kelvins);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from <see cref="TemperatureDelta"/> times <see cref="SpecificEntropy"/>.</summary>
         public static SpecificEnergy operator *(TemperatureDelta temperatureDelta, SpecificEntropy specificEntropy)
         {
             return specificEntropy * temperatureDelta;

--- a/UnitsNet/CustomCode/Quantities/Torque.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Torque.extra.cs
@@ -5,21 +5,25 @@ namespace UnitsNet
 {
     public partial struct Torque
     {
+        /// <summary>Get <see cref="Force"/> from <see cref="Torque"/> times <see cref="Length"/>.</summary>
         public static Force operator /(Torque torque, Length length)
         {
             return Force.FromNewtons(torque.NewtonMeters / length.Meters);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Torque"/> times <see cref="Force"/>.</summary>
         public static Length operator /(Torque torque, Force force)
         {
             return Length.FromMeters(torque.NewtonMeters / force.Newtons);
         }
 
+        /// <summary>Get <see cref="RotationalStiffness"/> from <see cref="Torque"/> times <see cref="Angle"/>.</summary>
         public static RotationalStiffness operator /(Torque torque, Angle angle)
         {
             return RotationalStiffness.FromNewtonMetersPerRadian(torque.NewtonMeters / angle.Radians);
         }
 
+        /// <summary>Get <see cref="Angle"/> from <see cref="Torque"/> times <see cref="RotationalStiffness"/>.</summary>
         public static Angle operator /(Torque torque, RotationalStiffness rotationalStiffness)
         {
             return Angle.FromRadians(torque.NewtonMeters / rotationalStiffness.NewtonMetersPerRadian);

--- a/UnitsNet/CustomCode/Quantities/Volume.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Volume.extra.cs
@@ -7,26 +7,31 @@ namespace UnitsNet
 {
     public partial struct Volume
     {
+        /// <summary>Get <see cref="Area"/> from <see cref="Volume"/> divided by <see cref="Length"/>.</summary>
         public static Area operator /(Volume volume, Length length)
         {
             return Area.FromSquareMeters(volume.CubicMeters / length.Meters);
         }
 
+        /// <summary>Get <see cref="Length"/> from <see cref="Volume"/> divided by <see cref="Area"/>.</summary>
         public static Length operator /(Volume volume, Area area)
         {
             return Length.FromMeters(volume.CubicMeters / area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from <see cref="Volume"/> divided by <see cref="Duration"/>.</summary>
         public static VolumeFlow operator /(Volume volume, Duration duration)
         {
             return VolumeFlow.FromCubicMetersPerSecond(volume.CubicMeters / duration.Seconds);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from <see cref="Volume"/> divided by <see cref="TimeSpan"/>.</summary>
         public static VolumeFlow operator /(Volume volume, TimeSpan timeSpan)
         {
             return VolumeFlow.FromCubicMetersPerSecond(volume.CubicMeters / timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="TimeSpan"/> from <see cref="Volume"/> divided by <see cref="VolumeFlow"/>.</summary>
         public static TimeSpan operator /(Volume volume, VolumeFlow volumeFlow)
         {
             return TimeSpan.FromSeconds(volume.CubicMeters / volumeFlow.CubicMetersPerSecond);

--- a/UnitsNet/CustomCode/Quantities/VolumeFlow.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/VolumeFlow.extra.cs
@@ -7,31 +7,37 @@ namespace UnitsNet
 {
     public partial struct VolumeFlow
     {
+        /// <summary>Get <see cref="Volume"/> from <see cref="VolumeFlow"/> times <see cref="TimeSpan"/>.</summary>
         public static Volume operator *(VolumeFlow volumeFlow, TimeSpan timeSpan)
         {
             return Volume.FromCubicMeters(volumeFlow.CubicMetersPerSecond * timeSpan.TotalSeconds);
         }
 
+        /// <summary>Get <see cref="Volume"/> from <see cref="VolumeFlow"/> times <see cref="Duration"/>.</summary>
         public static Volume operator *(VolumeFlow volumeFlow, Duration duration)
         {
             return Volume.FromCubicMeters(volumeFlow.CubicMetersPerSecond * duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Speed"/> from <see cref="VolumeFlow"/> divided by <see cref="Area"/>.</summary>
         public static Speed operator /(VolumeFlow volumeFlow, Area area)
         {
             return Speed.FromMetersPerSecond(volumeFlow.CubicMetersPerSecond / area.SquareMeters);
         }
 
+        /// <summary>Get <see cref="Area"/> from <see cref="VolumeFlow"/> divided by <see cref="Speed"/>.</summary>
         public static Area operator /(VolumeFlow volumeFlow, Speed speed)
         {
             return Area.FromSquareMeters(volumeFlow.CubicMetersPerSecond / speed.MetersPerSecond);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="VolumeFlow"/> times <see cref="Density"/>.</summary>
         public static MassFlow operator *(VolumeFlow volumeFlow, Density density)
         {
             return MassFlow.FromKilogramsPerSecond(volumeFlow.CubicMetersPerSecond * density.KilogramsPerCubicMeter);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from <see cref="Density"/> times <see cref="VolumeFlow"/>.</summary>
         public static MassFlow operator *(Density density, VolumeFlow volumeFlow)
         {
             return MassFlow.FromKilogramsPerSecond(volumeFlow.CubicMetersPerSecond * density.KilogramsPerCubicMeter);

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -60,6 +60,10 @@ namespace UnitsNet
                 $"Unit value {unit} of type {unit.GetType()} is not a known unit enum type. Expected types like UnitsNet.Units.LengthUnit. Did you pass in a third-party enum type defined outside UnitsNet library?");
         }
 
+        /// <summary>
+        ///     Get a list of quantities that has the given base dimensions.
+        /// </summary>
+        /// <param name="baseDimensions">The base dimensions to match.</param>
         public static IEnumerable<QuantityInfo> GetQuantitiesWithBaseDimensions(BaseDimensions baseDimensions)
         {
             return InfosLazy.Value.Where(info => info.BaseDimensions.Equals(baseDimensions));

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -14,6 +14,10 @@ using UnitTypeToLookup = System.Collections.Generic.Dictionary<System.Type, Unit
 // ReSharper disable once CheckNamespace
 namespace UnitsNet
 {
+    /// <summary>
+    ///     Cache of the mapping between unit enum values and unit abbreviation strings for one or more cultures.
+    ///     A static instance <see cref="Default"/> is used internally for ToString() and Parse() of quantities and units.
+    /// </summary>
     public sealed partial class UnitAbbreviationsCache
     {
         private readonly Dictionary<IFormatProvider, UnitTypeToLookup> _lookupsForCulture;
@@ -29,8 +33,14 @@ namespace UnitsNet
         /// </example>
         private static readonly CultureInfo FallbackCulture = new CultureInfo("en-US");
 
+        /// <summary>
+        ///     The static instance used internally for ToString() and Parse() of quantities and units.
+        /// </summary>
         public static UnitAbbreviationsCache Default { get; }
 
+        /// <summary>
+        ///     Create an instance of the cache and load all the abbreviations defined in the library.
+        /// </summary>
         public UnitAbbreviationsCache()
         {
             _lookupsForCulture = new Dictionary<IFormatProvider, UnitTypeToLookup>();

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -9,12 +9,25 @@ using UnitsNet.Units;
 // ReSharper disable once CheckNamespace
 namespace UnitsNet
 {
+    /// <summary>
+    ///     Parses units given a unit abbreviations cache.
+    ///     The static instance <see cref="Default"/> is used internally to parse quantities and units using the
+    ///     default abbreviations cache for all units and abbreviations defined in the library.
+    /// </summary>
     public sealed class UnitParser
     {
         private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
 
+        /// <summary>
+        ///     The default static instance used internally to parse quantities and units using the
+        ///     default abbreviations cache for all units and abbreviations defined in the library.
+        /// </summary>
         public static UnitParser Default { get; }
 
+        /// <summary>
+        ///     Create a parser using the given unit abbreviations cache.
+        /// </summary>
+        /// <param name="unitAbbreviationsCache"></param>
         public UnitParser(UnitAbbreviationsCache unitAbbreviationsCache)
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Acceleration, in physics, is the rate at which the velocity of an object changes over time. An object's acceleration is the net result of any and all forces acting on the object, as described by Newton's Second Law. The SI unit for acceleration is the Meter per second squared (m/s²). Accelerations are vector quantities (they have magnitude and direction) and add according to the parallelogram law. As a vector, the calculated net force is equal to the product of the object's mass (a scalar quantity) and the acceleration.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AccelerationUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AccelerationUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -486,6 +485,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AccelerationUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AccelerationUnit)"/>
         public static bool TryParseUnit(string str, out AccelerationUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -510,36 +510,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Acceleration operator -(Acceleration right)
         {
             return new Acceleration(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from adding two <see cref="Acceleration"/>.</summary>
         public static Acceleration operator +(Acceleration left, Acceleration right)
         {
             return new Acceleration(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from subtracting two <see cref="Acceleration"/>.</summary>
         public static Acceleration operator -(Acceleration left, Acceleration right)
         {
             return new Acceleration(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from multiplying value and <see cref="Acceleration"/>.</summary>
         public static Acceleration operator *(double left, Acceleration right)
         {
             return new Acceleration(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from multiplying value and <see cref="Acceleration"/>.</summary>
         public static Acceleration operator *(Acceleration left, double right)
         {
             return new Acceleration(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Acceleration"/> from dividing <see cref="Acceleration"/> by value.</summary>
         public static Acceleration operator /(Acceleration left, double right)
         {
             return new Acceleration(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Acceleration"/> by <see cref="Acceleration"/>.</summary>
         public static double operator /(Acceleration left, Acceleration right)
         {
             return left.MetersPerSecondSquared / right.MetersPerSecondSquared;
@@ -549,36 +556,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Acceleration left, Acceleration right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Acceleration left, Acceleration right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Acceleration left, Acceleration right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Acceleration left, Acceleration right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Acceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Acceleration left, Acceleration right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Acceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Acceleration left, Acceleration right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -587,11 +603,14 @@ namespace UnitsNet
             return CompareTo(objAcceleration);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Acceleration other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Acceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Acceleration objAcceleration))
@@ -600,6 +619,8 @@ namespace UnitsNet
             return Equals(objAcceleration);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Acceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Acceleration other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -684,6 +705,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AccelerationUnit) unit);
 
         /// <summary>
@@ -698,6 +720,7 @@ namespace UnitsNet
 
         IQuantity<AccelerationUnit> IQuantity<AccelerationUnit>.ToUnit(AccelerationUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AccelerationUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Mole is the amount of substance containing Avagadro's Number (6.02 x 10 ^ 23) of real particles such as molecules,atoms, ions or radicals.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AmountOfSubstanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AmountOfSubstanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -514,6 +513,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AmountOfSubstanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AmountOfSubstanceUnit)"/>
         public static bool TryParseUnit(string str, out AmountOfSubstanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -538,36 +538,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static AmountOfSubstance operator -(AmountOfSubstance right)
         {
             return new AmountOfSubstance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AmountOfSubstance"/> from adding two <see cref="AmountOfSubstance"/>.</summary>
         public static AmountOfSubstance operator +(AmountOfSubstance left, AmountOfSubstance right)
         {
             return new AmountOfSubstance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="AmountOfSubstance"/> from subtracting two <see cref="AmountOfSubstance"/>.</summary>
         public static AmountOfSubstance operator -(AmountOfSubstance left, AmountOfSubstance right)
         {
             return new AmountOfSubstance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="AmountOfSubstance"/> from multiplying value and <see cref="AmountOfSubstance"/>.</summary>
         public static AmountOfSubstance operator *(double left, AmountOfSubstance right)
         {
             return new AmountOfSubstance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AmountOfSubstance"/> from multiplying value and <see cref="AmountOfSubstance"/>.</summary>
         public static AmountOfSubstance operator *(AmountOfSubstance left, double right)
         {
             return new AmountOfSubstance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="AmountOfSubstance"/> from dividing <see cref="AmountOfSubstance"/> by value.</summary>
         public static AmountOfSubstance operator /(AmountOfSubstance left, double right)
         {
             return new AmountOfSubstance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="AmountOfSubstance"/> by <see cref="AmountOfSubstance"/>.</summary>
         public static double operator /(AmountOfSubstance left, AmountOfSubstance right)
         {
             return left.Moles / right.Moles;
@@ -577,36 +584,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(AmountOfSubstance left, AmountOfSubstance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(AmountOfSubstance left, AmountOfSubstance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(AmountOfSubstance left, AmountOfSubstance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(AmountOfSubstance left, AmountOfSubstance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AmountOfSubstance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(AmountOfSubstance left, AmountOfSubstance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AmountOfSubstance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(AmountOfSubstance left, AmountOfSubstance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -615,11 +631,14 @@ namespace UnitsNet
             return CompareTo(objAmountOfSubstance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(AmountOfSubstance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AmountOfSubstance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is AmountOfSubstance objAmountOfSubstance))
@@ -628,6 +647,8 @@ namespace UnitsNet
             return Equals(objAmountOfSubstance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AmountOfSubstance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(AmountOfSubstance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -712,6 +733,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AmountOfSubstanceUnit) unit);
 
         /// <summary>
@@ -726,6 +748,7 @@ namespace UnitsNet
 
         IQuantity<AmountOfSubstanceUnit> IQuantity<AmountOfSubstanceUnit>.ToUnit(AmountOfSubstanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AmountOfSubstanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The strength of a signal expressed in decibels (dB) relative to one volt RMS.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AmplitudeRatioUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AmplitudeRatioUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -360,6 +359,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AmplitudeRatioUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AmplitudeRatioUnit)"/>
         public static bool TryParseUnit(string str, out AmplitudeRatioUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -384,11 +384,13 @@ namespace UnitsNet
 
         #region Logarithmic Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static AmplitudeRatio operator -(AmplitudeRatio right)
         {
             return new AmplitudeRatio(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AmplitudeRatio"/> from logarithmic addition of two <see cref="AmplitudeRatio"/>.</summary>
         public static AmplitudeRatio operator +(AmplitudeRatio left, AmplitudeRatio right)
         {
             // Logarithmic addition
@@ -396,6 +398,7 @@ namespace UnitsNet
             return new AmplitudeRatio(20*Math.Log10(Math.Pow(10, left.Value/20) + Math.Pow(10, right.AsBaseNumericType(left.Unit)/20)), left.Unit);
         }
 
+        /// <summary>Get <see cref="AmplitudeRatio"/> from logarithmic subtraction of two <see cref="AmplitudeRatio"/>.</summary>
         public static AmplitudeRatio operator -(AmplitudeRatio left, AmplitudeRatio right)
         {
             // Logarithmic subtraction
@@ -403,24 +406,28 @@ namespace UnitsNet
             return new AmplitudeRatio(20*Math.Log10(Math.Pow(10, left.Value/20) - Math.Pow(10, right.AsBaseNumericType(left.Unit)/20)), left.Unit);
         }
 
+        /// <summary>Get <see cref="AmplitudeRatio"/> from logarithmic multiplication of value and <see cref="AmplitudeRatio"/>.</summary>
         public static AmplitudeRatio operator *(double left, AmplitudeRatio right)
         {
             // Logarithmic multiplication = addition
             return new AmplitudeRatio(left + right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AmplitudeRatio"/> from logarithmic multiplication of value and <see cref="AmplitudeRatio"/>.</summary>
         public static AmplitudeRatio operator *(AmplitudeRatio left, double right)
         {
             // Logarithmic multiplication = addition
             return new AmplitudeRatio(left.Value + (double)right, left.Unit);
         }
 
+        /// <summary>Get <see cref="AmplitudeRatio"/> from logarithmic division of <see cref="AmplitudeRatio"/> by value.</summary>
         public static AmplitudeRatio operator /(AmplitudeRatio left, double right)
         {
             // Logarithmic division = subtraction
             return new AmplitudeRatio(left.Value - (double)right, left.Unit);
         }
 
+        /// <summary>Get ratio value from logarithmic division of <see cref="AmplitudeRatio"/> by <see cref="AmplitudeRatio"/>.</summary>
         public static double operator /(AmplitudeRatio left, AmplitudeRatio right)
         {
             // Logarithmic division = subtraction
@@ -431,36 +438,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(AmplitudeRatio left, AmplitudeRatio right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(AmplitudeRatio left, AmplitudeRatio right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(AmplitudeRatio left, AmplitudeRatio right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(AmplitudeRatio left, AmplitudeRatio right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AmplitudeRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(AmplitudeRatio left, AmplitudeRatio right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AmplitudeRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(AmplitudeRatio left, AmplitudeRatio right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -469,11 +485,14 @@ namespace UnitsNet
             return CompareTo(objAmplitudeRatio);
         }
 
+        /// <inheritdoc />
         public int CompareTo(AmplitudeRatio other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AmplitudeRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is AmplitudeRatio objAmplitudeRatio))
@@ -482,6 +501,8 @@ namespace UnitsNet
             return Equals(objAmplitudeRatio);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AmplitudeRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(AmplitudeRatio other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -566,6 +587,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AmplitudeRatioUnit) unit);
 
         /// <summary>
@@ -580,6 +602,7 @@ namespace UnitsNet
 
         IQuantity<AmplitudeRatioUnit> IQuantity<AmplitudeRatioUnit>.ToUnit(AmplitudeRatioUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AmplitudeRatioUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In geometry, an angle is the figure formed by two rays, called the sides of the angle, sharing a common endpoint, called the vertex of the angle.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AngleUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AngleUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -500,6 +499,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AngleUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AngleUnit)"/>
         public static bool TryParseUnit(string str, out AngleUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -524,36 +524,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Angle operator -(Angle right)
         {
             return new Angle(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Angle"/> from adding two <see cref="Angle"/>.</summary>
         public static Angle operator +(Angle left, Angle right)
         {
             return new Angle(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Angle"/> from subtracting two <see cref="Angle"/>.</summary>
         public static Angle operator -(Angle left, Angle right)
         {
             return new Angle(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Angle"/> from multiplying value and <see cref="Angle"/>.</summary>
         public static Angle operator *(double left, Angle right)
         {
             return new Angle(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Angle"/> from multiplying value and <see cref="Angle"/>.</summary>
         public static Angle operator *(Angle left, double right)
         {
             return new Angle(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Angle"/> from dividing <see cref="Angle"/> by value.</summary>
         public static Angle operator /(Angle left, double right)
         {
             return new Angle(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Angle"/> by <see cref="Angle"/>.</summary>
         public static double operator /(Angle left, Angle right)
         {
             return left.Degrees / right.Degrees;
@@ -563,36 +570,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Angle left, Angle right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Angle left, Angle right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Angle left, Angle right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Angle left, Angle right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Angle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Angle left, Angle right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Angle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Angle left, Angle right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -601,11 +617,14 @@ namespace UnitsNet
             return CompareTo(objAngle);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Angle other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Angle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Angle objAngle))
@@ -614,6 +633,8 @@ namespace UnitsNet
             return Equals(objAngle);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Angle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Angle other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -698,6 +719,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AngleUnit) unit);
 
         /// <summary>
@@ -712,6 +734,7 @@ namespace UnitsNet
 
         IQuantity<AngleUnit> IQuantity<AngleUnit>.ToUnit(AngleUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AngleUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     A unit for expressing the integral of apparent power over time, equal to the product of 1 volt-ampere and 1 hour, or to 3600 joules.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ApparentEnergyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ApparentEnergyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ApparentEnergyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ApparentEnergyUnit)"/>
         public static bool TryParseUnit(string str, out ApparentEnergyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ApparentEnergy operator -(ApparentEnergy right)
         {
             return new ApparentEnergy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentEnergy"/> from adding two <see cref="ApparentEnergy"/>.</summary>
         public static ApparentEnergy operator +(ApparentEnergy left, ApparentEnergy right)
         {
             return new ApparentEnergy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentEnergy"/> from subtracting two <see cref="ApparentEnergy"/>.</summary>
         public static ApparentEnergy operator -(ApparentEnergy left, ApparentEnergy right)
         {
             return new ApparentEnergy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentEnergy"/> from multiplying value and <see cref="ApparentEnergy"/>.</summary>
         public static ApparentEnergy operator *(double left, ApparentEnergy right)
         {
             return new ApparentEnergy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentEnergy"/> from multiplying value and <see cref="ApparentEnergy"/>.</summary>
         public static ApparentEnergy operator *(ApparentEnergy left, double right)
         {
             return new ApparentEnergy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentEnergy"/> from dividing <see cref="ApparentEnergy"/> by value.</summary>
         public static ApparentEnergy operator /(ApparentEnergy left, double right)
         {
             return new ApparentEnergy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ApparentEnergy"/> by <see cref="ApparentEnergy"/>.</summary>
         public static double operator /(ApparentEnergy left, ApparentEnergy right)
         {
             return left.VoltampereHours / right.VoltampereHours;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ApparentEnergy left, ApparentEnergy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ApparentEnergy left, ApparentEnergy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ApparentEnergy left, ApparentEnergy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ApparentEnergy left, ApparentEnergy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ApparentEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ApparentEnergy left, ApparentEnergy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ApparentEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ApparentEnergy left, ApparentEnergy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objApparentEnergy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ApparentEnergy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ApparentEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ApparentEnergy objApparentEnergy))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objApparentEnergy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ApparentEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ApparentEnergy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ApparentEnergyUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<ApparentEnergyUnit> IQuantity<ApparentEnergyUnit>.ToUnit(ApparentEnergyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ApparentEnergyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Power engineers measure apparent power as the magnitude of the vector sum of active and reactive power. Apparent power is the product of the root-mean-square of voltage and current.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ApparentPowerUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ApparentPowerUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -360,6 +359,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ApparentPowerUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ApparentPowerUnit)"/>
         public static bool TryParseUnit(string str, out ApparentPowerUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -384,36 +384,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ApparentPower operator -(ApparentPower right)
         {
             return new ApparentPower(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentPower"/> from adding two <see cref="ApparentPower"/>.</summary>
         public static ApparentPower operator +(ApparentPower left, ApparentPower right)
         {
             return new ApparentPower(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentPower"/> from subtracting two <see cref="ApparentPower"/>.</summary>
         public static ApparentPower operator -(ApparentPower left, ApparentPower right)
         {
             return new ApparentPower(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentPower"/> from multiplying value and <see cref="ApparentPower"/>.</summary>
         public static ApparentPower operator *(double left, ApparentPower right)
         {
             return new ApparentPower(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentPower"/> from multiplying value and <see cref="ApparentPower"/>.</summary>
         public static ApparentPower operator *(ApparentPower left, double right)
         {
             return new ApparentPower(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ApparentPower"/> from dividing <see cref="ApparentPower"/> by value.</summary>
         public static ApparentPower operator /(ApparentPower left, double right)
         {
             return new ApparentPower(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ApparentPower"/> by <see cref="ApparentPower"/>.</summary>
         public static double operator /(ApparentPower left, ApparentPower right)
         {
             return left.Voltamperes / right.Voltamperes;
@@ -423,36 +430,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ApparentPower left, ApparentPower right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ApparentPower left, ApparentPower right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ApparentPower left, ApparentPower right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ApparentPower left, ApparentPower right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ApparentPower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ApparentPower left, ApparentPower right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ApparentPower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ApparentPower left, ApparentPower right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -461,11 +477,14 @@ namespace UnitsNet
             return CompareTo(objApparentPower);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ApparentPower other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ApparentPower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ApparentPower objApparentPower))
@@ -474,6 +493,8 @@ namespace UnitsNet
             return Equals(objApparentPower);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ApparentPower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ApparentPower other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -558,6 +579,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ApparentPowerUnit) unit);
 
         /// <summary>
@@ -572,6 +594,7 @@ namespace UnitsNet
 
         IQuantity<ApparentPowerUnit> IQuantity<ApparentPowerUnit>.ToUnit(ApparentPowerUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ApparentPowerUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Area is a quantity that expresses the extent of a two-dimensional surface or shape, or planar lamina, in the plane. Area can be understood as the amount of material with a given thickness that would be necessary to fashion a model of the shape, or the amount of paint necessary to cover the surface with a single coat.[1] It is the two-dimensional analog of the length of a curve (a one-dimensional concept) or the volume of a solid (a three-dimensional concept).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AreaUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AreaUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -486,6 +485,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AreaUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AreaUnit)"/>
         public static bool TryParseUnit(string str, out AreaUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -510,36 +510,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Area operator -(Area right)
         {
             return new Area(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Area"/> from adding two <see cref="Area"/>.</summary>
         public static Area operator +(Area left, Area right)
         {
             return new Area(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Area"/> from subtracting two <see cref="Area"/>.</summary>
         public static Area operator -(Area left, Area right)
         {
             return new Area(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Area"/> from multiplying value and <see cref="Area"/>.</summary>
         public static Area operator *(double left, Area right)
         {
             return new Area(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Area"/> from multiplying value and <see cref="Area"/>.</summary>
         public static Area operator *(Area left, double right)
         {
             return new Area(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Area"/> from dividing <see cref="Area"/> by value.</summary>
         public static Area operator /(Area left, double right)
         {
             return new Area(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Area"/> by <see cref="Area"/>.</summary>
         public static double operator /(Area left, Area right)
         {
             return left.SquareMeters / right.SquareMeters;
@@ -549,36 +556,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Area left, Area right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Area left, Area right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Area left, Area right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Area left, Area right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Area, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Area left, Area right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Area, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Area left, Area right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -587,11 +603,14 @@ namespace UnitsNet
             return CompareTo(objArea);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Area other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Area, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Area objArea))
@@ -600,6 +619,8 @@ namespace UnitsNet
             return Equals(objArea);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Area, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Area other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -684,6 +705,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AreaUnit) unit);
 
         /// <summary>
@@ -698,6 +720,7 @@ namespace UnitsNet
 
         IQuantity<AreaUnit> IQuantity<AreaUnit>.ToUnit(AreaUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AreaUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The area density of a two-dimensional object is calculated as the mass per unit area.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AreaDensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AreaDensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -318,6 +317,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AreaDensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AreaDensityUnit)"/>
         public static bool TryParseUnit(string str, out AreaDensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -342,36 +342,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static AreaDensity operator -(AreaDensity right)
         {
             return new AreaDensity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AreaDensity"/> from adding two <see cref="AreaDensity"/>.</summary>
         public static AreaDensity operator +(AreaDensity left, AreaDensity right)
         {
             return new AreaDensity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="AreaDensity"/> from subtracting two <see cref="AreaDensity"/>.</summary>
         public static AreaDensity operator -(AreaDensity left, AreaDensity right)
         {
             return new AreaDensity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="AreaDensity"/> from multiplying value and <see cref="AreaDensity"/>.</summary>
         public static AreaDensity operator *(double left, AreaDensity right)
         {
             return new AreaDensity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AreaDensity"/> from multiplying value and <see cref="AreaDensity"/>.</summary>
         public static AreaDensity operator *(AreaDensity left, double right)
         {
             return new AreaDensity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="AreaDensity"/> from dividing <see cref="AreaDensity"/> by value.</summary>
         public static AreaDensity operator /(AreaDensity left, double right)
         {
             return new AreaDensity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="AreaDensity"/> by <see cref="AreaDensity"/>.</summary>
         public static double operator /(AreaDensity left, AreaDensity right)
         {
             return left.KilogramsPerSquareMeter / right.KilogramsPerSquareMeter;
@@ -381,36 +388,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(AreaDensity left, AreaDensity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(AreaDensity left, AreaDensity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(AreaDensity left, AreaDensity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(AreaDensity left, AreaDensity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AreaDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(AreaDensity left, AreaDensity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AreaDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(AreaDensity left, AreaDensity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -419,11 +435,14 @@ namespace UnitsNet
             return CompareTo(objAreaDensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(AreaDensity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AreaDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is AreaDensity objAreaDensity))
@@ -432,6 +451,8 @@ namespace UnitsNet
             return Equals(objAreaDensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AreaDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(AreaDensity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -516,6 +537,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AreaDensityUnit) unit);
 
         /// <summary>
@@ -530,6 +552,7 @@ namespace UnitsNet
 
         IQuantity<AreaDensityUnit> IQuantity<AreaDensityUnit>.ToUnit(AreaDensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AreaDensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     A geometric property of an area that reflects how its points are distributed with regard to an axis.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public AreaMomentOfInertiaUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<AreaMomentOfInertiaUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -388,6 +387,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<AreaMomentOfInertiaUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.AreaMomentOfInertiaUnit)"/>
         public static bool TryParseUnit(string str, out AreaMomentOfInertiaUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -412,36 +412,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static AreaMomentOfInertia operator -(AreaMomentOfInertia right)
         {
             return new AreaMomentOfInertia(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AreaMomentOfInertia"/> from adding two <see cref="AreaMomentOfInertia"/>.</summary>
         public static AreaMomentOfInertia operator +(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return new AreaMomentOfInertia(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="AreaMomentOfInertia"/> from subtracting two <see cref="AreaMomentOfInertia"/>.</summary>
         public static AreaMomentOfInertia operator -(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return new AreaMomentOfInertia(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="AreaMomentOfInertia"/> from multiplying value and <see cref="AreaMomentOfInertia"/>.</summary>
         public static AreaMomentOfInertia operator *(double left, AreaMomentOfInertia right)
         {
             return new AreaMomentOfInertia(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="AreaMomentOfInertia"/> from multiplying value and <see cref="AreaMomentOfInertia"/>.</summary>
         public static AreaMomentOfInertia operator *(AreaMomentOfInertia left, double right)
         {
             return new AreaMomentOfInertia(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="AreaMomentOfInertia"/> from dividing <see cref="AreaMomentOfInertia"/> by value.</summary>
         public static AreaMomentOfInertia operator /(AreaMomentOfInertia left, double right)
         {
             return new AreaMomentOfInertia(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="AreaMomentOfInertia"/> by <see cref="AreaMomentOfInertia"/>.</summary>
         public static double operator /(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return left.MetersToTheFourth / right.MetersToTheFourth;
@@ -451,36 +458,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AreaMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(AreaMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(AreaMomentOfInertia left, AreaMomentOfInertia right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -489,11 +505,14 @@ namespace UnitsNet
             return CompareTo(objAreaMomentOfInertia);
         }
 
+        /// <inheritdoc />
         public int CompareTo(AreaMomentOfInertia other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AreaMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is AreaMomentOfInertia objAreaMomentOfInertia))
@@ -502,6 +521,8 @@ namespace UnitsNet
             return Equals(objAreaMomentOfInertia);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(AreaMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(AreaMomentOfInertia other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -586,6 +607,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((AreaMomentOfInertiaUnit) unit);
 
         /// <summary>
@@ -600,6 +622,7 @@ namespace UnitsNet
 
         IQuantity<AreaMomentOfInertiaUnit> IQuantity<AreaMomentOfInertiaUnit>.ToUnit(AreaMomentOfInertiaUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((AreaMomentOfInertiaUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In telecommunications and computing, bit rate is the number of bits that are conveyed or processed per unit of time.
     /// </summary>
@@ -118,14 +119,12 @@ namespace UnitsNet
 
         double IQuantity.Value => (double) _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public BitRateUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<BitRateUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -673,6 +672,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<BitRateUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.BitRateUnit)"/>
         public static bool TryParseUnit(string str, out BitRateUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -697,36 +697,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static BitRate operator -(BitRate right)
         {
             return new BitRate(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="BitRate"/> from adding two <see cref="BitRate"/>.</summary>
         public static BitRate operator +(BitRate left, BitRate right)
         {
             return new BitRate(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="BitRate"/> from subtracting two <see cref="BitRate"/>.</summary>
         public static BitRate operator -(BitRate left, BitRate right)
         {
             return new BitRate(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="BitRate"/> from multiplying value and <see cref="BitRate"/>.</summary>
         public static BitRate operator *(decimal left, BitRate right)
         {
             return new BitRate(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="BitRate"/> from multiplying value and <see cref="BitRate"/>.</summary>
         public static BitRate operator *(BitRate left, decimal right)
         {
             return new BitRate(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="BitRate"/> from dividing <see cref="BitRate"/> by value.</summary>
         public static BitRate operator /(BitRate left, decimal right)
         {
             return new BitRate(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="BitRate"/> by <see cref="BitRate"/>.</summary>
         public static double operator /(BitRate left, BitRate right)
         {
             return left.BitsPerSecond / right.BitsPerSecond;
@@ -736,36 +743,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(BitRate left, BitRate right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(BitRate left, BitRate right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(BitRate left, BitRate right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(BitRate left, BitRate right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(BitRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(BitRate left, BitRate right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(BitRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(BitRate left, BitRate right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -774,11 +790,14 @@ namespace UnitsNet
             return CompareTo(objBitRate);
         }
 
+        /// <inheritdoc />
         public int CompareTo(BitRate other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(BitRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is BitRate objBitRate))
@@ -787,6 +806,8 @@ namespace UnitsNet
             return Equals(objBitRate);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(BitRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(BitRate other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -871,6 +892,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((BitRateUnit) unit);
 
         /// <summary>
@@ -885,6 +907,7 @@ namespace UnitsNet
 
         IQuantity<BitRateUnit> IQuantity<BitRateUnit>.ToUnit(BitRateUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((BitRateUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Brake specific fuel consumption (BSFC) is a measure of the fuel efficiency of any prime mover that burns fuel and produces rotational, or shaft, power. It is typically used for comparing the efficiency of internal combustion engines with a shaft output.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public BrakeSpecificFuelConsumptionUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<BrakeSpecificFuelConsumptionUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<BrakeSpecificFuelConsumptionUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.BrakeSpecificFuelConsumptionUnit)"/>
         public static bool TryParseUnit(string str, out BrakeSpecificFuelConsumptionUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static BrakeSpecificFuelConsumption operator -(BrakeSpecificFuelConsumption right)
         {
             return new BrakeSpecificFuelConsumption(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from adding two <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static BrakeSpecificFuelConsumption operator +(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return new BrakeSpecificFuelConsumption(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from subtracting two <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static BrakeSpecificFuelConsumption operator -(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return new BrakeSpecificFuelConsumption(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from multiplying value and <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static BrakeSpecificFuelConsumption operator *(double left, BrakeSpecificFuelConsumption right)
         {
             return new BrakeSpecificFuelConsumption(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from multiplying value and <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static BrakeSpecificFuelConsumption operator *(BrakeSpecificFuelConsumption left, double right)
         {
             return new BrakeSpecificFuelConsumption(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="BrakeSpecificFuelConsumption"/> from dividing <see cref="BrakeSpecificFuelConsumption"/> by value.</summary>
         public static BrakeSpecificFuelConsumption operator /(BrakeSpecificFuelConsumption left, double right)
         {
             return new BrakeSpecificFuelConsumption(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="BrakeSpecificFuelConsumption"/> by <see cref="BrakeSpecificFuelConsumption"/>.</summary>
         public static double operator /(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return left.KilogramsPerJoule / right.KilogramsPerJoule;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(BrakeSpecificFuelConsumption, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(BrakeSpecificFuelConsumption, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(BrakeSpecificFuelConsumption left, BrakeSpecificFuelConsumption right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objBrakeSpecificFuelConsumption);
         }
 
+        /// <inheritdoc />
         public int CompareTo(BrakeSpecificFuelConsumption other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(BrakeSpecificFuelConsumption, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is BrakeSpecificFuelConsumption objBrakeSpecificFuelConsumption))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objBrakeSpecificFuelConsumption);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(BrakeSpecificFuelConsumption, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(BrakeSpecificFuelConsumption other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((BrakeSpecificFuelConsumptionUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<BrakeSpecificFuelConsumptionUnit> IQuantity<BrakeSpecificFuelConsumptionUnit>.ToUnit(BrakeSpecificFuelConsumptionUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((BrakeSpecificFuelConsumptionUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Capacitance is the ability of a body to store an electric charge.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public CapacitanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<CapacitanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -405,6 +404,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<CapacitanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.CapacitanceUnit)"/>
         public static bool TryParseUnit(string str, out CapacitanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -429,36 +429,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Capacitance operator -(Capacitance right)
         {
             return new Capacitance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Capacitance"/> from adding two <see cref="Capacitance"/>.</summary>
         public static Capacitance operator +(Capacitance left, Capacitance right)
         {
             return new Capacitance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Capacitance"/> from subtracting two <see cref="Capacitance"/>.</summary>
         public static Capacitance operator -(Capacitance left, Capacitance right)
         {
             return new Capacitance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Capacitance"/> from multiplying value and <see cref="Capacitance"/>.</summary>
         public static Capacitance operator *(double left, Capacitance right)
         {
             return new Capacitance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Capacitance"/> from multiplying value and <see cref="Capacitance"/>.</summary>
         public static Capacitance operator *(Capacitance left, double right)
         {
             return new Capacitance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Capacitance"/> from dividing <see cref="Capacitance"/> by value.</summary>
         public static Capacitance operator /(Capacitance left, double right)
         {
             return new Capacitance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Capacitance"/> by <see cref="Capacitance"/>.</summary>
         public static double operator /(Capacitance left, Capacitance right)
         {
             return left.Farads / right.Farads;
@@ -468,36 +475,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Capacitance left, Capacitance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Capacitance left, Capacitance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Capacitance left, Capacitance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Capacitance left, Capacitance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Capacitance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Capacitance left, Capacitance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Capacitance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Capacitance left, Capacitance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -506,11 +522,14 @@ namespace UnitsNet
             return CompareTo(objCapacitance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Capacitance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Capacitance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Capacitance objCapacitance))
@@ -519,6 +538,8 @@ namespace UnitsNet
             return Equals(objCapacitance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Capacitance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Capacitance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -603,6 +624,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((CapacitanceUnit) unit);
 
         /// <summary>
@@ -617,6 +639,7 @@ namespace UnitsNet
 
         IQuantity<CapacitanceUnit> IQuantity<CapacitanceUnit>.ToUnit(CapacitanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((CapacitanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     A unit that represents a fractional change in size in response to a change in temperature.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public CoefficientOfThermalExpansionUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<CoefficientOfThermalExpansionUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<CoefficientOfThermalExpansionUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.CoefficientOfThermalExpansionUnit)"/>
         public static bool TryParseUnit(string str, out CoefficientOfThermalExpansionUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static CoefficientOfThermalExpansion operator -(CoefficientOfThermalExpansion right)
         {
             return new CoefficientOfThermalExpansion(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="CoefficientOfThermalExpansion"/> from adding two <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static CoefficientOfThermalExpansion operator +(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return new CoefficientOfThermalExpansion(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="CoefficientOfThermalExpansion"/> from subtracting two <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static CoefficientOfThermalExpansion operator -(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return new CoefficientOfThermalExpansion(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="CoefficientOfThermalExpansion"/> from multiplying value and <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static CoefficientOfThermalExpansion operator *(double left, CoefficientOfThermalExpansion right)
         {
             return new CoefficientOfThermalExpansion(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="CoefficientOfThermalExpansion"/> from multiplying value and <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static CoefficientOfThermalExpansion operator *(CoefficientOfThermalExpansion left, double right)
         {
             return new CoefficientOfThermalExpansion(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="CoefficientOfThermalExpansion"/> from dividing <see cref="CoefficientOfThermalExpansion"/> by value.</summary>
         public static CoefficientOfThermalExpansion operator /(CoefficientOfThermalExpansion left, double right)
         {
             return new CoefficientOfThermalExpansion(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="CoefficientOfThermalExpansion"/> by <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static double operator /(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return left.InverseKelvin / right.InverseKelvin;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(CoefficientOfThermalExpansion, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(CoefficientOfThermalExpansion, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objCoefficientOfThermalExpansion);
         }
 
+        /// <inheritdoc />
         public int CompareTo(CoefficientOfThermalExpansion other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(CoefficientOfThermalExpansion, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is CoefficientOfThermalExpansion objCoefficientOfThermalExpansion))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objCoefficientOfThermalExpansion);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(CoefficientOfThermalExpansion, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(CoefficientOfThermalExpansion other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((CoefficientOfThermalExpansionUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<CoefficientOfThermalExpansionUnit> IQuantity<CoefficientOfThermalExpansionUnit>.ToUnit(CoefficientOfThermalExpansionUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((CoefficientOfThermalExpansionUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The density, or more precisely, the volumetric mass density, of a substance is its mass per unit volume.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public DensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<DensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -853,6 +852,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<DensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.DensityUnit)"/>
         public static bool TryParseUnit(string str, out DensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -877,36 +877,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Density operator -(Density right)
         {
             return new Density(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Density"/> from adding two <see cref="Density"/>.</summary>
         public static Density operator +(Density left, Density right)
         {
             return new Density(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Density"/> from subtracting two <see cref="Density"/>.</summary>
         public static Density operator -(Density left, Density right)
         {
             return new Density(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Density"/> from multiplying value and <see cref="Density"/>.</summary>
         public static Density operator *(double left, Density right)
         {
             return new Density(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Density"/> from multiplying value and <see cref="Density"/>.</summary>
         public static Density operator *(Density left, double right)
         {
             return new Density(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Density"/> from dividing <see cref="Density"/> by value.</summary>
         public static Density operator /(Density left, double right)
         {
             return new Density(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Density"/> by <see cref="Density"/>.</summary>
         public static double operator /(Density left, Density right)
         {
             return left.KilogramsPerCubicMeter / right.KilogramsPerCubicMeter;
@@ -916,36 +923,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Density left, Density right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Density left, Density right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Density left, Density right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Density left, Density right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Density, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Density left, Density right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Density, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Density left, Density right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -954,11 +970,14 @@ namespace UnitsNet
             return CompareTo(objDensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Density other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Density, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Density objDensity))
@@ -967,6 +986,8 @@ namespace UnitsNet
             return Equals(objDensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Density, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Density other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -1051,6 +1072,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((DensityUnit) unit);
 
         /// <summary>
@@ -1065,6 +1087,7 @@ namespace UnitsNet
 
         IQuantity<DensityUnit> IQuantity<DensityUnit>.ToUnit(DensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((DensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Time is a dimension in which events can be ordered from the past through the present into the future, and also the measure of durations of events and the intervals between them.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public DurationUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<DurationUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -444,6 +443,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<DurationUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.DurationUnit)"/>
         public static bool TryParseUnit(string str, out DurationUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -468,36 +468,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Duration operator -(Duration right)
         {
             return new Duration(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Duration"/> from adding two <see cref="Duration"/>.</summary>
         public static Duration operator +(Duration left, Duration right)
         {
             return new Duration(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Duration"/> from subtracting two <see cref="Duration"/>.</summary>
         public static Duration operator -(Duration left, Duration right)
         {
             return new Duration(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Duration"/> from multiplying value and <see cref="Duration"/>.</summary>
         public static Duration operator *(double left, Duration right)
         {
             return new Duration(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Duration"/> from multiplying value and <see cref="Duration"/>.</summary>
         public static Duration operator *(Duration left, double right)
         {
             return new Duration(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Duration"/> from dividing <see cref="Duration"/> by value.</summary>
         public static Duration operator /(Duration left, double right)
         {
             return new Duration(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Duration"/> by <see cref="Duration"/>.</summary>
         public static double operator /(Duration left, Duration right)
         {
             return left.Seconds / right.Seconds;
@@ -507,36 +514,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Duration left, Duration right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Duration left, Duration right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Duration left, Duration right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Duration left, Duration right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Duration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Duration left, Duration right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Duration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Duration left, Duration right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -545,11 +561,14 @@ namespace UnitsNet
             return CompareTo(objDuration);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Duration other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Duration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Duration objDuration))
@@ -558,6 +577,8 @@ namespace UnitsNet
             return Equals(objDuration);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Duration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Duration other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -642,6 +663,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((DurationUnit) unit);
 
         /// <summary>
@@ -656,6 +678,7 @@ namespace UnitsNet
 
         IQuantity<DurationUnit> IQuantity<DurationUnit>.ToUnit(DurationUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((DurationUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The dynamic (shear) viscosity of a fluid expresses its resistance to shearing flows, where adjacent layers move parallel to each other with different speeds
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public DynamicViscosityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<DynamicViscosityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -391,6 +390,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<DynamicViscosityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.DynamicViscosityUnit)"/>
         public static bool TryParseUnit(string str, out DynamicViscosityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -415,36 +415,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static DynamicViscosity operator -(DynamicViscosity right)
         {
             return new DynamicViscosity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from adding two <see cref="DynamicViscosity"/>.</summary>
         public static DynamicViscosity operator +(DynamicViscosity left, DynamicViscosity right)
         {
             return new DynamicViscosity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from subtracting two <see cref="DynamicViscosity"/>.</summary>
         public static DynamicViscosity operator -(DynamicViscosity left, DynamicViscosity right)
         {
             return new DynamicViscosity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from multiplying value and <see cref="DynamicViscosity"/>.</summary>
         public static DynamicViscosity operator *(double left, DynamicViscosity right)
         {
             return new DynamicViscosity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from multiplying value and <see cref="DynamicViscosity"/>.</summary>
         public static DynamicViscosity operator *(DynamicViscosity left, double right)
         {
             return new DynamicViscosity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="DynamicViscosity"/> from dividing <see cref="DynamicViscosity"/> by value.</summary>
         public static DynamicViscosity operator /(DynamicViscosity left, double right)
         {
             return new DynamicViscosity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="DynamicViscosity"/> by <see cref="DynamicViscosity"/>.</summary>
         public static double operator /(DynamicViscosity left, DynamicViscosity right)
         {
             return left.NewtonSecondsPerMeterSquared / right.NewtonSecondsPerMeterSquared;
@@ -454,36 +461,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(DynamicViscosity left, DynamicViscosity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(DynamicViscosity left, DynamicViscosity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(DynamicViscosity left, DynamicViscosity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(DynamicViscosity left, DynamicViscosity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(DynamicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(DynamicViscosity left, DynamicViscosity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(DynamicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(DynamicViscosity left, DynamicViscosity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -492,11 +508,14 @@ namespace UnitsNet
             return CompareTo(objDynamicViscosity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(DynamicViscosity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(DynamicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is DynamicViscosity objDynamicViscosity))
@@ -505,6 +524,8 @@ namespace UnitsNet
             return Equals(objDynamicViscosity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(DynamicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(DynamicViscosity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -589,6 +610,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((DynamicViscosityUnit) unit);
 
         /// <summary>
@@ -603,6 +625,7 @@ namespace UnitsNet
 
         IQuantity<DynamicViscosityUnit> IQuantity<DynamicViscosityUnit>.ToUnit(DynamicViscosityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((DynamicViscosityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Electric admittance is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of impedance. The SI unit of admittance is the siemens (symbol S).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricAdmittanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricAdmittanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -360,6 +359,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricAdmittanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricAdmittanceUnit)"/>
         public static bool TryParseUnit(string str, out ElectricAdmittanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -384,36 +384,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricAdmittance operator -(ElectricAdmittance right)
         {
             return new ElectricAdmittance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricAdmittance"/> from adding two <see cref="ElectricAdmittance"/>.</summary>
         public static ElectricAdmittance operator +(ElectricAdmittance left, ElectricAdmittance right)
         {
             return new ElectricAdmittance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricAdmittance"/> from subtracting two <see cref="ElectricAdmittance"/>.</summary>
         public static ElectricAdmittance operator -(ElectricAdmittance left, ElectricAdmittance right)
         {
             return new ElectricAdmittance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricAdmittance"/> from multiplying value and <see cref="ElectricAdmittance"/>.</summary>
         public static ElectricAdmittance operator *(double left, ElectricAdmittance right)
         {
             return new ElectricAdmittance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricAdmittance"/> from multiplying value and <see cref="ElectricAdmittance"/>.</summary>
         public static ElectricAdmittance operator *(ElectricAdmittance left, double right)
         {
             return new ElectricAdmittance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricAdmittance"/> from dividing <see cref="ElectricAdmittance"/> by value.</summary>
         public static ElectricAdmittance operator /(ElectricAdmittance left, double right)
         {
             return new ElectricAdmittance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricAdmittance"/> by <see cref="ElectricAdmittance"/>.</summary>
         public static double operator /(ElectricAdmittance left, ElectricAdmittance right)
         {
             return left.Siemens / right.Siemens;
@@ -423,36 +430,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricAdmittance left, ElectricAdmittance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricAdmittance left, ElectricAdmittance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricAdmittance left, ElectricAdmittance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricAdmittance left, ElectricAdmittance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricAdmittance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricAdmittance left, ElectricAdmittance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricAdmittance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricAdmittance left, ElectricAdmittance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -461,11 +477,14 @@ namespace UnitsNet
             return CompareTo(objElectricAdmittance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricAdmittance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricAdmittance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricAdmittance objElectricAdmittance))
@@ -474,6 +493,8 @@ namespace UnitsNet
             return Equals(objElectricAdmittance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricAdmittance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricAdmittance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -558,6 +579,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricAdmittanceUnit) unit);
 
         /// <summary>
@@ -572,6 +594,7 @@ namespace UnitsNet
 
         IQuantity<ElectricAdmittanceUnit> IQuantity<ElectricAdmittanceUnit>.ToUnit(ElectricAdmittanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricAdmittanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Electric charge is the physical property of matter that causes it to experience a force when placed in an electromagnetic field.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricChargeUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricChargeUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricChargeUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricChargeUnit)"/>
         public static bool TryParseUnit(string str, out ElectricChargeUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricCharge operator -(ElectricCharge right)
         {
             return new ElectricCharge(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCharge"/> from adding two <see cref="ElectricCharge"/>.</summary>
         public static ElectricCharge operator +(ElectricCharge left, ElectricCharge right)
         {
             return new ElectricCharge(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCharge"/> from subtracting two <see cref="ElectricCharge"/>.</summary>
         public static ElectricCharge operator -(ElectricCharge left, ElectricCharge right)
         {
             return new ElectricCharge(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCharge"/> from multiplying value and <see cref="ElectricCharge"/>.</summary>
         public static ElectricCharge operator *(double left, ElectricCharge right)
         {
             return new ElectricCharge(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCharge"/> from multiplying value and <see cref="ElectricCharge"/>.</summary>
         public static ElectricCharge operator *(ElectricCharge left, double right)
         {
             return new ElectricCharge(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCharge"/> from dividing <see cref="ElectricCharge"/> by value.</summary>
         public static ElectricCharge operator /(ElectricCharge left, double right)
         {
             return new ElectricCharge(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricCharge"/> by <see cref="ElectricCharge"/>.</summary>
         public static double operator /(ElectricCharge left, ElectricCharge right)
         {
             return left.Coulombs / right.Coulombs;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricCharge left, ElectricCharge right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricCharge left, ElectricCharge right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricCharge left, ElectricCharge right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricCharge left, ElectricCharge right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCharge, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricCharge left, ElectricCharge right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCharge, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricCharge left, ElectricCharge right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objElectricCharge);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricCharge other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCharge, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricCharge objElectricCharge))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objElectricCharge);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCharge, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricCharge other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricChargeUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<ElectricChargeUnit> IQuantity<ElectricChargeUnit>.ToUnit(ElectricChargeUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricChargeUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In electromagnetism, charge density is a measure of the amount of electric charge per unit length, surface area, or volume.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricChargeDensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricChargeDensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricChargeDensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricChargeDensityUnit)"/>
         public static bool TryParseUnit(string str, out ElectricChargeDensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricChargeDensity operator -(ElectricChargeDensity right)
         {
             return new ElectricChargeDensity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricChargeDensity"/> from adding two <see cref="ElectricChargeDensity"/>.</summary>
         public static ElectricChargeDensity operator +(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return new ElectricChargeDensity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricChargeDensity"/> from subtracting two <see cref="ElectricChargeDensity"/>.</summary>
         public static ElectricChargeDensity operator -(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return new ElectricChargeDensity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricChargeDensity"/> from multiplying value and <see cref="ElectricChargeDensity"/>.</summary>
         public static ElectricChargeDensity operator *(double left, ElectricChargeDensity right)
         {
             return new ElectricChargeDensity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricChargeDensity"/> from multiplying value and <see cref="ElectricChargeDensity"/>.</summary>
         public static ElectricChargeDensity operator *(ElectricChargeDensity left, double right)
         {
             return new ElectricChargeDensity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricChargeDensity"/> from dividing <see cref="ElectricChargeDensity"/> by value.</summary>
         public static ElectricChargeDensity operator /(ElectricChargeDensity left, double right)
         {
             return new ElectricChargeDensity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricChargeDensity"/> by <see cref="ElectricChargeDensity"/>.</summary>
         public static double operator /(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return left.CoulombsPerCubicMeter / right.CoulombsPerCubicMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricChargeDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricChargeDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricChargeDensity left, ElectricChargeDensity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objElectricChargeDensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricChargeDensity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricChargeDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricChargeDensity objElectricChargeDensity))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objElectricChargeDensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricChargeDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricChargeDensity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricChargeDensityUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<ElectricChargeDensityUnit> IQuantity<ElectricChargeDensityUnit>.ToUnit(ElectricChargeDensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricChargeDensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The electrical conductance of an electrical conductor is a measure of the easeness to pass an electric current through that conductor.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricConductanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricConductanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -349,6 +348,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricConductanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricConductanceUnit)"/>
         public static bool TryParseUnit(string str, out ElectricConductanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -373,36 +373,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricConductance operator -(ElectricConductance right)
         {
             return new ElectricConductance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductance"/> from adding two <see cref="ElectricConductance"/>.</summary>
         public static ElectricConductance operator +(ElectricConductance left, ElectricConductance right)
         {
             return new ElectricConductance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductance"/> from subtracting two <see cref="ElectricConductance"/>.</summary>
         public static ElectricConductance operator -(ElectricConductance left, ElectricConductance right)
         {
             return new ElectricConductance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductance"/> from multiplying value and <see cref="ElectricConductance"/>.</summary>
         public static ElectricConductance operator *(double left, ElectricConductance right)
         {
             return new ElectricConductance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductance"/> from multiplying value and <see cref="ElectricConductance"/>.</summary>
         public static ElectricConductance operator *(ElectricConductance left, double right)
         {
             return new ElectricConductance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductance"/> from dividing <see cref="ElectricConductance"/> by value.</summary>
         public static ElectricConductance operator /(ElectricConductance left, double right)
         {
             return new ElectricConductance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricConductance"/> by <see cref="ElectricConductance"/>.</summary>
         public static double operator /(ElectricConductance left, ElectricConductance right)
         {
             return left.Siemens / right.Siemens;
@@ -412,36 +419,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricConductance left, ElectricConductance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricConductance left, ElectricConductance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricConductance left, ElectricConductance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricConductance left, ElectricConductance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricConductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricConductance left, ElectricConductance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricConductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricConductance left, ElectricConductance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -450,11 +466,14 @@ namespace UnitsNet
             return CompareTo(objElectricConductance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricConductance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricConductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricConductance objElectricConductance))
@@ -463,6 +482,8 @@ namespace UnitsNet
             return Equals(objElectricConductance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricConductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricConductance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -547,6 +568,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricConductanceUnit) unit);
 
         /// <summary>
@@ -561,6 +583,7 @@ namespace UnitsNet
 
         IQuantity<ElectricConductanceUnit> IQuantity<ElectricConductanceUnit>.ToUnit(ElectricConductanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricConductanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Electrical conductivity or specific conductance is the reciprocal of electrical resistivity, and measures a material's ability to conduct an electric current.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricConductivityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricConductivityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricConductivityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricConductivityUnit)"/>
         public static bool TryParseUnit(string str, out ElectricConductivityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricConductivity operator -(ElectricConductivity right)
         {
             return new ElectricConductivity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductivity"/> from adding two <see cref="ElectricConductivity"/>.</summary>
         public static ElectricConductivity operator +(ElectricConductivity left, ElectricConductivity right)
         {
             return new ElectricConductivity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductivity"/> from subtracting two <see cref="ElectricConductivity"/>.</summary>
         public static ElectricConductivity operator -(ElectricConductivity left, ElectricConductivity right)
         {
             return new ElectricConductivity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductivity"/> from multiplying value and <see cref="ElectricConductivity"/>.</summary>
         public static ElectricConductivity operator *(double left, ElectricConductivity right)
         {
             return new ElectricConductivity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductivity"/> from multiplying value and <see cref="ElectricConductivity"/>.</summary>
         public static ElectricConductivity operator *(ElectricConductivity left, double right)
         {
             return new ElectricConductivity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricConductivity"/> from dividing <see cref="ElectricConductivity"/> by value.</summary>
         public static ElectricConductivity operator /(ElectricConductivity left, double right)
         {
             return new ElectricConductivity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricConductivity"/> by <see cref="ElectricConductivity"/>.</summary>
         public static double operator /(ElectricConductivity left, ElectricConductivity right)
         {
             return left.SiemensPerMeter / right.SiemensPerMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricConductivity left, ElectricConductivity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricConductivity left, ElectricConductivity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricConductivity left, ElectricConductivity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricConductivity left, ElectricConductivity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricConductivity left, ElectricConductivity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricConductivity left, ElectricConductivity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objElectricConductivity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricConductivity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricConductivity objElectricConductivity))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objElectricConductivity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricConductivity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricConductivityUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<ElectricConductivityUnit> IQuantity<ElectricConductivityUnit>.ToUnit(ElectricConductivityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricConductivityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     An electric current is a flow of electric charge. In electric circuits this charge is often carried by moving electrons in a wire. It can also be carried by ions in an electrolyte, or by both ions and electrons such as in a plasma.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricCurrentUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricCurrentUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -416,6 +415,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricCurrentUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricCurrentUnit)"/>
         public static bool TryParseUnit(string str, out ElectricCurrentUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -440,36 +440,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricCurrent operator -(ElectricCurrent right)
         {
             return new ElectricCurrent(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrent"/> from adding two <see cref="ElectricCurrent"/>.</summary>
         public static ElectricCurrent operator +(ElectricCurrent left, ElectricCurrent right)
         {
             return new ElectricCurrent(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrent"/> from subtracting two <see cref="ElectricCurrent"/>.</summary>
         public static ElectricCurrent operator -(ElectricCurrent left, ElectricCurrent right)
         {
             return new ElectricCurrent(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrent"/> from multiplying value and <see cref="ElectricCurrent"/>.</summary>
         public static ElectricCurrent operator *(double left, ElectricCurrent right)
         {
             return new ElectricCurrent(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrent"/> from multiplying value and <see cref="ElectricCurrent"/>.</summary>
         public static ElectricCurrent operator *(ElectricCurrent left, double right)
         {
             return new ElectricCurrent(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrent"/> from dividing <see cref="ElectricCurrent"/> by value.</summary>
         public static ElectricCurrent operator /(ElectricCurrent left, double right)
         {
             return new ElectricCurrent(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricCurrent"/> by <see cref="ElectricCurrent"/>.</summary>
         public static double operator /(ElectricCurrent left, ElectricCurrent right)
         {
             return left.Amperes / right.Amperes;
@@ -479,36 +486,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricCurrent left, ElectricCurrent right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricCurrent left, ElectricCurrent right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricCurrent left, ElectricCurrent right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricCurrent left, ElectricCurrent right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrent, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricCurrent left, ElectricCurrent right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrent, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricCurrent left, ElectricCurrent right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -517,11 +533,14 @@ namespace UnitsNet
             return CompareTo(objElectricCurrent);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricCurrent other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrent, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricCurrent objElectricCurrent))
@@ -530,6 +549,8 @@ namespace UnitsNet
             return Equals(objElectricCurrent);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrent, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricCurrent other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -614,6 +635,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricCurrentUnit) unit);
 
         /// <summary>
@@ -628,6 +650,7 @@ namespace UnitsNet
 
         IQuantity<ElectricCurrentUnit> IQuantity<ElectricCurrentUnit>.ToUnit(ElectricCurrentUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricCurrentUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In electromagnetism, current density is the electric current per unit area of cross section.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricCurrentDensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricCurrentDensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricCurrentDensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricCurrentDensityUnit)"/>
         public static bool TryParseUnit(string str, out ElectricCurrentDensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricCurrentDensity operator -(ElectricCurrentDensity right)
         {
             return new ElectricCurrentDensity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentDensity"/> from adding two <see cref="ElectricCurrentDensity"/>.</summary>
         public static ElectricCurrentDensity operator +(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return new ElectricCurrentDensity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentDensity"/> from subtracting two <see cref="ElectricCurrentDensity"/>.</summary>
         public static ElectricCurrentDensity operator -(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return new ElectricCurrentDensity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentDensity"/> from multiplying value and <see cref="ElectricCurrentDensity"/>.</summary>
         public static ElectricCurrentDensity operator *(double left, ElectricCurrentDensity right)
         {
             return new ElectricCurrentDensity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentDensity"/> from multiplying value and <see cref="ElectricCurrentDensity"/>.</summary>
         public static ElectricCurrentDensity operator *(ElectricCurrentDensity left, double right)
         {
             return new ElectricCurrentDensity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentDensity"/> from dividing <see cref="ElectricCurrentDensity"/> by value.</summary>
         public static ElectricCurrentDensity operator /(ElectricCurrentDensity left, double right)
         {
             return new ElectricCurrentDensity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricCurrentDensity"/> by <see cref="ElectricCurrentDensity"/>.</summary>
         public static double operator /(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return left.AmperesPerSquareMeter / right.AmperesPerSquareMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricCurrentDensity left, ElectricCurrentDensity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objElectricCurrentDensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricCurrentDensity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricCurrentDensity objElectricCurrentDensity))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objElectricCurrentDensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricCurrentDensity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricCurrentDensityUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<ElectricCurrentDensityUnit> IQuantity<ElectricCurrentDensityUnit>.ToUnit(ElectricCurrentDensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricCurrentDensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In electromagnetism, the current gradient describes how the current changes in time.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricCurrentGradientUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricCurrentGradientUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -318,6 +317,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricCurrentGradientUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricCurrentGradientUnit)"/>
         public static bool TryParseUnit(string str, out ElectricCurrentGradientUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -342,36 +342,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricCurrentGradient operator -(ElectricCurrentGradient right)
         {
             return new ElectricCurrentGradient(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from adding two <see cref="ElectricCurrentGradient"/>.</summary>
         public static ElectricCurrentGradient operator +(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return new ElectricCurrentGradient(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from subtracting two <see cref="ElectricCurrentGradient"/>.</summary>
         public static ElectricCurrentGradient operator -(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return new ElectricCurrentGradient(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from multiplying value and <see cref="ElectricCurrentGradient"/>.</summary>
         public static ElectricCurrentGradient operator *(double left, ElectricCurrentGradient right)
         {
             return new ElectricCurrentGradient(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from multiplying value and <see cref="ElectricCurrentGradient"/>.</summary>
         public static ElectricCurrentGradient operator *(ElectricCurrentGradient left, double right)
         {
             return new ElectricCurrentGradient(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from dividing <see cref="ElectricCurrentGradient"/> by value.</summary>
         public static ElectricCurrentGradient operator /(ElectricCurrentGradient left, double right)
         {
             return new ElectricCurrentGradient(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricCurrentGradient"/> by <see cref="ElectricCurrentGradient"/>.</summary>
         public static double operator /(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return left.AmperesPerSecond / right.AmperesPerSecond;
@@ -381,36 +388,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentGradient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentGradient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricCurrentGradient left, ElectricCurrentGradient right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -419,11 +435,14 @@ namespace UnitsNet
             return CompareTo(objElectricCurrentGradient);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricCurrentGradient other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentGradient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricCurrentGradient objElectricCurrentGradient))
@@ -432,6 +451,8 @@ namespace UnitsNet
             return Equals(objElectricCurrentGradient);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricCurrentGradient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricCurrentGradient other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -516,6 +537,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricCurrentGradientUnit) unit);
 
         /// <summary>
@@ -530,6 +552,7 @@ namespace UnitsNet
 
         IQuantity<ElectricCurrentGradientUnit> IQuantity<ElectricCurrentGradientUnit>.ToUnit(ElectricCurrentGradientUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricCurrentGradientUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     An electric field is a force field that surrounds electric charges that attracts or repels other electric charges.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricFieldUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricFieldUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricFieldUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricFieldUnit)"/>
         public static bool TryParseUnit(string str, out ElectricFieldUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricField operator -(ElectricField right)
         {
             return new ElectricField(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricField"/> from adding two <see cref="ElectricField"/>.</summary>
         public static ElectricField operator +(ElectricField left, ElectricField right)
         {
             return new ElectricField(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricField"/> from subtracting two <see cref="ElectricField"/>.</summary>
         public static ElectricField operator -(ElectricField left, ElectricField right)
         {
             return new ElectricField(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricField"/> from multiplying value and <see cref="ElectricField"/>.</summary>
         public static ElectricField operator *(double left, ElectricField right)
         {
             return new ElectricField(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricField"/> from multiplying value and <see cref="ElectricField"/>.</summary>
         public static ElectricField operator *(ElectricField left, double right)
         {
             return new ElectricField(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricField"/> from dividing <see cref="ElectricField"/> by value.</summary>
         public static ElectricField operator /(ElectricField left, double right)
         {
             return new ElectricField(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricField"/> by <see cref="ElectricField"/>.</summary>
         public static double operator /(ElectricField left, ElectricField right)
         {
             return left.VoltsPerMeter / right.VoltsPerMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricField left, ElectricField right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricField left, ElectricField right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricField left, ElectricField right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricField left, ElectricField right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricField left, ElectricField right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricField left, ElectricField right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objElectricField);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricField other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricField objElectricField))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objElectricField);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricField other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricFieldUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<ElectricFieldUnit> IQuantity<ElectricFieldUnit>.ToUnit(ElectricFieldUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricFieldUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Inductance is a property of an electrical conductor which opposes a change in current.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricInductanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricInductanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -363,6 +362,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricInductanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricInductanceUnit)"/>
         public static bool TryParseUnit(string str, out ElectricInductanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -387,36 +387,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricInductance operator -(ElectricInductance right)
         {
             return new ElectricInductance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricInductance"/> from adding two <see cref="ElectricInductance"/>.</summary>
         public static ElectricInductance operator +(ElectricInductance left, ElectricInductance right)
         {
             return new ElectricInductance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricInductance"/> from subtracting two <see cref="ElectricInductance"/>.</summary>
         public static ElectricInductance operator -(ElectricInductance left, ElectricInductance right)
         {
             return new ElectricInductance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricInductance"/> from multiplying value and <see cref="ElectricInductance"/>.</summary>
         public static ElectricInductance operator *(double left, ElectricInductance right)
         {
             return new ElectricInductance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricInductance"/> from multiplying value and <see cref="ElectricInductance"/>.</summary>
         public static ElectricInductance operator *(ElectricInductance left, double right)
         {
             return new ElectricInductance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricInductance"/> from dividing <see cref="ElectricInductance"/> by value.</summary>
         public static ElectricInductance operator /(ElectricInductance left, double right)
         {
             return new ElectricInductance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricInductance"/> by <see cref="ElectricInductance"/>.</summary>
         public static double operator /(ElectricInductance left, ElectricInductance right)
         {
             return left.Henries / right.Henries;
@@ -426,36 +433,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricInductance left, ElectricInductance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricInductance left, ElectricInductance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricInductance left, ElectricInductance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricInductance left, ElectricInductance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricInductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricInductance left, ElectricInductance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricInductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricInductance left, ElectricInductance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -464,11 +480,14 @@ namespace UnitsNet
             return CompareTo(objElectricInductance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricInductance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricInductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricInductance objElectricInductance))
@@ -477,6 +496,8 @@ namespace UnitsNet
             return Equals(objElectricInductance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricInductance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricInductance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -561,6 +582,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricInductanceUnit) unit);
 
         /// <summary>
@@ -575,6 +597,7 @@ namespace UnitsNet
 
         IQuantity<ElectricInductanceUnit> IQuantity<ElectricInductanceUnit>.ToUnit(ElectricInductanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricInductanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricPotentialUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricPotentialUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -374,6 +373,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricPotentialUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricPotentialUnit)"/>
         public static bool TryParseUnit(string str, out ElectricPotentialUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -398,36 +398,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricPotential operator -(ElectricPotential right)
         {
             return new ElectricPotential(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotential"/> from adding two <see cref="ElectricPotential"/>.</summary>
         public static ElectricPotential operator +(ElectricPotential left, ElectricPotential right)
         {
             return new ElectricPotential(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotential"/> from subtracting two <see cref="ElectricPotential"/>.</summary>
         public static ElectricPotential operator -(ElectricPotential left, ElectricPotential right)
         {
             return new ElectricPotential(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotential"/> from multiplying value and <see cref="ElectricPotential"/>.</summary>
         public static ElectricPotential operator *(double left, ElectricPotential right)
         {
             return new ElectricPotential(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotential"/> from multiplying value and <see cref="ElectricPotential"/>.</summary>
         public static ElectricPotential operator *(ElectricPotential left, double right)
         {
             return new ElectricPotential(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotential"/> from dividing <see cref="ElectricPotential"/> by value.</summary>
         public static ElectricPotential operator /(ElectricPotential left, double right)
         {
             return new ElectricPotential(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricPotential"/> by <see cref="ElectricPotential"/>.</summary>
         public static double operator /(ElectricPotential left, ElectricPotential right)
         {
             return left.Volts / right.Volts;
@@ -437,36 +444,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricPotential left, ElectricPotential right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricPotential left, ElectricPotential right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricPotential left, ElectricPotential right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricPotential left, ElectricPotential right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricPotential, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricPotential left, ElectricPotential right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricPotential, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricPotential left, ElectricPotential right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -475,11 +491,14 @@ namespace UnitsNet
             return CompareTo(objElectricPotential);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricPotential other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricPotential, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricPotential objElectricPotential))
@@ -488,6 +507,8 @@ namespace UnitsNet
             return Equals(objElectricPotential);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricPotential, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricPotential other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -572,6 +593,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricPotentialUnit) unit);
 
         /// <summary>
@@ -586,6 +608,7 @@ namespace UnitsNet
 
         IQuantity<ElectricPotentialUnit> IQuantity<ElectricPotentialUnit>.ToUnit(ElectricPotentialUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricPotentialUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The Electric Potential of a system known to use Alternating Current.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricPotentialAcUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricPotentialAcUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -374,6 +373,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricPotentialAcUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricPotentialAcUnit)"/>
         public static bool TryParseUnit(string str, out ElectricPotentialAcUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -398,36 +398,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricPotentialAc operator -(ElectricPotentialAc right)
         {
             return new ElectricPotentialAc(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialAc"/> from adding two <see cref="ElectricPotentialAc"/>.</summary>
         public static ElectricPotentialAc operator +(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return new ElectricPotentialAc(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialAc"/> from subtracting two <see cref="ElectricPotentialAc"/>.</summary>
         public static ElectricPotentialAc operator -(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return new ElectricPotentialAc(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialAc"/> from multiplying value and <see cref="ElectricPotentialAc"/>.</summary>
         public static ElectricPotentialAc operator *(double left, ElectricPotentialAc right)
         {
             return new ElectricPotentialAc(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialAc"/> from multiplying value and <see cref="ElectricPotentialAc"/>.</summary>
         public static ElectricPotentialAc operator *(ElectricPotentialAc left, double right)
         {
             return new ElectricPotentialAc(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialAc"/> from dividing <see cref="ElectricPotentialAc"/> by value.</summary>
         public static ElectricPotentialAc operator /(ElectricPotentialAc left, double right)
         {
             return new ElectricPotentialAc(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricPotentialAc"/> by <see cref="ElectricPotentialAc"/>.</summary>
         public static double operator /(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return left.VoltsAc / right.VoltsAc;
@@ -437,36 +444,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialAc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialAc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricPotentialAc left, ElectricPotentialAc right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -475,11 +491,14 @@ namespace UnitsNet
             return CompareTo(objElectricPotentialAc);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricPotentialAc other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialAc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricPotentialAc objElectricPotentialAc))
@@ -488,6 +507,8 @@ namespace UnitsNet
             return Equals(objElectricPotentialAc);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialAc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricPotentialAc other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -572,6 +593,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricPotentialAcUnit) unit);
 
         /// <summary>
@@ -586,6 +608,7 @@ namespace UnitsNet
 
         IQuantity<ElectricPotentialAcUnit> IQuantity<ElectricPotentialAcUnit>.ToUnit(ElectricPotentialAcUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricPotentialAcUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The Electric Potential of a system known to use Direct Current.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricPotentialDcUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricPotentialDcUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -374,6 +373,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricPotentialDcUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricPotentialDcUnit)"/>
         public static bool TryParseUnit(string str, out ElectricPotentialDcUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -398,36 +398,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricPotentialDc operator -(ElectricPotentialDc right)
         {
             return new ElectricPotentialDc(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialDc"/> from adding two <see cref="ElectricPotentialDc"/>.</summary>
         public static ElectricPotentialDc operator +(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return new ElectricPotentialDc(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialDc"/> from subtracting two <see cref="ElectricPotentialDc"/>.</summary>
         public static ElectricPotentialDc operator -(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return new ElectricPotentialDc(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialDc"/> from multiplying value and <see cref="ElectricPotentialDc"/>.</summary>
         public static ElectricPotentialDc operator *(double left, ElectricPotentialDc right)
         {
             return new ElectricPotentialDc(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialDc"/> from multiplying value and <see cref="ElectricPotentialDc"/>.</summary>
         public static ElectricPotentialDc operator *(ElectricPotentialDc left, double right)
         {
             return new ElectricPotentialDc(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricPotentialDc"/> from dividing <see cref="ElectricPotentialDc"/> by value.</summary>
         public static ElectricPotentialDc operator /(ElectricPotentialDc left, double right)
         {
             return new ElectricPotentialDc(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricPotentialDc"/> by <see cref="ElectricPotentialDc"/>.</summary>
         public static double operator /(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return left.VoltsDc / right.VoltsDc;
@@ -437,36 +444,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialDc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialDc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricPotentialDc left, ElectricPotentialDc right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -475,11 +491,14 @@ namespace UnitsNet
             return CompareTo(objElectricPotentialDc);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricPotentialDc other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialDc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricPotentialDc objElectricPotentialDc))
@@ -488,6 +507,8 @@ namespace UnitsNet
             return Equals(objElectricPotentialDc);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricPotentialDc, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricPotentialDc other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -572,6 +593,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricPotentialDcUnit) unit);
 
         /// <summary>
@@ -586,6 +608,7 @@ namespace UnitsNet
 
         IQuantity<ElectricPotentialDcUnit> IQuantity<ElectricPotentialDcUnit>.ToUnit(ElectricPotentialDcUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricPotentialDcUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The electrical resistance of an electrical conductor is the opposition to the passage of an electric current through that conductor.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricResistanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricResistanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -374,6 +373,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricResistanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricResistanceUnit)"/>
         public static bool TryParseUnit(string str, out ElectricResistanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -398,36 +398,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricResistance operator -(ElectricResistance right)
         {
             return new ElectricResistance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistance"/> from adding two <see cref="ElectricResistance"/>.</summary>
         public static ElectricResistance operator +(ElectricResistance left, ElectricResistance right)
         {
             return new ElectricResistance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistance"/> from subtracting two <see cref="ElectricResistance"/>.</summary>
         public static ElectricResistance operator -(ElectricResistance left, ElectricResistance right)
         {
             return new ElectricResistance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistance"/> from multiplying value and <see cref="ElectricResistance"/>.</summary>
         public static ElectricResistance operator *(double left, ElectricResistance right)
         {
             return new ElectricResistance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistance"/> from multiplying value and <see cref="ElectricResistance"/>.</summary>
         public static ElectricResistance operator *(ElectricResistance left, double right)
         {
             return new ElectricResistance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistance"/> from dividing <see cref="ElectricResistance"/> by value.</summary>
         public static ElectricResistance operator /(ElectricResistance left, double right)
         {
             return new ElectricResistance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricResistance"/> by <see cref="ElectricResistance"/>.</summary>
         public static double operator /(ElectricResistance left, ElectricResistance right)
         {
             return left.Ohms / right.Ohms;
@@ -437,36 +444,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricResistance left, ElectricResistance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricResistance left, ElectricResistance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricResistance left, ElectricResistance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricResistance left, ElectricResistance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricResistance left, ElectricResistance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricResistance left, ElectricResistance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -475,11 +491,14 @@ namespace UnitsNet
             return CompareTo(objElectricResistance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricResistance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricResistance objElectricResistance))
@@ -488,6 +507,8 @@ namespace UnitsNet
             return Equals(objElectricResistance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricResistance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -572,6 +593,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricResistanceUnit) unit);
 
         /// <summary>
@@ -586,6 +608,7 @@ namespace UnitsNet
 
         IQuantity<ElectricResistanceUnit> IQuantity<ElectricResistanceUnit>.ToUnit(ElectricResistanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricResistanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Electrical resistivity (also known as resistivity, specific electrical resistance, or volume resistivity) is a fundamental property that quantifies how strongly a given material opposes the flow of electric current.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ElectricResistivityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ElectricResistivityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -503,6 +502,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ElectricResistivityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ElectricResistivityUnit)"/>
         public static bool TryParseUnit(string str, out ElectricResistivityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -527,36 +527,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ElectricResistivity operator -(ElectricResistivity right)
         {
             return new ElectricResistivity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistivity"/> from adding two <see cref="ElectricResistivity"/>.</summary>
         public static ElectricResistivity operator +(ElectricResistivity left, ElectricResistivity right)
         {
             return new ElectricResistivity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistivity"/> from subtracting two <see cref="ElectricResistivity"/>.</summary>
         public static ElectricResistivity operator -(ElectricResistivity left, ElectricResistivity right)
         {
             return new ElectricResistivity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistivity"/> from multiplying value and <see cref="ElectricResistivity"/>.</summary>
         public static ElectricResistivity operator *(double left, ElectricResistivity right)
         {
             return new ElectricResistivity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistivity"/> from multiplying value and <see cref="ElectricResistivity"/>.</summary>
         public static ElectricResistivity operator *(ElectricResistivity left, double right)
         {
             return new ElectricResistivity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ElectricResistivity"/> from dividing <see cref="ElectricResistivity"/> by value.</summary>
         public static ElectricResistivity operator /(ElectricResistivity left, double right)
         {
             return new ElectricResistivity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ElectricResistivity"/> by <see cref="ElectricResistivity"/>.</summary>
         public static double operator /(ElectricResistivity left, ElectricResistivity right)
         {
             return left.OhmMeters / right.OhmMeters;
@@ -566,36 +573,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ElectricResistivity left, ElectricResistivity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ElectricResistivity left, ElectricResistivity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ElectricResistivity left, ElectricResistivity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ElectricResistivity left, ElectricResistivity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricResistivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ElectricResistivity left, ElectricResistivity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ElectricResistivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ElectricResistivity left, ElectricResistivity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -604,11 +620,14 @@ namespace UnitsNet
             return CompareTo(objElectricResistivity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ElectricResistivity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricResistivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ElectricResistivity objElectricResistivity))
@@ -617,6 +636,8 @@ namespace UnitsNet
             return Equals(objElectricResistivity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ElectricResistivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ElectricResistivity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -701,6 +722,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ElectricResistivityUnit) unit);
 
         /// <summary>
@@ -715,6 +737,7 @@ namespace UnitsNet
 
         IQuantity<ElectricResistivityUnit> IQuantity<ElectricResistivityUnit>.ToUnit(ElectricResistivityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ElectricResistivityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The joule, symbol J, is a derived unit of energy, work, or amount of heat in the International System of Units. It is equal to the energy transferred (or work done) when applying a force of one newton through a distance of one metre (1 newton metre or N·m), or in passing an electric current of one ampere through a resistance of one ohm for one second. Many other units of energy are included. Please do not confuse this definition of the calorie with the one colloquially used by the food industry, the large calorie, which is equivalent to 1 kcal. Thermochemical definition of the calorie is used. For BTU, the IT definition is used.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public EnergyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<EnergyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -626,6 +625,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<EnergyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.EnergyUnit)"/>
         public static bool TryParseUnit(string str, out EnergyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -650,36 +650,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Energy operator -(Energy right)
         {
             return new Energy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Energy"/> from adding two <see cref="Energy"/>.</summary>
         public static Energy operator +(Energy left, Energy right)
         {
             return new Energy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Energy"/> from subtracting two <see cref="Energy"/>.</summary>
         public static Energy operator -(Energy left, Energy right)
         {
             return new Energy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Energy"/> from multiplying value and <see cref="Energy"/>.</summary>
         public static Energy operator *(double left, Energy right)
         {
             return new Energy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Energy"/> from multiplying value and <see cref="Energy"/>.</summary>
         public static Energy operator *(Energy left, double right)
         {
             return new Energy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Energy"/> from dividing <see cref="Energy"/> by value.</summary>
         public static Energy operator /(Energy left, double right)
         {
             return new Energy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Energy"/> by <see cref="Energy"/>.</summary>
         public static double operator /(Energy left, Energy right)
         {
             return left.Joules / right.Joules;
@@ -689,36 +696,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Energy left, Energy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Energy left, Energy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Energy left, Energy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Energy left, Energy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Energy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Energy left, Energy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Energy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Energy left, Energy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -727,11 +743,14 @@ namespace UnitsNet
             return CompareTo(objEnergy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Energy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Energy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Energy objEnergy))
@@ -740,6 +759,8 @@ namespace UnitsNet
             return Equals(objEnergy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Energy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Energy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -824,6 +845,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((EnergyUnit) unit);
 
         /// <summary>
@@ -838,6 +860,7 @@ namespace UnitsNet
 
         IQuantity<EnergyUnit> IQuantity<EnergyUnit>.ToUnit(EnergyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((EnergyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Entropy is an important concept in the branch of science known as thermodynamics. The idea of "irreversibility" is central to the understanding of entropy.  It is often said that entropy is an expression of the disorder, or randomness of a system, or of our lack of information about it. Entropy is an extensive property. It has the dimension of energy divided by temperature, which has a unit of joules per kelvin (J/K) in the International System of Units
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public EntropyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<EntropyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -402,6 +401,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<EntropyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.EntropyUnit)"/>
         public static bool TryParseUnit(string str, out EntropyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -426,36 +426,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Entropy operator -(Entropy right)
         {
             return new Entropy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Entropy"/> from adding two <see cref="Entropy"/>.</summary>
         public static Entropy operator +(Entropy left, Entropy right)
         {
             return new Entropy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Entropy"/> from subtracting two <see cref="Entropy"/>.</summary>
         public static Entropy operator -(Entropy left, Entropy right)
         {
             return new Entropy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Entropy"/> from multiplying value and <see cref="Entropy"/>.</summary>
         public static Entropy operator *(double left, Entropy right)
         {
             return new Entropy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Entropy"/> from multiplying value and <see cref="Entropy"/>.</summary>
         public static Entropy operator *(Entropy left, double right)
         {
             return new Entropy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Entropy"/> from dividing <see cref="Entropy"/> by value.</summary>
         public static Entropy operator /(Entropy left, double right)
         {
             return new Entropy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Entropy"/> by <see cref="Entropy"/>.</summary>
         public static double operator /(Entropy left, Entropy right)
         {
             return left.JoulesPerKelvin / right.JoulesPerKelvin;
@@ -465,36 +472,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Entropy left, Entropy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Entropy left, Entropy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Entropy left, Entropy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Entropy left, Entropy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Entropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Entropy left, Entropy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Entropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Entropy left, Entropy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -503,11 +519,14 @@ namespace UnitsNet
             return CompareTo(objEntropy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Entropy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Entropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Entropy objEntropy))
@@ -516,6 +535,8 @@ namespace UnitsNet
             return Equals(objEntropy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Entropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Entropy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -600,6 +621,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((EntropyUnit) unit);
 
         /// <summary>
@@ -614,6 +636,7 @@ namespace UnitsNet
 
         IQuantity<EntropyUnit> IQuantity<EntropyUnit>.ToUnit(EntropyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((EntropyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In physics, a force is any influence that causes an object to undergo a certain change, either concerning its movement, direction, or geometrical construction. In other words, a force can cause an object with mass to change its velocity (which includes to begin moving from a state of rest), i.e., to accelerate, or a flexible object to deform, or both. Force can also be described by intuitive concepts such as a push or a pull. A force has both magnitude and direction, making it a vector quantity. It is measured in the SI unit of newtons and represented by the symbol F.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ForceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ForceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -486,6 +485,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ForceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ForceUnit)"/>
         public static bool TryParseUnit(string str, out ForceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -510,36 +510,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Force operator -(Force right)
         {
             return new Force(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Force"/> from adding two <see cref="Force"/>.</summary>
         public static Force operator +(Force left, Force right)
         {
             return new Force(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Force"/> from subtracting two <see cref="Force"/>.</summary>
         public static Force operator -(Force left, Force right)
         {
             return new Force(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Force"/> from multiplying value and <see cref="Force"/>.</summary>
         public static Force operator *(double left, Force right)
         {
             return new Force(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Force"/> from multiplying value and <see cref="Force"/>.</summary>
         public static Force operator *(Force left, double right)
         {
             return new Force(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Force"/> from dividing <see cref="Force"/> by value.</summary>
         public static Force operator /(Force left, double right)
         {
             return new Force(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Force"/> by <see cref="Force"/>.</summary>
         public static double operator /(Force left, Force right)
         {
             return left.Newtons / right.Newtons;
@@ -549,36 +556,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Force left, Force right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Force left, Force right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Force left, Force right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Force left, Force right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Force, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Force left, Force right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Force, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Force left, Force right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -587,11 +603,14 @@ namespace UnitsNet
             return CompareTo(objForce);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Force other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Force, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Force objForce))
@@ -600,6 +619,8 @@ namespace UnitsNet
             return Equals(objForce);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Force, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Force other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -684,6 +705,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ForceUnit) unit);
 
         /// <summary>
@@ -698,6 +720,7 @@ namespace UnitsNet
 
         IQuantity<ForceUnit> IQuantity<ForceUnit>.ToUnit(ForceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ForceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Force change rate is the ratio of the force change to the time during which the change occurred (value of force changes per unit time).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ForceChangeRateUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ForceChangeRateUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -458,6 +457,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ForceChangeRateUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ForceChangeRateUnit)"/>
         public static bool TryParseUnit(string str, out ForceChangeRateUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -482,36 +482,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ForceChangeRate operator -(ForceChangeRate right)
         {
             return new ForceChangeRate(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ForceChangeRate"/> from adding two <see cref="ForceChangeRate"/>.</summary>
         public static ForceChangeRate operator +(ForceChangeRate left, ForceChangeRate right)
         {
             return new ForceChangeRate(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ForceChangeRate"/> from subtracting two <see cref="ForceChangeRate"/>.</summary>
         public static ForceChangeRate operator -(ForceChangeRate left, ForceChangeRate right)
         {
             return new ForceChangeRate(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ForceChangeRate"/> from multiplying value and <see cref="ForceChangeRate"/>.</summary>
         public static ForceChangeRate operator *(double left, ForceChangeRate right)
         {
             return new ForceChangeRate(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ForceChangeRate"/> from multiplying value and <see cref="ForceChangeRate"/>.</summary>
         public static ForceChangeRate operator *(ForceChangeRate left, double right)
         {
             return new ForceChangeRate(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ForceChangeRate"/> from dividing <see cref="ForceChangeRate"/> by value.</summary>
         public static ForceChangeRate operator /(ForceChangeRate left, double right)
         {
             return new ForceChangeRate(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ForceChangeRate"/> by <see cref="ForceChangeRate"/>.</summary>
         public static double operator /(ForceChangeRate left, ForceChangeRate right)
         {
             return left.NewtonsPerSecond / right.NewtonsPerSecond;
@@ -521,36 +528,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ForceChangeRate left, ForceChangeRate right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ForceChangeRate left, ForceChangeRate right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ForceChangeRate left, ForceChangeRate right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ForceChangeRate left, ForceChangeRate right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ForceChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ForceChangeRate left, ForceChangeRate right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ForceChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ForceChangeRate left, ForceChangeRate right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -559,11 +575,14 @@ namespace UnitsNet
             return CompareTo(objForceChangeRate);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ForceChangeRate other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ForceChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ForceChangeRate objForceChangeRate))
@@ -572,6 +591,8 @@ namespace UnitsNet
             return Equals(objForceChangeRate);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ForceChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ForceChangeRate other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -656,6 +677,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ForceChangeRateUnit) unit);
 
         /// <summary>
@@ -670,6 +692,7 @@ namespace UnitsNet
 
         IQuantity<ForceChangeRateUnit> IQuantity<ForceChangeRateUnit>.ToUnit(ForceChangeRateUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ForceChangeRateUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The magnitude of force per unit length.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ForcePerLengthUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ForcePerLengthUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -430,6 +429,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ForcePerLengthUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ForcePerLengthUnit)"/>
         public static bool TryParseUnit(string str, out ForcePerLengthUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -454,36 +454,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ForcePerLength operator -(ForcePerLength right)
         {
             return new ForcePerLength(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ForcePerLength"/> from adding two <see cref="ForcePerLength"/>.</summary>
         public static ForcePerLength operator +(ForcePerLength left, ForcePerLength right)
         {
             return new ForcePerLength(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ForcePerLength"/> from subtracting two <see cref="ForcePerLength"/>.</summary>
         public static ForcePerLength operator -(ForcePerLength left, ForcePerLength right)
         {
             return new ForcePerLength(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ForcePerLength"/> from multiplying value and <see cref="ForcePerLength"/>.</summary>
         public static ForcePerLength operator *(double left, ForcePerLength right)
         {
             return new ForcePerLength(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ForcePerLength"/> from multiplying value and <see cref="ForcePerLength"/>.</summary>
         public static ForcePerLength operator *(ForcePerLength left, double right)
         {
             return new ForcePerLength(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ForcePerLength"/> from dividing <see cref="ForcePerLength"/> by value.</summary>
         public static ForcePerLength operator /(ForcePerLength left, double right)
         {
             return new ForcePerLength(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ForcePerLength"/> by <see cref="ForcePerLength"/>.</summary>
         public static double operator /(ForcePerLength left, ForcePerLength right)
         {
             return left.NewtonsPerMeter / right.NewtonsPerMeter;
@@ -493,36 +500,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ForcePerLength left, ForcePerLength right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ForcePerLength left, ForcePerLength right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ForcePerLength left, ForcePerLength right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ForcePerLength left, ForcePerLength right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ForcePerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ForcePerLength left, ForcePerLength right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ForcePerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ForcePerLength left, ForcePerLength right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -531,11 +547,14 @@ namespace UnitsNet
             return CompareTo(objForcePerLength);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ForcePerLength other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ForcePerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ForcePerLength objForcePerLength))
@@ -544,6 +563,8 @@ namespace UnitsNet
             return Equals(objForcePerLength);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ForcePerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ForcePerLength other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -628,6 +649,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ForcePerLengthUnit) unit);
 
         /// <summary>
@@ -642,6 +664,7 @@ namespace UnitsNet
 
         IQuantity<ForcePerLengthUnit> IQuantity<ForcePerLengthUnit>.ToUnit(ForcePerLengthUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ForcePerLengthUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The number of occurrences of a repeating event per unit time.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public FrequencyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<FrequencyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -430,6 +429,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<FrequencyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.FrequencyUnit)"/>
         public static bool TryParseUnit(string str, out FrequencyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -454,36 +454,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Frequency operator -(Frequency right)
         {
             return new Frequency(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Frequency"/> from adding two <see cref="Frequency"/>.</summary>
         public static Frequency operator +(Frequency left, Frequency right)
         {
             return new Frequency(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Frequency"/> from subtracting two <see cref="Frequency"/>.</summary>
         public static Frequency operator -(Frequency left, Frequency right)
         {
             return new Frequency(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Frequency"/> from multiplying value and <see cref="Frequency"/>.</summary>
         public static Frequency operator *(double left, Frequency right)
         {
             return new Frequency(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Frequency"/> from multiplying value and <see cref="Frequency"/>.</summary>
         public static Frequency operator *(Frequency left, double right)
         {
             return new Frequency(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Frequency"/> from dividing <see cref="Frequency"/> by value.</summary>
         public static Frequency operator /(Frequency left, double right)
         {
             return new Frequency(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Frequency"/> by <see cref="Frequency"/>.</summary>
         public static double operator /(Frequency left, Frequency right)
         {
             return left.Hertz / right.Hertz;
@@ -493,36 +500,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Frequency left, Frequency right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Frequency left, Frequency right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Frequency left, Frequency right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Frequency left, Frequency right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Frequency, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Frequency left, Frequency right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Frequency, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Frequency left, Frequency right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -531,11 +547,14 @@ namespace UnitsNet
             return CompareTo(objFrequency);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Frequency other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Frequency, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Frequency objFrequency))
@@ -544,6 +563,8 @@ namespace UnitsNet
             return Equals(objFrequency);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Frequency, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Frequency other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -628,6 +649,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((FrequencyUnit) unit);
 
         /// <summary>
@@ -642,6 +664,7 @@ namespace UnitsNet
 
         IQuantity<FrequencyUnit> IQuantity<FrequencyUnit>.ToUnit(FrequencyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((FrequencyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Heat flux is the flow of energy per unit of area per unit of time
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public HeatFluxUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<HeatFluxUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -556,6 +555,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<HeatFluxUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.HeatFluxUnit)"/>
         public static bool TryParseUnit(string str, out HeatFluxUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -580,36 +580,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static HeatFlux operator -(HeatFlux right)
         {
             return new HeatFlux(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="HeatFlux"/> from adding two <see cref="HeatFlux"/>.</summary>
         public static HeatFlux operator +(HeatFlux left, HeatFlux right)
         {
             return new HeatFlux(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="HeatFlux"/> from subtracting two <see cref="HeatFlux"/>.</summary>
         public static HeatFlux operator -(HeatFlux left, HeatFlux right)
         {
             return new HeatFlux(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="HeatFlux"/> from multiplying value and <see cref="HeatFlux"/>.</summary>
         public static HeatFlux operator *(double left, HeatFlux right)
         {
             return new HeatFlux(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="HeatFlux"/> from multiplying value and <see cref="HeatFlux"/>.</summary>
         public static HeatFlux operator *(HeatFlux left, double right)
         {
             return new HeatFlux(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="HeatFlux"/> from dividing <see cref="HeatFlux"/> by value.</summary>
         public static HeatFlux operator /(HeatFlux left, double right)
         {
             return new HeatFlux(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="HeatFlux"/> by <see cref="HeatFlux"/>.</summary>
         public static double operator /(HeatFlux left, HeatFlux right)
         {
             return left.WattsPerSquareMeter / right.WattsPerSquareMeter;
@@ -619,36 +626,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(HeatFlux left, HeatFlux right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(HeatFlux left, HeatFlux right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(HeatFlux left, HeatFlux right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(HeatFlux left, HeatFlux right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(HeatFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(HeatFlux left, HeatFlux right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(HeatFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(HeatFlux left, HeatFlux right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -657,11 +673,14 @@ namespace UnitsNet
             return CompareTo(objHeatFlux);
         }
 
+        /// <inheritdoc />
         public int CompareTo(HeatFlux other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(HeatFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is HeatFlux objHeatFlux))
@@ -670,6 +689,8 @@ namespace UnitsNet
             return Equals(objHeatFlux);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(HeatFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(HeatFlux other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -754,6 +775,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((HeatFluxUnit) unit);
 
         /// <summary>
@@ -768,6 +790,7 @@ namespace UnitsNet
 
         IQuantity<HeatFluxUnit> IQuantity<HeatFluxUnit>.ToUnit(HeatFluxUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((HeatFluxUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The heat transfer coefficient or film coefficient, or film effectiveness, in thermodynamics and in mechanics is the proportionality constant between the heat flux and the thermodynamic driving force for the flow of heat (i.e., the temperature difference, ΔT)
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public HeatTransferCoefficientUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<HeatTransferCoefficientUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -332,6 +331,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<HeatTransferCoefficientUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.HeatTransferCoefficientUnit)"/>
         public static bool TryParseUnit(string str, out HeatTransferCoefficientUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -356,36 +356,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static HeatTransferCoefficient operator -(HeatTransferCoefficient right)
         {
             return new HeatTransferCoefficient(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="HeatTransferCoefficient"/> from adding two <see cref="HeatTransferCoefficient"/>.</summary>
         public static HeatTransferCoefficient operator +(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return new HeatTransferCoefficient(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="HeatTransferCoefficient"/> from subtracting two <see cref="HeatTransferCoefficient"/>.</summary>
         public static HeatTransferCoefficient operator -(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return new HeatTransferCoefficient(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="HeatTransferCoefficient"/> from multiplying value and <see cref="HeatTransferCoefficient"/>.</summary>
         public static HeatTransferCoefficient operator *(double left, HeatTransferCoefficient right)
         {
             return new HeatTransferCoefficient(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="HeatTransferCoefficient"/> from multiplying value and <see cref="HeatTransferCoefficient"/>.</summary>
         public static HeatTransferCoefficient operator *(HeatTransferCoefficient left, double right)
         {
             return new HeatTransferCoefficient(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="HeatTransferCoefficient"/> from dividing <see cref="HeatTransferCoefficient"/> by value.</summary>
         public static HeatTransferCoefficient operator /(HeatTransferCoefficient left, double right)
         {
             return new HeatTransferCoefficient(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="HeatTransferCoefficient"/> by <see cref="HeatTransferCoefficient"/>.</summary>
         public static double operator /(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return left.WattsPerSquareMeterKelvin / right.WattsPerSquareMeterKelvin;
@@ -395,36 +402,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(HeatTransferCoefficient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(HeatTransferCoefficient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(HeatTransferCoefficient left, HeatTransferCoefficient right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -433,11 +449,14 @@ namespace UnitsNet
             return CompareTo(objHeatTransferCoefficient);
         }
 
+        /// <inheritdoc />
         public int CompareTo(HeatTransferCoefficient other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(HeatTransferCoefficient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is HeatTransferCoefficient objHeatTransferCoefficient))
@@ -446,6 +465,8 @@ namespace UnitsNet
             return Equals(objHeatTransferCoefficient);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(HeatTransferCoefficient, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(HeatTransferCoefficient other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -530,6 +551,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((HeatTransferCoefficientUnit) unit);
 
         /// <summary>
@@ -544,6 +566,7 @@ namespace UnitsNet
 
         IQuantity<HeatTransferCoefficientUnit> IQuantity<HeatTransferCoefficientUnit>.ToUnit(HeatTransferCoefficientUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((HeatTransferCoefficientUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In photometry, illuminance is the total luminous flux incident on a surface, per unit area.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public IlluminanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<IlluminanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -363,6 +362,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<IlluminanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.IlluminanceUnit)"/>
         public static bool TryParseUnit(string str, out IlluminanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -387,36 +387,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Illuminance operator -(Illuminance right)
         {
             return new Illuminance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Illuminance"/> from adding two <see cref="Illuminance"/>.</summary>
         public static Illuminance operator +(Illuminance left, Illuminance right)
         {
             return new Illuminance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Illuminance"/> from subtracting two <see cref="Illuminance"/>.</summary>
         public static Illuminance operator -(Illuminance left, Illuminance right)
         {
             return new Illuminance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Illuminance"/> from multiplying value and <see cref="Illuminance"/>.</summary>
         public static Illuminance operator *(double left, Illuminance right)
         {
             return new Illuminance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Illuminance"/> from multiplying value and <see cref="Illuminance"/>.</summary>
         public static Illuminance operator *(Illuminance left, double right)
         {
             return new Illuminance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Illuminance"/> from dividing <see cref="Illuminance"/> by value.</summary>
         public static Illuminance operator /(Illuminance left, double right)
         {
             return new Illuminance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Illuminance"/> by <see cref="Illuminance"/>.</summary>
         public static double operator /(Illuminance left, Illuminance right)
         {
             return left.Lux / right.Lux;
@@ -426,36 +433,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Illuminance left, Illuminance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Illuminance left, Illuminance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Illuminance left, Illuminance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Illuminance left, Illuminance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Illuminance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Illuminance left, Illuminance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Illuminance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Illuminance left, Illuminance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -464,11 +480,14 @@ namespace UnitsNet
             return CompareTo(objIlluminance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Illuminance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Illuminance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Illuminance objIlluminance))
@@ -477,6 +496,8 @@ namespace UnitsNet
             return Equals(objIlluminance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Illuminance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Illuminance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -561,6 +582,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((IlluminanceUnit) unit);
 
         /// <summary>
@@ -575,6 +597,7 @@ namespace UnitsNet
 
         IQuantity<IlluminanceUnit> IQuantity<IlluminanceUnit>.ToUnit(IlluminanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((IlluminanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables.
     /// </summary>
@@ -115,14 +116,12 @@ namespace UnitsNet
 
         double IQuantity.Value => (double) _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public InformationUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<InformationUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -670,6 +669,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<InformationUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.InformationUnit)"/>
         public static bool TryParseUnit(string str, out InformationUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -694,36 +694,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Information operator -(Information right)
         {
             return new Information(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Information"/> from adding two <see cref="Information"/>.</summary>
         public static Information operator +(Information left, Information right)
         {
             return new Information(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Information"/> from subtracting two <see cref="Information"/>.</summary>
         public static Information operator -(Information left, Information right)
         {
             return new Information(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Information"/> from multiplying value and <see cref="Information"/>.</summary>
         public static Information operator *(decimal left, Information right)
         {
             return new Information(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Information"/> from multiplying value and <see cref="Information"/>.</summary>
         public static Information operator *(Information left, decimal right)
         {
             return new Information(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Information"/> from dividing <see cref="Information"/> by value.</summary>
         public static Information operator /(Information left, decimal right)
         {
             return new Information(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Information"/> by <see cref="Information"/>.</summary>
         public static double operator /(Information left, Information right)
         {
             return left.Bits / right.Bits;
@@ -733,36 +740,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Information left, Information right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Information left, Information right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Information left, Information right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Information left, Information right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Information, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Information left, Information right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Information, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Information left, Information right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -771,11 +787,14 @@ namespace UnitsNet
             return CompareTo(objInformation);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Information other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Information, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Information objInformation))
@@ -784,6 +803,8 @@ namespace UnitsNet
             return Equals(objInformation);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Information, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Information other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -868,6 +889,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((InformationUnit) unit);
 
         /// <summary>
@@ -882,6 +904,7 @@ namespace UnitsNet
 
         IQuantity<InformationUnit> IQuantity<InformationUnit>.ToUnit(InformationUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((InformationUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Irradiance is the intensity of ultraviolet (UV) or visible light incident on a surface.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public IrradianceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<IrradianceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -500,6 +499,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<IrradianceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.IrradianceUnit)"/>
         public static bool TryParseUnit(string str, out IrradianceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -524,36 +524,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Irradiance operator -(Irradiance right)
         {
             return new Irradiance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiance"/> from adding two <see cref="Irradiance"/>.</summary>
         public static Irradiance operator +(Irradiance left, Irradiance right)
         {
             return new Irradiance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiance"/> from subtracting two <see cref="Irradiance"/>.</summary>
         public static Irradiance operator -(Irradiance left, Irradiance right)
         {
             return new Irradiance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiance"/> from multiplying value and <see cref="Irradiance"/>.</summary>
         public static Irradiance operator *(double left, Irradiance right)
         {
             return new Irradiance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiance"/> from multiplying value and <see cref="Irradiance"/>.</summary>
         public static Irradiance operator *(Irradiance left, double right)
         {
             return new Irradiance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiance"/> from dividing <see cref="Irradiance"/> by value.</summary>
         public static Irradiance operator /(Irradiance left, double right)
         {
             return new Irradiance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Irradiance"/> by <see cref="Irradiance"/>.</summary>
         public static double operator /(Irradiance left, Irradiance right)
         {
             return left.WattsPerSquareMeter / right.WattsPerSquareMeter;
@@ -563,36 +570,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Irradiance left, Irradiance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Irradiance left, Irradiance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Irradiance left, Irradiance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Irradiance left, Irradiance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Irradiance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Irradiance left, Irradiance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Irradiance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Irradiance left, Irradiance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -601,11 +617,14 @@ namespace UnitsNet
             return CompareTo(objIrradiance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Irradiance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Irradiance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Irradiance objIrradiance))
@@ -614,6 +633,8 @@ namespace UnitsNet
             return Equals(objIrradiance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Irradiance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Irradiance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -698,6 +719,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((IrradianceUnit) unit);
 
         /// <summary>
@@ -712,6 +734,7 @@ namespace UnitsNet
 
         IQuantity<IrradianceUnit> IQuantity<IrradianceUnit>.ToUnit(IrradianceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((IrradianceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Irradiation is the process by which an object is exposed to radiation. The exposure can originate from various sources, including natural sources.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public IrradiationUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<IrradiationUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -391,6 +390,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<IrradiationUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.IrradiationUnit)"/>
         public static bool TryParseUnit(string str, out IrradiationUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -415,36 +415,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Irradiation operator -(Irradiation right)
         {
             return new Irradiation(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiation"/> from adding two <see cref="Irradiation"/>.</summary>
         public static Irradiation operator +(Irradiation left, Irradiation right)
         {
             return new Irradiation(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiation"/> from subtracting two <see cref="Irradiation"/>.</summary>
         public static Irradiation operator -(Irradiation left, Irradiation right)
         {
             return new Irradiation(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiation"/> from multiplying value and <see cref="Irradiation"/>.</summary>
         public static Irradiation operator *(double left, Irradiation right)
         {
             return new Irradiation(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiation"/> from multiplying value and <see cref="Irradiation"/>.</summary>
         public static Irradiation operator *(Irradiation left, double right)
         {
             return new Irradiation(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Irradiation"/> from dividing <see cref="Irradiation"/> by value.</summary>
         public static Irradiation operator /(Irradiation left, double right)
         {
             return new Irradiation(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Irradiation"/> by <see cref="Irradiation"/>.</summary>
         public static double operator /(Irradiation left, Irradiation right)
         {
             return left.JoulesPerSquareMeter / right.JoulesPerSquareMeter;
@@ -454,36 +461,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Irradiation left, Irradiation right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Irradiation left, Irradiation right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Irradiation left, Irradiation right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Irradiation left, Irradiation right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Irradiation, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Irradiation left, Irradiation right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Irradiation, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Irradiation left, Irradiation right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -492,11 +508,14 @@ namespace UnitsNet
             return CompareTo(objIrradiation);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Irradiation other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Irradiation, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Irradiation objIrradiation))
@@ -505,6 +524,8 @@ namespace UnitsNet
             return Equals(objIrradiation);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Irradiation, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Irradiation other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -589,6 +610,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((IrradiationUnit) unit);
 
         /// <summary>
@@ -603,6 +625,7 @@ namespace UnitsNet
 
         IQuantity<IrradiationUnit> IQuantity<IrradiationUnit>.ToUnit(IrradiationUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((IrradiationUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The viscosity of a fluid is a measure of its resistance to gradual deformation by shear stress or tensile stress.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public KinematicViscosityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<KinematicViscosityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -419,6 +418,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<KinematicViscosityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.KinematicViscosityUnit)"/>
         public static bool TryParseUnit(string str, out KinematicViscosityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -443,36 +443,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static KinematicViscosity operator -(KinematicViscosity right)
         {
             return new KinematicViscosity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from adding two <see cref="KinematicViscosity"/>.</summary>
         public static KinematicViscosity operator +(KinematicViscosity left, KinematicViscosity right)
         {
             return new KinematicViscosity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from subtracting two <see cref="KinematicViscosity"/>.</summary>
         public static KinematicViscosity operator -(KinematicViscosity left, KinematicViscosity right)
         {
             return new KinematicViscosity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from multiplying value and <see cref="KinematicViscosity"/>.</summary>
         public static KinematicViscosity operator *(double left, KinematicViscosity right)
         {
             return new KinematicViscosity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from multiplying value and <see cref="KinematicViscosity"/>.</summary>
         public static KinematicViscosity operator *(KinematicViscosity left, double right)
         {
             return new KinematicViscosity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="KinematicViscosity"/> from dividing <see cref="KinematicViscosity"/> by value.</summary>
         public static KinematicViscosity operator /(KinematicViscosity left, double right)
         {
             return new KinematicViscosity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="KinematicViscosity"/> by <see cref="KinematicViscosity"/>.</summary>
         public static double operator /(KinematicViscosity left, KinematicViscosity right)
         {
             return left.SquareMetersPerSecond / right.SquareMetersPerSecond;
@@ -482,36 +489,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(KinematicViscosity left, KinematicViscosity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(KinematicViscosity left, KinematicViscosity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(KinematicViscosity left, KinematicViscosity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(KinematicViscosity left, KinematicViscosity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(KinematicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(KinematicViscosity left, KinematicViscosity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(KinematicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(KinematicViscosity left, KinematicViscosity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -520,11 +536,14 @@ namespace UnitsNet
             return CompareTo(objKinematicViscosity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(KinematicViscosity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(KinematicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is KinematicViscosity objKinematicViscosity))
@@ -533,6 +552,8 @@ namespace UnitsNet
             return Equals(objKinematicViscosity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(KinematicViscosity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(KinematicViscosity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -617,6 +638,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((KinematicViscosityUnit) unit);
 
         /// <summary>
@@ -631,6 +653,7 @@ namespace UnitsNet
 
         IQuantity<KinematicViscosityUnit> IQuantity<KinematicViscosityUnit>.ToUnit(KinematicViscosityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((KinematicViscosityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Lapse rate is the rate at which Earth's atmospheric temperature decreases with an increase in altitude, or increases with the decrease in altitude.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public LapseRateUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<LapseRateUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -318,6 +317,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<LapseRateUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.LapseRateUnit)"/>
         public static bool TryParseUnit(string str, out LapseRateUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -342,36 +342,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static LapseRate operator -(LapseRate right)
         {
             return new LapseRate(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LapseRate"/> from adding two <see cref="LapseRate"/>.</summary>
         public static LapseRate operator +(LapseRate left, LapseRate right)
         {
             return new LapseRate(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LapseRate"/> from subtracting two <see cref="LapseRate"/>.</summary>
         public static LapseRate operator -(LapseRate left, LapseRate right)
         {
             return new LapseRate(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LapseRate"/> from multiplying value and <see cref="LapseRate"/>.</summary>
         public static LapseRate operator *(double left, LapseRate right)
         {
             return new LapseRate(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LapseRate"/> from multiplying value and <see cref="LapseRate"/>.</summary>
         public static LapseRate operator *(LapseRate left, double right)
         {
             return new LapseRate(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="LapseRate"/> from dividing <see cref="LapseRate"/> by value.</summary>
         public static LapseRate operator /(LapseRate left, double right)
         {
             return new LapseRate(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="LapseRate"/> by <see cref="LapseRate"/>.</summary>
         public static double operator /(LapseRate left, LapseRate right)
         {
             return left.DegreesCelciusPerKilometer / right.DegreesCelciusPerKilometer;
@@ -381,36 +388,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(LapseRate left, LapseRate right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(LapseRate left, LapseRate right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(LapseRate left, LapseRate right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(LapseRate left, LapseRate right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LapseRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(LapseRate left, LapseRate right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LapseRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(LapseRate left, LapseRate right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -419,11 +435,14 @@ namespace UnitsNet
             return CompareTo(objLapseRate);
         }
 
+        /// <inheritdoc />
         public int CompareTo(LapseRate other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LapseRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is LapseRate objLapseRate))
@@ -432,6 +451,8 @@ namespace UnitsNet
             return Equals(objLapseRate);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LapseRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(LapseRate other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -516,6 +537,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((LapseRateUnit) unit);
 
         /// <summary>
@@ -530,6 +552,7 @@ namespace UnitsNet
 
         IQuantity<LapseRateUnit> IQuantity<LapseRateUnit>.ToUnit(LapseRateUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((LapseRateUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public LengthUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<LengthUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -612,6 +611,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<LengthUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.LengthUnit)"/>
         public static bool TryParseUnit(string str, out LengthUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -636,36 +636,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Length operator -(Length right)
         {
             return new Length(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Length"/> from adding two <see cref="Length"/>.</summary>
         public static Length operator +(Length left, Length right)
         {
             return new Length(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Length"/> from subtracting two <see cref="Length"/>.</summary>
         public static Length operator -(Length left, Length right)
         {
             return new Length(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Length"/> from multiplying value and <see cref="Length"/>.</summary>
         public static Length operator *(double left, Length right)
         {
             return new Length(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Length"/> from multiplying value and <see cref="Length"/>.</summary>
         public static Length operator *(Length left, double right)
         {
             return new Length(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Length"/> from dividing <see cref="Length"/> by value.</summary>
         public static Length operator /(Length left, double right)
         {
             return new Length(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Length"/> by <see cref="Length"/>.</summary>
         public static double operator /(Length left, Length right)
         {
             return left.Meters / right.Meters;
@@ -675,36 +682,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Length left, Length right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Length left, Length right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Length left, Length right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Length left, Length right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Length, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Length left, Length right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Length, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Length left, Length right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -713,11 +729,14 @@ namespace UnitsNet
             return CompareTo(objLength);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Length other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Length, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Length objLength))
@@ -726,6 +745,8 @@ namespace UnitsNet
             return Equals(objLength);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Length, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Length other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -810,6 +831,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((LengthUnit) unit);
 
         /// <summary>
@@ -824,6 +846,7 @@ namespace UnitsNet
 
         IQuantity<LengthUnit> IQuantity<LengthUnit>.ToUnit(LengthUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((LengthUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Level is the logarithm of the ratio of a quantity Q to a reference value of that quantity, Q₀, expressed in dimensionless units.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public LevelUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<LevelUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -332,6 +331,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<LevelUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.LevelUnit)"/>
         public static bool TryParseUnit(string str, out LevelUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -356,11 +356,13 @@ namespace UnitsNet
 
         #region Logarithmic Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Level operator -(Level right)
         {
             return new Level(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Level"/> from logarithmic addition of two <see cref="Level"/>.</summary>
         public static Level operator +(Level left, Level right)
         {
             // Logarithmic addition
@@ -368,6 +370,7 @@ namespace UnitsNet
             return new Level(10*Math.Log10(Math.Pow(10, left.Value/10) + Math.Pow(10, right.AsBaseNumericType(left.Unit)/10)), left.Unit);
         }
 
+        /// <summary>Get <see cref="Level"/> from logarithmic subtraction of two <see cref="Level"/>.</summary>
         public static Level operator -(Level left, Level right)
         {
             // Logarithmic subtraction
@@ -375,24 +378,28 @@ namespace UnitsNet
             return new Level(10*Math.Log10(Math.Pow(10, left.Value/10) - Math.Pow(10, right.AsBaseNumericType(left.Unit)/10)), left.Unit);
         }
 
+        /// <summary>Get <see cref="Level"/> from logarithmic multiplication of value and <see cref="Level"/>.</summary>
         public static Level operator *(double left, Level right)
         {
             // Logarithmic multiplication = addition
             return new Level(left + right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Level"/> from logarithmic multiplication of value and <see cref="Level"/>.</summary>
         public static Level operator *(Level left, double right)
         {
             // Logarithmic multiplication = addition
             return new Level(left.Value + (double)right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Level"/> from logarithmic division of <see cref="Level"/> by value.</summary>
         public static Level operator /(Level left, double right)
         {
             // Logarithmic division = subtraction
             return new Level(left.Value - (double)right, left.Unit);
         }
 
+        /// <summary>Get ratio value from logarithmic division of <see cref="Level"/> by <see cref="Level"/>.</summary>
         public static double operator /(Level left, Level right)
         {
             // Logarithmic division = subtraction
@@ -403,36 +410,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Level left, Level right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Level left, Level right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Level left, Level right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Level left, Level right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Level, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Level left, Level right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Level, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Level left, Level right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -441,11 +457,14 @@ namespace UnitsNet
             return CompareTo(objLevel);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Level other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Level, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Level objLevel))
@@ -454,6 +473,8 @@ namespace UnitsNet
             return Equals(objLevel);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Level, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Level other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -538,6 +559,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((LevelUnit) unit);
 
         /// <summary>
@@ -552,6 +574,7 @@ namespace UnitsNet
 
         IQuantity<LevelUnit> IQuantity<LevelUnit>.ToUnit(LevelUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((LevelUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The Linear Density, or more precisely, the linear mass density, of a substance is its mass per unit length.  The term linear density is most often used when describing the characteristics of one-dimensional objects, although linear density can also be used to describe the density of a three-dimensional quantity along one particular dimension.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public LinearDensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<LinearDensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -349,6 +348,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<LinearDensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.LinearDensityUnit)"/>
         public static bool TryParseUnit(string str, out LinearDensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -373,36 +373,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static LinearDensity operator -(LinearDensity right)
         {
             return new LinearDensity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LinearDensity"/> from adding two <see cref="LinearDensity"/>.</summary>
         public static LinearDensity operator +(LinearDensity left, LinearDensity right)
         {
             return new LinearDensity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LinearDensity"/> from subtracting two <see cref="LinearDensity"/>.</summary>
         public static LinearDensity operator -(LinearDensity left, LinearDensity right)
         {
             return new LinearDensity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LinearDensity"/> from multiplying value and <see cref="LinearDensity"/>.</summary>
         public static LinearDensity operator *(double left, LinearDensity right)
         {
             return new LinearDensity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LinearDensity"/> from multiplying value and <see cref="LinearDensity"/>.</summary>
         public static LinearDensity operator *(LinearDensity left, double right)
         {
             return new LinearDensity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="LinearDensity"/> from dividing <see cref="LinearDensity"/> by value.</summary>
         public static LinearDensity operator /(LinearDensity left, double right)
         {
             return new LinearDensity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="LinearDensity"/> by <see cref="LinearDensity"/>.</summary>
         public static double operator /(LinearDensity left, LinearDensity right)
         {
             return left.KilogramsPerMeter / right.KilogramsPerMeter;
@@ -412,36 +419,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(LinearDensity left, LinearDensity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(LinearDensity left, LinearDensity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(LinearDensity left, LinearDensity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(LinearDensity left, LinearDensity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LinearDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(LinearDensity left, LinearDensity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LinearDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(LinearDensity left, LinearDensity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -450,11 +466,14 @@ namespace UnitsNet
             return CompareTo(objLinearDensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(LinearDensity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LinearDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is LinearDensity objLinearDensity))
@@ -463,6 +482,8 @@ namespace UnitsNet
             return Equals(objLinearDensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LinearDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(LinearDensity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -547,6 +568,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((LinearDensityUnit) unit);
 
         /// <summary>
@@ -561,6 +583,7 @@ namespace UnitsNet
 
         IQuantity<LinearDensityUnit> IQuantity<LinearDensityUnit>.ToUnit(LinearDensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((LinearDensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In photometry, luminous flux or luminous power is the measure of the perceived power of light.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public LuminousFluxUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<LuminousFluxUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<LuminousFluxUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.LuminousFluxUnit)"/>
         public static bool TryParseUnit(string str, out LuminousFluxUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static LuminousFlux operator -(LuminousFlux right)
         {
             return new LuminousFlux(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousFlux"/> from adding two <see cref="LuminousFlux"/>.</summary>
         public static LuminousFlux operator +(LuminousFlux left, LuminousFlux right)
         {
             return new LuminousFlux(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousFlux"/> from subtracting two <see cref="LuminousFlux"/>.</summary>
         public static LuminousFlux operator -(LuminousFlux left, LuminousFlux right)
         {
             return new LuminousFlux(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousFlux"/> from multiplying value and <see cref="LuminousFlux"/>.</summary>
         public static LuminousFlux operator *(double left, LuminousFlux right)
         {
             return new LuminousFlux(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousFlux"/> from multiplying value and <see cref="LuminousFlux"/>.</summary>
         public static LuminousFlux operator *(LuminousFlux left, double right)
         {
             return new LuminousFlux(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousFlux"/> from dividing <see cref="LuminousFlux"/> by value.</summary>
         public static LuminousFlux operator /(LuminousFlux left, double right)
         {
             return new LuminousFlux(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="LuminousFlux"/> by <see cref="LuminousFlux"/>.</summary>
         public static double operator /(LuminousFlux left, LuminousFlux right)
         {
             return left.Lumens / right.Lumens;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(LuminousFlux left, LuminousFlux right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(LuminousFlux left, LuminousFlux right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(LuminousFlux left, LuminousFlux right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(LuminousFlux left, LuminousFlux right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LuminousFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(LuminousFlux left, LuminousFlux right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LuminousFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(LuminousFlux left, LuminousFlux right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objLuminousFlux);
         }
 
+        /// <inheritdoc />
         public int CompareTo(LuminousFlux other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LuminousFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is LuminousFlux objLuminousFlux))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objLuminousFlux);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LuminousFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(LuminousFlux other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((LuminousFluxUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<LuminousFluxUnit> IQuantity<LuminousFluxUnit>.ToUnit(LuminousFluxUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((LuminousFluxUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In photometry, luminous intensity is a measure of the wavelength-weighted power emitted by a light source in a particular direction per unit solid angle, based on the luminosity function, a standardized model of the sensitivity of the human eye.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public LuminousIntensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<LuminousIntensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<LuminousIntensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.LuminousIntensityUnit)"/>
         public static bool TryParseUnit(string str, out LuminousIntensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static LuminousIntensity operator -(LuminousIntensity right)
         {
             return new LuminousIntensity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousIntensity"/> from adding two <see cref="LuminousIntensity"/>.</summary>
         public static LuminousIntensity operator +(LuminousIntensity left, LuminousIntensity right)
         {
             return new LuminousIntensity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousIntensity"/> from subtracting two <see cref="LuminousIntensity"/>.</summary>
         public static LuminousIntensity operator -(LuminousIntensity left, LuminousIntensity right)
         {
             return new LuminousIntensity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousIntensity"/> from multiplying value and <see cref="LuminousIntensity"/>.</summary>
         public static LuminousIntensity operator *(double left, LuminousIntensity right)
         {
             return new LuminousIntensity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousIntensity"/> from multiplying value and <see cref="LuminousIntensity"/>.</summary>
         public static LuminousIntensity operator *(LuminousIntensity left, double right)
         {
             return new LuminousIntensity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="LuminousIntensity"/> from dividing <see cref="LuminousIntensity"/> by value.</summary>
         public static LuminousIntensity operator /(LuminousIntensity left, double right)
         {
             return new LuminousIntensity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="LuminousIntensity"/> by <see cref="LuminousIntensity"/>.</summary>
         public static double operator /(LuminousIntensity left, LuminousIntensity right)
         {
             return left.Candela / right.Candela;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(LuminousIntensity left, LuminousIntensity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(LuminousIntensity left, LuminousIntensity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(LuminousIntensity left, LuminousIntensity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(LuminousIntensity left, LuminousIntensity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LuminousIntensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(LuminousIntensity left, LuminousIntensity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(LuminousIntensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(LuminousIntensity left, LuminousIntensity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objLuminousIntensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(LuminousIntensity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LuminousIntensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is LuminousIntensity objLuminousIntensity))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objLuminousIntensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(LuminousIntensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(LuminousIntensity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((LuminousIntensityUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<LuminousIntensityUnit> IQuantity<LuminousIntensityUnit>.ToUnit(LuminousIntensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((LuminousIntensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     A magnetic field is a force field that is created by moving electric charges (electric currents) and magnetic dipoles, and exerts a force on other nearby moving charges and magnetic dipoles.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MagneticFieldUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MagneticFieldUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -363,6 +362,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MagneticFieldUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MagneticFieldUnit)"/>
         public static bool TryParseUnit(string str, out MagneticFieldUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -387,36 +387,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MagneticField operator -(MagneticField right)
         {
             return new MagneticField(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticField"/> from adding two <see cref="MagneticField"/>.</summary>
         public static MagneticField operator +(MagneticField left, MagneticField right)
         {
             return new MagneticField(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticField"/> from subtracting two <see cref="MagneticField"/>.</summary>
         public static MagneticField operator -(MagneticField left, MagneticField right)
         {
             return new MagneticField(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticField"/> from multiplying value and <see cref="MagneticField"/>.</summary>
         public static MagneticField operator *(double left, MagneticField right)
         {
             return new MagneticField(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticField"/> from multiplying value and <see cref="MagneticField"/>.</summary>
         public static MagneticField operator *(MagneticField left, double right)
         {
             return new MagneticField(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticField"/> from dividing <see cref="MagneticField"/> by value.</summary>
         public static MagneticField operator /(MagneticField left, double right)
         {
             return new MagneticField(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MagneticField"/> by <see cref="MagneticField"/>.</summary>
         public static double operator /(MagneticField left, MagneticField right)
         {
             return left.Teslas / right.Teslas;
@@ -426,36 +433,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MagneticField left, MagneticField right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MagneticField left, MagneticField right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MagneticField left, MagneticField right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MagneticField left, MagneticField right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MagneticField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MagneticField left, MagneticField right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MagneticField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MagneticField left, MagneticField right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -464,11 +480,14 @@ namespace UnitsNet
             return CompareTo(objMagneticField);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MagneticField other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MagneticField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MagneticField objMagneticField))
@@ -477,6 +496,8 @@ namespace UnitsNet
             return Equals(objMagneticField);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MagneticField, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MagneticField other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -561,6 +582,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MagneticFieldUnit) unit);
 
         /// <summary>
@@ -575,6 +597,7 @@ namespace UnitsNet
 
         IQuantity<MagneticFieldUnit> IQuantity<MagneticFieldUnit>.ToUnit(MagneticFieldUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MagneticFieldUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In physics, specifically electromagnetism, the magnetic flux through a surface is the surface integral of the normal component of the magnetic field B passing through that surface.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MagneticFluxUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MagneticFluxUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MagneticFluxUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MagneticFluxUnit)"/>
         public static bool TryParseUnit(string str, out MagneticFluxUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MagneticFlux operator -(MagneticFlux right)
         {
             return new MagneticFlux(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticFlux"/> from adding two <see cref="MagneticFlux"/>.</summary>
         public static MagneticFlux operator +(MagneticFlux left, MagneticFlux right)
         {
             return new MagneticFlux(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticFlux"/> from subtracting two <see cref="MagneticFlux"/>.</summary>
         public static MagneticFlux operator -(MagneticFlux left, MagneticFlux right)
         {
             return new MagneticFlux(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticFlux"/> from multiplying value and <see cref="MagneticFlux"/>.</summary>
         public static MagneticFlux operator *(double left, MagneticFlux right)
         {
             return new MagneticFlux(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticFlux"/> from multiplying value and <see cref="MagneticFlux"/>.</summary>
         public static MagneticFlux operator *(MagneticFlux left, double right)
         {
             return new MagneticFlux(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MagneticFlux"/> from dividing <see cref="MagneticFlux"/> by value.</summary>
         public static MagneticFlux operator /(MagneticFlux left, double right)
         {
             return new MagneticFlux(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MagneticFlux"/> by <see cref="MagneticFlux"/>.</summary>
         public static double operator /(MagneticFlux left, MagneticFlux right)
         {
             return left.Webers / right.Webers;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MagneticFlux left, MagneticFlux right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MagneticFlux left, MagneticFlux right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MagneticFlux left, MagneticFlux right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MagneticFlux left, MagneticFlux right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MagneticFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MagneticFlux left, MagneticFlux right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MagneticFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MagneticFlux left, MagneticFlux right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objMagneticFlux);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MagneticFlux other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MagneticFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MagneticFlux objMagneticFlux))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objMagneticFlux);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MagneticFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MagneticFlux other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MagneticFluxUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<MagneticFluxUnit> IQuantity<MagneticFluxUnit>.ToUnit(MagneticFluxUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MagneticFluxUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In classical electromagnetism, magnetization is the vector field that expresses the density of permanent or induced magnetic dipole moments in a magnetic material.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MagnetizationUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MagnetizationUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MagnetizationUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MagnetizationUnit)"/>
         public static bool TryParseUnit(string str, out MagnetizationUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Magnetization operator -(Magnetization right)
         {
             return new Magnetization(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Magnetization"/> from adding two <see cref="Magnetization"/>.</summary>
         public static Magnetization operator +(Magnetization left, Magnetization right)
         {
             return new Magnetization(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Magnetization"/> from subtracting two <see cref="Magnetization"/>.</summary>
         public static Magnetization operator -(Magnetization left, Magnetization right)
         {
             return new Magnetization(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Magnetization"/> from multiplying value and <see cref="Magnetization"/>.</summary>
         public static Magnetization operator *(double left, Magnetization right)
         {
             return new Magnetization(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Magnetization"/> from multiplying value and <see cref="Magnetization"/>.</summary>
         public static Magnetization operator *(Magnetization left, double right)
         {
             return new Magnetization(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Magnetization"/> from dividing <see cref="Magnetization"/> by value.</summary>
         public static Magnetization operator /(Magnetization left, double right)
         {
             return new Magnetization(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Magnetization"/> by <see cref="Magnetization"/>.</summary>
         public static double operator /(Magnetization left, Magnetization right)
         {
             return left.AmperesPerMeter / right.AmperesPerMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Magnetization left, Magnetization right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Magnetization left, Magnetization right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Magnetization left, Magnetization right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Magnetization left, Magnetization right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Magnetization, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Magnetization left, Magnetization right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Magnetization, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Magnetization left, Magnetization right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objMagnetization);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Magnetization other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Magnetization, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Magnetization objMagnetization))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objMagnetization);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Magnetization, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Magnetization other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MagnetizationUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<MagnetizationUnit> IQuantity<MagnetizationUnit>.ToUnit(MagnetizationUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MagnetizationUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In physics, mass (from Greek μᾶζα "barley cake, lump [of dough]") is a property of a physical system or body, giving rise to the phenomena of the body's resistance to being accelerated by a force and the strength of its mutual gravitational attraction with other bodies. Instruments such as mass balances or scales use those phenomena to measure mass. The SI unit of mass is the kilogram (kg).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MassUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MassUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -626,6 +625,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MassUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MassUnit)"/>
         public static bool TryParseUnit(string str, out MassUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -650,36 +650,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Mass operator -(Mass right)
         {
             return new Mass(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Mass"/> from adding two <see cref="Mass"/>.</summary>
         public static Mass operator +(Mass left, Mass right)
         {
             return new Mass(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Mass"/> from subtracting two <see cref="Mass"/>.</summary>
         public static Mass operator -(Mass left, Mass right)
         {
             return new Mass(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Mass"/> from multiplying value and <see cref="Mass"/>.</summary>
         public static Mass operator *(double left, Mass right)
         {
             return new Mass(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Mass"/> from multiplying value and <see cref="Mass"/>.</summary>
         public static Mass operator *(Mass left, double right)
         {
             return new Mass(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Mass"/> from dividing <see cref="Mass"/> by value.</summary>
         public static Mass operator /(Mass left, double right)
         {
             return new Mass(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Mass"/> by <see cref="Mass"/>.</summary>
         public static double operator /(Mass left, Mass right)
         {
             return left.Kilograms / right.Kilograms;
@@ -689,36 +696,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Mass left, Mass right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Mass left, Mass right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Mass left, Mass right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Mass left, Mass right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Mass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Mass left, Mass right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Mass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Mass left, Mass right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -727,11 +743,14 @@ namespace UnitsNet
             return CompareTo(objMass);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Mass other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Mass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Mass objMass))
@@ -740,6 +759,8 @@ namespace UnitsNet
             return Equals(objMass);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Mass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Mass other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -824,6 +845,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MassUnit) unit);
 
         /// <summary>
@@ -838,6 +860,7 @@ namespace UnitsNet
 
         IQuantity<MassUnit> IQuantity<MassUnit>.ToUnit(MassUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MassUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Mass flow is the ratio of the mass change to the time during which the change occurred (value of mass changes per unit time).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MassFlowUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MassFlowUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -738,6 +737,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MassFlowUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MassFlowUnit)"/>
         public static bool TryParseUnit(string str, out MassFlowUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -762,36 +762,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MassFlow operator -(MassFlow right)
         {
             return new MassFlow(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from adding two <see cref="MassFlow"/>.</summary>
         public static MassFlow operator +(MassFlow left, MassFlow right)
         {
             return new MassFlow(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from subtracting two <see cref="MassFlow"/>.</summary>
         public static MassFlow operator -(MassFlow left, MassFlow right)
         {
             return new MassFlow(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from multiplying value and <see cref="MassFlow"/>.</summary>
         public static MassFlow operator *(double left, MassFlow right)
         {
             return new MassFlow(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from multiplying value and <see cref="MassFlow"/>.</summary>
         public static MassFlow operator *(MassFlow left, double right)
         {
             return new MassFlow(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlow"/> from dividing <see cref="MassFlow"/> by value.</summary>
         public static MassFlow operator /(MassFlow left, double right)
         {
             return new MassFlow(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MassFlow"/> by <see cref="MassFlow"/>.</summary>
         public static double operator /(MassFlow left, MassFlow right)
         {
             return left.GramsPerSecond / right.GramsPerSecond;
@@ -801,36 +808,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MassFlow left, MassFlow right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MassFlow left, MassFlow right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MassFlow left, MassFlow right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MassFlow left, MassFlow right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MassFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MassFlow left, MassFlow right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MassFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MassFlow left, MassFlow right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -839,11 +855,14 @@ namespace UnitsNet
             return CompareTo(objMassFlow);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MassFlow other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MassFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MassFlow objMassFlow))
@@ -852,6 +871,8 @@ namespace UnitsNet
             return Equals(objMassFlow);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MassFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MassFlow other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -936,6 +957,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MassFlowUnit) unit);
 
         /// <summary>
@@ -950,6 +972,7 @@ namespace UnitsNet
 
         IQuantity<MassFlowUnit> IQuantity<MassFlowUnit>.ToUnit(MassFlowUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MassFlowUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Mass flux is the mass flow rate per unit area.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MassFluxUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MassFluxUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -332,6 +331,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MassFluxUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MassFluxUnit)"/>
         public static bool TryParseUnit(string str, out MassFluxUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -356,36 +356,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MassFlux operator -(MassFlux right)
         {
             return new MassFlux(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from adding two <see cref="MassFlux"/>.</summary>
         public static MassFlux operator +(MassFlux left, MassFlux right)
         {
             return new MassFlux(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from subtracting two <see cref="MassFlux"/>.</summary>
         public static MassFlux operator -(MassFlux left, MassFlux right)
         {
             return new MassFlux(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from multiplying value and <see cref="MassFlux"/>.</summary>
         public static MassFlux operator *(double left, MassFlux right)
         {
             return new MassFlux(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from multiplying value and <see cref="MassFlux"/>.</summary>
         public static MassFlux operator *(MassFlux left, double right)
         {
             return new MassFlux(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MassFlux"/> from dividing <see cref="MassFlux"/> by value.</summary>
         public static MassFlux operator /(MassFlux left, double right)
         {
             return new MassFlux(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MassFlux"/> by <see cref="MassFlux"/>.</summary>
         public static double operator /(MassFlux left, MassFlux right)
         {
             return left.KilogramsPerSecondPerSquareMeter / right.KilogramsPerSecondPerSquareMeter;
@@ -395,36 +402,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MassFlux left, MassFlux right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MassFlux left, MassFlux right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MassFlux left, MassFlux right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MassFlux left, MassFlux right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MassFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MassFlux left, MassFlux right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MassFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MassFlux left, MassFlux right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -433,11 +449,14 @@ namespace UnitsNet
             return CompareTo(objMassFlux);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MassFlux other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MassFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MassFlux objMassFlux))
@@ -446,6 +465,8 @@ namespace UnitsNet
             return Equals(objMassFlux);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MassFlux, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MassFlux other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -530,6 +551,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MassFluxUnit) unit);
 
         /// <summary>
@@ -544,6 +566,7 @@ namespace UnitsNet
 
         IQuantity<MassFluxUnit> IQuantity<MassFluxUnit>.ToUnit(MassFluxUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MassFluxUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     A property of body reflects how its mass is distributed with regard to an axis.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MassMomentOfInertiaUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MassMomentOfInertiaUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -696,6 +695,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MassMomentOfInertiaUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MassMomentOfInertiaUnit)"/>
         public static bool TryParseUnit(string str, out MassMomentOfInertiaUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -720,36 +720,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MassMomentOfInertia operator -(MassMomentOfInertia right)
         {
             return new MassMomentOfInertia(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MassMomentOfInertia"/> from adding two <see cref="MassMomentOfInertia"/>.</summary>
         public static MassMomentOfInertia operator +(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return new MassMomentOfInertia(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MassMomentOfInertia"/> from subtracting two <see cref="MassMomentOfInertia"/>.</summary>
         public static MassMomentOfInertia operator -(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return new MassMomentOfInertia(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MassMomentOfInertia"/> from multiplying value and <see cref="MassMomentOfInertia"/>.</summary>
         public static MassMomentOfInertia operator *(double left, MassMomentOfInertia right)
         {
             return new MassMomentOfInertia(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MassMomentOfInertia"/> from multiplying value and <see cref="MassMomentOfInertia"/>.</summary>
         public static MassMomentOfInertia operator *(MassMomentOfInertia left, double right)
         {
             return new MassMomentOfInertia(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MassMomentOfInertia"/> from dividing <see cref="MassMomentOfInertia"/> by value.</summary>
         public static MassMomentOfInertia operator /(MassMomentOfInertia left, double right)
         {
             return new MassMomentOfInertia(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MassMomentOfInertia"/> by <see cref="MassMomentOfInertia"/>.</summary>
         public static double operator /(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return left.KilogramSquareMeters / right.KilogramSquareMeters;
@@ -759,36 +766,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MassMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MassMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MassMomentOfInertia left, MassMomentOfInertia right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -797,11 +813,14 @@ namespace UnitsNet
             return CompareTo(objMassMomentOfInertia);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MassMomentOfInertia other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MassMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MassMomentOfInertia objMassMomentOfInertia))
@@ -810,6 +829,8 @@ namespace UnitsNet
             return Equals(objMassMomentOfInertia);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MassMomentOfInertia, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MassMomentOfInertia other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -894,6 +915,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MassMomentOfInertiaUnit) unit);
 
         /// <summary>
@@ -908,6 +930,7 @@ namespace UnitsNet
 
         IQuantity<MassMomentOfInertiaUnit> IQuantity<MassMomentOfInertiaUnit>.ToUnit(MassMomentOfInertiaUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MassMomentOfInertiaUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Molar energy is the amount of energy stored in 1 mole of a substance.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MolarEnergyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MolarEnergyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MolarEnergyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MolarEnergyUnit)"/>
         public static bool TryParseUnit(string str, out MolarEnergyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MolarEnergy operator -(MolarEnergy right)
         {
             return new MolarEnergy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEnergy"/> from adding two <see cref="MolarEnergy"/>.</summary>
         public static MolarEnergy operator +(MolarEnergy left, MolarEnergy right)
         {
             return new MolarEnergy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEnergy"/> from subtracting two <see cref="MolarEnergy"/>.</summary>
         public static MolarEnergy operator -(MolarEnergy left, MolarEnergy right)
         {
             return new MolarEnergy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEnergy"/> from multiplying value and <see cref="MolarEnergy"/>.</summary>
         public static MolarEnergy operator *(double left, MolarEnergy right)
         {
             return new MolarEnergy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEnergy"/> from multiplying value and <see cref="MolarEnergy"/>.</summary>
         public static MolarEnergy operator *(MolarEnergy left, double right)
         {
             return new MolarEnergy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEnergy"/> from dividing <see cref="MolarEnergy"/> by value.</summary>
         public static MolarEnergy operator /(MolarEnergy left, double right)
         {
             return new MolarEnergy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MolarEnergy"/> by <see cref="MolarEnergy"/>.</summary>
         public static double operator /(MolarEnergy left, MolarEnergy right)
         {
             return left.JoulesPerMole / right.JoulesPerMole;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MolarEnergy left, MolarEnergy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MolarEnergy left, MolarEnergy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MolarEnergy left, MolarEnergy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MolarEnergy left, MolarEnergy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MolarEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MolarEnergy left, MolarEnergy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MolarEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MolarEnergy left, MolarEnergy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objMolarEnergy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MolarEnergy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MolarEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MolarEnergy objMolarEnergy))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objMolarEnergy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MolarEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MolarEnergy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MolarEnergyUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<MolarEnergyUnit> IQuantity<MolarEnergyUnit>.ToUnit(MolarEnergyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MolarEnergyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Molar entropy is amount of energy required to increase temperature of 1 mole substance by 1 Kelvin.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MolarEntropyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MolarEntropyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MolarEntropyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MolarEntropyUnit)"/>
         public static bool TryParseUnit(string str, out MolarEntropyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MolarEntropy operator -(MolarEntropy right)
         {
             return new MolarEntropy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEntropy"/> from adding two <see cref="MolarEntropy"/>.</summary>
         public static MolarEntropy operator +(MolarEntropy left, MolarEntropy right)
         {
             return new MolarEntropy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEntropy"/> from subtracting two <see cref="MolarEntropy"/>.</summary>
         public static MolarEntropy operator -(MolarEntropy left, MolarEntropy right)
         {
             return new MolarEntropy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEntropy"/> from multiplying value and <see cref="MolarEntropy"/>.</summary>
         public static MolarEntropy operator *(double left, MolarEntropy right)
         {
             return new MolarEntropy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEntropy"/> from multiplying value and <see cref="MolarEntropy"/>.</summary>
         public static MolarEntropy operator *(MolarEntropy left, double right)
         {
             return new MolarEntropy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarEntropy"/> from dividing <see cref="MolarEntropy"/> by value.</summary>
         public static MolarEntropy operator /(MolarEntropy left, double right)
         {
             return new MolarEntropy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MolarEntropy"/> by <see cref="MolarEntropy"/>.</summary>
         public static double operator /(MolarEntropy left, MolarEntropy right)
         {
             return left.JoulesPerMoleKelvin / right.JoulesPerMoleKelvin;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MolarEntropy left, MolarEntropy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MolarEntropy left, MolarEntropy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MolarEntropy left, MolarEntropy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MolarEntropy left, MolarEntropy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MolarEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MolarEntropy left, MolarEntropy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MolarEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MolarEntropy left, MolarEntropy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objMolarEntropy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MolarEntropy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MolarEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MolarEntropy objMolarEntropy))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objMolarEntropy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MolarEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MolarEntropy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MolarEntropyUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<MolarEntropyUnit> IQuantity<MolarEntropyUnit>.ToUnit(MolarEntropyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MolarEntropyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In chemistry, the molar mass M is a physical property defined as the mass of a given substance (chemical element or chemical compound) divided by the amount of substance.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MolarMassUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MolarMassUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -472,6 +471,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MolarMassUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MolarMassUnit)"/>
         public static bool TryParseUnit(string str, out MolarMassUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -496,36 +496,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static MolarMass operator -(MolarMass right)
         {
             return new MolarMass(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MolarMass"/> from adding two <see cref="MolarMass"/>.</summary>
         public static MolarMass operator +(MolarMass left, MolarMass right)
         {
             return new MolarMass(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarMass"/> from subtracting two <see cref="MolarMass"/>.</summary>
         public static MolarMass operator -(MolarMass left, MolarMass right)
         {
             return new MolarMass(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarMass"/> from multiplying value and <see cref="MolarMass"/>.</summary>
         public static MolarMass operator *(double left, MolarMass right)
         {
             return new MolarMass(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="MolarMass"/> from multiplying value and <see cref="MolarMass"/>.</summary>
         public static MolarMass operator *(MolarMass left, double right)
         {
             return new MolarMass(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="MolarMass"/> from dividing <see cref="MolarMass"/> by value.</summary>
         public static MolarMass operator /(MolarMass left, double right)
         {
             return new MolarMass(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="MolarMass"/> by <see cref="MolarMass"/>.</summary>
         public static double operator /(MolarMass left, MolarMass right)
         {
             return left.KilogramsPerMole / right.KilogramsPerMole;
@@ -535,36 +542,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(MolarMass left, MolarMass right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(MolarMass left, MolarMass right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(MolarMass left, MolarMass right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(MolarMass left, MolarMass right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MolarMass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(MolarMass left, MolarMass right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(MolarMass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(MolarMass left, MolarMass right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -573,11 +589,14 @@ namespace UnitsNet
             return CompareTo(objMolarMass);
         }
 
+        /// <inheritdoc />
         public int CompareTo(MolarMass other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MolarMass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is MolarMass objMolarMass))
@@ -586,6 +605,8 @@ namespace UnitsNet
             return Equals(objMolarMass);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(MolarMass, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(MolarMass other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -670,6 +691,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MolarMassUnit) unit);
 
         /// <summary>
@@ -684,6 +706,7 @@ namespace UnitsNet
 
         IQuantity<MolarMassUnit> IQuantity<MolarMassUnit>.ToUnit(MolarMassUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MolarMassUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume. 
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public MolarityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<MolarityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -419,6 +418,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<MolarityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.MolarityUnit)"/>
         public static bool TryParseUnit(string str, out MolarityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -443,36 +443,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Molarity operator -(Molarity right)
         {
             return new Molarity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Molarity"/> from adding two <see cref="Molarity"/>.</summary>
         public static Molarity operator +(Molarity left, Molarity right)
         {
             return new Molarity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Molarity"/> from subtracting two <see cref="Molarity"/>.</summary>
         public static Molarity operator -(Molarity left, Molarity right)
         {
             return new Molarity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Molarity"/> from multiplying value and <see cref="Molarity"/>.</summary>
         public static Molarity operator *(double left, Molarity right)
         {
             return new Molarity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Molarity"/> from multiplying value and <see cref="Molarity"/>.</summary>
         public static Molarity operator *(Molarity left, double right)
         {
             return new Molarity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Molarity"/> from dividing <see cref="Molarity"/> by value.</summary>
         public static Molarity operator /(Molarity left, double right)
         {
             return new Molarity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Molarity"/> by <see cref="Molarity"/>.</summary>
         public static double operator /(Molarity left, Molarity right)
         {
             return left.MolesPerCubicMeter / right.MolesPerCubicMeter;
@@ -482,36 +489,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Molarity left, Molarity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Molarity left, Molarity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Molarity left, Molarity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Molarity left, Molarity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Molarity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Molarity left, Molarity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Molarity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Molarity left, Molarity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -520,11 +536,14 @@ namespace UnitsNet
             return CompareTo(objMolarity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Molarity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Molarity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Molarity objMolarity))
@@ -533,6 +552,8 @@ namespace UnitsNet
             return Equals(objMolarity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Molarity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Molarity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -617,6 +638,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((MolarityUnit) unit);
 
         /// <summary>
@@ -631,6 +653,7 @@ namespace UnitsNet
 
         IQuantity<MolarityUnit> IQuantity<MolarityUnit>.ToUnit(MolarityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((MolarityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In electromagnetism, permeability is the measure of the ability of a material to support the formation of a magnetic field within itself.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PermeabilityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PermeabilityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PermeabilityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PermeabilityUnit)"/>
         public static bool TryParseUnit(string str, out PermeabilityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Permeability operator -(Permeability right)
         {
             return new Permeability(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Permeability"/> from adding two <see cref="Permeability"/>.</summary>
         public static Permeability operator +(Permeability left, Permeability right)
         {
             return new Permeability(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Permeability"/> from subtracting two <see cref="Permeability"/>.</summary>
         public static Permeability operator -(Permeability left, Permeability right)
         {
             return new Permeability(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Permeability"/> from multiplying value and <see cref="Permeability"/>.</summary>
         public static Permeability operator *(double left, Permeability right)
         {
             return new Permeability(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Permeability"/> from multiplying value and <see cref="Permeability"/>.</summary>
         public static Permeability operator *(Permeability left, double right)
         {
             return new Permeability(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Permeability"/> from dividing <see cref="Permeability"/> by value.</summary>
         public static Permeability operator /(Permeability left, double right)
         {
             return new Permeability(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Permeability"/> by <see cref="Permeability"/>.</summary>
         public static double operator /(Permeability left, Permeability right)
         {
             return left.HenriesPerMeter / right.HenriesPerMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Permeability left, Permeability right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Permeability left, Permeability right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Permeability left, Permeability right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Permeability left, Permeability right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Permeability, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Permeability left, Permeability right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Permeability, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Permeability left, Permeability right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objPermeability);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Permeability other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Permeability, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Permeability objPermeability))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objPermeability);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Permeability, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Permeability other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PermeabilityUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<PermeabilityUnit> IQuantity<PermeabilityUnit>.ToUnit(PermeabilityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PermeabilityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In electromagnetism, permittivity is the measure of resistance that is encountered when forming an electric field in a particular medium.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PermittivityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PermittivityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PermittivityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PermittivityUnit)"/>
         public static bool TryParseUnit(string str, out PermittivityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Permittivity operator -(Permittivity right)
         {
             return new Permittivity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Permittivity"/> from adding two <see cref="Permittivity"/>.</summary>
         public static Permittivity operator +(Permittivity left, Permittivity right)
         {
             return new Permittivity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Permittivity"/> from subtracting two <see cref="Permittivity"/>.</summary>
         public static Permittivity operator -(Permittivity left, Permittivity right)
         {
             return new Permittivity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Permittivity"/> from multiplying value and <see cref="Permittivity"/>.</summary>
         public static Permittivity operator *(double left, Permittivity right)
         {
             return new Permittivity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Permittivity"/> from multiplying value and <see cref="Permittivity"/>.</summary>
         public static Permittivity operator *(Permittivity left, double right)
         {
             return new Permittivity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Permittivity"/> from dividing <see cref="Permittivity"/> by value.</summary>
         public static Permittivity operator /(Permittivity left, double right)
         {
             return new Permittivity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Permittivity"/> by <see cref="Permittivity"/>.</summary>
         public static double operator /(Permittivity left, Permittivity right)
         {
             return left.FaradsPerMeter / right.FaradsPerMeter;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Permittivity left, Permittivity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Permittivity left, Permittivity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Permittivity left, Permittivity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Permittivity left, Permittivity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Permittivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Permittivity left, Permittivity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Permittivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Permittivity left, Permittivity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objPermittivity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Permittivity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Permittivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Permittivity objPermittivity))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objPermittivity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Permittivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Permittivity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PermittivityUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<PermittivityUnit> IQuantity<PermittivityUnit>.ToUnit(PermittivityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PermittivityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In physics, power is the rate of doing work. It is equivalent to an amount of energy consumed per unit time.
     /// </summary>
@@ -115,14 +116,12 @@ namespace UnitsNet
 
         double IQuantity.Value => (double) _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PowerUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PowerUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -586,6 +585,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PowerUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PowerUnit)"/>
         public static bool TryParseUnit(string str, out PowerUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -610,36 +610,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Power operator -(Power right)
         {
             return new Power(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Power"/> from adding two <see cref="Power"/>.</summary>
         public static Power operator +(Power left, Power right)
         {
             return new Power(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Power"/> from subtracting two <see cref="Power"/>.</summary>
         public static Power operator -(Power left, Power right)
         {
             return new Power(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Power"/> from multiplying value and <see cref="Power"/>.</summary>
         public static Power operator *(decimal left, Power right)
         {
             return new Power(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Power"/> from multiplying value and <see cref="Power"/>.</summary>
         public static Power operator *(Power left, decimal right)
         {
             return new Power(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Power"/> from dividing <see cref="Power"/> by value.</summary>
         public static Power operator /(Power left, decimal right)
         {
             return new Power(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Power"/> by <see cref="Power"/>.</summary>
         public static double operator /(Power left, Power right)
         {
             return left.Watts / right.Watts;
@@ -649,36 +656,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Power left, Power right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Power left, Power right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Power left, Power right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Power left, Power right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Power, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Power left, Power right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Power, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Power left, Power right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -687,11 +703,14 @@ namespace UnitsNet
             return CompareTo(objPower);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Power other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Power, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Power objPower))
@@ -700,6 +719,8 @@ namespace UnitsNet
             return Equals(objPower);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Power, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Power other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -784,6 +805,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PowerUnit) unit);
 
         /// <summary>
@@ -798,6 +820,7 @@ namespace UnitsNet
 
         IQuantity<PowerUnit> IQuantity<PowerUnit>.ToUnit(PowerUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PowerUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The amount of power in a volume.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PowerDensityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PowerDensityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -920,6 +919,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PowerDensityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PowerDensityUnit)"/>
         public static bool TryParseUnit(string str, out PowerDensityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -944,36 +944,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static PowerDensity operator -(PowerDensity right)
         {
             return new PowerDensity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="PowerDensity"/> from adding two <see cref="PowerDensity"/>.</summary>
         public static PowerDensity operator +(PowerDensity left, PowerDensity right)
         {
             return new PowerDensity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="PowerDensity"/> from subtracting two <see cref="PowerDensity"/>.</summary>
         public static PowerDensity operator -(PowerDensity left, PowerDensity right)
         {
             return new PowerDensity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="PowerDensity"/> from multiplying value and <see cref="PowerDensity"/>.</summary>
         public static PowerDensity operator *(double left, PowerDensity right)
         {
             return new PowerDensity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="PowerDensity"/> from multiplying value and <see cref="PowerDensity"/>.</summary>
         public static PowerDensity operator *(PowerDensity left, double right)
         {
             return new PowerDensity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="PowerDensity"/> from dividing <see cref="PowerDensity"/> by value.</summary>
         public static PowerDensity operator /(PowerDensity left, double right)
         {
             return new PowerDensity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="PowerDensity"/> by <see cref="PowerDensity"/>.</summary>
         public static double operator /(PowerDensity left, PowerDensity right)
         {
             return left.WattsPerCubicMeter / right.WattsPerCubicMeter;
@@ -983,36 +990,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(PowerDensity left, PowerDensity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(PowerDensity left, PowerDensity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(PowerDensity left, PowerDensity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(PowerDensity left, PowerDensity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(PowerDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(PowerDensity left, PowerDensity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(PowerDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(PowerDensity left, PowerDensity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -1021,11 +1037,14 @@ namespace UnitsNet
             return CompareTo(objPowerDensity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(PowerDensity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(PowerDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is PowerDensity objPowerDensity))
@@ -1034,6 +1053,8 @@ namespace UnitsNet
             return Equals(objPowerDensity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(PowerDensity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(PowerDensity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -1118,6 +1139,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PowerDensityUnit) unit);
 
         /// <summary>
@@ -1132,6 +1154,7 @@ namespace UnitsNet
 
         IQuantity<PowerDensityUnit> IQuantity<PowerDensityUnit>.ToUnit(PowerDensityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PowerDensityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The strength of a signal expressed in decibels (dB) relative to one watt.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PowerRatioUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PowerRatioUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -332,6 +331,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PowerRatioUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PowerRatioUnit)"/>
         public static bool TryParseUnit(string str, out PowerRatioUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -356,11 +356,13 @@ namespace UnitsNet
 
         #region Logarithmic Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static PowerRatio operator -(PowerRatio right)
         {
             return new PowerRatio(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="PowerRatio"/> from logarithmic addition of two <see cref="PowerRatio"/>.</summary>
         public static PowerRatio operator +(PowerRatio left, PowerRatio right)
         {
             // Logarithmic addition
@@ -368,6 +370,7 @@ namespace UnitsNet
             return new PowerRatio(10*Math.Log10(Math.Pow(10, left.Value/10) + Math.Pow(10, right.AsBaseNumericType(left.Unit)/10)), left.Unit);
         }
 
+        /// <summary>Get <see cref="PowerRatio"/> from logarithmic subtraction of two <see cref="PowerRatio"/>.</summary>
         public static PowerRatio operator -(PowerRatio left, PowerRatio right)
         {
             // Logarithmic subtraction
@@ -375,24 +378,28 @@ namespace UnitsNet
             return new PowerRatio(10*Math.Log10(Math.Pow(10, left.Value/10) - Math.Pow(10, right.AsBaseNumericType(left.Unit)/10)), left.Unit);
         }
 
+        /// <summary>Get <see cref="PowerRatio"/> from logarithmic multiplication of value and <see cref="PowerRatio"/>.</summary>
         public static PowerRatio operator *(double left, PowerRatio right)
         {
             // Logarithmic multiplication = addition
             return new PowerRatio(left + right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="PowerRatio"/> from logarithmic multiplication of value and <see cref="PowerRatio"/>.</summary>
         public static PowerRatio operator *(PowerRatio left, double right)
         {
             // Logarithmic multiplication = addition
             return new PowerRatio(left.Value + (double)right, left.Unit);
         }
 
+        /// <summary>Get <see cref="PowerRatio"/> from logarithmic division of <see cref="PowerRatio"/> by value.</summary>
         public static PowerRatio operator /(PowerRatio left, double right)
         {
             // Logarithmic division = subtraction
             return new PowerRatio(left.Value - (double)right, left.Unit);
         }
 
+        /// <summary>Get ratio value from logarithmic division of <see cref="PowerRatio"/> by <see cref="PowerRatio"/>.</summary>
         public static double operator /(PowerRatio left, PowerRatio right)
         {
             // Logarithmic division = subtraction
@@ -403,36 +410,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(PowerRatio left, PowerRatio right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(PowerRatio left, PowerRatio right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(PowerRatio left, PowerRatio right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(PowerRatio left, PowerRatio right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(PowerRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(PowerRatio left, PowerRatio right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(PowerRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(PowerRatio left, PowerRatio right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -441,11 +457,14 @@ namespace UnitsNet
             return CompareTo(objPowerRatio);
         }
 
+        /// <inheritdoc />
         public int CompareTo(PowerRatio other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(PowerRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is PowerRatio objPowerRatio))
@@ -454,6 +473,8 @@ namespace UnitsNet
             return Equals(objPowerRatio);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(PowerRatio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(PowerRatio other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -538,6 +559,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PowerRatioUnit) unit);
 
         /// <summary>
@@ -552,6 +574,7 @@ namespace UnitsNet
 
         IQuantity<PowerRatioUnit> IQuantity<PowerRatioUnit>.ToUnit(PowerRatioUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PowerRatioUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Pressure (symbol: P or p) is the ratio of force to the area over which that force is distributed. Pressure is force per unit area applied in a direction perpendicular to the surface of an object. Gauge pressure (also spelled gage pressure)[a] is the pressure relative to the local atmospheric or ambient pressure. Pressure is measured in any unit of force divided by any unit of area. The SI unit of pressure is the newton per square metre, which is called the pascal (Pa) after the seventeenth-century philosopher and scientist Blaise Pascal. A pressure of 1 Pa is small; it approximately equals the pressure exerted by a dollar bill resting flat on a table. Everyday pressures are often stated in kilopascals (1 kPa = 1000 Pa).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PressureUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PressureUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -892,6 +891,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PressureUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PressureUnit)"/>
         public static bool TryParseUnit(string str, out PressureUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -916,36 +916,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Pressure operator -(Pressure right)
         {
             return new Pressure(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from adding two <see cref="Pressure"/>.</summary>
         public static Pressure operator +(Pressure left, Pressure right)
         {
             return new Pressure(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from subtracting two <see cref="Pressure"/>.</summary>
         public static Pressure operator -(Pressure left, Pressure right)
         {
             return new Pressure(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from multiplying value and <see cref="Pressure"/>.</summary>
         public static Pressure operator *(double left, Pressure right)
         {
             return new Pressure(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from multiplying value and <see cref="Pressure"/>.</summary>
         public static Pressure operator *(Pressure left, double right)
         {
             return new Pressure(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Pressure"/> from dividing <see cref="Pressure"/> by value.</summary>
         public static Pressure operator /(Pressure left, double right)
         {
             return new Pressure(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Pressure"/> by <see cref="Pressure"/>.</summary>
         public static double operator /(Pressure left, Pressure right)
         {
             return left.Pascals / right.Pascals;
@@ -955,36 +962,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Pressure left, Pressure right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Pressure left, Pressure right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Pressure left, Pressure right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Pressure left, Pressure right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Pressure, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Pressure left, Pressure right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Pressure, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Pressure left, Pressure right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -993,11 +1009,14 @@ namespace UnitsNet
             return CompareTo(objPressure);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Pressure other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Pressure, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Pressure objPressure))
@@ -1006,6 +1025,8 @@ namespace UnitsNet
             return Equals(objPressure);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Pressure, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Pressure other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -1090,6 +1111,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PressureUnit) unit);
 
         /// <summary>
@@ -1104,6 +1126,7 @@ namespace UnitsNet
 
         IQuantity<PressureUnit> IQuantity<PressureUnit>.ToUnit(PressureUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PressureUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Pressure change rate is the ratio of the pressure change to the time during which the change occurred (value of pressure changes per unit time).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public PressureChangeRateUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<PressureChangeRateUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -402,6 +401,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<PressureChangeRateUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.PressureChangeRateUnit)"/>
         public static bool TryParseUnit(string str, out PressureChangeRateUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -426,36 +426,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static PressureChangeRate operator -(PressureChangeRate right)
         {
             return new PressureChangeRate(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="PressureChangeRate"/> from adding two <see cref="PressureChangeRate"/>.</summary>
         public static PressureChangeRate operator +(PressureChangeRate left, PressureChangeRate right)
         {
             return new PressureChangeRate(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="PressureChangeRate"/> from subtracting two <see cref="PressureChangeRate"/>.</summary>
         public static PressureChangeRate operator -(PressureChangeRate left, PressureChangeRate right)
         {
             return new PressureChangeRate(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="PressureChangeRate"/> from multiplying value and <see cref="PressureChangeRate"/>.</summary>
         public static PressureChangeRate operator *(double left, PressureChangeRate right)
         {
             return new PressureChangeRate(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="PressureChangeRate"/> from multiplying value and <see cref="PressureChangeRate"/>.</summary>
         public static PressureChangeRate operator *(PressureChangeRate left, double right)
         {
             return new PressureChangeRate(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="PressureChangeRate"/> from dividing <see cref="PressureChangeRate"/> by value.</summary>
         public static PressureChangeRate operator /(PressureChangeRate left, double right)
         {
             return new PressureChangeRate(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="PressureChangeRate"/> by <see cref="PressureChangeRate"/>.</summary>
         public static double operator /(PressureChangeRate left, PressureChangeRate right)
         {
             return left.PascalsPerSecond / right.PascalsPerSecond;
@@ -465,36 +472,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(PressureChangeRate left, PressureChangeRate right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(PressureChangeRate left, PressureChangeRate right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(PressureChangeRate left, PressureChangeRate right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(PressureChangeRate left, PressureChangeRate right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(PressureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(PressureChangeRate left, PressureChangeRate right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(PressureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(PressureChangeRate left, PressureChangeRate right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -503,11 +519,14 @@ namespace UnitsNet
             return CompareTo(objPressureChangeRate);
         }
 
+        /// <inheritdoc />
         public int CompareTo(PressureChangeRate other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(PressureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is PressureChangeRate objPressureChangeRate))
@@ -516,6 +535,8 @@ namespace UnitsNet
             return Equals(objPressureChangeRate);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(PressureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(PressureChangeRate other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -600,6 +621,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((PressureChangeRateUnit) unit);
 
         /// <summary>
@@ -614,6 +636,7 @@ namespace UnitsNet
 
         IQuantity<PressureChangeRateUnit> IQuantity<PressureChangeRateUnit>.ToUnit(PressureChangeRateUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((PressureChangeRateUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In mathematics, a ratio is a relationship between two numbers of the same kind (e.g., objects, persons, students, spoonfuls, units of whatever identical dimension), usually expressed as "a to b" or a:b, sometimes expressed arithmetically as a dimensionless quotient of the two that explicitly indicates how many times the first number contains the second (not necessarily an integer).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public RatioUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<RatioUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -388,6 +387,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<RatioUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.RatioUnit)"/>
         public static bool TryParseUnit(string str, out RatioUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -412,36 +412,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Ratio operator -(Ratio right)
         {
             return new Ratio(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Ratio"/> from adding two <see cref="Ratio"/>.</summary>
         public static Ratio operator +(Ratio left, Ratio right)
         {
             return new Ratio(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Ratio"/> from subtracting two <see cref="Ratio"/>.</summary>
         public static Ratio operator -(Ratio left, Ratio right)
         {
             return new Ratio(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Ratio"/> from multiplying value and <see cref="Ratio"/>.</summary>
         public static Ratio operator *(double left, Ratio right)
         {
             return new Ratio(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Ratio"/> from multiplying value and <see cref="Ratio"/>.</summary>
         public static Ratio operator *(Ratio left, double right)
         {
             return new Ratio(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Ratio"/> from dividing <see cref="Ratio"/> by value.</summary>
         public static Ratio operator /(Ratio left, double right)
         {
             return new Ratio(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Ratio"/> by <see cref="Ratio"/>.</summary>
         public static double operator /(Ratio left, Ratio right)
         {
             return left.DecimalFractions / right.DecimalFractions;
@@ -451,36 +458,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Ratio left, Ratio right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Ratio left, Ratio right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Ratio left, Ratio right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Ratio left, Ratio right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Ratio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Ratio left, Ratio right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Ratio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Ratio left, Ratio right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -489,11 +505,14 @@ namespace UnitsNet
             return CompareTo(objRatio);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Ratio other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Ratio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Ratio objRatio))
@@ -502,6 +521,8 @@ namespace UnitsNet
             return Equals(objRatio);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Ratio, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Ratio other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -586,6 +607,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((RatioUnit) unit);
 
         /// <summary>
@@ -600,6 +622,7 @@ namespace UnitsNet
 
         IQuantity<RatioUnit> IQuantity<RatioUnit>.ToUnit(RatioUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((RatioUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The Volt-ampere reactive hour (expressed as varh) is the reactive power of one Volt-ampere reactive produced in one hour.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ReactiveEnergyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ReactiveEnergyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ReactiveEnergyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ReactiveEnergyUnit)"/>
         public static bool TryParseUnit(string str, out ReactiveEnergyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ReactiveEnergy operator -(ReactiveEnergy right)
         {
             return new ReactiveEnergy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ReactiveEnergy"/> from adding two <see cref="ReactiveEnergy"/>.</summary>
         public static ReactiveEnergy operator +(ReactiveEnergy left, ReactiveEnergy right)
         {
             return new ReactiveEnergy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ReactiveEnergy"/> from subtracting two <see cref="ReactiveEnergy"/>.</summary>
         public static ReactiveEnergy operator -(ReactiveEnergy left, ReactiveEnergy right)
         {
             return new ReactiveEnergy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ReactiveEnergy"/> from multiplying value and <see cref="ReactiveEnergy"/>.</summary>
         public static ReactiveEnergy operator *(double left, ReactiveEnergy right)
         {
             return new ReactiveEnergy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ReactiveEnergy"/> from multiplying value and <see cref="ReactiveEnergy"/>.</summary>
         public static ReactiveEnergy operator *(ReactiveEnergy left, double right)
         {
             return new ReactiveEnergy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ReactiveEnergy"/> from dividing <see cref="ReactiveEnergy"/> by value.</summary>
         public static ReactiveEnergy operator /(ReactiveEnergy left, double right)
         {
             return new ReactiveEnergy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ReactiveEnergy"/> by <see cref="ReactiveEnergy"/>.</summary>
         public static double operator /(ReactiveEnergy left, ReactiveEnergy right)
         {
             return left.VoltampereReactiveHours / right.VoltampereReactiveHours;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ReactiveEnergy left, ReactiveEnergy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ReactiveEnergy left, ReactiveEnergy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ReactiveEnergy left, ReactiveEnergy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ReactiveEnergy left, ReactiveEnergy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ReactiveEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ReactiveEnergy left, ReactiveEnergy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ReactiveEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ReactiveEnergy left, ReactiveEnergy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objReactiveEnergy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ReactiveEnergy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ReactiveEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ReactiveEnergy objReactiveEnergy))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objReactiveEnergy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ReactiveEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ReactiveEnergy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ReactiveEnergyUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<ReactiveEnergyUnit> IQuantity<ReactiveEnergyUnit>.ToUnit(ReactiveEnergyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ReactiveEnergyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Volt-ampere reactive (var) is a unit by which reactive power is expressed in an AC electric power system. Reactive power exists in an AC circuit when the current and voltage are not in phase.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ReactivePowerUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ReactivePowerUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -360,6 +359,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ReactivePowerUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ReactivePowerUnit)"/>
         public static bool TryParseUnit(string str, out ReactivePowerUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -384,36 +384,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ReactivePower operator -(ReactivePower right)
         {
             return new ReactivePower(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ReactivePower"/> from adding two <see cref="ReactivePower"/>.</summary>
         public static ReactivePower operator +(ReactivePower left, ReactivePower right)
         {
             return new ReactivePower(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ReactivePower"/> from subtracting two <see cref="ReactivePower"/>.</summary>
         public static ReactivePower operator -(ReactivePower left, ReactivePower right)
         {
             return new ReactivePower(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ReactivePower"/> from multiplying value and <see cref="ReactivePower"/>.</summary>
         public static ReactivePower operator *(double left, ReactivePower right)
         {
             return new ReactivePower(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ReactivePower"/> from multiplying value and <see cref="ReactivePower"/>.</summary>
         public static ReactivePower operator *(ReactivePower left, double right)
         {
             return new ReactivePower(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ReactivePower"/> from dividing <see cref="ReactivePower"/> by value.</summary>
         public static ReactivePower operator /(ReactivePower left, double right)
         {
             return new ReactivePower(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ReactivePower"/> by <see cref="ReactivePower"/>.</summary>
         public static double operator /(ReactivePower left, ReactivePower right)
         {
             return left.VoltamperesReactive / right.VoltamperesReactive;
@@ -423,36 +430,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ReactivePower left, ReactivePower right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ReactivePower left, ReactivePower right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ReactivePower left, ReactivePower right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ReactivePower left, ReactivePower right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ReactivePower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ReactivePower left, ReactivePower right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ReactivePower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ReactivePower left, ReactivePower right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -461,11 +477,14 @@ namespace UnitsNet
             return CompareTo(objReactivePower);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ReactivePower other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ReactivePower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ReactivePower objReactivePower))
@@ -474,6 +493,8 @@ namespace UnitsNet
             return Equals(objReactivePower);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ReactivePower, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ReactivePower other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -558,6 +579,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ReactivePowerUnit) unit);
 
         /// <summary>
@@ -572,6 +594,7 @@ namespace UnitsNet
 
         IQuantity<ReactivePowerUnit> IQuantity<ReactivePowerUnit>.ToUnit(ReactivePowerUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ReactivePowerUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Angular acceleration is the rate of change of rotational speed.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public RotationalAccelerationUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<RotationalAccelerationUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<RotationalAccelerationUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.RotationalAccelerationUnit)"/>
         public static bool TryParseUnit(string str, out RotationalAccelerationUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static RotationalAcceleration operator -(RotationalAcceleration right)
         {
             return new RotationalAcceleration(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalAcceleration"/> from adding two <see cref="RotationalAcceleration"/>.</summary>
         public static RotationalAcceleration operator +(RotationalAcceleration left, RotationalAcceleration right)
         {
             return new RotationalAcceleration(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalAcceleration"/> from subtracting two <see cref="RotationalAcceleration"/>.</summary>
         public static RotationalAcceleration operator -(RotationalAcceleration left, RotationalAcceleration right)
         {
             return new RotationalAcceleration(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalAcceleration"/> from multiplying value and <see cref="RotationalAcceleration"/>.</summary>
         public static RotationalAcceleration operator *(double left, RotationalAcceleration right)
         {
             return new RotationalAcceleration(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalAcceleration"/> from multiplying value and <see cref="RotationalAcceleration"/>.</summary>
         public static RotationalAcceleration operator *(RotationalAcceleration left, double right)
         {
             return new RotationalAcceleration(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalAcceleration"/> from dividing <see cref="RotationalAcceleration"/> by value.</summary>
         public static RotationalAcceleration operator /(RotationalAcceleration left, double right)
         {
             return new RotationalAcceleration(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="RotationalAcceleration"/> by <see cref="RotationalAcceleration"/>.</summary>
         public static double operator /(RotationalAcceleration left, RotationalAcceleration right)
         {
             return left.RadiansPerSecondSquared / right.RadiansPerSecondSquared;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(RotationalAcceleration left, RotationalAcceleration right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(RotationalAcceleration left, RotationalAcceleration right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(RotationalAcceleration left, RotationalAcceleration right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(RotationalAcceleration left, RotationalAcceleration right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalAcceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(RotationalAcceleration left, RotationalAcceleration right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalAcceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(RotationalAcceleration left, RotationalAcceleration right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objRotationalAcceleration);
         }
 
+        /// <inheritdoc />
         public int CompareTo(RotationalAcceleration other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalAcceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is RotationalAcceleration objRotationalAcceleration))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objRotationalAcceleration);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalAcceleration, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(RotationalAcceleration other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((RotationalAccelerationUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<RotationalAccelerationUnit> IQuantity<RotationalAccelerationUnit>.ToUnit(RotationalAccelerationUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((RotationalAccelerationUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Rotational speed (sometimes called speed of revolution) is the number of complete rotations, revolutions, cycles, or turns per time unit. Rotational speed is a cyclic frequency, measured in radians per second or in hertz in the SI System by scientists, or in revolutions per minute (rpm or min-1) or revolutions per second in everyday life. The symbol for rotational speed is ω (the Greek lowercase letter "omega").
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public RotationalSpeedUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<RotationalSpeedUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -486,6 +485,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<RotationalSpeedUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.RotationalSpeedUnit)"/>
         public static bool TryParseUnit(string str, out RotationalSpeedUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -510,36 +510,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static RotationalSpeed operator -(RotationalSpeed right)
         {
             return new RotationalSpeed(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalSpeed"/> from adding two <see cref="RotationalSpeed"/>.</summary>
         public static RotationalSpeed operator +(RotationalSpeed left, RotationalSpeed right)
         {
             return new RotationalSpeed(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalSpeed"/> from subtracting two <see cref="RotationalSpeed"/>.</summary>
         public static RotationalSpeed operator -(RotationalSpeed left, RotationalSpeed right)
         {
             return new RotationalSpeed(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalSpeed"/> from multiplying value and <see cref="RotationalSpeed"/>.</summary>
         public static RotationalSpeed operator *(double left, RotationalSpeed right)
         {
             return new RotationalSpeed(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalSpeed"/> from multiplying value and <see cref="RotationalSpeed"/>.</summary>
         public static RotationalSpeed operator *(RotationalSpeed left, double right)
         {
             return new RotationalSpeed(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalSpeed"/> from dividing <see cref="RotationalSpeed"/> by value.</summary>
         public static RotationalSpeed operator /(RotationalSpeed left, double right)
         {
             return new RotationalSpeed(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="RotationalSpeed"/> by <see cref="RotationalSpeed"/>.</summary>
         public static double operator /(RotationalSpeed left, RotationalSpeed right)
         {
             return left.RadiansPerSecond / right.RadiansPerSecond;
@@ -549,36 +556,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(RotationalSpeed left, RotationalSpeed right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(RotationalSpeed left, RotationalSpeed right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(RotationalSpeed left, RotationalSpeed right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(RotationalSpeed left, RotationalSpeed right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalSpeed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(RotationalSpeed left, RotationalSpeed right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalSpeed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(RotationalSpeed left, RotationalSpeed right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -587,11 +603,14 @@ namespace UnitsNet
             return CompareTo(objRotationalSpeed);
         }
 
+        /// <inheritdoc />
         public int CompareTo(RotationalSpeed other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalSpeed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is RotationalSpeed objRotationalSpeed))
@@ -600,6 +619,8 @@ namespace UnitsNet
             return Equals(objRotationalSpeed);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalSpeed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(RotationalSpeed other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -684,6 +705,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((RotationalSpeedUnit) unit);
 
         /// <summary>
@@ -698,6 +720,7 @@ namespace UnitsNet
 
         IQuantity<RotationalSpeedUnit> IQuantity<RotationalSpeedUnit>.ToUnit(RotationalSpeedUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((RotationalSpeedUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public RotationalStiffnessUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<RotationalStiffnessUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<RotationalStiffnessUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.RotationalStiffnessUnit)"/>
         public static bool TryParseUnit(string str, out RotationalStiffnessUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static RotationalStiffness operator -(RotationalStiffness right)
         {
             return new RotationalStiffness(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffness"/> from adding two <see cref="RotationalStiffness"/>.</summary>
         public static RotationalStiffness operator +(RotationalStiffness left, RotationalStiffness right)
         {
             return new RotationalStiffness(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffness"/> from subtracting two <see cref="RotationalStiffness"/>.</summary>
         public static RotationalStiffness operator -(RotationalStiffness left, RotationalStiffness right)
         {
             return new RotationalStiffness(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffness"/> from multiplying value and <see cref="RotationalStiffness"/>.</summary>
         public static RotationalStiffness operator *(double left, RotationalStiffness right)
         {
             return new RotationalStiffness(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffness"/> from multiplying value and <see cref="RotationalStiffness"/>.</summary>
         public static RotationalStiffness operator *(RotationalStiffness left, double right)
         {
             return new RotationalStiffness(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffness"/> from dividing <see cref="RotationalStiffness"/> by value.</summary>
         public static RotationalStiffness operator /(RotationalStiffness left, double right)
         {
             return new RotationalStiffness(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="RotationalStiffness"/> by <see cref="RotationalStiffness"/>.</summary>
         public static double operator /(RotationalStiffness left, RotationalStiffness right)
         {
             return left.NewtonMetersPerRadian / right.NewtonMetersPerRadian;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(RotationalStiffness left, RotationalStiffness right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(RotationalStiffness left, RotationalStiffness right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(RotationalStiffness left, RotationalStiffness right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(RotationalStiffness left, RotationalStiffness right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffness, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(RotationalStiffness left, RotationalStiffness right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffness, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(RotationalStiffness left, RotationalStiffness right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objRotationalStiffness);
         }
 
+        /// <inheritdoc />
         public int CompareTo(RotationalStiffness other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffness, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is RotationalStiffness objRotationalStiffness))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objRotationalStiffness);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffness, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(RotationalStiffness other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((RotationalStiffnessUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<RotationalStiffnessUnit> IQuantity<RotationalStiffnessUnit>.ToUnit(RotationalStiffnessUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((RotationalStiffnessUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public RotationalStiffnessPerLengthUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<RotationalStiffnessPerLengthUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<RotationalStiffnessPerLengthUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.RotationalStiffnessPerLengthUnit)"/>
         public static bool TryParseUnit(string str, out RotationalStiffnessPerLengthUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static RotationalStiffnessPerLength operator -(RotationalStiffnessPerLength right)
         {
             return new RotationalStiffnessPerLength(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffnessPerLength"/> from adding two <see cref="RotationalStiffnessPerLength"/>.</summary>
         public static RotationalStiffnessPerLength operator +(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return new RotationalStiffnessPerLength(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffnessPerLength"/> from subtracting two <see cref="RotationalStiffnessPerLength"/>.</summary>
         public static RotationalStiffnessPerLength operator -(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return new RotationalStiffnessPerLength(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffnessPerLength"/> from multiplying value and <see cref="RotationalStiffnessPerLength"/>.</summary>
         public static RotationalStiffnessPerLength operator *(double left, RotationalStiffnessPerLength right)
         {
             return new RotationalStiffnessPerLength(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffnessPerLength"/> from multiplying value and <see cref="RotationalStiffnessPerLength"/>.</summary>
         public static RotationalStiffnessPerLength operator *(RotationalStiffnessPerLength left, double right)
         {
             return new RotationalStiffnessPerLength(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="RotationalStiffnessPerLength"/> from dividing <see cref="RotationalStiffnessPerLength"/> by value.</summary>
         public static RotationalStiffnessPerLength operator /(RotationalStiffnessPerLength left, double right)
         {
             return new RotationalStiffnessPerLength(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="RotationalStiffnessPerLength"/> by <see cref="RotationalStiffnessPerLength"/>.</summary>
         public static double operator /(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return left.NewtonMetersPerRadianPerMeter / right.NewtonMetersPerRadianPerMeter;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffnessPerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffnessPerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(RotationalStiffnessPerLength left, RotationalStiffnessPerLength right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objRotationalStiffnessPerLength);
         }
 
+        /// <inheritdoc />
         public int CompareTo(RotationalStiffnessPerLength other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffnessPerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is RotationalStiffnessPerLength objRotationalStiffnessPerLength))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objRotationalStiffnessPerLength);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(RotationalStiffnessPerLength, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(RotationalStiffnessPerLength other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((RotationalStiffnessPerLengthUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<RotationalStiffnessPerLengthUnit> IQuantity<RotationalStiffnessPerLengthUnit>.ToUnit(RotationalStiffnessPerLengthUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((RotationalStiffnessPerLengthUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In geometry, a solid angle is the two-dimensional angle in three-dimensional space that an object subtends at a point.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public SolidAngleUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<SolidAngleUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -321,6 +320,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<SolidAngleUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.SolidAngleUnit)"/>
         public static bool TryParseUnit(string str, out SolidAngleUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -345,36 +345,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static SolidAngle operator -(SolidAngle right)
         {
             return new SolidAngle(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SolidAngle"/> from adding two <see cref="SolidAngle"/>.</summary>
         public static SolidAngle operator +(SolidAngle left, SolidAngle right)
         {
             return new SolidAngle(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SolidAngle"/> from subtracting two <see cref="SolidAngle"/>.</summary>
         public static SolidAngle operator -(SolidAngle left, SolidAngle right)
         {
             return new SolidAngle(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SolidAngle"/> from multiplying value and <see cref="SolidAngle"/>.</summary>
         public static SolidAngle operator *(double left, SolidAngle right)
         {
             return new SolidAngle(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SolidAngle"/> from multiplying value and <see cref="SolidAngle"/>.</summary>
         public static SolidAngle operator *(SolidAngle left, double right)
         {
             return new SolidAngle(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="SolidAngle"/> from dividing <see cref="SolidAngle"/> by value.</summary>
         public static SolidAngle operator /(SolidAngle left, double right)
         {
             return new SolidAngle(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="SolidAngle"/> by <see cref="SolidAngle"/>.</summary>
         public static double operator /(SolidAngle left, SolidAngle right)
         {
             return left.Steradians / right.Steradians;
@@ -384,36 +391,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(SolidAngle left, SolidAngle right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(SolidAngle left, SolidAngle right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(SolidAngle left, SolidAngle right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(SolidAngle left, SolidAngle right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SolidAngle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(SolidAngle left, SolidAngle right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SolidAngle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(SolidAngle left, SolidAngle right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -422,11 +438,14 @@ namespace UnitsNet
             return CompareTo(objSolidAngle);
         }
 
+        /// <inheritdoc />
         public int CompareTo(SolidAngle other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SolidAngle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is SolidAngle objSolidAngle))
@@ -435,6 +454,8 @@ namespace UnitsNet
             return Equals(objSolidAngle);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SolidAngle, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(SolidAngle other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -519,6 +540,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((SolidAngleUnit) unit);
 
         /// <summary>
@@ -533,6 +555,7 @@ namespace UnitsNet
 
         IQuantity<SolidAngleUnit> IQuantity<SolidAngleUnit>.ToUnit(SolidAngleUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((SolidAngleUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The SpecificEnergy
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public SpecificEnergyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<SpecificEnergyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -433,6 +432,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<SpecificEnergyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.SpecificEnergyUnit)"/>
         public static bool TryParseUnit(string str, out SpecificEnergyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -457,36 +457,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static SpecificEnergy operator -(SpecificEnergy right)
         {
             return new SpecificEnergy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from adding two <see cref="SpecificEnergy"/>.</summary>
         public static SpecificEnergy operator +(SpecificEnergy left, SpecificEnergy right)
         {
             return new SpecificEnergy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from subtracting two <see cref="SpecificEnergy"/>.</summary>
         public static SpecificEnergy operator -(SpecificEnergy left, SpecificEnergy right)
         {
             return new SpecificEnergy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from multiplying value and <see cref="SpecificEnergy"/>.</summary>
         public static SpecificEnergy operator *(double left, SpecificEnergy right)
         {
             return new SpecificEnergy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from multiplying value and <see cref="SpecificEnergy"/>.</summary>
         public static SpecificEnergy operator *(SpecificEnergy left, double right)
         {
             return new SpecificEnergy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEnergy"/> from dividing <see cref="SpecificEnergy"/> by value.</summary>
         public static SpecificEnergy operator /(SpecificEnergy left, double right)
         {
             return new SpecificEnergy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="SpecificEnergy"/> by <see cref="SpecificEnergy"/>.</summary>
         public static double operator /(SpecificEnergy left, SpecificEnergy right)
         {
             return left.JoulesPerKilogram / right.JoulesPerKilogram;
@@ -496,36 +503,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(SpecificEnergy left, SpecificEnergy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(SpecificEnergy left, SpecificEnergy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(SpecificEnergy left, SpecificEnergy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(SpecificEnergy left, SpecificEnergy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(SpecificEnergy left, SpecificEnergy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(SpecificEnergy left, SpecificEnergy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -534,11 +550,14 @@ namespace UnitsNet
             return CompareTo(objSpecificEnergy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(SpecificEnergy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is SpecificEnergy objSpecificEnergy))
@@ -547,6 +566,8 @@ namespace UnitsNet
             return Equals(objSpecificEnergy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificEnergy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(SpecificEnergy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -631,6 +652,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((SpecificEnergyUnit) unit);
 
         /// <summary>
@@ -645,6 +667,7 @@ namespace UnitsNet
 
         IQuantity<SpecificEnergyUnit> IQuantity<SpecificEnergyUnit>.ToUnit(SpecificEnergyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((SpecificEnergyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Specific entropy is an amount of energy required to raise temperature of a substance by 1 Kelvin per unit mass.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public SpecificEntropyUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<SpecificEntropyUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -416,6 +415,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<SpecificEntropyUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.SpecificEntropyUnit)"/>
         public static bool TryParseUnit(string str, out SpecificEntropyUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -440,36 +440,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static SpecificEntropy operator -(SpecificEntropy right)
         {
             return new SpecificEntropy(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEntropy"/> from adding two <see cref="SpecificEntropy"/>.</summary>
         public static SpecificEntropy operator +(SpecificEntropy left, SpecificEntropy right)
         {
             return new SpecificEntropy(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEntropy"/> from subtracting two <see cref="SpecificEntropy"/>.</summary>
         public static SpecificEntropy operator -(SpecificEntropy left, SpecificEntropy right)
         {
             return new SpecificEntropy(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEntropy"/> from multiplying value and <see cref="SpecificEntropy"/>.</summary>
         public static SpecificEntropy operator *(double left, SpecificEntropy right)
         {
             return new SpecificEntropy(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEntropy"/> from multiplying value and <see cref="SpecificEntropy"/>.</summary>
         public static SpecificEntropy operator *(SpecificEntropy left, double right)
         {
             return new SpecificEntropy(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificEntropy"/> from dividing <see cref="SpecificEntropy"/> by value.</summary>
         public static SpecificEntropy operator /(SpecificEntropy left, double right)
         {
             return new SpecificEntropy(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="SpecificEntropy"/> by <see cref="SpecificEntropy"/>.</summary>
         public static double operator /(SpecificEntropy left, SpecificEntropy right)
         {
             return left.JoulesPerKilogramKelvin / right.JoulesPerKilogramKelvin;
@@ -479,36 +486,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(SpecificEntropy left, SpecificEntropy right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(SpecificEntropy left, SpecificEntropy right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(SpecificEntropy left, SpecificEntropy right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(SpecificEntropy left, SpecificEntropy right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(SpecificEntropy left, SpecificEntropy right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(SpecificEntropy left, SpecificEntropy right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -517,11 +533,14 @@ namespace UnitsNet
             return CompareTo(objSpecificEntropy);
         }
 
+        /// <inheritdoc />
         public int CompareTo(SpecificEntropy other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is SpecificEntropy objSpecificEntropy))
@@ -530,6 +549,8 @@ namespace UnitsNet
             return Equals(objSpecificEntropy);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificEntropy, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(SpecificEntropy other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -614,6 +635,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((SpecificEntropyUnit) unit);
 
         /// <summary>
@@ -628,6 +650,7 @@ namespace UnitsNet
 
         IQuantity<SpecificEntropyUnit> IQuantity<SpecificEntropyUnit>.ToUnit(SpecificEntropyUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((SpecificEntropyUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In thermodynamics, the specific volume of a substance is the ratio of the substance's volume to its mass. It is the reciprocal of density and an intrinsic property of matter as well.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public SpecificVolumeUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<SpecificVolumeUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -346,6 +345,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<SpecificVolumeUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.SpecificVolumeUnit)"/>
         public static bool TryParseUnit(string str, out SpecificVolumeUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -370,36 +370,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static SpecificVolume operator -(SpecificVolume right)
         {
             return new SpecificVolume(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificVolume"/> from adding two <see cref="SpecificVolume"/>.</summary>
         public static SpecificVolume operator +(SpecificVolume left, SpecificVolume right)
         {
             return new SpecificVolume(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificVolume"/> from subtracting two <see cref="SpecificVolume"/>.</summary>
         public static SpecificVolume operator -(SpecificVolume left, SpecificVolume right)
         {
             return new SpecificVolume(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificVolume"/> from multiplying value and <see cref="SpecificVolume"/>.</summary>
         public static SpecificVolume operator *(double left, SpecificVolume right)
         {
             return new SpecificVolume(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificVolume"/> from multiplying value and <see cref="SpecificVolume"/>.</summary>
         public static SpecificVolume operator *(SpecificVolume left, double right)
         {
             return new SpecificVolume(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificVolume"/> from dividing <see cref="SpecificVolume"/> by value.</summary>
         public static SpecificVolume operator /(SpecificVolume left, double right)
         {
             return new SpecificVolume(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="SpecificVolume"/> by <see cref="SpecificVolume"/>.</summary>
         public static double operator /(SpecificVolume left, SpecificVolume right)
         {
             return left.CubicMetersPerKilogram / right.CubicMetersPerKilogram;
@@ -409,36 +416,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(SpecificVolume left, SpecificVolume right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(SpecificVolume left, SpecificVolume right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(SpecificVolume left, SpecificVolume right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(SpecificVolume left, SpecificVolume right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificVolume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(SpecificVolume left, SpecificVolume right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificVolume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(SpecificVolume left, SpecificVolume right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -447,11 +463,14 @@ namespace UnitsNet
             return CompareTo(objSpecificVolume);
         }
 
+        /// <inheritdoc />
         public int CompareTo(SpecificVolume other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificVolume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is SpecificVolume objSpecificVolume))
@@ -460,6 +479,8 @@ namespace UnitsNet
             return Equals(objSpecificVolume);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificVolume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(SpecificVolume other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -544,6 +565,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((SpecificVolumeUnit) unit);
 
         /// <summary>
@@ -558,6 +580,7 @@ namespace UnitsNet
 
         IQuantity<SpecificVolumeUnit> IQuantity<SpecificVolumeUnit>.ToUnit(SpecificVolumeUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((SpecificVolumeUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     The SpecificWeight, or more precisely, the volumetric weight density, of a substance is its weight per unit volume.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public SpecificWeightUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<SpecificWeightUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -545,6 +544,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<SpecificWeightUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.SpecificWeightUnit)"/>
         public static bool TryParseUnit(string str, out SpecificWeightUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -569,36 +569,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static SpecificWeight operator -(SpecificWeight right)
         {
             return new SpecificWeight(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from adding two <see cref="SpecificWeight"/>.</summary>
         public static SpecificWeight operator +(SpecificWeight left, SpecificWeight right)
         {
             return new SpecificWeight(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from subtracting two <see cref="SpecificWeight"/>.</summary>
         public static SpecificWeight operator -(SpecificWeight left, SpecificWeight right)
         {
             return new SpecificWeight(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from multiplying value and <see cref="SpecificWeight"/>.</summary>
         public static SpecificWeight operator *(double left, SpecificWeight right)
         {
             return new SpecificWeight(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from multiplying value and <see cref="SpecificWeight"/>.</summary>
         public static SpecificWeight operator *(SpecificWeight left, double right)
         {
             return new SpecificWeight(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="SpecificWeight"/> from dividing <see cref="SpecificWeight"/> by value.</summary>
         public static SpecificWeight operator /(SpecificWeight left, double right)
         {
             return new SpecificWeight(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="SpecificWeight"/> by <see cref="SpecificWeight"/>.</summary>
         public static double operator /(SpecificWeight left, SpecificWeight right)
         {
             return left.NewtonsPerCubicMeter / right.NewtonsPerCubicMeter;
@@ -608,36 +615,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(SpecificWeight left, SpecificWeight right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(SpecificWeight left, SpecificWeight right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(SpecificWeight left, SpecificWeight right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(SpecificWeight left, SpecificWeight right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificWeight, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(SpecificWeight left, SpecificWeight right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(SpecificWeight, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(SpecificWeight left, SpecificWeight right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -646,11 +662,14 @@ namespace UnitsNet
             return CompareTo(objSpecificWeight);
         }
 
+        /// <inheritdoc />
         public int CompareTo(SpecificWeight other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificWeight, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is SpecificWeight objSpecificWeight))
@@ -659,6 +678,8 @@ namespace UnitsNet
             return Equals(objSpecificWeight);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(SpecificWeight, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(SpecificWeight other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -743,6 +764,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((SpecificWeightUnit) unit);
 
         /// <summary>
@@ -757,6 +779,7 @@ namespace UnitsNet
 
         IQuantity<SpecificWeightUnit> IQuantity<SpecificWeightUnit>.ToUnit(SpecificWeightUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((SpecificWeightUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In everyday use and in kinematics, the speed of an object is the magnitude of its velocity (the rate of change of its position); it is thus a scalar quantity.[1] The average speed of an object in an interval of time is the distance travelled by the object divided by the duration of the interval;[2] the instantaneous speed is the limit of the average speed as the duration of the time interval approaches zero.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public SpeedUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<SpeedUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -752,6 +751,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<SpeedUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.SpeedUnit)"/>
         public static bool TryParseUnit(string str, out SpeedUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -776,36 +776,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Speed operator -(Speed right)
         {
             return new Speed(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Speed"/> from adding two <see cref="Speed"/>.</summary>
         public static Speed operator +(Speed left, Speed right)
         {
             return new Speed(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Speed"/> from subtracting two <see cref="Speed"/>.</summary>
         public static Speed operator -(Speed left, Speed right)
         {
             return new Speed(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Speed"/> from multiplying value and <see cref="Speed"/>.</summary>
         public static Speed operator *(double left, Speed right)
         {
             return new Speed(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Speed"/> from multiplying value and <see cref="Speed"/>.</summary>
         public static Speed operator *(Speed left, double right)
         {
             return new Speed(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Speed"/> from dividing <see cref="Speed"/> by value.</summary>
         public static Speed operator /(Speed left, double right)
         {
             return new Speed(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Speed"/> by <see cref="Speed"/>.</summary>
         public static double operator /(Speed left, Speed right)
         {
             return left.MetersPerSecond / right.MetersPerSecond;
@@ -815,36 +822,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Speed left, Speed right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Speed left, Speed right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Speed left, Speed right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Speed left, Speed right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Speed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Speed left, Speed right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Speed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Speed left, Speed right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -853,11 +869,14 @@ namespace UnitsNet
             return CompareTo(objSpeed);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Speed other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Speed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Speed objSpeed))
@@ -866,6 +885,8 @@ namespace UnitsNet
             return Equals(objSpeed);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Speed, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Speed other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -950,6 +971,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((SpeedUnit) unit);
 
         /// <summary>
@@ -964,6 +986,7 @@ namespace UnitsNet
 
         IQuantity<SpeedUnit> IQuantity<SpeedUnit>.ToUnit(SpeedUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((SpeedUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     A temperature is a numerical measure of hot or cold. Its measurement is by detection of heat radiation or particle velocity or kinetic energy, or by the bulk behavior of a thermometric material. It may be calibrated in any of various temperature scales, Celsius, Fahrenheit, Kelvin, etc. The fundamental physical definition of temperature is provided by thermodynamics.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public TemperatureUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<TemperatureUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -416,6 +415,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<TemperatureUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.TemperatureUnit)"/>
         public static bool TryParseUnit(string str, out TemperatureUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -440,36 +440,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Temperature left, Temperature right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Temperature left, Temperature right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Temperature left, Temperature right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Temperature left, Temperature right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Temperature, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Temperature left, Temperature right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Temperature, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Temperature left, Temperature right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -478,11 +487,14 @@ namespace UnitsNet
             return CompareTo(objTemperature);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Temperature other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Temperature, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Temperature objTemperature))
@@ -491,6 +503,8 @@ namespace UnitsNet
             return Equals(objTemperature);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Temperature, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Temperature other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -575,6 +589,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((TemperatureUnit) unit);
 
         /// <summary>
@@ -589,6 +604,7 @@ namespace UnitsNet
 
         IQuantity<TemperatureUnit> IQuantity<TemperatureUnit>.ToUnit(TemperatureUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((TemperatureUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Temperature change rate is the ratio of the temperature change to the time during which the change occurred (value of temperature changes per unit time).
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public TemperatureChangeRateUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<TemperatureChangeRateUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -444,6 +443,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<TemperatureChangeRateUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.TemperatureChangeRateUnit)"/>
         public static bool TryParseUnit(string str, out TemperatureChangeRateUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -468,36 +468,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static TemperatureChangeRate operator -(TemperatureChangeRate right)
         {
             return new TemperatureChangeRate(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureChangeRate"/> from adding two <see cref="TemperatureChangeRate"/>.</summary>
         public static TemperatureChangeRate operator +(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return new TemperatureChangeRate(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureChangeRate"/> from subtracting two <see cref="TemperatureChangeRate"/>.</summary>
         public static TemperatureChangeRate operator -(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return new TemperatureChangeRate(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureChangeRate"/> from multiplying value and <see cref="TemperatureChangeRate"/>.</summary>
         public static TemperatureChangeRate operator *(double left, TemperatureChangeRate right)
         {
             return new TemperatureChangeRate(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureChangeRate"/> from multiplying value and <see cref="TemperatureChangeRate"/>.</summary>
         public static TemperatureChangeRate operator *(TemperatureChangeRate left, double right)
         {
             return new TemperatureChangeRate(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureChangeRate"/> from dividing <see cref="TemperatureChangeRate"/> by value.</summary>
         public static TemperatureChangeRate operator /(TemperatureChangeRate left, double right)
         {
             return new TemperatureChangeRate(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="TemperatureChangeRate"/> by <see cref="TemperatureChangeRate"/>.</summary>
         public static double operator /(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return left.DegreesCelsiusPerSecond / right.DegreesCelsiusPerSecond;
@@ -507,36 +514,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(TemperatureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(TemperatureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(TemperatureChangeRate left, TemperatureChangeRate right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -545,11 +561,14 @@ namespace UnitsNet
             return CompareTo(objTemperatureChangeRate);
         }
 
+        /// <inheritdoc />
         public int CompareTo(TemperatureChangeRate other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(TemperatureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is TemperatureChangeRate objTemperatureChangeRate))
@@ -558,6 +577,8 @@ namespace UnitsNet
             return Equals(objTemperatureChangeRate);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(TemperatureChangeRate, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(TemperatureChangeRate other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -642,6 +663,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((TemperatureChangeRateUnit) unit);
 
         /// <summary>
@@ -656,6 +678,7 @@ namespace UnitsNet
 
         IQuantity<TemperatureChangeRateUnit> IQuantity<TemperatureChangeRateUnit>.ToUnit(TemperatureChangeRateUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((TemperatureChangeRateUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Difference between two temperatures. The conversions are different than for Temperature.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public TemperatureDeltaUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<TemperatureDeltaUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -416,6 +415,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<TemperatureDeltaUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.TemperatureDeltaUnit)"/>
         public static bool TryParseUnit(string str, out TemperatureDeltaUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -440,36 +440,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static TemperatureDelta operator -(TemperatureDelta right)
         {
             return new TemperatureDelta(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from adding two <see cref="TemperatureDelta"/>.</summary>
         public static TemperatureDelta operator +(TemperatureDelta left, TemperatureDelta right)
         {
             return new TemperatureDelta(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from subtracting two <see cref="TemperatureDelta"/>.</summary>
         public static TemperatureDelta operator -(TemperatureDelta left, TemperatureDelta right)
         {
             return new TemperatureDelta(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from multiplying value and <see cref="TemperatureDelta"/>.</summary>
         public static TemperatureDelta operator *(double left, TemperatureDelta right)
         {
             return new TemperatureDelta(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from multiplying value and <see cref="TemperatureDelta"/>.</summary>
         public static TemperatureDelta operator *(TemperatureDelta left, double right)
         {
             return new TemperatureDelta(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="TemperatureDelta"/> from dividing <see cref="TemperatureDelta"/> by value.</summary>
         public static TemperatureDelta operator /(TemperatureDelta left, double right)
         {
             return new TemperatureDelta(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="TemperatureDelta"/> by <see cref="TemperatureDelta"/>.</summary>
         public static double operator /(TemperatureDelta left, TemperatureDelta right)
         {
             return left.Kelvins / right.Kelvins;
@@ -479,36 +486,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(TemperatureDelta left, TemperatureDelta right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(TemperatureDelta left, TemperatureDelta right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(TemperatureDelta left, TemperatureDelta right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(TemperatureDelta left, TemperatureDelta right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(TemperatureDelta, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(TemperatureDelta left, TemperatureDelta right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(TemperatureDelta, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(TemperatureDelta left, TemperatureDelta right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -517,11 +533,14 @@ namespace UnitsNet
             return CompareTo(objTemperatureDelta);
         }
 
+        /// <inheritdoc />
         public int CompareTo(TemperatureDelta other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(TemperatureDelta, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is TemperatureDelta objTemperatureDelta))
@@ -530,6 +549,8 @@ namespace UnitsNet
             return Equals(objTemperatureDelta);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(TemperatureDelta, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(TemperatureDelta other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -614,6 +635,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((TemperatureDeltaUnit) unit);
 
         /// <summary>
@@ -628,6 +650,7 @@ namespace UnitsNet
 
         IQuantity<TemperatureDeltaUnit> IQuantity<TemperatureDeltaUnit>.ToUnit(TemperatureDeltaUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((TemperatureDeltaUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Thermal conductivity is the property of a material to conduct heat.
     /// </summary>
@@ -116,14 +117,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ThermalConductivityUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ThermalConductivityUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -335,6 +334,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ThermalConductivityUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ThermalConductivityUnit)"/>
         public static bool TryParseUnit(string str, out ThermalConductivityUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -359,36 +359,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ThermalConductivity operator -(ThermalConductivity right)
         {
             return new ThermalConductivity(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalConductivity"/> from adding two <see cref="ThermalConductivity"/>.</summary>
         public static ThermalConductivity operator +(ThermalConductivity left, ThermalConductivity right)
         {
             return new ThermalConductivity(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalConductivity"/> from subtracting two <see cref="ThermalConductivity"/>.</summary>
         public static ThermalConductivity operator -(ThermalConductivity left, ThermalConductivity right)
         {
             return new ThermalConductivity(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalConductivity"/> from multiplying value and <see cref="ThermalConductivity"/>.</summary>
         public static ThermalConductivity operator *(double left, ThermalConductivity right)
         {
             return new ThermalConductivity(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalConductivity"/> from multiplying value and <see cref="ThermalConductivity"/>.</summary>
         public static ThermalConductivity operator *(ThermalConductivity left, double right)
         {
             return new ThermalConductivity(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalConductivity"/> from dividing <see cref="ThermalConductivity"/> by value.</summary>
         public static ThermalConductivity operator /(ThermalConductivity left, double right)
         {
             return new ThermalConductivity(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ThermalConductivity"/> by <see cref="ThermalConductivity"/>.</summary>
         public static double operator /(ThermalConductivity left, ThermalConductivity right)
         {
             return left.WattsPerMeterKelvin / right.WattsPerMeterKelvin;
@@ -398,36 +405,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ThermalConductivity left, ThermalConductivity right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ThermalConductivity left, ThermalConductivity right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ThermalConductivity left, ThermalConductivity right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ThermalConductivity left, ThermalConductivity right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ThermalConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ThermalConductivity left, ThermalConductivity right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ThermalConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ThermalConductivity left, ThermalConductivity right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -436,11 +452,14 @@ namespace UnitsNet
             return CompareTo(objThermalConductivity);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ThermalConductivity other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ThermalConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ThermalConductivity objThermalConductivity))
@@ -449,6 +468,8 @@ namespace UnitsNet
             return Equals(objThermalConductivity);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ThermalConductivity, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ThermalConductivity other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -533,6 +554,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ThermalConductivityUnit) unit);
 
         /// <summary>
@@ -547,6 +569,7 @@ namespace UnitsNet
 
         IQuantity<ThermalConductivityUnit> IQuantity<ThermalConductivityUnit>.ToUnit(ThermalConductivityUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ThermalConductivityUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Heat Transfer Coefficient or Thermal conductivity - indicates a materials ability to conduct heat.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public ThermalResistanceUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<ThermalResistanceUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -374,6 +373,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<ThermalResistanceUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.ThermalResistanceUnit)"/>
         public static bool TryParseUnit(string str, out ThermalResistanceUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -398,36 +398,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static ThermalResistance operator -(ThermalResistance right)
         {
             return new ThermalResistance(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalResistance"/> from adding two <see cref="ThermalResistance"/>.</summary>
         public static ThermalResistance operator +(ThermalResistance left, ThermalResistance right)
         {
             return new ThermalResistance(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalResistance"/> from subtracting two <see cref="ThermalResistance"/>.</summary>
         public static ThermalResistance operator -(ThermalResistance left, ThermalResistance right)
         {
             return new ThermalResistance(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalResistance"/> from multiplying value and <see cref="ThermalResistance"/>.</summary>
         public static ThermalResistance operator *(double left, ThermalResistance right)
         {
             return new ThermalResistance(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalResistance"/> from multiplying value and <see cref="ThermalResistance"/>.</summary>
         public static ThermalResistance operator *(ThermalResistance left, double right)
         {
             return new ThermalResistance(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="ThermalResistance"/> from dividing <see cref="ThermalResistance"/> by value.</summary>
         public static ThermalResistance operator /(ThermalResistance left, double right)
         {
             return new ThermalResistance(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="ThermalResistance"/> by <see cref="ThermalResistance"/>.</summary>
         public static double operator /(ThermalResistance left, ThermalResistance right)
         {
             return left.SquareMeterKelvinsPerKilowatt / right.SquareMeterKelvinsPerKilowatt;
@@ -437,36 +444,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(ThermalResistance left, ThermalResistance right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(ThermalResistance left, ThermalResistance right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(ThermalResistance left, ThermalResistance right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(ThermalResistance left, ThermalResistance right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ThermalResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(ThermalResistance left, ThermalResistance right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(ThermalResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(ThermalResistance left, ThermalResistance right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -475,11 +491,14 @@ namespace UnitsNet
             return CompareTo(objThermalResistance);
         }
 
+        /// <inheritdoc />
         public int CompareTo(ThermalResistance other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ThermalResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is ThermalResistance objThermalResistance))
@@ -488,6 +507,8 @@ namespace UnitsNet
             return Equals(objThermalResistance);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(ThermalResistance, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(ThermalResistance other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -572,6 +593,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((ThermalResistanceUnit) unit);
 
         /// <summary>
@@ -586,6 +608,7 @@ namespace UnitsNet
 
         IQuantity<ThermalResistanceUnit> IQuantity<ThermalResistanceUnit>.ToUnit(ThermalResistanceUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((ThermalResistanceUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Torque, moment or moment of force (see the terminology below), is the tendency of a force to rotate an object about an axis,[1] fulcrum, or pivot. Just as a force is a push or a pull, a torque can be thought of as a twist to an object. Mathematically, torque is defined as the cross product of the lever-arm distance and force, which tends to produce rotation. Loosely speaking, torque is a measure of the turning force on an object such as a bolt or a flywheel. For example, pushing or pulling the handle of a wrench connected to a nut or bolt produces a torque (turning force) that loosens or tightens the nut or bolt.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public TorqueUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<TorqueUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -598,6 +597,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<TorqueUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.TorqueUnit)"/>
         public static bool TryParseUnit(string str, out TorqueUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -622,36 +622,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Torque operator -(Torque right)
         {
             return new Torque(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Torque"/> from adding two <see cref="Torque"/>.</summary>
         public static Torque operator +(Torque left, Torque right)
         {
             return new Torque(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Torque"/> from subtracting two <see cref="Torque"/>.</summary>
         public static Torque operator -(Torque left, Torque right)
         {
             return new Torque(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Torque"/> from multiplying value and <see cref="Torque"/>.</summary>
         public static Torque operator *(double left, Torque right)
         {
             return new Torque(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Torque"/> from multiplying value and <see cref="Torque"/>.</summary>
         public static Torque operator *(Torque left, double right)
         {
             return new Torque(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Torque"/> from dividing <see cref="Torque"/> by value.</summary>
         public static Torque operator /(Torque left, double right)
         {
             return new Torque(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Torque"/> by <see cref="Torque"/>.</summary>
         public static double operator /(Torque left, Torque right)
         {
             return left.NewtonMeters / right.NewtonMeters;
@@ -661,36 +668,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Torque left, Torque right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Torque left, Torque right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Torque left, Torque right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Torque left, Torque right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Torque, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Torque left, Torque right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Torque, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Torque left, Torque right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -699,11 +715,14 @@ namespace UnitsNet
             return CompareTo(objTorque);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Torque other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Torque, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Torque objTorque))
@@ -712,6 +731,8 @@ namespace UnitsNet
             return Equals(objTorque);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Torque, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Torque other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -796,6 +817,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((TorqueUnit) unit);
 
         /// <summary>
@@ -810,6 +832,7 @@ namespace UnitsNet
 
         IQuantity<TorqueUnit> IQuantity<TorqueUnit>.ToUnit(TorqueUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((TorqueUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Vitamin A: 1 IU is the biological equivalent of 0.3 µg retinol, or of 0.6 µg beta-carotene.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public VitaminAUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<VitaminAUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -318,6 +317,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<VitaminAUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.VitaminAUnit)"/>
         public static bool TryParseUnit(string str, out VitaminAUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -342,36 +342,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static VitaminA operator -(VitaminA right)
         {
             return new VitaminA(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="VitaminA"/> from adding two <see cref="VitaminA"/>.</summary>
         public static VitaminA operator +(VitaminA left, VitaminA right)
         {
             return new VitaminA(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="VitaminA"/> from subtracting two <see cref="VitaminA"/>.</summary>
         public static VitaminA operator -(VitaminA left, VitaminA right)
         {
             return new VitaminA(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="VitaminA"/> from multiplying value and <see cref="VitaminA"/>.</summary>
         public static VitaminA operator *(double left, VitaminA right)
         {
             return new VitaminA(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="VitaminA"/> from multiplying value and <see cref="VitaminA"/>.</summary>
         public static VitaminA operator *(VitaminA left, double right)
         {
             return new VitaminA(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="VitaminA"/> from dividing <see cref="VitaminA"/> by value.</summary>
         public static VitaminA operator /(VitaminA left, double right)
         {
             return new VitaminA(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="VitaminA"/> by <see cref="VitaminA"/>.</summary>
         public static double operator /(VitaminA left, VitaminA right)
         {
             return left.InternationalUnits / right.InternationalUnits;
@@ -381,36 +388,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(VitaminA left, VitaminA right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(VitaminA left, VitaminA right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(VitaminA left, VitaminA right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(VitaminA left, VitaminA right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(VitaminA, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(VitaminA left, VitaminA right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(VitaminA, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(VitaminA left, VitaminA right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -419,11 +435,14 @@ namespace UnitsNet
             return CompareTo(objVitaminA);
         }
 
+        /// <inheritdoc />
         public int CompareTo(VitaminA other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(VitaminA, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is VitaminA objVitaminA))
@@ -432,6 +451,8 @@ namespace UnitsNet
             return Equals(objVitaminA);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(VitaminA, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(VitaminA other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -516,6 +537,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((VitaminAUnit) unit);
 
         /// <summary>
@@ -530,6 +552,7 @@ namespace UnitsNet
 
         IQuantity<VitaminAUnit> IQuantity<VitaminAUnit>.ToUnit(VitaminAUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((VitaminAUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     Volume is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains.[1] Volume is often quantified numerically using the SI derived unit, the cubic metre. The volume of a container is generally understood to be the capacity of the container, i. e. the amount of fluid (gas or liquid) that the container could hold, rather than the amount of space the container itself displaces.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public VolumeUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<VolumeUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -934,6 +933,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<VolumeUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.VolumeUnit)"/>
         public static bool TryParseUnit(string str, out VolumeUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -958,36 +958,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static Volume operator -(Volume right)
         {
             return new Volume(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Volume"/> from adding two <see cref="Volume"/>.</summary>
         public static Volume operator +(Volume left, Volume right)
         {
             return new Volume(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Volume"/> from subtracting two <see cref="Volume"/>.</summary>
         public static Volume operator -(Volume left, Volume right)
         {
             return new Volume(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="Volume"/> from multiplying value and <see cref="Volume"/>.</summary>
         public static Volume operator *(double left, Volume right)
         {
             return new Volume(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="Volume"/> from multiplying value and <see cref="Volume"/>.</summary>
         public static Volume operator *(Volume left, double right)
         {
             return new Volume(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="Volume"/> from dividing <see cref="Volume"/> by value.</summary>
         public static Volume operator /(Volume left, double right)
         {
             return new Volume(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="Volume"/> by <see cref="Volume"/>.</summary>
         public static double operator /(Volume left, Volume right)
         {
             return left.CubicMeters / right.CubicMeters;
@@ -997,36 +1004,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(Volume left, Volume right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(Volume left, Volume right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(Volume left, Volume right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(Volume left, Volume right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Volume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(Volume left, Volume right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(Volume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(Volume left, Volume right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -1035,11 +1051,14 @@ namespace UnitsNet
             return CompareTo(objVolume);
         }
 
+        /// <inheritdoc />
         public int CompareTo(Volume other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Volume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is Volume objVolume))
@@ -1048,6 +1067,8 @@ namespace UnitsNet
             return Equals(objVolume);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(Volume, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(Volume other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -1132,6 +1153,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((VolumeUnit) unit);
 
         /// <summary>
@@ -1146,6 +1168,7 @@ namespace UnitsNet
 
         IQuantity<VolumeUnit> IQuantity<VolumeUnit>.ToUnit(VolumeUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((VolumeUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
@@ -28,6 +28,7 @@ using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
+    /// <inheritdoc />
     /// <summary>
     ///     In physics and engineering, in particular fluid dynamics and hydrometry, the volumetric flow rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time. The SI unit is m³/s (cubic meters per second). In US Customary Units and British Imperial Units, volumetric flow rate is often expressed as ft³/s (cubic feet per second). It is usually represented by the symbol Q.
     /// </summary>
@@ -113,14 +114,12 @@ namespace UnitsNet
         /// </summary>
         public double Value => _value;
 
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public VolumeFlowUnit Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<VolumeFlowUnit> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -976,6 +975,7 @@ namespace UnitsNet
             return UnitParser.Default.Parse<VolumeFlowUnit>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.VolumeFlowUnit)"/>
         public static bool TryParseUnit(string str, out VolumeFlowUnit unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -1000,36 +1000,43 @@ namespace UnitsNet
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static VolumeFlow operator -(VolumeFlow right)
         {
             return new VolumeFlow(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from adding two <see cref="VolumeFlow"/>.</summary>
         public static VolumeFlow operator +(VolumeFlow left, VolumeFlow right)
         {
             return new VolumeFlow(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from subtracting two <see cref="VolumeFlow"/>.</summary>
         public static VolumeFlow operator -(VolumeFlow left, VolumeFlow right)
         {
             return new VolumeFlow(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from multiplying value and <see cref="VolumeFlow"/>.</summary>
         public static VolumeFlow operator *(double left, VolumeFlow right)
         {
             return new VolumeFlow(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from multiplying value and <see cref="VolumeFlow"/>.</summary>
         public static VolumeFlow operator *(VolumeFlow left, double right)
         {
             return new VolumeFlow(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="VolumeFlow"/> from dividing <see cref="VolumeFlow"/> by value.</summary>
         public static VolumeFlow operator /(VolumeFlow left, double right)
         {
             return new VolumeFlow(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="VolumeFlow"/> by <see cref="VolumeFlow"/>.</summary>
         public static double operator /(VolumeFlow left, VolumeFlow right)
         {
             return left.CubicMetersPerSecond / right.CubicMetersPerSecond;
@@ -1039,36 +1046,45 @@ namespace UnitsNet
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=(VolumeFlow left, VolumeFlow right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=(VolumeFlow left, VolumeFlow right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <(VolumeFlow left, VolumeFlow right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >(VolumeFlow left, VolumeFlow right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(VolumeFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==(VolumeFlow left, VolumeFlow right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals(VolumeFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=(VolumeFlow left, VolumeFlow right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -1077,11 +1093,14 @@ namespace UnitsNet
             return CompareTo(objVolumeFlow);
         }
 
+        /// <inheritdoc />
         public int CompareTo(VolumeFlow other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(VolumeFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is VolumeFlow objVolumeFlow))
@@ -1090,6 +1109,8 @@ namespace UnitsNet
             return Equals(objVolumeFlow);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals(VolumeFlow, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals(VolumeFlow other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -1174,6 +1195,7 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As((VolumeFlowUnit) unit);
 
         /// <summary>
@@ -1188,6 +1210,7 @@ namespace UnitsNet
 
         IQuantity<VolumeFlowUnit> IQuantity<VolumeFlowUnit>.ToUnit(VolumeFlowUnit unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit((VolumeFlowUnit) unit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/QuantityType.g.cs
+++ b/UnitsNet/GeneratedCode/QuantityType.g.cs
@@ -28,6 +28,8 @@ namespace UnitsNet
     /// </summary>
     public enum QuantityType
     {
+// Missing XML comment for public type or member
+#pragma warning disable CS1591
         Undefined = 0,
         Acceleration,
         AmountOfSubstance,
@@ -119,5 +121,7 @@ namespace UnitsNet
         VitaminA,
         Volume,
         VolumeFlow,
+// Missing XML comment for public type or member
+#pragma warning restore CS1591
     }
 }

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -36,7 +36,7 @@ namespace UnitsNet
         double As(Enum unit);
 
         /// <summary>
-        ///     The unit this quantity was constructed with or the BaseUnit if the default constructor was used.
+        ///     The unit this quantity was constructed with -or- BaseUnit if default ctor was used.
         /// </summary>
         Enum Unit { get; }
 
@@ -77,6 +77,14 @@ namespace UnitsNet
         string ToString([CanBeNull] IFormatProvider provider, [NotNull] string format, [NotNull] params object[] args);
     }
 
+    /// <summary>
+    ///     A stronger typed interface where the unit enum type is known, to avoid passing in the
+    ///     wrong unit enum type and not having to cast from <see cref="Enum"/>.
+    /// </summary>
+    /// <example>
+    ///     IQuantity{LengthUnit} length;
+    ///     double centimeters = length.As(LengthUnit.Centimeter); // Type safety on enum type
+    /// </example>
     public interface IQuantity<TUnitType> : IQuantity where TUnitType : Enum
     {
         /// <summary>

--- a/UnitsNet/QuantityInfo.cs
+++ b/UnitsNet/QuantityInfo.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
@@ -30,25 +29,38 @@ namespace UnitsNet
             .Where(t => t.Wrap().IsEnum && t.Namespace == UnitEnumNamespace && t.Name.EndsWith("Unit"))
             .ToArray();
 
+        /// <summary>
+        ///     Constructs an instance.
+        /// </summary>
+        /// <param name="quantityType">The quantity enum value.</param>
+        /// <param name="units">The list of unit enum values.</param>
+        /// <param name="baseUnit">The base unit enum value.</param>
+        /// <param name="zero">The zero quantity.</param>
+        /// <param name="baseDimensions">The base dimensions of the quantity.</param>
+        /// <exception cref="ArgumentException">Quantity type can not be undefined.</exception>
+        /// <exception cref="ArgumentNullException">If units -or- baseUnit -or- zero -or- baseDimensions is null.</exception>
         public QuantityInfo(QuantityType quantityType, [NotNull] Enum[] units, [NotNull] Enum baseUnit, [NotNull] IQuantity zero, [NotNull] BaseDimensions baseDimensions)
         {
             if(quantityType == QuantityType.Undefined) throw new ArgumentException("Quantity type can not be undefined.", nameof(quantityType));
             if(units == null) throw new ArgumentNullException(nameof(units));
             if(baseUnit == null) throw new ArgumentNullException(nameof(baseUnit));
-            if(zero == null) throw new ArgumentNullException(nameof(zero));
-            if(baseDimensions == null) throw new ArgumentNullException(nameof(baseDimensions));
+
+            BaseDimensions = baseDimensions ?? throw new ArgumentNullException(nameof(baseDimensions));
+            Zero = zero ?? throw new ArgumentNullException(nameof(zero));
 
             Name = quantityType.ToString();
             QuantityType = quantityType;
             UnitType = UnitEnumTypes.First(t => t.Name == $"{quantityType}Unit");
             UnitInfos = units.Select(unit => new UnitInfo(unit)).ToArray();
+            BaseUnitInfo = new UnitInfo(baseUnit);
+            ValueType = zero.GetType();
+
+            // Ignore warning about populating obsolete types/members until they are removed
+#pragma warning disable 618
             UnitNames = UnitInfos.Select(unitInfo => unitInfo.Name).ToArray();
             Units = units;
-            BaseUnitInfo = new UnitInfo(baseUnit);
             BaseUnit = BaseUnitInfo.Value;
-            Zero = zero;
-            ValueType = zero.GetType();
-            BaseDimensions = baseDimensions;
+#pragma warning restore 618
         }
 
         /// <summary>
@@ -61,6 +73,9 @@ namespace UnitsNet
         /// </summary>
         public QuantityType QuantityType { get; }
 
+        /// <summary>
+        ///     The units for this quantity.
+        /// </summary>
         public UnitInfo[] UnitInfos { get; }
 
         /// <summary>
@@ -76,6 +91,9 @@ namespace UnitsNet
         [Obsolete("This property is deprecated and will be removed at a future release. Please use the UnitInfos property.")]
         public Enum[] Units { get; }
 
+        /// <summary>
+        ///     The base unit of this quantity.
+        /// </summary>
         public UnitInfo BaseUnitInfo { get; }
 
         /// <summary>
@@ -115,14 +133,19 @@ namespace UnitsNet
     public class QuantityInfo<TUnit> : QuantityInfo
         where TUnit : Enum
     {
+        /// <inheritdoc />
         public QuantityInfo(QuantityType quantityType, TUnit[] units, TUnit baseUnit, IQuantity<TUnit> zero, BaseDimensions baseDimensions)
             : base(quantityType, units.Cast<Enum>().ToArray(), baseUnit, zero, baseDimensions)
         {
             Zero = zero;
             UnitInfos = units.Select(unit => new UnitInfo<TUnit>(unit)).ToArray();
-            Units = units;
             BaseUnitInfo = new UnitInfo<TUnit>(baseUnit);
+
+            // Ignore warning about populating obsolete types/members until they are removed
+#pragma warning disable 618
+            Units = units;
             BaseUnit = BaseUnitInfo.Value;
+#pragma warning restore 618
         }
 
         /// <inheritdoc cref="QuantityInfo.UnitInfos" />

--- a/UnitsNet/QuantityNotFoundException.cs
+++ b/UnitsNet/QuantityNotFoundException.cs
@@ -11,14 +11,17 @@ namespace UnitsNet
     /// </summary>
     public class QuantityNotFoundException : UnitsNetException
     {
+        /// <inheritdoc />
         public QuantityNotFoundException()
         {
         }
 
+        /// <inheritdoc />
         public QuantityNotFoundException(string message) : base(message)
         {
         }
 
+        /// <inheritdoc />
         public QuantityNotFoundException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -52,12 +52,19 @@ namespace UnitsNet
         // Prefer double for integer types, since most quantities use that type as of now and
         // that avoids unnecessary casts back and forth.
         // If we later change to use decimal more, we should revisit this.
+        /// <summary>Implicit cast from <see cref="byte"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(byte val) => new QuantityValue((double) val);
+        /// <summary>Implicit cast from <see cref="short"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(short val) => new QuantityValue((double) val);
+        /// <summary>Implicit cast from <see cref="int"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(int val) => new QuantityValue((double) val);
+        /// <summary>Implicit cast from <see cref="long"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(long val) => new QuantityValue((double) val);
+        /// <summary>Implicit cast from <see cref="float"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(float val) => new QuantityValue(val); // double
+        /// <summary>Implicit cast from <see cref="double"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(double val) => new QuantityValue(val); // double
+        /// <summary>Implicit cast from <see cref="decimal"/> to <see cref="QuantityValue"/>.</summary>
         public static implicit operator QuantityValue(decimal val) => new QuantityValue(val); // decimal
 #pragma warning restore 618
 
@@ -65,6 +72,7 @@ namespace UnitsNet
 
         #region To double
 
+        /// <summary>Explicit cast from <see cref="QuantityValue"/> to <see cref="double"/>.</summary>
         public static explicit operator double(QuantityValue number)
         {
             // double -> decimal -> zero (since we can't implement the default struct ctor)
@@ -75,6 +83,7 @@ namespace UnitsNet
 
         #region To decimal
 
+        /// <summary>Explicit cast from <see cref="QuantityValue"/> to <see cref="decimal"/>.</summary>
         public static explicit operator decimal(QuantityValue number)
         {
             // decimal -> double -> zero (since we can't implement the default struct ctor)
@@ -83,6 +92,7 @@ namespace UnitsNet
 
         #endregion
 
+        /// <summary>Returns the string representation of the numeric value.</summary>
         public override string ToString()
         {
             return _value.HasValue ? _value.ToString() : _valueDecimal.ToString();

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -57,6 +57,7 @@ if ($obsoleteAttribute)
   $obsoleteAttribute = "`r`n    " + $obsoleteAttribute; # apply padding to conformance with code format in this section
 }
 @"
+    /// <inheritdoc />
     /// <summary>
     ///     $($quantity.XmlDocSummary)
     /// </summary>
@@ -345,14 +346,12 @@ function GenerateProperties([GeneratorArgs]$genArgs)
         double IQuantity.Value => (double) _value;
 
 "@; } @"
-        /// <inheritdoc cref="IQuantity.Unit"/>
         Enum IQuantity.Unit => Unit;
 
-        /// <summary>
-        ///     The unit this quantity was constructed with -or- <see cref="BaseUnit" /> if default ctor was used.
-        /// </summary>
+        /// <inheritdoc />
         public $unitEnumName Unit => _unit.GetValueOrDefault(BaseUnit);
 
+        /// <inheritdoc />
         public QuantityInfo<$unitEnumName> QuantityInfo => Info;
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
@@ -608,6 +607,7 @@ function GenerateStaticParseMethods([GeneratorArgs]$genArgs)
             return UnitParser.Default.Parse<$unitEnumName>(str, provider);
         }
 
+        /// <inheritdoc cref="TryParseUnit(string,IFormatProvider,out UnitsNet.Units.$unitEnumName)"/>
         public static bool TryParseUnit(string str, out $unitEnumName unit)
         {
             return TryParseUnit(str, null, out unit);
@@ -643,11 +643,13 @@ function GenerateLogarithmicArithmeticOperators([GeneratorArgs]$genArgs)
 
         #region Logarithmic Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static $quantityName operator -($quantityName right)
         {
             return new $quantityName(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from logarithmic addition of two <see cref="$quantityName"/>.</summary>
         public static $quantityName operator +($quantityName left, $quantityName right)
         {
             // Logarithmic addition
@@ -655,6 +657,7 @@ function GenerateLogarithmicArithmeticOperators([GeneratorArgs]$genArgs)
             return new $quantityName($x*Math.Log10(Math.Pow(10, left.Value/$x) + Math.Pow(10, right.AsBaseNumericType(left.Unit)/$x)), left.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from logarithmic subtraction of two <see cref="$quantityName"/>.</summary>
         public static $quantityName operator -($quantityName left, $quantityName right)
         {
             // Logarithmic subtraction
@@ -662,24 +665,28 @@ function GenerateLogarithmicArithmeticOperators([GeneratorArgs]$genArgs)
             return new $quantityName($x*Math.Log10(Math.Pow(10, left.Value/$x) - Math.Pow(10, right.AsBaseNumericType(left.Unit)/$x)), left.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from logarithmic multiplication of value and <see cref="$quantityName"/>.</summary>
         public static $quantityName operator *($valueType left, $quantityName right)
         {
             // Logarithmic multiplication = addition
             return new $quantityName(left + right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from logarithmic multiplication of value and <see cref="$quantityName"/>.</summary>
         public static $quantityName operator *($quantityName left, double right)
         {
             // Logarithmic multiplication = addition
             return new $quantityName(left.Value + ($valueType)right, left.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from logarithmic division of <see cref="$quantityName"/> by value.</summary>
         public static $quantityName operator /($quantityName left, double right)
         {
             // Logarithmic division = subtraction
             return new $quantityName(left.Value - ($valueType)right, left.Unit);
         }
 
+        /// <summary>Get ratio value from logarithmic division of <see cref="$quantityName"/> by <see cref="$quantityName"/>.</summary>
         public static double operator /($quantityName left, $quantityName right)
         {
             // Logarithmic division = subtraction
@@ -707,36 +714,43 @@ function GenerateArithmeticOperators([GeneratorArgs]$genArgs)
 
         #region Arithmetic Operators
 
+        /// <summary>Negate the value.</summary>
         public static $quantityName operator -($quantityName right)
         {
             return new $quantityName(-right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from adding two <see cref="$quantityName"/>.</summary>
         public static $quantityName operator +($quantityName left, $quantityName right)
         {
             return new $quantityName(left.Value + right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from subtracting two <see cref="$quantityName"/>.</summary>
         public static $quantityName operator -($quantityName left, $quantityName right)
         {
             return new $quantityName(left.Value - right.AsBaseNumericType(left.Unit), left.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from multiplying value and <see cref="$quantityName"/>.</summary>
         public static $quantityName operator *($valueType left, $quantityName right)
         {
             return new $quantityName(left * right.Value, right.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from multiplying value and <see cref="$quantityName"/>.</summary>
         public static $quantityName operator *($quantityName left, $valueType right)
         {
             return new $quantityName(left.Value * right, left.Unit);
         }
 
+        /// <summary>Get <see cref="$quantityName"/> from dividing <see cref="$quantityName"/> by value.</summary>
         public static $quantityName operator /($quantityName left, $valueType right)
         {
             return new $quantityName(left.Value / right, left.Unit);
         }
 
+        /// <summary>Get ratio value from dividing <see cref="$quantityName"/> by <see cref="$quantityName"/>.</summary>
         public static double operator /($quantityName left, $quantityName right)
         {
             return left.$baseUnitPluralName / right.$baseUnitPluralName;
@@ -753,36 +767,45 @@ function GenerateEqualityAndComparison([GeneratorArgs]$genArgs)
 
         #region Equality / IComparable
 
+        /// <summary>Returns true if less or equal to.</summary>
         public static bool operator <=($quantityName left, $quantityName right)
         {
             return left.Value <= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than or equal to.</summary>
         public static bool operator >=($quantityName left, $quantityName right)
         {
             return left.Value >= right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if less than.</summary>
         public static bool operator <($quantityName left, $quantityName right)
         {
             return left.Value < right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if greater than.</summary>
         public static bool operator >($quantityName left, $quantityName right)
         {
             return left.Value > right.AsBaseNumericType(left.Unit);
         }
 
+        /// <summary>Returns true if exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals($quantityName, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator ==($quantityName left, $quantityName right)
         {
             return left.Equals(right);
         }
 
+        /// <summary>Returns true if not exactly equal.</summary>
+        /// <remarks>Consider using <see cref="Equals($quantityName, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public static bool operator !=($quantityName left, $quantityName right)
         {
             return !(left == right);
         }
 
+        /// <inheritdoc />
         public int CompareTo(object obj)
         {
             if(obj is null) throw new ArgumentNullException(nameof(obj));
@@ -791,11 +814,14 @@ function GenerateEqualityAndComparison([GeneratorArgs]$genArgs)
             return CompareTo(obj$quantityName);
         }
 
+        /// <inheritdoc />
         public int CompareTo($quantityName other)
         {
             return _value.CompareTo(other.AsBaseNumericType(this.Unit));
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals($quantityName, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public override bool Equals(object obj)
         {
             if(obj is null || !(obj is $quantityName obj$quantityName))
@@ -804,6 +830,8 @@ function GenerateEqualityAndComparison([GeneratorArgs]$genArgs)
             return Equals(obj$quantityName);
         }
 
+        /// <inheritdoc />
+        /// <remarks>Consider using <see cref="Equals($quantityName, double, ComparisonType)"/> for safely comparing floating point values.</remarks>
         public bool Equals($quantityName other)
         {
             return _value.Equals(other.AsBaseNumericType(this.Unit));
@@ -897,6 +925,7 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
             return Convert.ToDouble(converted);
         }
 
+        /// <inheritdoc />
         public double As(Enum unit) => As(($unitEnumName) unit);
 
         /// <summary>
@@ -911,6 +940,7 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
 
         IQuantity<$unitEnumName> IQuantity<$unitEnumName>.ToUnit($unitEnumName unit) => ToUnit(unit);
 
+        /// <inheritdoc />
         public IQuantity ToUnit(Enum unit) => ToUnit(($unitEnumName) unit);
 
         /// <summary>

--- a/UnitsNet/Scripts/Include-GenerateQuantityTypeSourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantityTypeSourceCode.ps1
@@ -31,11 +31,15 @@ namespace UnitsNet
     /// </summary>
     public enum QuantityType
     {
+// Missing XML comment for public type or member
+#pragma warning disable CS1591
         Undefined = 0,
 "@; foreach ($quantity in $quantities) {
 @"
         $($quantity.Name),
 "@; }@"
+// Missing XML comment for public type or member
+#pragma warning restore CS1591
     }
 }
 "@;

--- a/UnitsNet/UnitInfo.cs
+++ b/UnitsNet/UnitInfo.cs
@@ -17,6 +17,9 @@ namespace UnitsNet
     /// </remarks>
     public class UnitInfo
     {
+        /// <summary>Creates an instance from a unit enum value.</summary>
+        /// <param name="value">The unit enum value.</param>
+        /// <example>new UnitInfo(LengthUnit.Meter)</example>
         public UnitInfo(Enum value)
         {
             Value = value;
@@ -27,7 +30,7 @@ namespace UnitsNet
         /// The enum value of the unit, such as [<see cref="LengthUnit.Centimeter" />,
         /// <see cref="LengthUnit.Decimeter" />, <see cref="LengthUnit.Meter" />, ...].
         /// </summary>
-        public Enum Value;
+        public Enum Value { get; }
 
         /// <summary>
         /// The name of the unit, such as ["Centimeter", "Decimeter", "Meter", ...].
@@ -45,11 +48,13 @@ namespace UnitsNet
     public class UnitInfo<TUnit> : UnitInfo
         where TUnit : Enum
     {
+        /// <inheritdoc />
         public UnitInfo(TUnit value) : base(value)
         {
             Value = value;
         }
 
+        /// <inheritdoc cref="UnitInfo.Value"/>
         public new TUnit Value { get; }
     }
 }

--- a/UnitsNet/UnitNotFoundException.cs
+++ b/UnitsNet/UnitNotFoundException.cs
@@ -11,14 +11,17 @@ namespace UnitsNet
     /// </summary>
     public class UnitNotFoundException : UnitsNetException
     {
+        /// <inheritdoc />
         public UnitNotFoundException()
         {
         }
 
+        /// <inheritdoc />
         public UnitNotFoundException(string message) : base(message)
         {
         }
 
+        /// <inheritdoc />
         public UnitNotFoundException(string message, Exception innerException) : base(message, innerException)
         {
         }

--- a/UnitsNet/UnitSystem.cs
+++ b/UnitsNet/UnitSystem.cs
@@ -2,11 +2,15 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
-using System.Text;
 using UnitsNet.Units;
 
 namespace UnitsNet
 {
+    /// <summary>
+    ///     A unit system defined by a combination of base units.
+    ///     This is typically used to define the "working units" for consistently creating and presenting quantities in the selected base units,
+    ///     such as <see cref="SI"/> to use SI base units such as meters, kilograms and seconds.
+    /// </summary>
     public sealed class UnitSystem : IEquatable<UnitSystem>
     {
         /// <summary>
@@ -45,6 +49,7 @@ namespace UnitsNet
             return Equals((UnitSystem)obj);
         }
 
+        /// <inheritdoc />
         public bool Equals(UnitSystem other)
         {
             if(other is null)
@@ -83,6 +88,9 @@ namespace UnitsNet
             return new {BaseUnits}.GetHashCode();
         }
 
+        /// <summary>
+        ///     The base units of this unit system.
+        /// </summary>
         public BaseUnits BaseUnits{ get; }
 
         private static readonly BaseUnits SIBaseUnits = new BaseUnits(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second,
@@ -91,6 +99,6 @@ namespace UnitsNet
         /// <summary>
         /// Gets the SI unit system.
         /// </summary>
-        public static UnitSystem SI{ get; } = new UnitSystem(SIBaseUnits);
+        public static UnitSystem SI { get; } = new UnitSystem(SIBaseUnits);
     }
 }

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -22,6 +22,7 @@
     <LangVersion>7.3</LangVersion>
     <RootNamespace>UnitsNet</RootNamespace>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <!-- SourceLink -->

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -20,7 +20,6 @@
   <PropertyGroup>
     <AssemblyVersion>4.0.0.0</AssemblyVersion> <!-- Should reflect major part of Version -->
     <LangVersion>7.3</LangVersion>
-    <NoWarn>CS1701;CS1702;CS1705;CS0618;CS0809;CS1591</NoWarn>
     <RootNamespace>UnitsNet</RootNamespace>
     <TargetFrameworks>netstandard2.0;net40</TargetFrameworks>
   </PropertyGroup>

--- a/UnitsNet/UnitsNetException.cs
+++ b/UnitsNet/UnitsNetException.cs
@@ -5,18 +5,24 @@ using System;
 
 namespace UnitsNet
 {
+    /// <summary>
+    ///     The base type for UnitsNet exceptions.
+    /// </summary>
     public class UnitsNetException : Exception
     {
+        /// <inheritdoc />
         public UnitsNetException()
         {
             HResult = 1;
         }
 
+        /// <inheritdoc />
         public UnitsNetException(string message) : base(message)
         {
             HResult = 1;
         }
 
+        /// <inheritdoc />
         public UnitsNetException(string message, Exception innerException) : base(message, innerException)
         {
             HResult = 1;


### PR DESCRIPTION
Fixes #495 .

This PR fixes several thousands of warnings. Left WRC projects alone as-is.
Moving forward, all public types/members should have xmldoc and this PR helps enforce that.

- Add tons of xmldoc for public types/members
- Remove `<NoWarn>` from projects to unmute
- Mute a few warnings
- Add pragma around internal uses of obsolete members