### PR TITLE
Moving implemented interfaces to IQuantity

### DIFF
--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Acceleration, in physics, is the rate at which the velocity of an object changes over time. An object's acceleration is the net result of any and all forces acting on the object, as described by Newton's Second Law. The SI unit for acceleration is the Meter per second squared (m/s²). Accelerations are vector quantities (they have magnitude and direction) and add according to the parallelogram law. As a vector, the calculated net force is equal to the product of the object's mass (a scalar quantity) and the acceleration.
     /// </summary>
-    public partial struct Acceleration : IQuantity<AccelerationUnit>, IEquatable<Acceleration>, IComparable, IComparable<Acceleration>, IConvertible
+    public partial struct Acceleration : IQuantity<AccelerationUnit>, IEquatable<Acceleration>, IComparable<Acceleration>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -894,11 +894,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Mole is the amount of substance containing Avagadro's Number (6.02 x 10 ^ 23) of real particles such as molecules,atoms, ions or radicals.
     /// </summary>
-    public partial struct AmountOfSubstance : IQuantity<AmountOfSubstanceUnit>, IEquatable<AmountOfSubstance>, IComparable, IComparable<AmountOfSubstance>, IConvertible
+    public partial struct AmountOfSubstance : IQuantity<AmountOfSubstanceUnit>, IEquatable<AmountOfSubstance>, IComparable<AmountOfSubstance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -926,11 +926,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The strength of a signal expressed in decibels (dB) relative to one volt RMS.
     /// </summary>
-    public partial struct AmplitudeRatio : IQuantity<AmplitudeRatioUnit>, IEquatable<AmplitudeRatio>, IComparable, IComparable<AmplitudeRatio>, IConvertible
+    public partial struct AmplitudeRatio : IQuantity<AmplitudeRatioUnit>, IEquatable<AmplitudeRatio>, IComparable<AmplitudeRatio>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -758,11 +758,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In geometry, an angle is the figure formed by two rays, called the sides of the angle, sharing a common endpoint, called the vertex of the angle.
     /// </summary>
-    public partial struct Angle : IQuantity<AngleUnit>, IEquatable<Angle>, IComparable, IComparable<Angle>, IConvertible
+    public partial struct Angle : IQuantity<AngleUnit>, IEquatable<Angle>, IComparable<Angle>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -910,11 +910,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     A unit for expressing the integral of apparent power over time, equal to the product of 1 volt-ampere and 1 hour, or to 3600 joules.
     /// </summary>
-    public partial struct ApparentEnergy : IQuantity<ApparentEnergyUnit>, IEquatable<ApparentEnergy>, IComparable, IComparable<ApparentEnergy>, IConvertible
+    public partial struct ApparentEnergy : IQuantity<ApparentEnergyUnit>, IEquatable<ApparentEnergy>, IComparable<ApparentEnergy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Power engineers measure apparent power as the magnitude of the vector sum of active and reactive power. Apparent power is the product of the root-mean-square of voltage and current.
     /// </summary>
-    public partial struct ApparentPower : IQuantity<ApparentPowerUnit>, IEquatable<ApparentPower>, IComparable, IComparable<ApparentPower>, IConvertible
+    public partial struct ApparentPower : IQuantity<ApparentPowerUnit>, IEquatable<ApparentPower>, IComparable<ApparentPower>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -750,11 +750,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Area is a quantity that expresses the extent of a two-dimensional surface or shape, or planar lamina, in the plane. Area can be understood as the amount of material with a given thickness that would be necessary to fashion a model of the shape, or the amount of paint necessary to cover the surface with a single coat.[1] It is the two-dimensional analog of the length of a curve (a one-dimensional concept) or the volume of a solid (a three-dimensional concept).
     /// </summary>
-    public partial struct Area : IQuantity<AreaUnit>, IEquatable<Area>, IComparable, IComparable<Area>, IConvertible
+    public partial struct Area : IQuantity<AreaUnit>, IEquatable<Area>, IComparable<Area>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -894,11 +894,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The area density of a two-dimensional object is calculated as the mass per unit area.
     /// </summary>
-    public partial struct AreaDensity : IQuantity<AreaDensityUnit>, IEquatable<AreaDensity>, IComparable, IComparable<AreaDensity>, IConvertible
+    public partial struct AreaDensity : IQuantity<AreaDensityUnit>, IEquatable<AreaDensity>, IComparable<AreaDensity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -702,11 +702,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     A geometric property of an area that reflects how its points are distributed with regard to an axis.
     /// </summary>
-    public partial struct AreaMomentOfInertia : IQuantity<AreaMomentOfInertiaUnit>, IEquatable<AreaMomentOfInertia>, IComparable, IComparable<AreaMomentOfInertia>, IConvertible
+    public partial struct AreaMomentOfInertia : IQuantity<AreaMomentOfInertiaUnit>, IEquatable<AreaMomentOfInertia>, IComparable<AreaMomentOfInertia>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -782,11 +782,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Bit_rate
     /// </remarks>
-    public partial struct BitRate : IQuantity<BitRateUnit>, IEquatable<BitRate>, IComparable, IComparable<BitRate>, IConvertible
+    public partial struct BitRate : IQuantity<BitRateUnit>, IEquatable<BitRate>, IComparable<BitRate>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1107,11 +1107,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Brake specific fuel consumption (BSFC) is a measure of the fuel efficiency of any prime mover that burns fuel and produces rotational, or shaft, power. It is typically used for comparing the efficiency of internal combustion engines with a shaft output.
     /// </summary>
-    public partial struct BrakeSpecificFuelConsumption : IQuantity<BrakeSpecificFuelConsumptionUnit>, IEquatable<BrakeSpecificFuelConsumption>, IComparable, IComparable<BrakeSpecificFuelConsumption>, IConvertible
+    public partial struct BrakeSpecificFuelConsumption : IQuantity<BrakeSpecificFuelConsumptionUnit>, IEquatable<BrakeSpecificFuelConsumption>, IComparable<BrakeSpecificFuelConsumption>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Capacitance
     /// </remarks>
-    public partial struct Capacitance : IQuantity<CapacitanceUnit>, IEquatable<Capacitance>, IComparable, IComparable<Capacitance>, IConvertible
+    public partial struct Capacitance : IQuantity<CapacitanceUnit>, IEquatable<Capacitance>, IComparable<Capacitance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -801,11 +801,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     A unit that represents a fractional change in size in response to a change in temperature.
     /// </summary>
-    public partial struct CoefficientOfThermalExpansion : IQuantity<CoefficientOfThermalExpansionUnit>, IEquatable<CoefficientOfThermalExpansion>, IComparable, IComparable<CoefficientOfThermalExpansion>, IConvertible
+    public partial struct CoefficientOfThermalExpansion : IQuantity<CoefficientOfThermalExpansionUnit>, IEquatable<CoefficientOfThermalExpansion>, IComparable<CoefficientOfThermalExpansion>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     http://en.wikipedia.org/wiki/Density
     /// </remarks>
-    public partial struct Density : IQuantity<DensityUnit>, IEquatable<Density>, IComparable, IComparable<Density>, IConvertible
+    public partial struct Density : IQuantity<DensityUnit>, IEquatable<Density>, IComparable<Density>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1313,11 +1313,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Time is a dimension in which events can be ordered from the past through the present into the future, and also the measure of durations of events and the intervals between them.
     /// </summary>
-    public partial struct Duration : IQuantity<DurationUnit>, IEquatable<Duration>, IComparable, IComparable<Duration>, IConvertible
+    public partial struct Duration : IQuantity<DurationUnit>, IEquatable<Duration>, IComparable<Duration>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -846,11 +846,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Viscosity#Dynamic_.28shear.29_viscosity
     /// </remarks>
-    public partial struct DynamicViscosity : IQuantity<DynamicViscosityUnit>, IEquatable<DynamicViscosity>, IComparable, IComparable<DynamicViscosity>, IConvertible
+    public partial struct DynamicViscosity : IQuantity<DynamicViscosityUnit>, IEquatable<DynamicViscosity>, IComparable<DynamicViscosity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -785,11 +785,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Electric admittance is a measure of how easily a circuit or device will allow a current to flow. It is defined as the inverse of impedance. The SI unit of admittance is the siemens (symbol S).
     /// </summary>
-    public partial struct ElectricAdmittance : IQuantity<ElectricAdmittanceUnit>, IEquatable<ElectricAdmittance>, IComparable, IComparable<ElectricAdmittance>, IConvertible
+    public partial struct ElectricAdmittance : IQuantity<ElectricAdmittanceUnit>, IEquatable<ElectricAdmittance>, IComparable<ElectricAdmittance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -750,11 +750,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Electric_charge
     /// </remarks>
-    public partial struct ElectricCharge : IQuantity<ElectricChargeUnit>, IEquatable<ElectricCharge>, IComparable, IComparable<ElectricCharge>, IConvertible
+    public partial struct ElectricCharge : IQuantity<ElectricChargeUnit>, IEquatable<ElectricCharge>, IComparable<ElectricCharge>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Charge_density
     /// </remarks>
-    public partial struct ElectricChargeDensity : IQuantity<ElectricChargeDensityUnit>, IEquatable<ElectricChargeDensity>, IComparable, IComparable<ElectricChargeDensity>, IConvertible
+    public partial struct ElectricChargeDensity : IQuantity<ElectricChargeDensityUnit>, IEquatable<ElectricChargeDensity>, IComparable<ElectricChargeDensity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Electrical_resistance_and_conductance
     /// </remarks>
-    public partial struct ElectricConductance : IQuantity<ElectricConductanceUnit>, IEquatable<ElectricConductance>, IComparable, IComparable<ElectricConductance>, IConvertible
+    public partial struct ElectricConductance : IQuantity<ElectricConductanceUnit>, IEquatable<ElectricConductance>, IComparable<ElectricConductance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -737,11 +737,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity
     /// </remarks>
-    public partial struct ElectricConductivity : IQuantity<ElectricConductivityUnit>, IEquatable<ElectricConductivity>, IComparable, IComparable<ElectricConductivity>, IConvertible
+    public partial struct ElectricConductivity : IQuantity<ElectricConductivityUnit>, IEquatable<ElectricConductivity>, IComparable<ElectricConductivity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     An electric current is a flow of electric charge. In electric circuits this charge is often carried by moving electrons in a wire. It can also be carried by ions in an electrolyte, or by both ions and electrons such as in a plasma.
     /// </summary>
-    public partial struct ElectricCurrent : IQuantity<ElectricCurrentUnit>, IEquatable<ElectricCurrent>, IComparable, IComparable<ElectricCurrent>, IConvertible
+    public partial struct ElectricCurrent : IQuantity<ElectricCurrentUnit>, IEquatable<ElectricCurrent>, IComparable<ElectricCurrent>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -814,11 +814,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Current_density
     /// </remarks>
-    public partial struct ElectricCurrentDensity : IQuantity<ElectricCurrentDensityUnit>, IEquatable<ElectricCurrentDensity>, IComparable, IComparable<ElectricCurrentDensity>, IConvertible
+    public partial struct ElectricCurrentDensity : IQuantity<ElectricCurrentDensityUnit>, IEquatable<ElectricCurrentDensity>, IComparable<ElectricCurrentDensity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In electromagnetism, the current gradient describes how the current changes in time.
     /// </summary>
-    public partial struct ElectricCurrentGradient : IQuantity<ElectricCurrentGradientUnit>, IEquatable<ElectricCurrentGradient>, IComparable, IComparable<ElectricCurrentGradient>, IConvertible
+    public partial struct ElectricCurrentGradient : IQuantity<ElectricCurrentGradientUnit>, IEquatable<ElectricCurrentGradient>, IComparable<ElectricCurrentGradient>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -702,11 +702,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Electric_field
     /// </remarks>
-    public partial struct ElectricField : IQuantity<ElectricFieldUnit>, IEquatable<ElectricField>, IComparable, IComparable<ElectricField>, IConvertible
+    public partial struct ElectricField : IQuantity<ElectricFieldUnit>, IEquatable<ElectricField>, IComparable<ElectricField>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Inductance
     /// </remarks>
-    public partial struct ElectricInductance : IQuantity<ElectricInductanceUnit>, IEquatable<ElectricInductance>, IComparable, IComparable<ElectricInductance>, IConvertible
+    public partial struct ElectricInductance : IQuantity<ElectricInductanceUnit>, IEquatable<ElectricInductance>, IComparable<ElectricInductance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -753,11 +753,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In classical electromagnetism, the electric potential (a scalar quantity denoted by Φ, ΦE or V and also called the electric field potential or the electrostatic potential) at a point is the amount of electric potential energy that a unitary point charge would have when located at that point.
     /// </summary>
-    public partial struct ElectricPotential : IQuantity<ElectricPotentialUnit>, IEquatable<ElectricPotential>, IComparable, IComparable<ElectricPotential>, IConvertible
+    public partial struct ElectricPotential : IQuantity<ElectricPotentialUnit>, IEquatable<ElectricPotential>, IComparable<ElectricPotential>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -766,11 +766,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The Electric Potential of a system known to use Alternating Current.
     /// </summary>
-    public partial struct ElectricPotentialAc : IQuantity<ElectricPotentialAcUnit>, IEquatable<ElectricPotentialAc>, IComparable, IComparable<ElectricPotentialAc>, IConvertible
+    public partial struct ElectricPotentialAc : IQuantity<ElectricPotentialAcUnit>, IEquatable<ElectricPotentialAc>, IComparable<ElectricPotentialAc>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -766,11 +766,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The Electric Potential of a system known to use Direct Current.
     /// </summary>
-    public partial struct ElectricPotentialDc : IQuantity<ElectricPotentialDcUnit>, IEquatable<ElectricPotentialDc>, IComparable, IComparable<ElectricPotentialDc>, IConvertible
+    public partial struct ElectricPotentialDc : IQuantity<ElectricPotentialDcUnit>, IEquatable<ElectricPotentialDc>, IComparable<ElectricPotentialDc>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -766,11 +766,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The electrical resistance of an electrical conductor is the opposition to the passage of an electric current through that conductor.
     /// </summary>
-    public partial struct ElectricResistance : IQuantity<ElectricResistanceUnit>, IEquatable<ElectricResistance>, IComparable, IComparable<ElectricResistance>, IConvertible
+    public partial struct ElectricResistance : IQuantity<ElectricResistanceUnit>, IEquatable<ElectricResistance>, IComparable<ElectricResistance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -766,11 +766,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Electrical_resistivity_and_conductivity
     /// </remarks>
-    public partial struct ElectricResistivity : IQuantity<ElectricResistivityUnit>, IEquatable<ElectricResistivity>, IComparable, IComparable<ElectricResistivity>, IConvertible
+    public partial struct ElectricResistivity : IQuantity<ElectricResistivityUnit>, IEquatable<ElectricResistivity>, IComparable<ElectricResistivity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -913,11 +913,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The joule, symbol J, is a derived unit of energy, work, or amount of heat in the International System of Units. It is equal to the energy transferred (or work done) when applying a force of one newton through a distance of one metre (1 newton metre or N·m), or in passing an electric current of one ampere through a resistance of one ohm for one second. Many other units of energy are included. Please do not confuse this definition of the calorie with the one colloquially used by the food industry, the large calorie, which is equivalent to 1 kcal. Thermochemical definition of the calorie is used. For BTU, the IT definition is used.
     /// </summary>
-    public partial struct Energy : IQuantity<EnergyUnit>, IEquatable<Energy>, IComparable, IComparable<Energy>, IConvertible
+    public partial struct Energy : IQuantity<EnergyUnit>, IEquatable<Energy>, IComparable<Energy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1054,11 +1054,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Entropy is an important concept in the branch of science known as thermodynamics. The idea of "irreversibility" is central to the understanding of entropy.  It is often said that entropy is an expression of the disorder, or randomness of a system, or of our lack of information about it. Entropy is an extensive property. It has the dimension of energy divided by temperature, which has a unit of joules per kelvin (J/K) in the International System of Units
     /// </summary>
-    public partial struct Entropy : IQuantity<EntropyUnit>, IEquatable<Entropy>, IComparable, IComparable<Entropy>, IConvertible
+    public partial struct Entropy : IQuantity<EntropyUnit>, IEquatable<Entropy>, IComparable<Entropy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -798,11 +798,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In physics, a force is any influence that causes an object to undergo a certain change, either concerning its movement, direction, or geometrical construction. In other words, a force can cause an object with mass to change its velocity (which includes to begin moving from a state of rest), i.e., to accelerate, or a flexible object to deform, or both. Force can also be described by intuitive concepts such as a push or a pull. A force has both magnitude and direction, making it a vector quantity. It is measured in the SI unit of newtons and represented by the symbol F.
     /// </summary>
-    public partial struct Force : IQuantity<ForceUnit>, IEquatable<Force>, IComparable, IComparable<Force>, IConvertible
+    public partial struct Force : IQuantity<ForceUnit>, IEquatable<Force>, IComparable<Force>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -894,11 +894,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Force change rate is the ratio of the force change to the time during which the change occurred (value of force changes per unit time).
     /// </summary>
-    public partial struct ForceChangeRate : IQuantity<ForceChangeRateUnit>, IEquatable<ForceChangeRate>, IComparable, IComparable<ForceChangeRate>, IConvertible
+    public partial struct ForceChangeRate : IQuantity<ForceChangeRateUnit>, IEquatable<ForceChangeRate>, IComparable<ForceChangeRate>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -862,11 +862,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The magnitude of force per unit length.
     /// </summary>
-    public partial struct ForcePerLength : IQuantity<ForcePerLengthUnit>, IEquatable<ForcePerLength>, IComparable, IComparable<ForcePerLength>, IConvertible
+    public partial struct ForcePerLength : IQuantity<ForcePerLengthUnit>, IEquatable<ForcePerLength>, IComparable<ForcePerLength>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -830,11 +830,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The number of occurrences of a repeating event per unit time.
     /// </summary>
-    public partial struct Frequency : IQuantity<FrequencyUnit>, IEquatable<Frequency>, IComparable, IComparable<Frequency>, IConvertible
+    public partial struct Frequency : IQuantity<FrequencyUnit>, IEquatable<Frequency>, IComparable<Frequency>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -830,11 +830,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Heat flux is the flow of energy per unit of area per unit of time
     /// </summary>
-    public partial struct HeatFlux : IQuantity<HeatFluxUnit>, IEquatable<HeatFlux>, IComparable, IComparable<HeatFlux>, IConvertible
+    public partial struct HeatFlux : IQuantity<HeatFluxUnit>, IEquatable<HeatFlux>, IComparable<HeatFlux>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -974,11 +974,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The heat transfer coefficient or film coefficient, or film effectiveness, in thermodynamics and in mechanics is the proportionality constant between the heat flux and the thermodynamic driving force for the flow of heat (i.e., the temperature difference, ΔT)
     /// </summary>
-    public partial struct HeatTransferCoefficient : IQuantity<HeatTransferCoefficientUnit>, IEquatable<HeatTransferCoefficient>, IComparable, IComparable<HeatTransferCoefficient>, IConvertible
+    public partial struct HeatTransferCoefficient : IQuantity<HeatTransferCoefficientUnit>, IEquatable<HeatTransferCoefficient>, IComparable<HeatTransferCoefficient>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -718,11 +718,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Illuminance
     /// </remarks>
-    public partial struct Illuminance : IQuantity<IlluminanceUnit>, IEquatable<Illuminance>, IComparable, IComparable<Illuminance>, IConvertible
+    public partial struct Illuminance : IQuantity<IlluminanceUnit>, IEquatable<Illuminance>, IComparable<Illuminance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -753,11 +753,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables.
     /// </summary>
-    public partial struct Information : IQuantity<InformationUnit>, IEquatable<Information>, IComparable, IComparable<Information>, IConvertible
+    public partial struct Information : IQuantity<InformationUnit>, IEquatable<Information>, IComparable<Information>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1104,11 +1104,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Irradiance is the intensity of ultraviolet (UV) or visible light incident on a surface.
     /// </summary>
-    public partial struct Irradiance : IQuantity<IrradianceUnit>, IEquatable<Irradiance>, IComparable, IComparable<Irradiance>, IConvertible
+    public partial struct Irradiance : IQuantity<IrradianceUnit>, IEquatable<Irradiance>, IComparable<Irradiance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -910,11 +910,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Irradiation
     /// </remarks>
-    public partial struct Irradiation : IQuantity<IrradiationUnit>, IEquatable<Irradiation>, IComparable, IComparable<Irradiation>, IConvertible
+    public partial struct Irradiation : IQuantity<IrradiationUnit>, IEquatable<Irradiation>, IComparable<Irradiation>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -785,11 +785,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     http://en.wikipedia.org/wiki/Viscosity
     /// </remarks>
-    public partial struct KinematicViscosity : IQuantity<KinematicViscosityUnit>, IEquatable<KinematicViscosity>, IComparable, IComparable<KinematicViscosity>, IConvertible
+    public partial struct KinematicViscosity : IQuantity<KinematicViscosityUnit>, IEquatable<KinematicViscosity>, IComparable<KinematicViscosity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -817,11 +817,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Lapse rate is the rate at which Earth's atmospheric temperature decreases with an increase in altitude, or increases with the decrease in altitude.
     /// </summary>
-    public partial struct LapseRate : IQuantity<LapseRateUnit>, IEquatable<LapseRate>, IComparable, IComparable<LapseRate>, IConvertible
+    public partial struct LapseRate : IQuantity<LapseRateUnit>, IEquatable<LapseRate>, IComparable<LapseRate>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -702,11 +702,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Many different units of length have been used around the world. The main units in modern use are U.S. customary units in the United States and the Metric system elsewhere. British Imperial units are still used for some purposes in the United Kingdom and some other countries. The metric system is sub-divided into SI and non-SI units.
     /// </summary>
-    public partial struct Length : IQuantity<LengthUnit>, IEquatable<Length>, IComparable, IComparable<Length>, IConvertible
+    public partial struct Length : IQuantity<LengthUnit>, IEquatable<Length>, IComparable<Length>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1038,11 +1038,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Level is the logarithm of the ratio of a quantity Q to a reference value of that quantity, Q₀, expressed in dimensionless units.
     /// </summary>
-    public partial struct Level : IQuantity<LevelUnit>, IEquatable<Level>, IComparable, IComparable<Level>, IConvertible
+    public partial struct Level : IQuantity<LevelUnit>, IEquatable<Level>, IComparable<Level>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -726,11 +726,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     http://en.wikipedia.org/wiki/Linear_density
     /// </remarks>
-    public partial struct LinearDensity : IQuantity<LinearDensityUnit>, IEquatable<LinearDensity>, IComparable, IComparable<LinearDensity>, IConvertible
+    public partial struct LinearDensity : IQuantity<LinearDensityUnit>, IEquatable<LinearDensity>, IComparable<LinearDensity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -737,11 +737,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Luminous_flux
     /// </remarks>
-    public partial struct LuminousFlux : IQuantity<LuminousFluxUnit>, IEquatable<LuminousFlux>, IComparable, IComparable<LuminousFlux>, IConvertible
+    public partial struct LuminousFlux : IQuantity<LuminousFluxUnit>, IEquatable<LuminousFlux>, IComparable<LuminousFlux>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Luminous_intensity
     /// </remarks>
-    public partial struct LuminousIntensity : IQuantity<LuminousIntensityUnit>, IEquatable<LuminousIntensity>, IComparable, IComparable<LuminousIntensity>, IConvertible
+    public partial struct LuminousIntensity : IQuantity<LuminousIntensityUnit>, IEquatable<LuminousIntensity>, IComparable<LuminousIntensity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Magnetic_field
     /// </remarks>
-    public partial struct MagneticField : IQuantity<MagneticFieldUnit>, IEquatable<MagneticField>, IComparable, IComparable<MagneticField>, IConvertible
+    public partial struct MagneticField : IQuantity<MagneticFieldUnit>, IEquatable<MagneticField>, IComparable<MagneticField>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -753,11 +753,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Magnetic_flux
     /// </remarks>
-    public partial struct MagneticFlux : IQuantity<MagneticFluxUnit>, IEquatable<MagneticFlux>, IComparable, IComparable<MagneticFlux>, IConvertible
+    public partial struct MagneticFlux : IQuantity<MagneticFluxUnit>, IEquatable<MagneticFlux>, IComparable<MagneticFlux>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Magnetization
     /// </remarks>
-    public partial struct Magnetization : IQuantity<MagnetizationUnit>, IEquatable<Magnetization>, IComparable, IComparable<Magnetization>, IConvertible
+    public partial struct Magnetization : IQuantity<MagnetizationUnit>, IEquatable<Magnetization>, IComparable<Magnetization>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In physics, mass (from Greek μᾶζα "barley cake, lump [of dough]") is a property of a physical system or body, giving rise to the phenomena of the body's resistance to being accelerated by a force and the strength of its mutual gravitational attraction with other bodies. Instruments such as mass balances or scales use those phenomena to measure mass. The SI unit of mass is the kilogram (kg).
     /// </summary>
-    public partial struct Mass : IQuantity<MassUnit>, IEquatable<Mass>, IComparable, IComparable<Mass>, IConvertible
+    public partial struct Mass : IQuantity<MassUnit>, IEquatable<Mass>, IComparable<Mass>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1054,11 +1054,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Mass flow is the ratio of the mass change to the time during which the change occurred (value of mass changes per unit time).
     /// </summary>
-    public partial struct MassFlow : IQuantity<MassFlowUnit>, IEquatable<MassFlow>, IComparable, IComparable<MassFlow>, IConvertible
+    public partial struct MassFlow : IQuantity<MassFlowUnit>, IEquatable<MassFlow>, IComparable<MassFlow>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1182,11 +1182,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Mass flux is the mass flow rate per unit area.
     /// </summary>
-    public partial struct MassFlux : IQuantity<MassFluxUnit>, IEquatable<MassFlux>, IComparable, IComparable<MassFlux>, IConvertible
+    public partial struct MassFlux : IQuantity<MassFluxUnit>, IEquatable<MassFlux>, IComparable<MassFlux>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -718,11 +718,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     A property of body reflects how its mass is distributed with regard to an axis.
     /// </summary>
-    public partial struct MassMomentOfInertia : IQuantity<MassMomentOfInertiaUnit>, IEquatable<MassMomentOfInertia>, IComparable, IComparable<MassMomentOfInertia>, IConvertible
+    public partial struct MassMomentOfInertia : IQuantity<MassMomentOfInertiaUnit>, IEquatable<MassMomentOfInertia>, IComparable<MassMomentOfInertia>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1134,11 +1134,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Molar energy is the amount of energy stored in 1 mole of a substance.
     /// </summary>
-    public partial struct MolarEnergy : IQuantity<MolarEnergyUnit>, IEquatable<MolarEnergy>, IComparable, IComparable<MolarEnergy>, IConvertible
+    public partial struct MolarEnergy : IQuantity<MolarEnergyUnit>, IEquatable<MolarEnergy>, IComparable<MolarEnergy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Molar entropy is amount of energy required to increase temperature of 1 mole substance by 1 Kelvin.
     /// </summary>
-    public partial struct MolarEntropy : IQuantity<MolarEntropyUnit>, IEquatable<MolarEntropy>, IComparable, IComparable<MolarEntropy>, IConvertible
+    public partial struct MolarEntropy : IQuantity<MolarEntropyUnit>, IEquatable<MolarEntropy>, IComparable<MolarEntropy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In chemistry, the molar mass M is a physical property defined as the mass of a given substance (chemical element or chemical compound) divided by the amount of substance.
     /// </summary>
-    public partial struct MolarMass : IQuantity<MolarMassUnit>, IEquatable<MolarMass>, IComparable, IComparable<MolarMass>, IConvertible
+    public partial struct MolarMass : IQuantity<MolarMassUnit>, IEquatable<MolarMass>, IComparable<MolarMass>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -878,11 +878,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Molar_concentration
     /// </remarks>
-    public partial struct Molarity : IQuantity<MolarityUnit>, IEquatable<Molarity>, IComparable, IComparable<Molarity>, IConvertible
+    public partial struct Molarity : IQuantity<MolarityUnit>, IEquatable<Molarity>, IComparable<Molarity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -817,11 +817,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Permeability_(electromagnetism)
     /// </remarks>
-    public partial struct Permeability : IQuantity<PermeabilityUnit>, IEquatable<Permeability>, IComparable, IComparable<Permeability>, IConvertible
+    public partial struct Permeability : IQuantity<PermeabilityUnit>, IEquatable<Permeability>, IComparable<Permeability>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Permittivity
     /// </remarks>
-    public partial struct Permittivity : IQuantity<PermittivityUnit>, IEquatable<Permittivity>, IComparable, IComparable<Permittivity>, IConvertible
+    public partial struct Permittivity : IQuantity<PermittivityUnit>, IEquatable<Permittivity>, IComparable<Permittivity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In physics, power is the rate of doing work. It is equivalent to an amount of energy consumed per unit time.
     /// </summary>
-    public partial struct Power : IQuantity<PowerUnit>, IEquatable<Power>, IComparable, IComparable<Power>, IConvertible
+    public partial struct Power : IQuantity<PowerUnit>, IEquatable<Power>, IComparable<Power>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1008,11 +1008,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The amount of power in a volume.
     /// </summary>
-    public partial struct PowerDensity : IQuantity<PowerDensityUnit>, IEquatable<PowerDensity>, IComparable, IComparable<PowerDensity>, IConvertible
+    public partial struct PowerDensity : IQuantity<PowerDensityUnit>, IEquatable<PowerDensity>, IComparable<PowerDensity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1390,11 +1390,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The strength of a signal expressed in decibels (dB) relative to one watt.
     /// </summary>
-    public partial struct PowerRatio : IQuantity<PowerRatioUnit>, IEquatable<PowerRatio>, IComparable, IComparable<PowerRatio>, IConvertible
+    public partial struct PowerRatio : IQuantity<PowerRatioUnit>, IEquatable<PowerRatio>, IComparable<PowerRatio>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -726,11 +726,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Pressure (symbol: P or p) is the ratio of force to the area over which that force is distributed. Pressure is force per unit area applied in a direction perpendicular to the surface of an object. Gauge pressure (also spelled gage pressure)[a] is the pressure relative to the local atmospheric or ambient pressure. Pressure is measured in any unit of force divided by any unit of area. The SI unit of pressure is the newton per square metre, which is called the pascal (Pa) after the seventeenth-century philosopher and scientist Blaise Pascal. A pressure of 1 Pa is small; it approximately equals the pressure exerted by a dollar bill resting flat on a table. Everyday pressures are often stated in kilopascals (1 kPa = 1000 Pa).
     /// </summary>
-    public partial struct Pressure : IQuantity<PressureUnit>, IEquatable<Pressure>, IComparable, IComparable<Pressure>, IConvertible
+    public partial struct Pressure : IQuantity<PressureUnit>, IEquatable<Pressure>, IComparable<Pressure>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1358,11 +1358,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Pressure change rate is the ratio of the pressure change to the time during which the change occurred (value of pressure changes per unit time).
     /// </summary>
-    public partial struct PressureChangeRate : IQuantity<PressureChangeRateUnit>, IEquatable<PressureChangeRate>, IComparable, IComparable<PressureChangeRate>, IConvertible
+    public partial struct PressureChangeRate : IQuantity<PressureChangeRateUnit>, IEquatable<PressureChangeRate>, IComparable<PressureChangeRate>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -798,11 +798,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In mathematics, a ratio is a relationship between two numbers of the same kind (e.g., objects, persons, students, spoonfuls, units of whatever identical dimension), usually expressed as "a to b" or a:b, sometimes expressed arithmetically as a dimensionless quotient of the two that explicitly indicates how many times the first number contains the second (not necessarily an integer).
     /// </summary>
-    public partial struct Ratio : IQuantity<RatioUnit>, IEquatable<Ratio>, IComparable, IComparable<Ratio>, IConvertible
+    public partial struct Ratio : IQuantity<RatioUnit>, IEquatable<Ratio>, IComparable<Ratio>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -782,11 +782,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     The Volt-ampere reactive hour (expressed as varh) is the reactive power of one Volt-ampere reactive produced in one hour.
     /// </summary>
-    public partial struct ReactiveEnergy : IQuantity<ReactiveEnergyUnit>, IEquatable<ReactiveEnergy>, IComparable, IComparable<ReactiveEnergy>, IConvertible
+    public partial struct ReactiveEnergy : IQuantity<ReactiveEnergyUnit>, IEquatable<ReactiveEnergy>, IComparable<ReactiveEnergy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Volt-ampere reactive (var) is a unit by which reactive power is expressed in an AC electric power system. Reactive power exists in an AC circuit when the current and voltage are not in phase.
     /// </summary>
-    public partial struct ReactivePower : IQuantity<ReactivePowerUnit>, IEquatable<ReactivePower>, IComparable, IComparable<ReactivePower>, IConvertible
+    public partial struct ReactivePower : IQuantity<ReactivePowerUnit>, IEquatable<ReactivePower>, IComparable<ReactivePower>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -750,11 +750,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Angular acceleration is the rate of change of rotational speed.
     /// </summary>
-    public partial struct RotationalAcceleration : IQuantity<RotationalAccelerationUnit>, IEquatable<RotationalAcceleration>, IComparable, IComparable<RotationalAcceleration>, IConvertible
+    public partial struct RotationalAcceleration : IQuantity<RotationalAccelerationUnit>, IEquatable<RotationalAcceleration>, IComparable<RotationalAcceleration>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Rotational speed (sometimes called speed of revolution) is the number of complete rotations, revolutions, cycles, or turns per time unit. Rotational speed is a cyclic frequency, measured in radians per second or in hertz in the SI System by scientists, or in revolutions per minute (rpm or min-1) or revolutions per second in everyday life. The symbol for rotational speed is ω (the Greek lowercase letter "omega").
     /// </summary>
-    public partial struct RotationalSpeed : IQuantity<RotationalSpeedUnit>, IEquatable<RotationalSpeed>, IComparable, IComparable<RotationalSpeed>, IConvertible
+    public partial struct RotationalSpeed : IQuantity<RotationalSpeedUnit>, IEquatable<RotationalSpeed>, IComparable<RotationalSpeed>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -894,11 +894,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness
     /// </summary>
-    public partial struct RotationalStiffness : IQuantity<RotationalStiffnessUnit>, IEquatable<RotationalStiffness>, IComparable, IComparable<RotationalStiffness>, IConvertible
+    public partial struct RotationalStiffness : IQuantity<RotationalStiffnessUnit>, IEquatable<RotationalStiffness>, IComparable<RotationalStiffness>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     https://en.wikipedia.org/wiki/Stiffness#Rotational_stiffness
     /// </summary>
-    public partial struct RotationalStiffnessPerLength : IQuantity<RotationalStiffnessPerLengthUnit>, IEquatable<RotationalStiffnessPerLength>, IComparable, IComparable<RotationalStiffnessPerLength>, IConvertible
+    public partial struct RotationalStiffnessPerLength : IQuantity<RotationalStiffnessPerLengthUnit>, IEquatable<RotationalStiffnessPerLength>, IComparable<RotationalStiffnessPerLength>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Solid_angle
     /// </remarks>
-    public partial struct SolidAngle : IQuantity<SolidAngleUnit>, IEquatable<SolidAngle>, IComparable, IComparable<SolidAngle>, IConvertible
+    public partial struct SolidAngle : IQuantity<SolidAngleUnit>, IEquatable<SolidAngle>, IComparable<SolidAngle>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -705,11 +705,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Specific_energy
     /// </remarks>
-    public partial struct SpecificEnergy : IQuantity<SpecificEnergyUnit>, IEquatable<SpecificEnergy>, IComparable, IComparable<SpecificEnergy>, IConvertible
+    public partial struct SpecificEnergy : IQuantity<SpecificEnergyUnit>, IEquatable<SpecificEnergy>, IComparable<SpecificEnergy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -833,11 +833,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Specific entropy is an amount of energy required to raise temperature of a substance by 1 Kelvin per unit mass.
     /// </summary>
-    public partial struct SpecificEntropy : IQuantity<SpecificEntropyUnit>, IEquatable<SpecificEntropy>, IComparable, IComparable<SpecificEntropy>, IConvertible
+    public partial struct SpecificEntropy : IQuantity<SpecificEntropyUnit>, IEquatable<SpecificEntropy>, IComparable<SpecificEntropy>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -814,11 +814,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In thermodynamics, the specific volume of a substance is the ratio of the substance's volume to its mass. It is the reciprocal of density and an intrinsic property of matter as well.
     /// </summary>
-    public partial struct SpecificVolume : IQuantity<SpecificVolumeUnit>, IEquatable<SpecificVolume>, IComparable, IComparable<SpecificVolume>, IConvertible
+    public partial struct SpecificVolume : IQuantity<SpecificVolumeUnit>, IEquatable<SpecificVolume>, IComparable<SpecificVolume>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -734,11 +734,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     http://en.wikipedia.org/wiki/Specificweight
     /// </remarks>
-    public partial struct SpecificWeight : IQuantity<SpecificWeightUnit>, IEquatable<SpecificWeight>, IComparable, IComparable<SpecificWeight>, IConvertible
+    public partial struct SpecificWeight : IQuantity<SpecificWeightUnit>, IEquatable<SpecificWeight>, IComparable<SpecificWeight>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -961,11 +961,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In everyday use and in kinematics, the speed of an object is the magnitude of its velocity (the rate of change of its position); it is thus a scalar quantity.[1] The average speed of an object in an interval of time is the distance travelled by the object divided by the duration of the interval;[2] the instantaneous speed is the limit of the average speed as the duration of the time interval approaches zero.
     /// </summary>
-    public partial struct Speed : IQuantity<SpeedUnit>, IEquatable<Speed>, IComparable, IComparable<Speed>, IConvertible
+    public partial struct Speed : IQuantity<SpeedUnit>, IEquatable<Speed>, IComparable<Speed>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1198,11 +1198,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     A temperature is a numerical measure of hot or cold. Its measurement is by detection of heat radiation or particle velocity or kinetic energy, or by the bulk behavior of a thermometric material. It may be calibrated in any of various temperature scales, Celsius, Fahrenheit, Kelvin, etc. The fundamental physical definition of temperature is provided by thermodynamics.
     /// </summary>
-    public partial struct Temperature : IQuantity<TemperatureUnit>, IEquatable<Temperature>, IComparable, IComparable<Temperature>, IConvertible
+    public partial struct Temperature : IQuantity<TemperatureUnit>, IEquatable<Temperature>, IComparable<Temperature>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -768,11 +768,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Temperature change rate is the ratio of the temperature change to the time during which the change occurred (value of temperature changes per unit time).
     /// </summary>
-    public partial struct TemperatureChangeRate : IQuantity<TemperatureChangeRateUnit>, IEquatable<TemperatureChangeRate>, IComparable, IComparable<TemperatureChangeRate>, IConvertible
+    public partial struct TemperatureChangeRate : IQuantity<TemperatureChangeRateUnit>, IEquatable<TemperatureChangeRate>, IComparable<TemperatureChangeRate>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -846,11 +846,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Difference between two temperatures. The conversions are different than for Temperature.
     /// </summary>
-    public partial struct TemperatureDelta : IQuantity<TemperatureDeltaUnit>, IEquatable<TemperatureDelta>, IComparable, IComparable<TemperatureDelta>, IConvertible
+    public partial struct TemperatureDelta : IQuantity<TemperatureDeltaUnit>, IEquatable<TemperatureDelta>, IComparable<TemperatureDelta>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -814,11 +814,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
@@ -35,7 +35,7 @@ namespace UnitsNet
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Thermal_Conductivity
     /// </remarks>
-    public partial struct ThermalConductivity : IQuantity<ThermalConductivityUnit>, IEquatable<ThermalConductivity>, IComparable, IComparable<ThermalConductivity>, IConvertible
+    public partial struct ThermalConductivity : IQuantity<ThermalConductivityUnit>, IEquatable<ThermalConductivity>, IComparable<ThermalConductivity>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -721,11 +721,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Heat Transfer Coefficient or Thermal conductivity - indicates a materials ability to conduct heat.
     /// </summary>
-    public partial struct ThermalResistance : IQuantity<ThermalResistanceUnit>, IEquatable<ThermalResistance>, IComparable, IComparable<ThermalResistance>, IConvertible
+    public partial struct ThermalResistance : IQuantity<ThermalResistanceUnit>, IEquatable<ThermalResistance>, IComparable<ThermalResistance>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -766,11 +766,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Torque, moment or moment of force (see the terminology below), is the tendency of a force to rotate an object about an axis,[1] fulcrum, or pivot. Just as a force is a push or a pull, a torque can be thought of as a twist to an object. Mathematically, torque is defined as the cross product of the lever-arm distance and force, which tends to produce rotation. Loosely speaking, torque is a measure of the turning force on an object such as a bolt or a flywheel. For example, pushing or pulling the handle of a wrench connected to a nut or bolt produces a torque (turning force) that loosens or tightens the nut or bolt.
     /// </summary>
-    public partial struct Torque : IQuantity<TorqueUnit>, IEquatable<Torque>, IComparable, IComparable<Torque>, IConvertible
+    public partial struct Torque : IQuantity<TorqueUnit>, IEquatable<Torque>, IComparable<Torque>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1022,11 +1022,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Vitamin A: 1 IU is the biological equivalent of 0.3 µg retinol, or of 0.6 µg beta-carotene.
     /// </summary>
-    public partial struct VitaminA : IQuantity<VitaminAUnit>, IEquatable<VitaminA>, IComparable, IComparable<VitaminA>, IConvertible
+    public partial struct VitaminA : IQuantity<VitaminAUnit>, IEquatable<VitaminA>, IComparable<VitaminA>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -702,11 +702,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     Volume is the quantity of three-dimensional space enclosed by some closed boundary, for example, the space that a substance (solid, liquid, gas, or plasma) or shape occupies or contains.[1] Volume is often quantified numerically using the SI derived unit, the cubic metre. The volume of a container is generally understood to be the capacity of the container, i. e. the amount of fluid (gas or liquid) that the container could hold, rather than the amount of space the container itself displaces.
     /// </summary>
-    public partial struct Volume : IQuantity<VolumeUnit>, IEquatable<Volume>, IComparable, IComparable<Volume>, IConvertible
+    public partial struct Volume : IQuantity<VolumeUnit>, IEquatable<Volume>, IComparable<Volume>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1406,11 +1406,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
@@ -32,7 +32,7 @@ namespace UnitsNet
     /// <summary>
     ///     In physics and engineering, in particular fluid dynamics and hydrometry, the volumetric flow rate, (also known as volume flow rate, rate of fluid flow or volume velocity) is the volume of fluid which passes through a given surface per unit time. The SI unit is m³/s (cubic meters per second). In US Customary Units and British Imperial Units, volumetric flow rate is often expressed as ft³/s (cubic feet per second). It is usually represented by the symbol Q.
     /// </summary>
-    public partial struct VolumeFlow : IQuantity<VolumeFlowUnit>, IEquatable<VolumeFlow>, IComparable, IComparable<VolumeFlow>, IConvertible
+    public partial struct VolumeFlow : IQuantity<VolumeFlowUnit>, IEquatable<VolumeFlow>, IComparable<VolumeFlow>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -1454,11 +1454,6 @@ namespace UnitsNet
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -11,7 +11,7 @@ namespace UnitsNet
     /// <summary>
     ///     Represents a quantity.
     /// </summary>
-    public interface IQuantity
+    public interface IQuantity : IComparable, IConvertible
     {
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
@@ -47,18 +47,11 @@ namespace UnitsNet
         double Value { get; }
 
         /// <summary>
-        ///     Change the default unit representation of the quantity, which affects things like <see cref="IQuantity.ToString(System.IFormatProvider)"/>.
+        ///     Change the default unit representation of the quantity, which affects things like <see cref="object.ToString()"/>.
         /// </summary>
         /// <param name="unit">The unit enum value. The unit must be compatible, so for <see cref="Length"/> you should provide a <see cref="LengthUnit"/> value.</param>
         /// <returns>A new quantity with the given unit as default unit representation.</returns>
         IQuantity ToUnit(Enum unit);
-
-        /// <summary>
-        ///     Get string representation of value and unit. Using two significant digits after radix.
-        /// </summary>
-        /// <returns>String representation.</returns>
-        /// <param name="provider">Format to use for localization and number formatting. Defaults to <see cref="CultureInfo.CurrentUICulture" /> if null.</param>
-        string ToString([CanBeNull] IFormatProvider provider);
 
         /// <summary>
         ///     Get string representation of value and unit.
@@ -101,7 +94,7 @@ namespace UnitsNet
         new QuantityInfo<TUnitType> QuantityInfo { get; }
 
         /// <summary>
-        ///     Change the default unit representation of the quantity, which affects things like <see cref="IQuantity.ToString(System.IFormatProvider)"/>.
+        ///     Change the default unit representation of the quantity, which affects things like <see cref="object.ToString()"/>.
         /// </summary>
         /// <param name="unit"></param>
         /// <returns></returns>

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -66,7 +66,7 @@ if ($obsoleteAttribute)
     ///     $($quantity.XmlDocRemarks)
     /// </remarks>
 "@; }@"
-    public partial struct $quantityName : IQuantity<$unitEnumName>, IEquatable<$quantityName>, IComparable, IComparable<$quantityName>, IConvertible
+    public partial struct $quantityName : IQuantity<$unitEnumName>, IEquatable<$quantityName>, IComparable<$quantityName>
     {
         /// <summary>
         ///     The numeric value this quantity was constructed with.
@@ -233,11 +233,6 @@ if ($obsoleteAttribute)
         float IConvertible.ToSingle(IFormatProvider provider)
         {
             return Convert.ToSingle(_value);
-        }
-
-        string IConvertible.ToString(IFormatProvider provider)
-        {
-            return ToString(provider);
         }
 
         object IConvertible.ToType(Type conversionType, IFormatProvider provider)


### PR DESCRIPTION
Allows more to be done with IQuantity interface, for example:
- Use Linq on collections of IQuantity (sort, min/max, etc.)
- Pass an IQuantity instance to methods that take an IComparable or IConvertible