### PR TITLE
IQuantity As/ToUnit method exceptions

### DIFF
--- a/UnitsNet.Tests/IQuantityTests.cs
+++ b/UnitsNet.Tests/IQuantityTests.cs
@@ -1,0 +1,26 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+using UnitsNet.Units;
+using Xunit;
+
+namespace UnitsNet.Tests
+{
+    public class IQuantityTests
+    {
+        [Fact]
+        public void As_GivenWrongUnitType_ThrowsArgumentException()
+        {
+            IQuantity quantity = Length.FromMeters(1.2345);
+            Assert.Throws<ArgumentException>(() => quantity.As(MassUnit.Kilogram));
+        }
+
+        [Fact]
+        public void ToUnit_GivenWrongUnitType_ThrowsArgumentException()
+        {
+            IQuantity quantity = Length.FromMeters(1.2345);
+            Assert.Throws<ArgumentException>(() => quantity.ToUnit(MassUnit.Kilogram));
+        }
+    }
+}

--- a/UnitsNet.Tests/IQuantityTests.cs
+++ b/UnitsNet.Tests/IQuantityTests.cs
@@ -12,15 +12,15 @@ namespace UnitsNet.Tests
         [Fact]
         public void As_GivenWrongUnitType_ThrowsArgumentException()
         {
-            IQuantity quantity = Length.FromMeters(1.2345);
-            Assert.Throws<ArgumentException>(() => quantity.As(MassUnit.Kilogram));
+            IQuantity length = Length.FromMeters(1.2345);
+            Assert.Throws<ArgumentException>(() => length.As(MassUnit.Kilogram));
         }
 
         [Fact]
         public void ToUnit_GivenWrongUnitType_ThrowsArgumentException()
         {
-            IQuantity quantity = Length.FromMeters(1.2345);
-            Assert.Throws<ArgumentException>(() => quantity.ToUnit(MassUnit.Kilogram));
+            IQuantity length = Length.FromMeters(1.2345);
+            Assert.Throws<ArgumentException>(() => length.ToUnit(MassUnit.Kilogram));
         }
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
@@ -723,7 +723,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AccelerationUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AccelerationUnit))
+                throw new ArgumentException("The given unit is not of type AccelerationUnit.", nameof(unit));
+
+            return As((AccelerationUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -738,9 +745,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AccelerationUnit) unit);
-
         /// <summary>
         ///     Converts this Acceleration to another Acceleration with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -751,10 +755,17 @@ namespace UnitsNet
             return new Acceleration(convertedValue, unit);
         }
 
-        IQuantity<AccelerationUnit> IQuantity<AccelerationUnit>.ToUnit(AccelerationUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AccelerationUnit))
+                throw new ArgumentException("The given unit is not of type AccelerationUnit.", nameof(unit));
+
+            return ToUnit((AccelerationUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AccelerationUnit) unit);
+        IQuantity<AccelerationUnit> IQuantity<AccelerationUnit>.ToUnit(AccelerationUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.NetFramework.g.cs
@@ -723,15 +723,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AccelerationUnit))
-                throw new ArgumentException("The given unit is not of type AccelerationUnit.", nameof(unit));
-
-            return As((AccelerationUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -743,6 +734,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AccelerationUnit unitAsAccelerationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AccelerationUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAccelerationUnit);
         }
 
         /// <summary>
@@ -758,10 +758,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AccelerationUnit))
-                throw new ArgumentException("The given unit is not of type AccelerationUnit.", nameof(unit));
+            if(!(unit is AccelerationUnit unitAsAccelerationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AccelerationUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AccelerationUnit)unit);
+            return ToUnit(unitAsAccelerationUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
@@ -753,15 +753,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AmountOfSubstanceUnit))
-                throw new ArgumentException("The given unit is not of type AmountOfSubstanceUnit.", nameof(unit));
-
-            return As((AmountOfSubstanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -773,6 +764,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AmountOfSubstanceUnit unitAsAmountOfSubstanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AmountOfSubstanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAmountOfSubstanceUnit);
         }
 
         /// <summary>
@@ -788,10 +788,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AmountOfSubstanceUnit))
-                throw new ArgumentException("The given unit is not of type AmountOfSubstanceUnit.", nameof(unit));
+            if(!(unit is AmountOfSubstanceUnit unitAsAmountOfSubstanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AmountOfSubstanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AmountOfSubstanceUnit)unit);
+            return ToUnit(unitAsAmountOfSubstanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.NetFramework.g.cs
@@ -753,7 +753,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AmountOfSubstanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AmountOfSubstanceUnit))
+                throw new ArgumentException("The given unit is not of type AmountOfSubstanceUnit.", nameof(unit));
+
+            return As((AmountOfSubstanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -768,9 +775,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AmountOfSubstanceUnit) unit);
-
         /// <summary>
         ///     Converts this AmountOfSubstance to another AmountOfSubstance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -781,10 +785,17 @@ namespace UnitsNet
             return new AmountOfSubstance(convertedValue, unit);
         }
 
-        IQuantity<AmountOfSubstanceUnit> IQuantity<AmountOfSubstanceUnit>.ToUnit(AmountOfSubstanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AmountOfSubstanceUnit))
+                throw new ArgumentException("The given unit is not of type AmountOfSubstanceUnit.", nameof(unit));
+
+            return ToUnit((AmountOfSubstanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AmountOfSubstanceUnit) unit);
+        IQuantity<AmountOfSubstanceUnit> IQuantity<AmountOfSubstanceUnit>.ToUnit(AmountOfSubstanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
@@ -596,15 +596,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AmplitudeRatioUnit))
-                throw new ArgumentException("The given unit is not of type AmplitudeRatioUnit.", nameof(unit));
-
-            return As((AmplitudeRatioUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -616,6 +607,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AmplitudeRatioUnit unitAsAmplitudeRatioUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AmplitudeRatioUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAmplitudeRatioUnit);
         }
 
         /// <summary>
@@ -631,10 +631,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AmplitudeRatioUnit))
-                throw new ArgumentException("The given unit is not of type AmplitudeRatioUnit.", nameof(unit));
+            if(!(unit is AmplitudeRatioUnit unitAsAmplitudeRatioUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AmplitudeRatioUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AmplitudeRatioUnit)unit);
+            return ToUnit(unitAsAmplitudeRatioUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.NetFramework.g.cs
@@ -596,7 +596,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AmplitudeRatioUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AmplitudeRatioUnit))
+                throw new ArgumentException("The given unit is not of type AmplitudeRatioUnit.", nameof(unit));
+
+            return As((AmplitudeRatioUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -611,9 +618,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AmplitudeRatioUnit) unit);
-
         /// <summary>
         ///     Converts this AmplitudeRatio to another AmplitudeRatio with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -624,10 +628,17 @@ namespace UnitsNet
             return new AmplitudeRatio(convertedValue, unit);
         }
 
-        IQuantity<AmplitudeRatioUnit> IQuantity<AmplitudeRatioUnit>.ToUnit(AmplitudeRatioUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AmplitudeRatioUnit))
+                throw new ArgumentException("The given unit is not of type AmplitudeRatioUnit.", nameof(unit));
+
+            return ToUnit((AmplitudeRatioUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AmplitudeRatioUnit) unit);
+        IQuantity<AmplitudeRatioUnit> IQuantity<AmplitudeRatioUnit>.ToUnit(AmplitudeRatioUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
@@ -738,7 +738,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AngleUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AngleUnit))
+                throw new ArgumentException("The given unit is not of type AngleUnit.", nameof(unit));
+
+            return As((AngleUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -753,9 +760,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AngleUnit) unit);
-
         /// <summary>
         ///     Converts this Angle to another Angle with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -766,10 +770,17 @@ namespace UnitsNet
             return new Angle(convertedValue, unit);
         }
 
-        IQuantity<AngleUnit> IQuantity<AngleUnit>.ToUnit(AngleUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AngleUnit))
+                throw new ArgumentException("The given unit is not of type AngleUnit.", nameof(unit));
+
+            return ToUnit((AngleUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AngleUnit) unit);
+        IQuantity<AngleUnit> IQuantity<AngleUnit>.ToUnit(AngleUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.NetFramework.g.cs
@@ -738,15 +738,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AngleUnit))
-                throw new ArgumentException("The given unit is not of type AngleUnit.", nameof(unit));
-
-            return As((AngleUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -758,6 +749,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AngleUnit unitAsAngleUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AngleUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAngleUnit);
         }
 
         /// <summary>
@@ -773,10 +773,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AngleUnit))
-                throw new ArgumentException("The given unit is not of type AngleUnit.", nameof(unit));
+            if(!(unit is AngleUnit unitAsAngleUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AngleUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AngleUnit)unit);
+            return ToUnit(unitAsAngleUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ApparentEnergyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ApparentEnergyUnit))
+                throw new ArgumentException("The given unit is not of type ApparentEnergyUnit.", nameof(unit));
+
+            return As((ApparentEnergyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ApparentEnergyUnit) unit);
-
         /// <summary>
         ///     Converts this ApparentEnergy to another ApparentEnergy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new ApparentEnergy(convertedValue, unit);
         }
 
-        IQuantity<ApparentEnergyUnit> IQuantity<ApparentEnergyUnit>.ToUnit(ApparentEnergyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ApparentEnergyUnit))
+                throw new ArgumentException("The given unit is not of type ApparentEnergyUnit.", nameof(unit));
+
+            return ToUnit((ApparentEnergyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ApparentEnergyUnit) unit);
+        IQuantity<ApparentEnergyUnit> IQuantity<ApparentEnergyUnit>.ToUnit(ApparentEnergyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ApparentEnergyUnit))
-                throw new ArgumentException("The given unit is not of type ApparentEnergyUnit.", nameof(unit));
-
-            return As((ApparentEnergyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ApparentEnergyUnit unitAsApparentEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ApparentEnergyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsApparentEnergyUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ApparentEnergyUnit))
-                throw new ArgumentException("The given unit is not of type ApparentEnergyUnit.", nameof(unit));
+            if(!(unit is ApparentEnergyUnit unitAsApparentEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ApparentEnergyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ApparentEnergyUnit)unit);
+            return ToUnit(unitAsApparentEnergyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
@@ -588,7 +588,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ApparentPowerUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ApparentPowerUnit))
+                throw new ArgumentException("The given unit is not of type ApparentPowerUnit.", nameof(unit));
+
+            return As((ApparentPowerUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -603,9 +610,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ApparentPowerUnit) unit);
-
         /// <summary>
         ///     Converts this ApparentPower to another ApparentPower with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -616,10 +620,17 @@ namespace UnitsNet
             return new ApparentPower(convertedValue, unit);
         }
 
-        IQuantity<ApparentPowerUnit> IQuantity<ApparentPowerUnit>.ToUnit(ApparentPowerUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ApparentPowerUnit))
+                throw new ArgumentException("The given unit is not of type ApparentPowerUnit.", nameof(unit));
+
+            return ToUnit((ApparentPowerUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ApparentPowerUnit) unit);
+        IQuantity<ApparentPowerUnit> IQuantity<ApparentPowerUnit>.ToUnit(ApparentPowerUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.NetFramework.g.cs
@@ -588,15 +588,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ApparentPowerUnit))
-                throw new ArgumentException("The given unit is not of type ApparentPowerUnit.", nameof(unit));
-
-            return As((ApparentPowerUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -608,6 +599,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ApparentPowerUnit unitAsApparentPowerUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ApparentPowerUnit)} is supported.", nameof(unit));
+
+            return As(unitAsApparentPowerUnit);
         }
 
         /// <summary>
@@ -623,10 +623,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ApparentPowerUnit))
-                throw new ArgumentException("The given unit is not of type ApparentPowerUnit.", nameof(unit));
+            if(!(unit is ApparentPowerUnit unitAsApparentPowerUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ApparentPowerUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ApparentPowerUnit)unit);
+            return ToUnit(unitAsApparentPowerUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
@@ -723,7 +723,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AreaUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AreaUnit))
+                throw new ArgumentException("The given unit is not of type AreaUnit.", nameof(unit));
+
+            return As((AreaUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -738,9 +745,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AreaUnit) unit);
-
         /// <summary>
         ///     Converts this Area to another Area with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -751,10 +755,17 @@ namespace UnitsNet
             return new Area(convertedValue, unit);
         }
 
-        IQuantity<AreaUnit> IQuantity<AreaUnit>.ToUnit(AreaUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AreaUnit))
+                throw new ArgumentException("The given unit is not of type AreaUnit.", nameof(unit));
+
+            return ToUnit((AreaUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AreaUnit) unit);
+        IQuantity<AreaUnit> IQuantity<AreaUnit>.ToUnit(AreaUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.NetFramework.g.cs
@@ -723,15 +723,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AreaUnit))
-                throw new ArgumentException("The given unit is not of type AreaUnit.", nameof(unit));
-
-            return As((AreaUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -743,6 +734,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AreaUnit unitAsAreaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AreaUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAreaUnit);
         }
 
         /// <summary>
@@ -758,10 +758,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AreaUnit))
-                throw new ArgumentException("The given unit is not of type AreaUnit.", nameof(unit));
+            if(!(unit is AreaUnit unitAsAreaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AreaUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AreaUnit)unit);
+            return ToUnit(unitAsAreaUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
@@ -543,15 +543,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AreaDensityUnit))
-                throw new ArgumentException("The given unit is not of type AreaDensityUnit.", nameof(unit));
-
-            return As((AreaDensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -563,6 +554,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AreaDensityUnit unitAsAreaDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AreaDensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAreaDensityUnit);
         }
 
         /// <summary>
@@ -578,10 +578,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AreaDensityUnit))
-                throw new ArgumentException("The given unit is not of type AreaDensityUnit.", nameof(unit));
+            if(!(unit is AreaDensityUnit unitAsAreaDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AreaDensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AreaDensityUnit)unit);
+            return ToUnit(unitAsAreaDensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.NetFramework.g.cs
@@ -543,7 +543,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AreaDensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AreaDensityUnit))
+                throw new ArgumentException("The given unit is not of type AreaDensityUnit.", nameof(unit));
+
+            return As((AreaDensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -558,9 +565,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AreaDensityUnit) unit);
-
         /// <summary>
         ///     Converts this AreaDensity to another AreaDensity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -571,10 +575,17 @@ namespace UnitsNet
             return new AreaDensity(convertedValue, unit);
         }
 
-        IQuantity<AreaDensityUnit> IQuantity<AreaDensityUnit>.ToUnit(AreaDensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AreaDensityUnit))
+                throw new ArgumentException("The given unit is not of type AreaDensityUnit.", nameof(unit));
+
+            return ToUnit((AreaDensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AreaDensityUnit) unit);
+        IQuantity<AreaDensityUnit> IQuantity<AreaDensityUnit>.ToUnit(AreaDensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
@@ -618,7 +618,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((AreaMomentOfInertiaUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AreaMomentOfInertiaUnit))
+                throw new ArgumentException("The given unit is not of type AreaMomentOfInertiaUnit.", nameof(unit));
+
+            return As((AreaMomentOfInertiaUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -633,9 +640,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((AreaMomentOfInertiaUnit) unit);
-
         /// <summary>
         ///     Converts this AreaMomentOfInertia to another AreaMomentOfInertia with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -646,10 +650,17 @@ namespace UnitsNet
             return new AreaMomentOfInertia(convertedValue, unit);
         }
 
-        IQuantity<AreaMomentOfInertiaUnit> IQuantity<AreaMomentOfInertiaUnit>.ToUnit(AreaMomentOfInertiaUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is AreaMomentOfInertiaUnit))
+                throw new ArgumentException("The given unit is not of type AreaMomentOfInertiaUnit.", nameof(unit));
+
+            return ToUnit((AreaMomentOfInertiaUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((AreaMomentOfInertiaUnit) unit);
+        IQuantity<AreaMomentOfInertiaUnit> IQuantity<AreaMomentOfInertiaUnit>.ToUnit(AreaMomentOfInertiaUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.NetFramework.g.cs
@@ -618,15 +618,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is AreaMomentOfInertiaUnit))
-                throw new ArgumentException("The given unit is not of type AreaMomentOfInertiaUnit.", nameof(unit));
-
-            return As((AreaMomentOfInertiaUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -638,6 +629,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is AreaMomentOfInertiaUnit unitAsAreaMomentOfInertiaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AreaMomentOfInertiaUnit)} is supported.", nameof(unit));
+
+            return As(unitAsAreaMomentOfInertiaUnit);
         }
 
         /// <summary>
@@ -653,10 +653,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is AreaMomentOfInertiaUnit))
-                throw new ArgumentException("The given unit is not of type AreaMomentOfInertiaUnit.", nameof(unit));
+            if(!(unit is AreaMomentOfInertiaUnit unitAsAreaMomentOfInertiaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(AreaMomentOfInertiaUnit)} is supported.", nameof(unit));
 
-            return ToUnit((AreaMomentOfInertiaUnit)unit);
+            return ToUnit(unitAsAreaMomentOfInertiaUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -923,7 +923,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((BitRateUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is BitRateUnit))
+                throw new ArgumentException("The given unit is not of type BitRateUnit.", nameof(unit));
+
+            return As((BitRateUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -938,9 +945,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((BitRateUnit) unit);
-
         /// <summary>
         ///     Converts this BitRate to another BitRate with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -951,10 +955,17 @@ namespace UnitsNet
             return new BitRate(convertedValue, unit);
         }
 
-        IQuantity<BitRateUnit> IQuantity<BitRateUnit>.ToUnit(BitRateUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is BitRateUnit))
+                throw new ArgumentException("The given unit is not of type BitRateUnit.", nameof(unit));
+
+            return ToUnit((BitRateUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((BitRateUnit) unit);
+        IQuantity<BitRateUnit> IQuantity<BitRateUnit>.ToUnit(BitRateUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.NetFramework.g.cs
@@ -923,15 +923,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is BitRateUnit))
-                throw new ArgumentException("The given unit is not of type BitRateUnit.", nameof(unit));
-
-            return As((BitRateUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -943,6 +934,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is BitRateUnit unitAsBitRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(BitRateUnit)} is supported.", nameof(unit));
+
+            return As(unitAsBitRateUnit);
         }
 
         /// <summary>
@@ -958,10 +958,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is BitRateUnit))
-                throw new ArgumentException("The given unit is not of type BitRateUnit.", nameof(unit));
+            if(!(unit is BitRateUnit unitAsBitRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(BitRateUnit)} is supported.", nameof(unit));
 
-            return ToUnit((BitRateUnit)unit);
+            return ToUnit(unitAsBitRateUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is BrakeSpecificFuelConsumptionUnit))
-                throw new ArgumentException("The given unit is not of type BrakeSpecificFuelConsumptionUnit.", nameof(unit));
-
-            return As((BrakeSpecificFuelConsumptionUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is BrakeSpecificFuelConsumptionUnit unitAsBrakeSpecificFuelConsumptionUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(BrakeSpecificFuelConsumptionUnit)} is supported.", nameof(unit));
+
+            return As(unitAsBrakeSpecificFuelConsumptionUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is BrakeSpecificFuelConsumptionUnit))
-                throw new ArgumentException("The given unit is not of type BrakeSpecificFuelConsumptionUnit.", nameof(unit));
+            if(!(unit is BrakeSpecificFuelConsumptionUnit unitAsBrakeSpecificFuelConsumptionUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(BrakeSpecificFuelConsumptionUnit)} is supported.", nameof(unit));
 
-            return ToUnit((BrakeSpecificFuelConsumptionUnit)unit);
+            return ToUnit(unitAsBrakeSpecificFuelConsumptionUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((BrakeSpecificFuelConsumptionUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is BrakeSpecificFuelConsumptionUnit))
+                throw new ArgumentException("The given unit is not of type BrakeSpecificFuelConsumptionUnit.", nameof(unit));
+
+            return As((BrakeSpecificFuelConsumptionUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((BrakeSpecificFuelConsumptionUnit) unit);
-
         /// <summary>
         ///     Converts this BrakeSpecificFuelConsumption to another BrakeSpecificFuelConsumption with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new BrakeSpecificFuelConsumption(convertedValue, unit);
         }
 
-        IQuantity<BrakeSpecificFuelConsumptionUnit> IQuantity<BrakeSpecificFuelConsumptionUnit>.ToUnit(BrakeSpecificFuelConsumptionUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is BrakeSpecificFuelConsumptionUnit))
+                throw new ArgumentException("The given unit is not of type BrakeSpecificFuelConsumptionUnit.", nameof(unit));
+
+            return ToUnit((BrakeSpecificFuelConsumptionUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((BrakeSpecificFuelConsumptionUnit) unit);
+        IQuantity<BrakeSpecificFuelConsumptionUnit> IQuantity<BrakeSpecificFuelConsumptionUnit>.ToUnit(BrakeSpecificFuelConsumptionUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
@@ -636,15 +636,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is CapacitanceUnit))
-                throw new ArgumentException("The given unit is not of type CapacitanceUnit.", nameof(unit));
-
-            return As((CapacitanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -656,6 +647,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is CapacitanceUnit unitAsCapacitanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(CapacitanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsCapacitanceUnit);
         }
 
         /// <summary>
@@ -671,10 +671,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is CapacitanceUnit))
-                throw new ArgumentException("The given unit is not of type CapacitanceUnit.", nameof(unit));
+            if(!(unit is CapacitanceUnit unitAsCapacitanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(CapacitanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((CapacitanceUnit)unit);
+            return ToUnit(unitAsCapacitanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.NetFramework.g.cs
@@ -636,7 +636,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((CapacitanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is CapacitanceUnit))
+                throw new ArgumentException("The given unit is not of type CapacitanceUnit.", nameof(unit));
+
+            return As((CapacitanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -651,9 +658,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((CapacitanceUnit) unit);
-
         /// <summary>
         ///     Converts this Capacitance to another Capacitance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -664,10 +668,17 @@ namespace UnitsNet
             return new Capacitance(convertedValue, unit);
         }
 
-        IQuantity<CapacitanceUnit> IQuantity<CapacitanceUnit>.ToUnit(CapacitanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is CapacitanceUnit))
+                throw new ArgumentException("The given unit is not of type CapacitanceUnit.", nameof(unit));
+
+            return ToUnit((CapacitanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((CapacitanceUnit) unit);
+        IQuantity<CapacitanceUnit> IQuantity<CapacitanceUnit>.ToUnit(CapacitanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is CoefficientOfThermalExpansionUnit))
-                throw new ArgumentException("The given unit is not of type CoefficientOfThermalExpansionUnit.", nameof(unit));
-
-            return As((CoefficientOfThermalExpansionUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is CoefficientOfThermalExpansionUnit unitAsCoefficientOfThermalExpansionUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(CoefficientOfThermalExpansionUnit)} is supported.", nameof(unit));
+
+            return As(unitAsCoefficientOfThermalExpansionUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is CoefficientOfThermalExpansionUnit))
-                throw new ArgumentException("The given unit is not of type CoefficientOfThermalExpansionUnit.", nameof(unit));
+            if(!(unit is CoefficientOfThermalExpansionUnit unitAsCoefficientOfThermalExpansionUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(CoefficientOfThermalExpansionUnit)} is supported.", nameof(unit));
 
-            return ToUnit((CoefficientOfThermalExpansionUnit)unit);
+            return ToUnit(unitAsCoefficientOfThermalExpansionUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((CoefficientOfThermalExpansionUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is CoefficientOfThermalExpansionUnit))
+                throw new ArgumentException("The given unit is not of type CoefficientOfThermalExpansionUnit.", nameof(unit));
+
+            return As((CoefficientOfThermalExpansionUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((CoefficientOfThermalExpansionUnit) unit);
-
         /// <summary>
         ///     Converts this CoefficientOfThermalExpansion to another CoefficientOfThermalExpansion with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new CoefficientOfThermalExpansion(convertedValue, unit);
         }
 
-        IQuantity<CoefficientOfThermalExpansionUnit> IQuantity<CoefficientOfThermalExpansionUnit>.ToUnit(CoefficientOfThermalExpansionUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is CoefficientOfThermalExpansionUnit))
+                throw new ArgumentException("The given unit is not of type CoefficientOfThermalExpansionUnit.", nameof(unit));
+
+            return ToUnit((CoefficientOfThermalExpansionUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((CoefficientOfThermalExpansionUnit) unit);
+        IQuantity<CoefficientOfThermalExpansionUnit> IQuantity<CoefficientOfThermalExpansionUnit>.ToUnit(CoefficientOfThermalExpansionUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
@@ -1116,15 +1116,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is DensityUnit))
-                throw new ArgumentException("The given unit is not of type DensityUnit.", nameof(unit));
-
-            return As((DensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1136,6 +1127,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is DensityUnit unitAsDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(DensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsDensityUnit);
         }
 
         /// <summary>
@@ -1151,10 +1151,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is DensityUnit))
-                throw new ArgumentException("The given unit is not of type DensityUnit.", nameof(unit));
+            if(!(unit is DensityUnit unitAsDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(DensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((DensityUnit)unit);
+            return ToUnit(unitAsDensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.NetFramework.g.cs
@@ -1116,7 +1116,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((DensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is DensityUnit))
+                throw new ArgumentException("The given unit is not of type DensityUnit.", nameof(unit));
+
+            return As((DensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1131,9 +1138,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((DensityUnit) unit);
-
         /// <summary>
         ///     Converts this Density to another Density with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1144,10 +1148,17 @@ namespace UnitsNet
             return new Density(convertedValue, unit);
         }
 
-        IQuantity<DensityUnit> IQuantity<DensityUnit>.ToUnit(DensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is DensityUnit))
+                throw new ArgumentException("The given unit is not of type DensityUnit.", nameof(unit));
+
+            return ToUnit((DensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((DensityUnit) unit);
+        IQuantity<DensityUnit> IQuantity<DensityUnit>.ToUnit(DensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
@@ -678,15 +678,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is DurationUnit))
-                throw new ArgumentException("The given unit is not of type DurationUnit.", nameof(unit));
-
-            return As((DurationUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -698,6 +689,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is DurationUnit unitAsDurationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(DurationUnit)} is supported.", nameof(unit));
+
+            return As(unitAsDurationUnit);
         }
 
         /// <summary>
@@ -713,10 +713,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is DurationUnit))
-                throw new ArgumentException("The given unit is not of type DurationUnit.", nameof(unit));
+            if(!(unit is DurationUnit unitAsDurationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(DurationUnit)} is supported.", nameof(unit));
 
-            return ToUnit((DurationUnit)unit);
+            return ToUnit(unitAsDurationUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.NetFramework.g.cs
@@ -678,7 +678,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((DurationUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is DurationUnit))
+                throw new ArgumentException("The given unit is not of type DurationUnit.", nameof(unit));
+
+            return As((DurationUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -693,9 +700,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((DurationUnit) unit);
-
         /// <summary>
         ///     Converts this Duration to another Duration with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -706,10 +710,17 @@ namespace UnitsNet
             return new Duration(convertedValue, unit);
         }
 
-        IQuantity<DurationUnit> IQuantity<DurationUnit>.ToUnit(DurationUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is DurationUnit))
+                throw new ArgumentException("The given unit is not of type DurationUnit.", nameof(unit));
+
+            return ToUnit((DurationUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((DurationUnit) unit);
+        IQuantity<DurationUnit> IQuantity<DurationUnit>.ToUnit(DurationUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
@@ -621,7 +621,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((DynamicViscosityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is DynamicViscosityUnit))
+                throw new ArgumentException("The given unit is not of type DynamicViscosityUnit.", nameof(unit));
+
+            return As((DynamicViscosityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -636,9 +643,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((DynamicViscosityUnit) unit);
-
         /// <summary>
         ///     Converts this DynamicViscosity to another DynamicViscosity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -649,10 +653,17 @@ namespace UnitsNet
             return new DynamicViscosity(convertedValue, unit);
         }
 
-        IQuantity<DynamicViscosityUnit> IQuantity<DynamicViscosityUnit>.ToUnit(DynamicViscosityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is DynamicViscosityUnit))
+                throw new ArgumentException("The given unit is not of type DynamicViscosityUnit.", nameof(unit));
+
+            return ToUnit((DynamicViscosityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((DynamicViscosityUnit) unit);
+        IQuantity<DynamicViscosityUnit> IQuantity<DynamicViscosityUnit>.ToUnit(DynamicViscosityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.NetFramework.g.cs
@@ -621,15 +621,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is DynamicViscosityUnit))
-                throw new ArgumentException("The given unit is not of type DynamicViscosityUnit.", nameof(unit));
-
-            return As((DynamicViscosityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -641,6 +632,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is DynamicViscosityUnit unitAsDynamicViscosityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(DynamicViscosityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsDynamicViscosityUnit);
         }
 
         /// <summary>
@@ -656,10 +656,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is DynamicViscosityUnit))
-                throw new ArgumentException("The given unit is not of type DynamicViscosityUnit.", nameof(unit));
+            if(!(unit is DynamicViscosityUnit unitAsDynamicViscosityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(DynamicViscosityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((DynamicViscosityUnit)unit);
+            return ToUnit(unitAsDynamicViscosityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
@@ -588,7 +588,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricAdmittanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricAdmittanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricAdmittanceUnit.", nameof(unit));
+
+            return As((ElectricAdmittanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -603,9 +610,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricAdmittanceUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricAdmittance to another ElectricAdmittance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -616,10 +620,17 @@ namespace UnitsNet
             return new ElectricAdmittance(convertedValue, unit);
         }
 
-        IQuantity<ElectricAdmittanceUnit> IQuantity<ElectricAdmittanceUnit>.ToUnit(ElectricAdmittanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricAdmittanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricAdmittanceUnit.", nameof(unit));
+
+            return ToUnit((ElectricAdmittanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricAdmittanceUnit) unit);
+        IQuantity<ElectricAdmittanceUnit> IQuantity<ElectricAdmittanceUnit>.ToUnit(ElectricAdmittanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.NetFramework.g.cs
@@ -588,15 +588,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricAdmittanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricAdmittanceUnit.", nameof(unit));
-
-            return As((ElectricAdmittanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -608,6 +599,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricAdmittanceUnit unitAsElectricAdmittanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricAdmittanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricAdmittanceUnit);
         }
 
         /// <summary>
@@ -623,10 +623,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricAdmittanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricAdmittanceUnit.", nameof(unit));
+            if(!(unit is ElectricAdmittanceUnit unitAsElectricAdmittanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricAdmittanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricAdmittanceUnit)unit);
+            return ToUnit(unitAsElectricAdmittanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricChargeUnit))
-                throw new ArgumentException("The given unit is not of type ElectricChargeUnit.", nameof(unit));
-
-            return As((ElectricChargeUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricChargeUnit unitAsElectricChargeUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricChargeUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricChargeUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricChargeUnit))
-                throw new ArgumentException("The given unit is not of type ElectricChargeUnit.", nameof(unit));
+            if(!(unit is ElectricChargeUnit unitAsElectricChargeUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricChargeUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricChargeUnit)unit);
+            return ToUnit(unitAsElectricChargeUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricChargeUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricChargeUnit))
+                throw new ArgumentException("The given unit is not of type ElectricChargeUnit.", nameof(unit));
+
+            return As((ElectricChargeUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricChargeUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricCharge to another ElectricCharge with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new ElectricCharge(convertedValue, unit);
         }
 
-        IQuantity<ElectricChargeUnit> IQuantity<ElectricChargeUnit>.ToUnit(ElectricChargeUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricChargeUnit))
+                throw new ArgumentException("The given unit is not of type ElectricChargeUnit.", nameof(unit));
+
+            return ToUnit((ElectricChargeUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricChargeUnit) unit);
+        IQuantity<ElectricChargeUnit> IQuantity<ElectricChargeUnit>.ToUnit(ElectricChargeUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricChargeDensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricChargeDensityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricChargeDensityUnit.", nameof(unit));
+
+            return As((ElectricChargeDensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricChargeDensityUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricChargeDensity to another ElectricChargeDensity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new ElectricChargeDensity(convertedValue, unit);
         }
 
-        IQuantity<ElectricChargeDensityUnit> IQuantity<ElectricChargeDensityUnit>.ToUnit(ElectricChargeDensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricChargeDensityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricChargeDensityUnit.", nameof(unit));
+
+            return ToUnit((ElectricChargeDensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricChargeDensityUnit) unit);
+        IQuantity<ElectricChargeDensityUnit> IQuantity<ElectricChargeDensityUnit>.ToUnit(ElectricChargeDensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricChargeDensityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricChargeDensityUnit.", nameof(unit));
-
-            return As((ElectricChargeDensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricChargeDensityUnit unitAsElectricChargeDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricChargeDensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricChargeDensityUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricChargeDensityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricChargeDensityUnit.", nameof(unit));
+            if(!(unit is ElectricChargeDensityUnit unitAsElectricChargeDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricChargeDensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricChargeDensityUnit)unit);
+            return ToUnit(unitAsElectricChargeDensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
@@ -576,7 +576,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricConductanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricConductanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricConductanceUnit.", nameof(unit));
+
+            return As((ElectricConductanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -591,9 +598,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricConductanceUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricConductance to another ElectricConductance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -604,10 +608,17 @@ namespace UnitsNet
             return new ElectricConductance(convertedValue, unit);
         }
 
-        IQuantity<ElectricConductanceUnit> IQuantity<ElectricConductanceUnit>.ToUnit(ElectricConductanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricConductanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricConductanceUnit.", nameof(unit));
+
+            return ToUnit((ElectricConductanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricConductanceUnit) unit);
+        IQuantity<ElectricConductanceUnit> IQuantity<ElectricConductanceUnit>.ToUnit(ElectricConductanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.NetFramework.g.cs
@@ -576,15 +576,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricConductanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricConductanceUnit.", nameof(unit));
-
-            return As((ElectricConductanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -596,6 +587,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricConductanceUnit unitAsElectricConductanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricConductanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricConductanceUnit);
         }
 
         /// <summary>
@@ -611,10 +611,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricConductanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricConductanceUnit.", nameof(unit));
+            if(!(unit is ElectricConductanceUnit unitAsElectricConductanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricConductanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricConductanceUnit)unit);
+            return ToUnit(unitAsElectricConductanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricConductivityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricConductivityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricConductivityUnit.", nameof(unit));
+
+            return As((ElectricConductivityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricConductivityUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricConductivity to another ElectricConductivity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new ElectricConductivity(convertedValue, unit);
         }
 
-        IQuantity<ElectricConductivityUnit> IQuantity<ElectricConductivityUnit>.ToUnit(ElectricConductivityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricConductivityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricConductivityUnit.", nameof(unit));
+
+            return ToUnit((ElectricConductivityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricConductivityUnit) unit);
+        IQuantity<ElectricConductivityUnit> IQuantity<ElectricConductivityUnit>.ToUnit(ElectricConductivityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricConductivityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricConductivityUnit.", nameof(unit));
-
-            return As((ElectricConductivityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricConductivityUnit unitAsElectricConductivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricConductivityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricConductivityUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricConductivityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricConductivityUnit.", nameof(unit));
+            if(!(unit is ElectricConductivityUnit unitAsElectricConductivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricConductivityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricConductivityUnit)unit);
+            return ToUnit(unitAsElectricConductivityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
@@ -648,7 +648,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricCurrentUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricCurrentUnit))
+                throw new ArgumentException("The given unit is not of type ElectricCurrentUnit.", nameof(unit));
+
+            return As((ElectricCurrentUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -663,9 +670,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricCurrentUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricCurrent to another ElectricCurrent with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -676,10 +680,17 @@ namespace UnitsNet
             return new ElectricCurrent(convertedValue, unit);
         }
 
-        IQuantity<ElectricCurrentUnit> IQuantity<ElectricCurrentUnit>.ToUnit(ElectricCurrentUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricCurrentUnit))
+                throw new ArgumentException("The given unit is not of type ElectricCurrentUnit.", nameof(unit));
+
+            return ToUnit((ElectricCurrentUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricCurrentUnit) unit);
+        IQuantity<ElectricCurrentUnit> IQuantity<ElectricCurrentUnit>.ToUnit(ElectricCurrentUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.NetFramework.g.cs
@@ -648,15 +648,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricCurrentUnit))
-                throw new ArgumentException("The given unit is not of type ElectricCurrentUnit.", nameof(unit));
-
-            return As((ElectricCurrentUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -668,6 +659,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricCurrentUnit unitAsElectricCurrentUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricCurrentUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricCurrentUnit);
         }
 
         /// <summary>
@@ -683,10 +683,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricCurrentUnit))
-                throw new ArgumentException("The given unit is not of type ElectricCurrentUnit.", nameof(unit));
+            if(!(unit is ElectricCurrentUnit unitAsElectricCurrentUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricCurrentUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricCurrentUnit)unit);
+            return ToUnit(unitAsElectricCurrentUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricCurrentDensityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricCurrentDensityUnit.", nameof(unit));
-
-            return As((ElectricCurrentDensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricCurrentDensityUnit unitAsElectricCurrentDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricCurrentDensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricCurrentDensityUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricCurrentDensityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricCurrentDensityUnit.", nameof(unit));
+            if(!(unit is ElectricCurrentDensityUnit unitAsElectricCurrentDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricCurrentDensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricCurrentDensityUnit)unit);
+            return ToUnit(unitAsElectricCurrentDensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricCurrentDensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricCurrentDensityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricCurrentDensityUnit.", nameof(unit));
+
+            return As((ElectricCurrentDensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricCurrentDensityUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricCurrentDensity to another ElectricCurrentDensity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new ElectricCurrentDensity(convertedValue, unit);
         }
 
-        IQuantity<ElectricCurrentDensityUnit> IQuantity<ElectricCurrentDensityUnit>.ToUnit(ElectricCurrentDensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricCurrentDensityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricCurrentDensityUnit.", nameof(unit));
+
+            return ToUnit((ElectricCurrentDensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricCurrentDensityUnit) unit);
+        IQuantity<ElectricCurrentDensityUnit> IQuantity<ElectricCurrentDensityUnit>.ToUnit(ElectricCurrentDensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
@@ -543,7 +543,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricCurrentGradientUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricCurrentGradientUnit))
+                throw new ArgumentException("The given unit is not of type ElectricCurrentGradientUnit.", nameof(unit));
+
+            return As((ElectricCurrentGradientUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -558,9 +565,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricCurrentGradientUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricCurrentGradient to another ElectricCurrentGradient with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -571,10 +575,17 @@ namespace UnitsNet
             return new ElectricCurrentGradient(convertedValue, unit);
         }
 
-        IQuantity<ElectricCurrentGradientUnit> IQuantity<ElectricCurrentGradientUnit>.ToUnit(ElectricCurrentGradientUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricCurrentGradientUnit))
+                throw new ArgumentException("The given unit is not of type ElectricCurrentGradientUnit.", nameof(unit));
+
+            return ToUnit((ElectricCurrentGradientUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricCurrentGradientUnit) unit);
+        IQuantity<ElectricCurrentGradientUnit> IQuantity<ElectricCurrentGradientUnit>.ToUnit(ElectricCurrentGradientUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.NetFramework.g.cs
@@ -543,15 +543,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricCurrentGradientUnit))
-                throw new ArgumentException("The given unit is not of type ElectricCurrentGradientUnit.", nameof(unit));
-
-            return As((ElectricCurrentGradientUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -563,6 +554,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricCurrentGradientUnit unitAsElectricCurrentGradientUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricCurrentGradientUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricCurrentGradientUnit);
         }
 
         /// <summary>
@@ -578,10 +578,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricCurrentGradientUnit))
-                throw new ArgumentException("The given unit is not of type ElectricCurrentGradientUnit.", nameof(unit));
+            if(!(unit is ElectricCurrentGradientUnit unitAsElectricCurrentGradientUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricCurrentGradientUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricCurrentGradientUnit)unit);
+            return ToUnit(unitAsElectricCurrentGradientUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricFieldUnit))
-                throw new ArgumentException("The given unit is not of type ElectricFieldUnit.", nameof(unit));
-
-            return As((ElectricFieldUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricFieldUnit unitAsElectricFieldUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricFieldUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricFieldUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricFieldUnit))
-                throw new ArgumentException("The given unit is not of type ElectricFieldUnit.", nameof(unit));
+            if(!(unit is ElectricFieldUnit unitAsElectricFieldUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricFieldUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricFieldUnit)unit);
+            return ToUnit(unitAsElectricFieldUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricFieldUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricFieldUnit))
+                throw new ArgumentException("The given unit is not of type ElectricFieldUnit.", nameof(unit));
+
+            return As((ElectricFieldUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricFieldUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricField to another ElectricField with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new ElectricField(convertedValue, unit);
         }
 
-        IQuantity<ElectricFieldUnit> IQuantity<ElectricFieldUnit>.ToUnit(ElectricFieldUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricFieldUnit))
+                throw new ArgumentException("The given unit is not of type ElectricFieldUnit.", nameof(unit));
+
+            return ToUnit((ElectricFieldUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricFieldUnit) unit);
+        IQuantity<ElectricFieldUnit> IQuantity<ElectricFieldUnit>.ToUnit(ElectricFieldUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
@@ -591,15 +591,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricInductanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricInductanceUnit.", nameof(unit));
-
-            return As((ElectricInductanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -611,6 +602,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricInductanceUnit unitAsElectricInductanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricInductanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricInductanceUnit);
         }
 
         /// <summary>
@@ -626,10 +626,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricInductanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricInductanceUnit.", nameof(unit));
+            if(!(unit is ElectricInductanceUnit unitAsElectricInductanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricInductanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricInductanceUnit)unit);
+            return ToUnit(unitAsElectricInductanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.NetFramework.g.cs
@@ -591,7 +591,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricInductanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricInductanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricInductanceUnit.", nameof(unit));
+
+            return As((ElectricInductanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -606,9 +613,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricInductanceUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricInductance to another ElectricInductance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -619,10 +623,17 @@ namespace UnitsNet
             return new ElectricInductance(convertedValue, unit);
         }
 
-        IQuantity<ElectricInductanceUnit> IQuantity<ElectricInductanceUnit>.ToUnit(ElectricInductanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricInductanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricInductanceUnit.", nameof(unit));
+
+            return ToUnit((ElectricInductanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricInductanceUnit) unit);
+        IQuantity<ElectricInductanceUnit> IQuantity<ElectricInductanceUnit>.ToUnit(ElectricInductanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
@@ -603,7 +603,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricPotentialUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricPotentialUnit))
+                throw new ArgumentException("The given unit is not of type ElectricPotentialUnit.", nameof(unit));
+
+            return As((ElectricPotentialUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -618,9 +625,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricPotentialUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricPotential to another ElectricPotential with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -631,10 +635,17 @@ namespace UnitsNet
             return new ElectricPotential(convertedValue, unit);
         }
 
-        IQuantity<ElectricPotentialUnit> IQuantity<ElectricPotentialUnit>.ToUnit(ElectricPotentialUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricPotentialUnit))
+                throw new ArgumentException("The given unit is not of type ElectricPotentialUnit.", nameof(unit));
+
+            return ToUnit((ElectricPotentialUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricPotentialUnit) unit);
+        IQuantity<ElectricPotentialUnit> IQuantity<ElectricPotentialUnit>.ToUnit(ElectricPotentialUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.NetFramework.g.cs
@@ -603,15 +603,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricPotentialUnit))
-                throw new ArgumentException("The given unit is not of type ElectricPotentialUnit.", nameof(unit));
-
-            return As((ElectricPotentialUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -623,6 +614,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricPotentialUnit unitAsElectricPotentialUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricPotentialUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricPotentialUnit);
         }
 
         /// <summary>
@@ -638,10 +638,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricPotentialUnit))
-                throw new ArgumentException("The given unit is not of type ElectricPotentialUnit.", nameof(unit));
+            if(!(unit is ElectricPotentialUnit unitAsElectricPotentialUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricPotentialUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricPotentialUnit)unit);
+            return ToUnit(unitAsElectricPotentialUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
@@ -603,15 +603,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricPotentialAcUnit))
-                throw new ArgumentException("The given unit is not of type ElectricPotentialAcUnit.", nameof(unit));
-
-            return As((ElectricPotentialAcUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -623,6 +614,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricPotentialAcUnit unitAsElectricPotentialAcUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricPotentialAcUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricPotentialAcUnit);
         }
 
         /// <summary>
@@ -638,10 +638,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricPotentialAcUnit))
-                throw new ArgumentException("The given unit is not of type ElectricPotentialAcUnit.", nameof(unit));
+            if(!(unit is ElectricPotentialAcUnit unitAsElectricPotentialAcUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricPotentialAcUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricPotentialAcUnit)unit);
+            return ToUnit(unitAsElectricPotentialAcUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.NetFramework.g.cs
@@ -603,7 +603,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricPotentialAcUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricPotentialAcUnit))
+                throw new ArgumentException("The given unit is not of type ElectricPotentialAcUnit.", nameof(unit));
+
+            return As((ElectricPotentialAcUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -618,9 +625,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricPotentialAcUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricPotentialAc to another ElectricPotentialAc with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -631,10 +635,17 @@ namespace UnitsNet
             return new ElectricPotentialAc(convertedValue, unit);
         }
 
-        IQuantity<ElectricPotentialAcUnit> IQuantity<ElectricPotentialAcUnit>.ToUnit(ElectricPotentialAcUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricPotentialAcUnit))
+                throw new ArgumentException("The given unit is not of type ElectricPotentialAcUnit.", nameof(unit));
+
+            return ToUnit((ElectricPotentialAcUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricPotentialAcUnit) unit);
+        IQuantity<ElectricPotentialAcUnit> IQuantity<ElectricPotentialAcUnit>.ToUnit(ElectricPotentialAcUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
@@ -603,15 +603,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricPotentialDcUnit))
-                throw new ArgumentException("The given unit is not of type ElectricPotentialDcUnit.", nameof(unit));
-
-            return As((ElectricPotentialDcUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -623,6 +614,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricPotentialDcUnit unitAsElectricPotentialDcUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricPotentialDcUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricPotentialDcUnit);
         }
 
         /// <summary>
@@ -638,10 +638,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricPotentialDcUnit))
-                throw new ArgumentException("The given unit is not of type ElectricPotentialDcUnit.", nameof(unit));
+            if(!(unit is ElectricPotentialDcUnit unitAsElectricPotentialDcUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricPotentialDcUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricPotentialDcUnit)unit);
+            return ToUnit(unitAsElectricPotentialDcUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.NetFramework.g.cs
@@ -603,7 +603,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricPotentialDcUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricPotentialDcUnit))
+                throw new ArgumentException("The given unit is not of type ElectricPotentialDcUnit.", nameof(unit));
+
+            return As((ElectricPotentialDcUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -618,9 +625,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricPotentialDcUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricPotentialDc to another ElectricPotentialDc with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -631,10 +635,17 @@ namespace UnitsNet
             return new ElectricPotentialDc(convertedValue, unit);
         }
 
-        IQuantity<ElectricPotentialDcUnit> IQuantity<ElectricPotentialDcUnit>.ToUnit(ElectricPotentialDcUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricPotentialDcUnit))
+                throw new ArgumentException("The given unit is not of type ElectricPotentialDcUnit.", nameof(unit));
+
+            return ToUnit((ElectricPotentialDcUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricPotentialDcUnit) unit);
+        IQuantity<ElectricPotentialDcUnit> IQuantity<ElectricPotentialDcUnit>.ToUnit(ElectricPotentialDcUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
@@ -603,7 +603,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricResistanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricResistanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricResistanceUnit.", nameof(unit));
+
+            return As((ElectricResistanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -618,9 +625,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricResistanceUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricResistance to another ElectricResistance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -631,10 +635,17 @@ namespace UnitsNet
             return new ElectricResistance(convertedValue, unit);
         }
 
-        IQuantity<ElectricResistanceUnit> IQuantity<ElectricResistanceUnit>.ToUnit(ElectricResistanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricResistanceUnit))
+                throw new ArgumentException("The given unit is not of type ElectricResistanceUnit.", nameof(unit));
+
+            return ToUnit((ElectricResistanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricResistanceUnit) unit);
+        IQuantity<ElectricResistanceUnit> IQuantity<ElectricResistanceUnit>.ToUnit(ElectricResistanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.NetFramework.g.cs
@@ -603,15 +603,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricResistanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricResistanceUnit.", nameof(unit));
-
-            return As((ElectricResistanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -623,6 +614,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricResistanceUnit unitAsElectricResistanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricResistanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricResistanceUnit);
         }
 
         /// <summary>
@@ -638,10 +638,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricResistanceUnit))
-                throw new ArgumentException("The given unit is not of type ElectricResistanceUnit.", nameof(unit));
+            if(!(unit is ElectricResistanceUnit unitAsElectricResistanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricResistanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricResistanceUnit)unit);
+            return ToUnit(unitAsElectricResistanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
@@ -741,15 +741,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ElectricResistivityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricResistivityUnit.", nameof(unit));
-
-            return As((ElectricResistivityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -761,6 +752,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricResistivityUnit unitAsElectricResistivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricResistivityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsElectricResistivityUnit);
         }
 
         /// <summary>
@@ -776,10 +776,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ElectricResistivityUnit))
-                throw new ArgumentException("The given unit is not of type ElectricResistivityUnit.", nameof(unit));
+            if(!(unit is ElectricResistivityUnit unitAsElectricResistivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ElectricResistivityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ElectricResistivityUnit)unit);
+            return ToUnit(unitAsElectricResistivityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.NetFramework.g.cs
@@ -741,7 +741,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ElectricResistivityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ElectricResistivityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricResistivityUnit.", nameof(unit));
+
+            return As((ElectricResistivityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -756,9 +763,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ElectricResistivityUnit) unit);
-
         /// <summary>
         ///     Converts this ElectricResistivity to another ElectricResistivity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -769,10 +773,17 @@ namespace UnitsNet
             return new ElectricResistivity(convertedValue, unit);
         }
 
-        IQuantity<ElectricResistivityUnit> IQuantity<ElectricResistivityUnit>.ToUnit(ElectricResistivityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ElectricResistivityUnit))
+                throw new ArgumentException("The given unit is not of type ElectricResistivityUnit.", nameof(unit));
+
+            return ToUnit((ElectricResistivityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ElectricResistivityUnit) unit);
+        IQuantity<ElectricResistivityUnit> IQuantity<ElectricResistivityUnit>.ToUnit(ElectricResistivityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
@@ -873,15 +873,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is EnergyUnit))
-                throw new ArgumentException("The given unit is not of type EnergyUnit.", nameof(unit));
-
-            return As((EnergyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -893,6 +884,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is EnergyUnit unitAsEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(EnergyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsEnergyUnit);
         }
 
         /// <summary>
@@ -908,10 +908,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is EnergyUnit))
-                throw new ArgumentException("The given unit is not of type EnergyUnit.", nameof(unit));
+            if(!(unit is EnergyUnit unitAsEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(EnergyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((EnergyUnit)unit);
+            return ToUnit(unitAsEnergyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.NetFramework.g.cs
@@ -873,7 +873,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((EnergyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is EnergyUnit))
+                throw new ArgumentException("The given unit is not of type EnergyUnit.", nameof(unit));
+
+            return As((EnergyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -888,9 +895,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((EnergyUnit) unit);
-
         /// <summary>
         ///     Converts this Energy to another Energy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -901,10 +905,17 @@ namespace UnitsNet
             return new Energy(convertedValue, unit);
         }
 
-        IQuantity<EnergyUnit> IQuantity<EnergyUnit>.ToUnit(EnergyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is EnergyUnit))
+                throw new ArgumentException("The given unit is not of type EnergyUnit.", nameof(unit));
+
+            return ToUnit((EnergyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((EnergyUnit) unit);
+        IQuantity<EnergyUnit> IQuantity<EnergyUnit>.ToUnit(EnergyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
@@ -633,15 +633,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is EntropyUnit))
-                throw new ArgumentException("The given unit is not of type EntropyUnit.", nameof(unit));
-
-            return As((EntropyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -653,6 +644,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is EntropyUnit unitAsEntropyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(EntropyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsEntropyUnit);
         }
 
         /// <summary>
@@ -668,10 +668,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is EntropyUnit))
-                throw new ArgumentException("The given unit is not of type EntropyUnit.", nameof(unit));
+            if(!(unit is EntropyUnit unitAsEntropyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(EntropyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((EntropyUnit)unit);
+            return ToUnit(unitAsEntropyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.NetFramework.g.cs
@@ -633,7 +633,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((EntropyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is EntropyUnit))
+                throw new ArgumentException("The given unit is not of type EntropyUnit.", nameof(unit));
+
+            return As((EntropyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -648,9 +655,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((EntropyUnit) unit);
-
         /// <summary>
         ///     Converts this Entropy to another Entropy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -661,10 +665,17 @@ namespace UnitsNet
             return new Entropy(convertedValue, unit);
         }
 
-        IQuantity<EntropyUnit> IQuantity<EntropyUnit>.ToUnit(EntropyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is EntropyUnit))
+                throw new ArgumentException("The given unit is not of type EntropyUnit.", nameof(unit));
+
+            return ToUnit((EntropyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((EntropyUnit) unit);
+        IQuantity<EntropyUnit> IQuantity<EntropyUnit>.ToUnit(EntropyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
@@ -723,7 +723,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ForceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ForceUnit))
+                throw new ArgumentException("The given unit is not of type ForceUnit.", nameof(unit));
+
+            return As((ForceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -738,9 +745,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ForceUnit) unit);
-
         /// <summary>
         ///     Converts this Force to another Force with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -751,10 +755,17 @@ namespace UnitsNet
             return new Force(convertedValue, unit);
         }
 
-        IQuantity<ForceUnit> IQuantity<ForceUnit>.ToUnit(ForceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ForceUnit))
+                throw new ArgumentException("The given unit is not of type ForceUnit.", nameof(unit));
+
+            return ToUnit((ForceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ForceUnit) unit);
+        IQuantity<ForceUnit> IQuantity<ForceUnit>.ToUnit(ForceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.NetFramework.g.cs
@@ -723,15 +723,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ForceUnit))
-                throw new ArgumentException("The given unit is not of type ForceUnit.", nameof(unit));
-
-            return As((ForceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -743,6 +734,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ForceUnit unitAsForceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ForceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsForceUnit);
         }
 
         /// <summary>
@@ -758,10 +758,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ForceUnit))
-                throw new ArgumentException("The given unit is not of type ForceUnit.", nameof(unit));
+            if(!(unit is ForceUnit unitAsForceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ForceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ForceUnit)unit);
+            return ToUnit(unitAsForceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
@@ -693,7 +693,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ForceChangeRateUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ForceChangeRateUnit))
+                throw new ArgumentException("The given unit is not of type ForceChangeRateUnit.", nameof(unit));
+
+            return As((ForceChangeRateUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -708,9 +715,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ForceChangeRateUnit) unit);
-
         /// <summary>
         ///     Converts this ForceChangeRate to another ForceChangeRate with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -721,10 +725,17 @@ namespace UnitsNet
             return new ForceChangeRate(convertedValue, unit);
         }
 
-        IQuantity<ForceChangeRateUnit> IQuantity<ForceChangeRateUnit>.ToUnit(ForceChangeRateUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ForceChangeRateUnit))
+                throw new ArgumentException("The given unit is not of type ForceChangeRateUnit.", nameof(unit));
+
+            return ToUnit((ForceChangeRateUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ForceChangeRateUnit) unit);
+        IQuantity<ForceChangeRateUnit> IQuantity<ForceChangeRateUnit>.ToUnit(ForceChangeRateUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.NetFramework.g.cs
@@ -693,15 +693,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ForceChangeRateUnit))
-                throw new ArgumentException("The given unit is not of type ForceChangeRateUnit.", nameof(unit));
-
-            return As((ForceChangeRateUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -713,6 +704,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ForceChangeRateUnit unitAsForceChangeRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ForceChangeRateUnit)} is supported.", nameof(unit));
+
+            return As(unitAsForceChangeRateUnit);
         }
 
         /// <summary>
@@ -728,10 +728,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ForceChangeRateUnit))
-                throw new ArgumentException("The given unit is not of type ForceChangeRateUnit.", nameof(unit));
+            if(!(unit is ForceChangeRateUnit unitAsForceChangeRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ForceChangeRateUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ForceChangeRateUnit)unit);
+            return ToUnit(unitAsForceChangeRateUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
@@ -663,7 +663,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ForcePerLengthUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ForcePerLengthUnit))
+                throw new ArgumentException("The given unit is not of type ForcePerLengthUnit.", nameof(unit));
+
+            return As((ForcePerLengthUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -678,9 +685,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ForcePerLengthUnit) unit);
-
         /// <summary>
         ///     Converts this ForcePerLength to another ForcePerLength with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -691,10 +695,17 @@ namespace UnitsNet
             return new ForcePerLength(convertedValue, unit);
         }
 
-        IQuantity<ForcePerLengthUnit> IQuantity<ForcePerLengthUnit>.ToUnit(ForcePerLengthUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ForcePerLengthUnit))
+                throw new ArgumentException("The given unit is not of type ForcePerLengthUnit.", nameof(unit));
+
+            return ToUnit((ForcePerLengthUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ForcePerLengthUnit) unit);
+        IQuantity<ForcePerLengthUnit> IQuantity<ForcePerLengthUnit>.ToUnit(ForcePerLengthUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.NetFramework.g.cs
@@ -663,15 +663,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ForcePerLengthUnit))
-                throw new ArgumentException("The given unit is not of type ForcePerLengthUnit.", nameof(unit));
-
-            return As((ForcePerLengthUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -683,6 +674,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ForcePerLengthUnit unitAsForcePerLengthUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ForcePerLengthUnit)} is supported.", nameof(unit));
+
+            return As(unitAsForcePerLengthUnit);
         }
 
         /// <summary>
@@ -698,10 +698,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ForcePerLengthUnit))
-                throw new ArgumentException("The given unit is not of type ForcePerLengthUnit.", nameof(unit));
+            if(!(unit is ForcePerLengthUnit unitAsForcePerLengthUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ForcePerLengthUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ForcePerLengthUnit)unit);
+            return ToUnit(unitAsForcePerLengthUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
@@ -663,15 +663,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is FrequencyUnit))
-                throw new ArgumentException("The given unit is not of type FrequencyUnit.", nameof(unit));
-
-            return As((FrequencyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -683,6 +674,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is FrequencyUnit unitAsFrequencyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(FrequencyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsFrequencyUnit);
         }
 
         /// <summary>
@@ -698,10 +698,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is FrequencyUnit))
-                throw new ArgumentException("The given unit is not of type FrequencyUnit.", nameof(unit));
+            if(!(unit is FrequencyUnit unitAsFrequencyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(FrequencyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((FrequencyUnit)unit);
+            return ToUnit(unitAsFrequencyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.NetFramework.g.cs
@@ -663,7 +663,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((FrequencyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is FrequencyUnit))
+                throw new ArgumentException("The given unit is not of type FrequencyUnit.", nameof(unit));
+
+            return As((FrequencyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -678,9 +685,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((FrequencyUnit) unit);
-
         /// <summary>
         ///     Converts this Frequency to another Frequency with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -691,10 +695,17 @@ namespace UnitsNet
             return new Frequency(convertedValue, unit);
         }
 
-        IQuantity<FrequencyUnit> IQuantity<FrequencyUnit>.ToUnit(FrequencyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is FrequencyUnit))
+                throw new ArgumentException("The given unit is not of type FrequencyUnit.", nameof(unit));
+
+            return ToUnit((FrequencyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((FrequencyUnit) unit);
+        IQuantity<FrequencyUnit> IQuantity<FrequencyUnit>.ToUnit(FrequencyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
@@ -798,15 +798,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is HeatFluxUnit))
-                throw new ArgumentException("The given unit is not of type HeatFluxUnit.", nameof(unit));
-
-            return As((HeatFluxUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -818,6 +809,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is HeatFluxUnit unitAsHeatFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(HeatFluxUnit)} is supported.", nameof(unit));
+
+            return As(unitAsHeatFluxUnit);
         }
 
         /// <summary>
@@ -833,10 +833,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is HeatFluxUnit))
-                throw new ArgumentException("The given unit is not of type HeatFluxUnit.", nameof(unit));
+            if(!(unit is HeatFluxUnit unitAsHeatFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(HeatFluxUnit)} is supported.", nameof(unit));
 
-            return ToUnit((HeatFluxUnit)unit);
+            return ToUnit(unitAsHeatFluxUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.NetFramework.g.cs
@@ -798,7 +798,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((HeatFluxUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is HeatFluxUnit))
+                throw new ArgumentException("The given unit is not of type HeatFluxUnit.", nameof(unit));
+
+            return As((HeatFluxUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -813,9 +820,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((HeatFluxUnit) unit);
-
         /// <summary>
         ///     Converts this HeatFlux to another HeatFlux with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -826,10 +830,17 @@ namespace UnitsNet
             return new HeatFlux(convertedValue, unit);
         }
 
-        IQuantity<HeatFluxUnit> IQuantity<HeatFluxUnit>.ToUnit(HeatFluxUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is HeatFluxUnit))
+                throw new ArgumentException("The given unit is not of type HeatFluxUnit.", nameof(unit));
+
+            return ToUnit((HeatFluxUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((HeatFluxUnit) unit);
+        IQuantity<HeatFluxUnit> IQuantity<HeatFluxUnit>.ToUnit(HeatFluxUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
@@ -558,7 +558,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((HeatTransferCoefficientUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is HeatTransferCoefficientUnit))
+                throw new ArgumentException("The given unit is not of type HeatTransferCoefficientUnit.", nameof(unit));
+
+            return As((HeatTransferCoefficientUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -573,9 +580,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((HeatTransferCoefficientUnit) unit);
-
         /// <summary>
         ///     Converts this HeatTransferCoefficient to another HeatTransferCoefficient with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -586,10 +590,17 @@ namespace UnitsNet
             return new HeatTransferCoefficient(convertedValue, unit);
         }
 
-        IQuantity<HeatTransferCoefficientUnit> IQuantity<HeatTransferCoefficientUnit>.ToUnit(HeatTransferCoefficientUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is HeatTransferCoefficientUnit))
+                throw new ArgumentException("The given unit is not of type HeatTransferCoefficientUnit.", nameof(unit));
+
+            return ToUnit((HeatTransferCoefficientUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((HeatTransferCoefficientUnit) unit);
+        IQuantity<HeatTransferCoefficientUnit> IQuantity<HeatTransferCoefficientUnit>.ToUnit(HeatTransferCoefficientUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.NetFramework.g.cs
@@ -558,15 +558,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is HeatTransferCoefficientUnit))
-                throw new ArgumentException("The given unit is not of type HeatTransferCoefficientUnit.", nameof(unit));
-
-            return As((HeatTransferCoefficientUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -578,6 +569,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is HeatTransferCoefficientUnit unitAsHeatTransferCoefficientUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(HeatTransferCoefficientUnit)} is supported.", nameof(unit));
+
+            return As(unitAsHeatTransferCoefficientUnit);
         }
 
         /// <summary>
@@ -593,10 +593,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is HeatTransferCoefficientUnit))
-                throw new ArgumentException("The given unit is not of type HeatTransferCoefficientUnit.", nameof(unit));
+            if(!(unit is HeatTransferCoefficientUnit unitAsHeatTransferCoefficientUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(HeatTransferCoefficientUnit)} is supported.", nameof(unit));
 
-            return ToUnit((HeatTransferCoefficientUnit)unit);
+            return ToUnit(unitAsHeatTransferCoefficientUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
@@ -591,15 +591,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is IlluminanceUnit))
-                throw new ArgumentException("The given unit is not of type IlluminanceUnit.", nameof(unit));
-
-            return As((IlluminanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -611,6 +602,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is IlluminanceUnit unitAsIlluminanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(IlluminanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsIlluminanceUnit);
         }
 
         /// <summary>
@@ -626,10 +626,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is IlluminanceUnit))
-                throw new ArgumentException("The given unit is not of type IlluminanceUnit.", nameof(unit));
+            if(!(unit is IlluminanceUnit unitAsIlluminanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(IlluminanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((IlluminanceUnit)unit);
+            return ToUnit(unitAsIlluminanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.NetFramework.g.cs
@@ -591,7 +591,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((IlluminanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is IlluminanceUnit))
+                throw new ArgumentException("The given unit is not of type IlluminanceUnit.", nameof(unit));
+
+            return As((IlluminanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -606,9 +613,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((IlluminanceUnit) unit);
-
         /// <summary>
         ///     Converts this Illuminance to another Illuminance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -619,10 +623,17 @@ namespace UnitsNet
             return new Illuminance(convertedValue, unit);
         }
 
-        IQuantity<IlluminanceUnit> IQuantity<IlluminanceUnit>.ToUnit(IlluminanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is IlluminanceUnit))
+                throw new ArgumentException("The given unit is not of type IlluminanceUnit.", nameof(unit));
+
+            return ToUnit((IlluminanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((IlluminanceUnit) unit);
+        IQuantity<IlluminanceUnit> IQuantity<IlluminanceUnit>.ToUnit(IlluminanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -920,7 +920,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((InformationUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is InformationUnit))
+                throw new ArgumentException("The given unit is not of type InformationUnit.", nameof(unit));
+
+            return As((InformationUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -935,9 +942,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((InformationUnit) unit);
-
         /// <summary>
         ///     Converts this Information to another Information with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -948,10 +952,17 @@ namespace UnitsNet
             return new Information(convertedValue, unit);
         }
 
-        IQuantity<InformationUnit> IQuantity<InformationUnit>.ToUnit(InformationUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is InformationUnit))
+                throw new ArgumentException("The given unit is not of type InformationUnit.", nameof(unit));
+
+            return ToUnit((InformationUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((InformationUnit) unit);
+        IQuantity<InformationUnit> IQuantity<InformationUnit>.ToUnit(InformationUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.NetFramework.g.cs
@@ -920,15 +920,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is InformationUnit))
-                throw new ArgumentException("The given unit is not of type InformationUnit.", nameof(unit));
-
-            return As((InformationUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -940,6 +931,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is InformationUnit unitAsInformationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(InformationUnit)} is supported.", nameof(unit));
+
+            return As(unitAsInformationUnit);
         }
 
         /// <summary>
@@ -955,10 +955,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is InformationUnit))
-                throw new ArgumentException("The given unit is not of type InformationUnit.", nameof(unit));
+            if(!(unit is InformationUnit unitAsInformationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(InformationUnit)} is supported.", nameof(unit));
 
-            return ToUnit((InformationUnit)unit);
+            return ToUnit(unitAsInformationUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
@@ -738,15 +738,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is IrradianceUnit))
-                throw new ArgumentException("The given unit is not of type IrradianceUnit.", nameof(unit));
-
-            return As((IrradianceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -758,6 +749,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is IrradianceUnit unitAsIrradianceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(IrradianceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsIrradianceUnit);
         }
 
         /// <summary>
@@ -773,10 +773,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is IrradianceUnit))
-                throw new ArgumentException("The given unit is not of type IrradianceUnit.", nameof(unit));
+            if(!(unit is IrradianceUnit unitAsIrradianceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(IrradianceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((IrradianceUnit)unit);
+            return ToUnit(unitAsIrradianceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.NetFramework.g.cs
@@ -738,7 +738,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((IrradianceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is IrradianceUnit))
+                throw new ArgumentException("The given unit is not of type IrradianceUnit.", nameof(unit));
+
+            return As((IrradianceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -753,9 +760,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((IrradianceUnit) unit);
-
         /// <summary>
         ///     Converts this Irradiance to another Irradiance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -766,10 +770,17 @@ namespace UnitsNet
             return new Irradiance(convertedValue, unit);
         }
 
-        IQuantity<IrradianceUnit> IQuantity<IrradianceUnit>.ToUnit(IrradianceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is IrradianceUnit))
+                throw new ArgumentException("The given unit is not of type IrradianceUnit.", nameof(unit));
+
+            return ToUnit((IrradianceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((IrradianceUnit) unit);
+        IQuantity<IrradianceUnit> IQuantity<IrradianceUnit>.ToUnit(IrradianceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
@@ -621,15 +621,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is IrradiationUnit))
-                throw new ArgumentException("The given unit is not of type IrradiationUnit.", nameof(unit));
-
-            return As((IrradiationUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -641,6 +632,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is IrradiationUnit unitAsIrradiationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(IrradiationUnit)} is supported.", nameof(unit));
+
+            return As(unitAsIrradiationUnit);
         }
 
         /// <summary>
@@ -656,10 +656,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is IrradiationUnit))
-                throw new ArgumentException("The given unit is not of type IrradiationUnit.", nameof(unit));
+            if(!(unit is IrradiationUnit unitAsIrradiationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(IrradiationUnit)} is supported.", nameof(unit));
 
-            return ToUnit((IrradiationUnit)unit);
+            return ToUnit(unitAsIrradiationUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.NetFramework.g.cs
@@ -621,7 +621,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((IrradiationUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is IrradiationUnit))
+                throw new ArgumentException("The given unit is not of type IrradiationUnit.", nameof(unit));
+
+            return As((IrradiationUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -636,9 +643,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((IrradiationUnit) unit);
-
         /// <summary>
         ///     Converts this Irradiation to another Irradiation with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -649,10 +653,17 @@ namespace UnitsNet
             return new Irradiation(convertedValue, unit);
         }
 
-        IQuantity<IrradiationUnit> IQuantity<IrradiationUnit>.ToUnit(IrradiationUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is IrradiationUnit))
+                throw new ArgumentException("The given unit is not of type IrradiationUnit.", nameof(unit));
+
+            return ToUnit((IrradiationUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((IrradiationUnit) unit);
+        IQuantity<IrradiationUnit> IQuantity<IrradiationUnit>.ToUnit(IrradiationUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
@@ -651,7 +651,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((KinematicViscosityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is KinematicViscosityUnit))
+                throw new ArgumentException("The given unit is not of type KinematicViscosityUnit.", nameof(unit));
+
+            return As((KinematicViscosityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -666,9 +673,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((KinematicViscosityUnit) unit);
-
         /// <summary>
         ///     Converts this KinematicViscosity to another KinematicViscosity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -679,10 +683,17 @@ namespace UnitsNet
             return new KinematicViscosity(convertedValue, unit);
         }
 
-        IQuantity<KinematicViscosityUnit> IQuantity<KinematicViscosityUnit>.ToUnit(KinematicViscosityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is KinematicViscosityUnit))
+                throw new ArgumentException("The given unit is not of type KinematicViscosityUnit.", nameof(unit));
+
+            return ToUnit((KinematicViscosityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((KinematicViscosityUnit) unit);
+        IQuantity<KinematicViscosityUnit> IQuantity<KinematicViscosityUnit>.ToUnit(KinematicViscosityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.NetFramework.g.cs
@@ -651,15 +651,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is KinematicViscosityUnit))
-                throw new ArgumentException("The given unit is not of type KinematicViscosityUnit.", nameof(unit));
-
-            return As((KinematicViscosityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -671,6 +662,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is KinematicViscosityUnit unitAsKinematicViscosityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(KinematicViscosityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsKinematicViscosityUnit);
         }
 
         /// <summary>
@@ -686,10 +686,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is KinematicViscosityUnit))
-                throw new ArgumentException("The given unit is not of type KinematicViscosityUnit.", nameof(unit));
+            if(!(unit is KinematicViscosityUnit unitAsKinematicViscosityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(KinematicViscosityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((KinematicViscosityUnit)unit);
+            return ToUnit(unitAsKinematicViscosityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
@@ -543,7 +543,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((LapseRateUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LapseRateUnit))
+                throw new ArgumentException("The given unit is not of type LapseRateUnit.", nameof(unit));
+
+            return As((LapseRateUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -558,9 +565,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((LapseRateUnit) unit);
-
         /// <summary>
         ///     Converts this LapseRate to another LapseRate with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -571,10 +575,17 @@ namespace UnitsNet
             return new LapseRate(convertedValue, unit);
         }
 
-        IQuantity<LapseRateUnit> IQuantity<LapseRateUnit>.ToUnit(LapseRateUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is LapseRateUnit))
+                throw new ArgumentException("The given unit is not of type LapseRateUnit.", nameof(unit));
+
+            return ToUnit((LapseRateUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((LapseRateUnit) unit);
+        IQuantity<LapseRateUnit> IQuantity<LapseRateUnit>.ToUnit(LapseRateUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.NetFramework.g.cs
@@ -543,15 +543,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is LapseRateUnit))
-                throw new ArgumentException("The given unit is not of type LapseRateUnit.", nameof(unit));
-
-            return As((LapseRateUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -563,6 +554,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LapseRateUnit unitAsLapseRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LapseRateUnit)} is supported.", nameof(unit));
+
+            return As(unitAsLapseRateUnit);
         }
 
         /// <summary>
@@ -578,10 +578,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is LapseRateUnit))
-                throw new ArgumentException("The given unit is not of type LapseRateUnit.", nameof(unit));
+            if(!(unit is LapseRateUnit unitAsLapseRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LapseRateUnit)} is supported.", nameof(unit));
 
-            return ToUnit((LapseRateUnit)unit);
+            return ToUnit(unitAsLapseRateUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -858,7 +858,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((LengthUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LengthUnit))
+                throw new ArgumentException("The given unit is not of type LengthUnit.", nameof(unit));
+
+            return As((LengthUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -873,9 +880,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((LengthUnit) unit);
-
         /// <summary>
         ///     Converts this Length to another Length with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -886,10 +890,17 @@ namespace UnitsNet
             return new Length(convertedValue, unit);
         }
 
-        IQuantity<LengthUnit> IQuantity<LengthUnit>.ToUnit(LengthUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is LengthUnit))
+                throw new ArgumentException("The given unit is not of type LengthUnit.", nameof(unit));
+
+            return ToUnit((LengthUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((LengthUnit) unit);
+        IQuantity<LengthUnit> IQuantity<LengthUnit>.ToUnit(LengthUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.NetFramework.g.cs
@@ -858,15 +858,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is LengthUnit))
-                throw new ArgumentException("The given unit is not of type LengthUnit.", nameof(unit));
-
-            return As((LengthUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -878,6 +869,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LengthUnit unitAsLengthUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LengthUnit)} is supported.", nameof(unit));
+
+            return As(unitAsLengthUnit);
         }
 
         /// <summary>
@@ -893,10 +893,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is LengthUnit))
-                throw new ArgumentException("The given unit is not of type LengthUnit.", nameof(unit));
+            if(!(unit is LengthUnit unitAsLengthUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LengthUnit)} is supported.", nameof(unit));
 
-            return ToUnit((LengthUnit)unit);
+            return ToUnit(unitAsLengthUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -566,15 +566,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is LevelUnit))
-                throw new ArgumentException("The given unit is not of type LevelUnit.", nameof(unit));
-
-            return As((LevelUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -586,6 +577,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LevelUnit unitAsLevelUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LevelUnit)} is supported.", nameof(unit));
+
+            return As(unitAsLevelUnit);
         }
 
         /// <summary>
@@ -601,10 +601,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is LevelUnit))
-                throw new ArgumentException("The given unit is not of type LevelUnit.", nameof(unit));
+            if(!(unit is LevelUnit unitAsLevelUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LevelUnit)} is supported.", nameof(unit));
 
-            return ToUnit((LevelUnit)unit);
+            return ToUnit(unitAsLevelUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.NetFramework.g.cs
@@ -566,7 +566,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((LevelUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LevelUnit))
+                throw new ArgumentException("The given unit is not of type LevelUnit.", nameof(unit));
+
+            return As((LevelUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -581,9 +588,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((LevelUnit) unit);
-
         /// <summary>
         ///     Converts this Level to another Level with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -594,10 +598,17 @@ namespace UnitsNet
             return new Level(convertedValue, unit);
         }
 
-        IQuantity<LevelUnit> IQuantity<LevelUnit>.ToUnit(LevelUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is LevelUnit))
+                throw new ArgumentException("The given unit is not of type LevelUnit.", nameof(unit));
+
+            return ToUnit((LevelUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((LevelUnit) unit);
+        IQuantity<LevelUnit> IQuantity<LevelUnit>.ToUnit(LevelUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
@@ -576,7 +576,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((LinearDensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LinearDensityUnit))
+                throw new ArgumentException("The given unit is not of type LinearDensityUnit.", nameof(unit));
+
+            return As((LinearDensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -591,9 +598,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((LinearDensityUnit) unit);
-
         /// <summary>
         ///     Converts this LinearDensity to another LinearDensity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -604,10 +608,17 @@ namespace UnitsNet
             return new LinearDensity(convertedValue, unit);
         }
 
-        IQuantity<LinearDensityUnit> IQuantity<LinearDensityUnit>.ToUnit(LinearDensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is LinearDensityUnit))
+                throw new ArgumentException("The given unit is not of type LinearDensityUnit.", nameof(unit));
+
+            return ToUnit((LinearDensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((LinearDensityUnit) unit);
+        IQuantity<LinearDensityUnit> IQuantity<LinearDensityUnit>.ToUnit(LinearDensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.NetFramework.g.cs
@@ -576,15 +576,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is LinearDensityUnit))
-                throw new ArgumentException("The given unit is not of type LinearDensityUnit.", nameof(unit));
-
-            return As((LinearDensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -596,6 +587,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LinearDensityUnit unitAsLinearDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LinearDensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsLinearDensityUnit);
         }
 
         /// <summary>
@@ -611,10 +611,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is LinearDensityUnit))
-                throw new ArgumentException("The given unit is not of type LinearDensityUnit.", nameof(unit));
+            if(!(unit is LinearDensityUnit unitAsLinearDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LinearDensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((LinearDensityUnit)unit);
+            return ToUnit(unitAsLinearDensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is LuminousFluxUnit))
-                throw new ArgumentException("The given unit is not of type LuminousFluxUnit.", nameof(unit));
-
-            return As((LuminousFluxUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LuminousFluxUnit unitAsLuminousFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LuminousFluxUnit)} is supported.", nameof(unit));
+
+            return As(unitAsLuminousFluxUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is LuminousFluxUnit))
-                throw new ArgumentException("The given unit is not of type LuminousFluxUnit.", nameof(unit));
+            if(!(unit is LuminousFluxUnit unitAsLuminousFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LuminousFluxUnit)} is supported.", nameof(unit));
 
-            return ToUnit((LuminousFluxUnit)unit);
+            return ToUnit(unitAsLuminousFluxUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((LuminousFluxUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LuminousFluxUnit))
+                throw new ArgumentException("The given unit is not of type LuminousFluxUnit.", nameof(unit));
+
+            return As((LuminousFluxUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((LuminousFluxUnit) unit);
-
         /// <summary>
         ///     Converts this LuminousFlux to another LuminousFlux with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new LuminousFlux(convertedValue, unit);
         }
 
-        IQuantity<LuminousFluxUnit> IQuantity<LuminousFluxUnit>.ToUnit(LuminousFluxUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is LuminousFluxUnit))
+                throw new ArgumentException("The given unit is not of type LuminousFluxUnit.", nameof(unit));
+
+            return ToUnit((LuminousFluxUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((LuminousFluxUnit) unit);
+        IQuantity<LuminousFluxUnit> IQuantity<LuminousFluxUnit>.ToUnit(LuminousFluxUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is LuminousIntensityUnit))
-                throw new ArgumentException("The given unit is not of type LuminousIntensityUnit.", nameof(unit));
-
-            return As((LuminousIntensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LuminousIntensityUnit unitAsLuminousIntensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LuminousIntensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsLuminousIntensityUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is LuminousIntensityUnit))
-                throw new ArgumentException("The given unit is not of type LuminousIntensityUnit.", nameof(unit));
+            if(!(unit is LuminousIntensityUnit unitAsLuminousIntensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(LuminousIntensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((LuminousIntensityUnit)unit);
+            return ToUnit(unitAsLuminousIntensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((LuminousIntensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is LuminousIntensityUnit))
+                throw new ArgumentException("The given unit is not of type LuminousIntensityUnit.", nameof(unit));
+
+            return As((LuminousIntensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((LuminousIntensityUnit) unit);
-
         /// <summary>
         ///     Converts this LuminousIntensity to another LuminousIntensity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new LuminousIntensity(convertedValue, unit);
         }
 
-        IQuantity<LuminousIntensityUnit> IQuantity<LuminousIntensityUnit>.ToUnit(LuminousIntensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is LuminousIntensityUnit))
+                throw new ArgumentException("The given unit is not of type LuminousIntensityUnit.", nameof(unit));
+
+            return ToUnit((LuminousIntensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((LuminousIntensityUnit) unit);
+        IQuantity<LuminousIntensityUnit> IQuantity<LuminousIntensityUnit>.ToUnit(LuminousIntensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
@@ -591,7 +591,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MagneticFieldUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MagneticFieldUnit))
+                throw new ArgumentException("The given unit is not of type MagneticFieldUnit.", nameof(unit));
+
+            return As((MagneticFieldUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -606,9 +613,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MagneticFieldUnit) unit);
-
         /// <summary>
         ///     Converts this MagneticField to another MagneticField with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -619,10 +623,17 @@ namespace UnitsNet
             return new MagneticField(convertedValue, unit);
         }
 
-        IQuantity<MagneticFieldUnit> IQuantity<MagneticFieldUnit>.ToUnit(MagneticFieldUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MagneticFieldUnit))
+                throw new ArgumentException("The given unit is not of type MagneticFieldUnit.", nameof(unit));
+
+            return ToUnit((MagneticFieldUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MagneticFieldUnit) unit);
+        IQuantity<MagneticFieldUnit> IQuantity<MagneticFieldUnit>.ToUnit(MagneticFieldUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.NetFramework.g.cs
@@ -591,15 +591,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MagneticFieldUnit))
-                throw new ArgumentException("The given unit is not of type MagneticFieldUnit.", nameof(unit));
-
-            return As((MagneticFieldUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -611,6 +602,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MagneticFieldUnit unitAsMagneticFieldUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MagneticFieldUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMagneticFieldUnit);
         }
 
         /// <summary>
@@ -626,10 +626,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MagneticFieldUnit))
-                throw new ArgumentException("The given unit is not of type MagneticFieldUnit.", nameof(unit));
+            if(!(unit is MagneticFieldUnit unitAsMagneticFieldUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MagneticFieldUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MagneticFieldUnit)unit);
+            return ToUnit(unitAsMagneticFieldUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MagneticFluxUnit))
-                throw new ArgumentException("The given unit is not of type MagneticFluxUnit.", nameof(unit));
-
-            return As((MagneticFluxUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MagneticFluxUnit unitAsMagneticFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MagneticFluxUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMagneticFluxUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MagneticFluxUnit))
-                throw new ArgumentException("The given unit is not of type MagneticFluxUnit.", nameof(unit));
+            if(!(unit is MagneticFluxUnit unitAsMagneticFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MagneticFluxUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MagneticFluxUnit)unit);
+            return ToUnit(unitAsMagneticFluxUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MagneticFluxUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MagneticFluxUnit))
+                throw new ArgumentException("The given unit is not of type MagneticFluxUnit.", nameof(unit));
+
+            return As((MagneticFluxUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MagneticFluxUnit) unit);
-
         /// <summary>
         ///     Converts this MagneticFlux to another MagneticFlux with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new MagneticFlux(convertedValue, unit);
         }
 
-        IQuantity<MagneticFluxUnit> IQuantity<MagneticFluxUnit>.ToUnit(MagneticFluxUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MagneticFluxUnit))
+                throw new ArgumentException("The given unit is not of type MagneticFluxUnit.", nameof(unit));
+
+            return ToUnit((MagneticFluxUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MagneticFluxUnit) unit);
+        IQuantity<MagneticFluxUnit> IQuantity<MagneticFluxUnit>.ToUnit(MagneticFluxUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MagnetizationUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MagnetizationUnit))
+                throw new ArgumentException("The given unit is not of type MagnetizationUnit.", nameof(unit));
+
+            return As((MagnetizationUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MagnetizationUnit) unit);
-
         /// <summary>
         ///     Converts this Magnetization to another Magnetization with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new Magnetization(convertedValue, unit);
         }
 
-        IQuantity<MagnetizationUnit> IQuantity<MagnetizationUnit>.ToUnit(MagnetizationUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MagnetizationUnit))
+                throw new ArgumentException("The given unit is not of type MagnetizationUnit.", nameof(unit));
+
+            return ToUnit((MagnetizationUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MagnetizationUnit) unit);
+        IQuantity<MagnetizationUnit> IQuantity<MagnetizationUnit>.ToUnit(MagnetizationUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MagnetizationUnit))
-                throw new ArgumentException("The given unit is not of type MagnetizationUnit.", nameof(unit));
-
-            return As((MagnetizationUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MagnetizationUnit unitAsMagnetizationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MagnetizationUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMagnetizationUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MagnetizationUnit))
-                throw new ArgumentException("The given unit is not of type MagnetizationUnit.", nameof(unit));
+            if(!(unit is MagnetizationUnit unitAsMagnetizationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MagnetizationUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MagnetizationUnit)unit);
+            return ToUnit(unitAsMagnetizationUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
@@ -873,7 +873,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MassUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassUnit))
+                throw new ArgumentException("The given unit is not of type MassUnit.", nameof(unit));
+
+            return As((MassUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -888,9 +895,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MassUnit) unit);
-
         /// <summary>
         ///     Converts this Mass to another Mass with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -901,10 +905,17 @@ namespace UnitsNet
             return new Mass(convertedValue, unit);
         }
 
-        IQuantity<MassUnit> IQuantity<MassUnit>.ToUnit(MassUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MassUnit))
+                throw new ArgumentException("The given unit is not of type MassUnit.", nameof(unit));
+
+            return ToUnit((MassUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MassUnit) unit);
+        IQuantity<MassUnit> IQuantity<MassUnit>.ToUnit(MassUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.NetFramework.g.cs
@@ -873,15 +873,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MassUnit))
-                throw new ArgumentException("The given unit is not of type MassUnit.", nameof(unit));
-
-            return As((MassUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -893,6 +884,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassUnit unitAsMassUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMassUnit);
         }
 
         /// <summary>
@@ -908,10 +908,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MassUnit))
-                throw new ArgumentException("The given unit is not of type MassUnit.", nameof(unit));
+            if(!(unit is MassUnit unitAsMassUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MassUnit)unit);
+            return ToUnit(unitAsMassUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
@@ -993,15 +993,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MassFlowUnit))
-                throw new ArgumentException("The given unit is not of type MassFlowUnit.", nameof(unit));
-
-            return As((MassFlowUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1013,6 +1004,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassFlowUnit unitAsMassFlowUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassFlowUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMassFlowUnit);
         }
 
         /// <summary>
@@ -1028,10 +1028,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MassFlowUnit))
-                throw new ArgumentException("The given unit is not of type MassFlowUnit.", nameof(unit));
+            if(!(unit is MassFlowUnit unitAsMassFlowUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassFlowUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MassFlowUnit)unit);
+            return ToUnit(unitAsMassFlowUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.NetFramework.g.cs
@@ -993,7 +993,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MassFlowUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassFlowUnit))
+                throw new ArgumentException("The given unit is not of type MassFlowUnit.", nameof(unit));
+
+            return As((MassFlowUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1008,9 +1015,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MassFlowUnit) unit);
-
         /// <summary>
         ///     Converts this MassFlow to another MassFlow with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1021,10 +1025,17 @@ namespace UnitsNet
             return new MassFlow(convertedValue, unit);
         }
 
-        IQuantity<MassFlowUnit> IQuantity<MassFlowUnit>.ToUnit(MassFlowUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MassFlowUnit))
+                throw new ArgumentException("The given unit is not of type MassFlowUnit.", nameof(unit));
+
+            return ToUnit((MassFlowUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MassFlowUnit) unit);
+        IQuantity<MassFlowUnit> IQuantity<MassFlowUnit>.ToUnit(MassFlowUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
@@ -558,15 +558,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MassFluxUnit))
-                throw new ArgumentException("The given unit is not of type MassFluxUnit.", nameof(unit));
-
-            return As((MassFluxUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -578,6 +569,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassFluxUnit unitAsMassFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassFluxUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMassFluxUnit);
         }
 
         /// <summary>
@@ -593,10 +593,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MassFluxUnit))
-                throw new ArgumentException("The given unit is not of type MassFluxUnit.", nameof(unit));
+            if(!(unit is MassFluxUnit unitAsMassFluxUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassFluxUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MassFluxUnit)unit);
+            return ToUnit(unitAsMassFluxUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.NetFramework.g.cs
@@ -558,7 +558,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MassFluxUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassFluxUnit))
+                throw new ArgumentException("The given unit is not of type MassFluxUnit.", nameof(unit));
+
+            return As((MassFluxUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -573,9 +580,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MassFluxUnit) unit);
-
         /// <summary>
         ///     Converts this MassFlux to another MassFlux with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -586,10 +590,17 @@ namespace UnitsNet
             return new MassFlux(convertedValue, unit);
         }
 
-        IQuantity<MassFluxUnit> IQuantity<MassFluxUnit>.ToUnit(MassFluxUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MassFluxUnit))
+                throw new ArgumentException("The given unit is not of type MassFluxUnit.", nameof(unit));
+
+            return ToUnit((MassFluxUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MassFluxUnit) unit);
+        IQuantity<MassFluxUnit> IQuantity<MassFluxUnit>.ToUnit(MassFluxUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
@@ -948,7 +948,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MassMomentOfInertiaUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassMomentOfInertiaUnit))
+                throw new ArgumentException("The given unit is not of type MassMomentOfInertiaUnit.", nameof(unit));
+
+            return As((MassMomentOfInertiaUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -963,9 +970,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MassMomentOfInertiaUnit) unit);
-
         /// <summary>
         ///     Converts this MassMomentOfInertia to another MassMomentOfInertia with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -976,10 +980,17 @@ namespace UnitsNet
             return new MassMomentOfInertia(convertedValue, unit);
         }
 
-        IQuantity<MassMomentOfInertiaUnit> IQuantity<MassMomentOfInertiaUnit>.ToUnit(MassMomentOfInertiaUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MassMomentOfInertiaUnit))
+                throw new ArgumentException("The given unit is not of type MassMomentOfInertiaUnit.", nameof(unit));
+
+            return ToUnit((MassMomentOfInertiaUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MassMomentOfInertiaUnit) unit);
+        IQuantity<MassMomentOfInertiaUnit> IQuantity<MassMomentOfInertiaUnit>.ToUnit(MassMomentOfInertiaUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.NetFramework.g.cs
@@ -948,15 +948,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MassMomentOfInertiaUnit))
-                throw new ArgumentException("The given unit is not of type MassMomentOfInertiaUnit.", nameof(unit));
-
-            return As((MassMomentOfInertiaUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -968,6 +959,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MassMomentOfInertiaUnit unitAsMassMomentOfInertiaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassMomentOfInertiaUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMassMomentOfInertiaUnit);
         }
 
         /// <summary>
@@ -983,10 +983,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MassMomentOfInertiaUnit))
-                throw new ArgumentException("The given unit is not of type MassMomentOfInertiaUnit.", nameof(unit));
+            if(!(unit is MassMomentOfInertiaUnit unitAsMassMomentOfInertiaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MassMomentOfInertiaUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MassMomentOfInertiaUnit)unit);
+            return ToUnit(unitAsMassMomentOfInertiaUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MolarEnergyUnit))
-                throw new ArgumentException("The given unit is not of type MolarEnergyUnit.", nameof(unit));
-
-            return As((MolarEnergyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarEnergyUnit unitAsMolarEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarEnergyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMolarEnergyUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MolarEnergyUnit))
-                throw new ArgumentException("The given unit is not of type MolarEnergyUnit.", nameof(unit));
+            if(!(unit is MolarEnergyUnit unitAsMolarEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarEnergyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MolarEnergyUnit)unit);
+            return ToUnit(unitAsMolarEnergyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MolarEnergyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarEnergyUnit))
+                throw new ArgumentException("The given unit is not of type MolarEnergyUnit.", nameof(unit));
+
+            return As((MolarEnergyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MolarEnergyUnit) unit);
-
         /// <summary>
         ///     Converts this MolarEnergy to another MolarEnergy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new MolarEnergy(convertedValue, unit);
         }
 
-        IQuantity<MolarEnergyUnit> IQuantity<MolarEnergyUnit>.ToUnit(MolarEnergyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MolarEnergyUnit))
+                throw new ArgumentException("The given unit is not of type MolarEnergyUnit.", nameof(unit));
+
+            return ToUnit((MolarEnergyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MolarEnergyUnit) unit);
+        IQuantity<MolarEnergyUnit> IQuantity<MolarEnergyUnit>.ToUnit(MolarEnergyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MolarEntropyUnit))
-                throw new ArgumentException("The given unit is not of type MolarEntropyUnit.", nameof(unit));
-
-            return As((MolarEntropyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarEntropyUnit unitAsMolarEntropyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarEntropyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMolarEntropyUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MolarEntropyUnit))
-                throw new ArgumentException("The given unit is not of type MolarEntropyUnit.", nameof(unit));
+            if(!(unit is MolarEntropyUnit unitAsMolarEntropyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarEntropyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MolarEntropyUnit)unit);
+            return ToUnit(unitAsMolarEntropyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MolarEntropyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarEntropyUnit))
+                throw new ArgumentException("The given unit is not of type MolarEntropyUnit.", nameof(unit));
+
+            return As((MolarEntropyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MolarEntropyUnit) unit);
-
         /// <summary>
         ///     Converts this MolarEntropy to another MolarEntropy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new MolarEntropy(convertedValue, unit);
         }
 
-        IQuantity<MolarEntropyUnit> IQuantity<MolarEntropyUnit>.ToUnit(MolarEntropyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MolarEntropyUnit))
+                throw new ArgumentException("The given unit is not of type MolarEntropyUnit.", nameof(unit));
+
+            return ToUnit((MolarEntropyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MolarEntropyUnit) unit);
+        IQuantity<MolarEntropyUnit> IQuantity<MolarEntropyUnit>.ToUnit(MolarEntropyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
@@ -708,15 +708,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MolarMassUnit))
-                throw new ArgumentException("The given unit is not of type MolarMassUnit.", nameof(unit));
-
-            return As((MolarMassUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -728,6 +719,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarMassUnit unitAsMolarMassUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarMassUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMolarMassUnit);
         }
 
         /// <summary>
@@ -743,10 +743,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MolarMassUnit))
-                throw new ArgumentException("The given unit is not of type MolarMassUnit.", nameof(unit));
+            if(!(unit is MolarMassUnit unitAsMolarMassUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarMassUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MolarMassUnit)unit);
+            return ToUnit(unitAsMolarMassUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.NetFramework.g.cs
@@ -708,7 +708,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MolarMassUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarMassUnit))
+                throw new ArgumentException("The given unit is not of type MolarMassUnit.", nameof(unit));
+
+            return As((MolarMassUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -723,9 +730,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MolarMassUnit) unit);
-
         /// <summary>
         ///     Converts this MolarMass to another MolarMass with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -736,10 +740,17 @@ namespace UnitsNet
             return new MolarMass(convertedValue, unit);
         }
 
-        IQuantity<MolarMassUnit> IQuantity<MolarMassUnit>.ToUnit(MolarMassUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MolarMassUnit))
+                throw new ArgumentException("The given unit is not of type MolarMassUnit.", nameof(unit));
+
+            return ToUnit((MolarMassUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MolarMassUnit) unit);
+        IQuantity<MolarMassUnit> IQuantity<MolarMassUnit>.ToUnit(MolarMassUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
@@ -651,15 +651,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is MolarityUnit))
-                throw new ArgumentException("The given unit is not of type MolarityUnit.", nameof(unit));
-
-            return As((MolarityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -671,6 +662,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarityUnit unitAsMolarityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsMolarityUnit);
         }
 
         /// <summary>
@@ -686,10 +686,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is MolarityUnit))
-                throw new ArgumentException("The given unit is not of type MolarityUnit.", nameof(unit));
+            if(!(unit is MolarityUnit unitAsMolarityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(MolarityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((MolarityUnit)unit);
+            return ToUnit(unitAsMolarityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.NetFramework.g.cs
@@ -651,7 +651,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((MolarityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is MolarityUnit))
+                throw new ArgumentException("The given unit is not of type MolarityUnit.", nameof(unit));
+
+            return As((MolarityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -666,9 +673,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((MolarityUnit) unit);
-
         /// <summary>
         ///     Converts this Molarity to another Molarity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -679,10 +683,17 @@ namespace UnitsNet
             return new Molarity(convertedValue, unit);
         }
 
-        IQuantity<MolarityUnit> IQuantity<MolarityUnit>.ToUnit(MolarityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is MolarityUnit))
+                throw new ArgumentException("The given unit is not of type MolarityUnit.", nameof(unit));
+
+            return ToUnit((MolarityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((MolarityUnit) unit);
+        IQuantity<MolarityUnit> IQuantity<MolarityUnit>.ToUnit(MolarityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PermeabilityUnit))
-                throw new ArgumentException("The given unit is not of type PermeabilityUnit.", nameof(unit));
-
-            return As((PermeabilityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PermeabilityUnit unitAsPermeabilityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PermeabilityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPermeabilityUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PermeabilityUnit))
-                throw new ArgumentException("The given unit is not of type PermeabilityUnit.", nameof(unit));
+            if(!(unit is PermeabilityUnit unitAsPermeabilityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PermeabilityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PermeabilityUnit)unit);
+            return ToUnit(unitAsPermeabilityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PermeabilityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PermeabilityUnit))
+                throw new ArgumentException("The given unit is not of type PermeabilityUnit.", nameof(unit));
+
+            return As((PermeabilityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PermeabilityUnit) unit);
-
         /// <summary>
         ///     Converts this Permeability to another Permeability with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new Permeability(convertedValue, unit);
         }
 
-        IQuantity<PermeabilityUnit> IQuantity<PermeabilityUnit>.ToUnit(PermeabilityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PermeabilityUnit))
+                throw new ArgumentException("The given unit is not of type PermeabilityUnit.", nameof(unit));
+
+            return ToUnit((PermeabilityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PermeabilityUnit) unit);
+        IQuantity<PermeabilityUnit> IQuantity<PermeabilityUnit>.ToUnit(PermeabilityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PermittivityUnit))
-                throw new ArgumentException("The given unit is not of type PermittivityUnit.", nameof(unit));
-
-            return As((PermittivityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PermittivityUnit unitAsPermittivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PermittivityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPermittivityUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PermittivityUnit))
-                throw new ArgumentException("The given unit is not of type PermittivityUnit.", nameof(unit));
+            if(!(unit is PermittivityUnit unitAsPermittivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PermittivityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PermittivityUnit)unit);
+            return ToUnit(unitAsPermittivityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PermittivityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PermittivityUnit))
+                throw new ArgumentException("The given unit is not of type PermittivityUnit.", nameof(unit));
+
+            return As((PermittivityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PermittivityUnit) unit);
-
         /// <summary>
         ///     Converts this Permittivity to another Permittivity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new Permittivity(convertedValue, unit);
         }
 
-        IQuantity<PermittivityUnit> IQuantity<PermittivityUnit>.ToUnit(PermittivityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PermittivityUnit))
+                throw new ArgumentException("The given unit is not of type PermittivityUnit.", nameof(unit));
+
+            return ToUnit((PermittivityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PermittivityUnit) unit);
+        IQuantity<PermittivityUnit> IQuantity<PermittivityUnit>.ToUnit(PermittivityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
@@ -830,15 +830,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PowerUnit))
-                throw new ArgumentException("The given unit is not of type PowerUnit.", nameof(unit));
-
-            return As((PowerUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -850,6 +841,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PowerUnit unitAsPowerUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PowerUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPowerUnit);
         }
 
         /// <summary>
@@ -865,10 +865,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PowerUnit))
-                throw new ArgumentException("The given unit is not of type PowerUnit.", nameof(unit));
+            if(!(unit is PowerUnit unitAsPowerUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PowerUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PowerUnit)unit);
+            return ToUnit(unitAsPowerUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.NetFramework.g.cs
@@ -830,7 +830,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PowerUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PowerUnit))
+                throw new ArgumentException("The given unit is not of type PowerUnit.", nameof(unit));
+
+            return As((PowerUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -845,9 +852,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PowerUnit) unit);
-
         /// <summary>
         ///     Converts this Power to another Power with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -858,10 +862,17 @@ namespace UnitsNet
             return new Power(convertedValue, unit);
         }
 
-        IQuantity<PowerUnit> IQuantity<PowerUnit>.ToUnit(PowerUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PowerUnit))
+                throw new ArgumentException("The given unit is not of type PowerUnit.", nameof(unit));
+
+            return ToUnit((PowerUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PowerUnit) unit);
+        IQuantity<PowerUnit> IQuantity<PowerUnit>.ToUnit(PowerUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
@@ -1188,7 +1188,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PowerDensityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PowerDensityUnit))
+                throw new ArgumentException("The given unit is not of type PowerDensityUnit.", nameof(unit));
+
+            return As((PowerDensityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1203,9 +1210,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PowerDensityUnit) unit);
-
         /// <summary>
         ///     Converts this PowerDensity to another PowerDensity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1216,10 +1220,17 @@ namespace UnitsNet
             return new PowerDensity(convertedValue, unit);
         }
 
-        IQuantity<PowerDensityUnit> IQuantity<PowerDensityUnit>.ToUnit(PowerDensityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PowerDensityUnit))
+                throw new ArgumentException("The given unit is not of type PowerDensityUnit.", nameof(unit));
+
+            return ToUnit((PowerDensityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PowerDensityUnit) unit);
+        IQuantity<PowerDensityUnit> IQuantity<PowerDensityUnit>.ToUnit(PowerDensityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.NetFramework.g.cs
@@ -1188,15 +1188,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PowerDensityUnit))
-                throw new ArgumentException("The given unit is not of type PowerDensityUnit.", nameof(unit));
-
-            return As((PowerDensityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1208,6 +1199,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PowerDensityUnit unitAsPowerDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PowerDensityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPowerDensityUnit);
         }
 
         /// <summary>
@@ -1223,10 +1223,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PowerDensityUnit))
-                throw new ArgumentException("The given unit is not of type PowerDensityUnit.", nameof(unit));
+            if(!(unit is PowerDensityUnit unitAsPowerDensityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PowerDensityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PowerDensityUnit)unit);
+            return ToUnit(unitAsPowerDensityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
@@ -566,15 +566,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PowerRatioUnit))
-                throw new ArgumentException("The given unit is not of type PowerRatioUnit.", nameof(unit));
-
-            return As((PowerRatioUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -586,6 +577,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PowerRatioUnit unitAsPowerRatioUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PowerRatioUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPowerRatioUnit);
         }
 
         /// <summary>
@@ -601,10 +601,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PowerRatioUnit))
-                throw new ArgumentException("The given unit is not of type PowerRatioUnit.", nameof(unit));
+            if(!(unit is PowerRatioUnit unitAsPowerRatioUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PowerRatioUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PowerRatioUnit)unit);
+            return ToUnit(unitAsPowerRatioUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.NetFramework.g.cs
@@ -566,7 +566,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PowerRatioUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PowerRatioUnit))
+                throw new ArgumentException("The given unit is not of type PowerRatioUnit.", nameof(unit));
+
+            return As((PowerRatioUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -581,9 +588,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PowerRatioUnit) unit);
-
         /// <summary>
         ///     Converts this PowerRatio to another PowerRatio with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -594,10 +598,17 @@ namespace UnitsNet
             return new PowerRatio(convertedValue, unit);
         }
 
-        IQuantity<PowerRatioUnit> IQuantity<PowerRatioUnit>.ToUnit(PowerRatioUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PowerRatioUnit))
+                throw new ArgumentException("The given unit is not of type PowerRatioUnit.", nameof(unit));
+
+            return ToUnit((PowerRatioUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PowerRatioUnit) unit);
+        IQuantity<PowerRatioUnit> IQuantity<PowerRatioUnit>.ToUnit(PowerRatioUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
@@ -1158,15 +1158,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PressureUnit))
-                throw new ArgumentException("The given unit is not of type PressureUnit.", nameof(unit));
-
-            return As((PressureUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1178,6 +1169,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PressureUnit unitAsPressureUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PressureUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPressureUnit);
         }
 
         /// <summary>
@@ -1193,10 +1193,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PressureUnit))
-                throw new ArgumentException("The given unit is not of type PressureUnit.", nameof(unit));
+            if(!(unit is PressureUnit unitAsPressureUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PressureUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PressureUnit)unit);
+            return ToUnit(unitAsPressureUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.NetFramework.g.cs
@@ -1158,7 +1158,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PressureUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PressureUnit))
+                throw new ArgumentException("The given unit is not of type PressureUnit.", nameof(unit));
+
+            return As((PressureUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1173,9 +1180,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PressureUnit) unit);
-
         /// <summary>
         ///     Converts this Pressure to another Pressure with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1186,10 +1190,17 @@ namespace UnitsNet
             return new Pressure(convertedValue, unit);
         }
 
-        IQuantity<PressureUnit> IQuantity<PressureUnit>.ToUnit(PressureUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PressureUnit))
+                throw new ArgumentException("The given unit is not of type PressureUnit.", nameof(unit));
+
+            return ToUnit((PressureUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PressureUnit) unit);
+        IQuantity<PressureUnit> IQuantity<PressureUnit>.ToUnit(PressureUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
@@ -633,7 +633,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((PressureChangeRateUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PressureChangeRateUnit))
+                throw new ArgumentException("The given unit is not of type PressureChangeRateUnit.", nameof(unit));
+
+            return As((PressureChangeRateUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -648,9 +655,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((PressureChangeRateUnit) unit);
-
         /// <summary>
         ///     Converts this PressureChangeRate to another PressureChangeRate with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -661,10 +665,17 @@ namespace UnitsNet
             return new PressureChangeRate(convertedValue, unit);
         }
 
-        IQuantity<PressureChangeRateUnit> IQuantity<PressureChangeRateUnit>.ToUnit(PressureChangeRateUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is PressureChangeRateUnit))
+                throw new ArgumentException("The given unit is not of type PressureChangeRateUnit.", nameof(unit));
+
+            return ToUnit((PressureChangeRateUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((PressureChangeRateUnit) unit);
+        IQuantity<PressureChangeRateUnit> IQuantity<PressureChangeRateUnit>.ToUnit(PressureChangeRateUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.NetFramework.g.cs
@@ -633,15 +633,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is PressureChangeRateUnit))
-                throw new ArgumentException("The given unit is not of type PressureChangeRateUnit.", nameof(unit));
-
-            return As((PressureChangeRateUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -653,6 +644,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is PressureChangeRateUnit unitAsPressureChangeRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PressureChangeRateUnit)} is supported.", nameof(unit));
+
+            return As(unitAsPressureChangeRateUnit);
         }
 
         /// <summary>
@@ -668,10 +668,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is PressureChangeRateUnit))
-                throw new ArgumentException("The given unit is not of type PressureChangeRateUnit.", nameof(unit));
+            if(!(unit is PressureChangeRateUnit unitAsPressureChangeRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(PressureChangeRateUnit)} is supported.", nameof(unit));
 
-            return ToUnit((PressureChangeRateUnit)unit);
+            return ToUnit(unitAsPressureChangeRateUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
@@ -618,7 +618,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((RatioUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RatioUnit))
+                throw new ArgumentException("The given unit is not of type RatioUnit.", nameof(unit));
+
+            return As((RatioUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -633,9 +640,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((RatioUnit) unit);
-
         /// <summary>
         ///     Converts this Ratio to another Ratio with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -646,10 +650,17 @@ namespace UnitsNet
             return new Ratio(convertedValue, unit);
         }
 
-        IQuantity<RatioUnit> IQuantity<RatioUnit>.ToUnit(RatioUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is RatioUnit))
+                throw new ArgumentException("The given unit is not of type RatioUnit.", nameof(unit));
+
+            return ToUnit((RatioUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((RatioUnit) unit);
+        IQuantity<RatioUnit> IQuantity<RatioUnit>.ToUnit(RatioUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.NetFramework.g.cs
@@ -618,15 +618,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is RatioUnit))
-                throw new ArgumentException("The given unit is not of type RatioUnit.", nameof(unit));
-
-            return As((RatioUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -638,6 +629,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RatioUnit unitAsRatioUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RatioUnit)} is supported.", nameof(unit));
+
+            return As(unitAsRatioUnit);
         }
 
         /// <summary>
@@ -653,10 +653,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is RatioUnit))
-                throw new ArgumentException("The given unit is not of type RatioUnit.", nameof(unit));
+            if(!(unit is RatioUnit unitAsRatioUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RatioUnit)} is supported.", nameof(unit));
 
-            return ToUnit((RatioUnit)unit);
+            return ToUnit(unitAsRatioUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ReactiveEnergyUnit))
-                throw new ArgumentException("The given unit is not of type ReactiveEnergyUnit.", nameof(unit));
-
-            return As((ReactiveEnergyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ReactiveEnergyUnit unitAsReactiveEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ReactiveEnergyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsReactiveEnergyUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ReactiveEnergyUnit))
-                throw new ArgumentException("The given unit is not of type ReactiveEnergyUnit.", nameof(unit));
+            if(!(unit is ReactiveEnergyUnit unitAsReactiveEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ReactiveEnergyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ReactiveEnergyUnit)unit);
+            return ToUnit(unitAsReactiveEnergyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ReactiveEnergyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ReactiveEnergyUnit))
+                throw new ArgumentException("The given unit is not of type ReactiveEnergyUnit.", nameof(unit));
+
+            return As((ReactiveEnergyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ReactiveEnergyUnit) unit);
-
         /// <summary>
         ///     Converts this ReactiveEnergy to another ReactiveEnergy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new ReactiveEnergy(convertedValue, unit);
         }
 
-        IQuantity<ReactiveEnergyUnit> IQuantity<ReactiveEnergyUnit>.ToUnit(ReactiveEnergyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ReactiveEnergyUnit))
+                throw new ArgumentException("The given unit is not of type ReactiveEnergyUnit.", nameof(unit));
+
+            return ToUnit((ReactiveEnergyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ReactiveEnergyUnit) unit);
+        IQuantity<ReactiveEnergyUnit> IQuantity<ReactiveEnergyUnit>.ToUnit(ReactiveEnergyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
@@ -588,7 +588,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ReactivePowerUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ReactivePowerUnit))
+                throw new ArgumentException("The given unit is not of type ReactivePowerUnit.", nameof(unit));
+
+            return As((ReactivePowerUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -603,9 +610,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ReactivePowerUnit) unit);
-
         /// <summary>
         ///     Converts this ReactivePower to another ReactivePower with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -616,10 +620,17 @@ namespace UnitsNet
             return new ReactivePower(convertedValue, unit);
         }
 
-        IQuantity<ReactivePowerUnit> IQuantity<ReactivePowerUnit>.ToUnit(ReactivePowerUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ReactivePowerUnit))
+                throw new ArgumentException("The given unit is not of type ReactivePowerUnit.", nameof(unit));
+
+            return ToUnit((ReactivePowerUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ReactivePowerUnit) unit);
+        IQuantity<ReactivePowerUnit> IQuantity<ReactivePowerUnit>.ToUnit(ReactivePowerUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.NetFramework.g.cs
@@ -588,15 +588,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ReactivePowerUnit))
-                throw new ArgumentException("The given unit is not of type ReactivePowerUnit.", nameof(unit));
-
-            return As((ReactivePowerUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -608,6 +599,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ReactivePowerUnit unitAsReactivePowerUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ReactivePowerUnit)} is supported.", nameof(unit));
+
+            return As(unitAsReactivePowerUnit);
         }
 
         /// <summary>
@@ -623,10 +623,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ReactivePowerUnit))
-                throw new ArgumentException("The given unit is not of type ReactivePowerUnit.", nameof(unit));
+            if(!(unit is ReactivePowerUnit unitAsReactivePowerUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ReactivePowerUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ReactivePowerUnit)unit);
+            return ToUnit(unitAsReactivePowerUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is RotationalAccelerationUnit))
-                throw new ArgumentException("The given unit is not of type RotationalAccelerationUnit.", nameof(unit));
-
-            return As((RotationalAccelerationUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalAccelerationUnit unitAsRotationalAccelerationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalAccelerationUnit)} is supported.", nameof(unit));
+
+            return As(unitAsRotationalAccelerationUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is RotationalAccelerationUnit))
-                throw new ArgumentException("The given unit is not of type RotationalAccelerationUnit.", nameof(unit));
+            if(!(unit is RotationalAccelerationUnit unitAsRotationalAccelerationUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalAccelerationUnit)} is supported.", nameof(unit));
 
-            return ToUnit((RotationalAccelerationUnit)unit);
+            return ToUnit(unitAsRotationalAccelerationUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((RotationalAccelerationUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalAccelerationUnit))
+                throw new ArgumentException("The given unit is not of type RotationalAccelerationUnit.", nameof(unit));
+
+            return As((RotationalAccelerationUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((RotationalAccelerationUnit) unit);
-
         /// <summary>
         ///     Converts this RotationalAcceleration to another RotationalAcceleration with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new RotationalAcceleration(convertedValue, unit);
         }
 
-        IQuantity<RotationalAccelerationUnit> IQuantity<RotationalAccelerationUnit>.ToUnit(RotationalAccelerationUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is RotationalAccelerationUnit))
+                throw new ArgumentException("The given unit is not of type RotationalAccelerationUnit.", nameof(unit));
+
+            return ToUnit((RotationalAccelerationUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((RotationalAccelerationUnit) unit);
+        IQuantity<RotationalAccelerationUnit> IQuantity<RotationalAccelerationUnit>.ToUnit(RotationalAccelerationUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
@@ -723,7 +723,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((RotationalSpeedUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalSpeedUnit))
+                throw new ArgumentException("The given unit is not of type RotationalSpeedUnit.", nameof(unit));
+
+            return As((RotationalSpeedUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -738,9 +745,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((RotationalSpeedUnit) unit);
-
         /// <summary>
         ///     Converts this RotationalSpeed to another RotationalSpeed with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -751,10 +755,17 @@ namespace UnitsNet
             return new RotationalSpeed(convertedValue, unit);
         }
 
-        IQuantity<RotationalSpeedUnit> IQuantity<RotationalSpeedUnit>.ToUnit(RotationalSpeedUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is RotationalSpeedUnit))
+                throw new ArgumentException("The given unit is not of type RotationalSpeedUnit.", nameof(unit));
+
+            return ToUnit((RotationalSpeedUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((RotationalSpeedUnit) unit);
+        IQuantity<RotationalSpeedUnit> IQuantity<RotationalSpeedUnit>.ToUnit(RotationalSpeedUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.NetFramework.g.cs
@@ -723,15 +723,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is RotationalSpeedUnit))
-                throw new ArgumentException("The given unit is not of type RotationalSpeedUnit.", nameof(unit));
-
-            return As((RotationalSpeedUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -743,6 +734,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalSpeedUnit unitAsRotationalSpeedUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalSpeedUnit)} is supported.", nameof(unit));
+
+            return As(unitAsRotationalSpeedUnit);
         }
 
         /// <summary>
@@ -758,10 +758,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is RotationalSpeedUnit))
-                throw new ArgumentException("The given unit is not of type RotationalSpeedUnit.", nameof(unit));
+            if(!(unit is RotationalSpeedUnit unitAsRotationalSpeedUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalSpeedUnit)} is supported.", nameof(unit));
 
-            return ToUnit((RotationalSpeedUnit)unit);
+            return ToUnit(unitAsRotationalSpeedUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is RotationalStiffnessUnit))
-                throw new ArgumentException("The given unit is not of type RotationalStiffnessUnit.", nameof(unit));
-
-            return As((RotationalStiffnessUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalStiffnessUnit unitAsRotationalStiffnessUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalStiffnessUnit)} is supported.", nameof(unit));
+
+            return As(unitAsRotationalStiffnessUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is RotationalStiffnessUnit))
-                throw new ArgumentException("The given unit is not of type RotationalStiffnessUnit.", nameof(unit));
+            if(!(unit is RotationalStiffnessUnit unitAsRotationalStiffnessUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalStiffnessUnit)} is supported.", nameof(unit));
 
-            return ToUnit((RotationalStiffnessUnit)unit);
+            return ToUnit(unitAsRotationalStiffnessUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((RotationalStiffnessUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalStiffnessUnit))
+                throw new ArgumentException("The given unit is not of type RotationalStiffnessUnit.", nameof(unit));
+
+            return As((RotationalStiffnessUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((RotationalStiffnessUnit) unit);
-
         /// <summary>
         ///     Converts this RotationalStiffness to another RotationalStiffness with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new RotationalStiffness(convertedValue, unit);
         }
 
-        IQuantity<RotationalStiffnessUnit> IQuantity<RotationalStiffnessUnit>.ToUnit(RotationalStiffnessUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is RotationalStiffnessUnit))
+                throw new ArgumentException("The given unit is not of type RotationalStiffnessUnit.", nameof(unit));
+
+            return ToUnit((RotationalStiffnessUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((RotationalStiffnessUnit) unit);
+        IQuantity<RotationalStiffnessUnit> IQuantity<RotationalStiffnessUnit>.ToUnit(RotationalStiffnessUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is RotationalStiffnessPerLengthUnit))
-                throw new ArgumentException("The given unit is not of type RotationalStiffnessPerLengthUnit.", nameof(unit));
-
-            return As((RotationalStiffnessPerLengthUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalStiffnessPerLengthUnit unitAsRotationalStiffnessPerLengthUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalStiffnessPerLengthUnit)} is supported.", nameof(unit));
+
+            return As(unitAsRotationalStiffnessPerLengthUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is RotationalStiffnessPerLengthUnit))
-                throw new ArgumentException("The given unit is not of type RotationalStiffnessPerLengthUnit.", nameof(unit));
+            if(!(unit is RotationalStiffnessPerLengthUnit unitAsRotationalStiffnessPerLengthUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(RotationalStiffnessPerLengthUnit)} is supported.", nameof(unit));
 
-            return ToUnit((RotationalStiffnessPerLengthUnit)unit);
+            return ToUnit(unitAsRotationalStiffnessPerLengthUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((RotationalStiffnessPerLengthUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is RotationalStiffnessPerLengthUnit))
+                throw new ArgumentException("The given unit is not of type RotationalStiffnessPerLengthUnit.", nameof(unit));
+
+            return As((RotationalStiffnessPerLengthUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((RotationalStiffnessPerLengthUnit) unit);
-
         /// <summary>
         ///     Converts this RotationalStiffnessPerLength to another RotationalStiffnessPerLength with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new RotationalStiffnessPerLength(convertedValue, unit);
         }
 
-        IQuantity<RotationalStiffnessPerLengthUnit> IQuantity<RotationalStiffnessPerLengthUnit>.ToUnit(RotationalStiffnessPerLengthUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is RotationalStiffnessPerLengthUnit))
+                throw new ArgumentException("The given unit is not of type RotationalStiffnessPerLengthUnit.", nameof(unit));
+
+            return ToUnit((RotationalStiffnessPerLengthUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((RotationalStiffnessPerLengthUnit) unit);
+        IQuantity<RotationalStiffnessPerLengthUnit> IQuantity<RotationalStiffnessPerLengthUnit>.ToUnit(RotationalStiffnessPerLengthUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
@@ -546,7 +546,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((SolidAngleUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SolidAngleUnit))
+                throw new ArgumentException("The given unit is not of type SolidAngleUnit.", nameof(unit));
+
+            return As((SolidAngleUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -561,9 +568,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((SolidAngleUnit) unit);
-
         /// <summary>
         ///     Converts this SolidAngle to another SolidAngle with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -574,10 +578,17 @@ namespace UnitsNet
             return new SolidAngle(convertedValue, unit);
         }
 
-        IQuantity<SolidAngleUnit> IQuantity<SolidAngleUnit>.ToUnit(SolidAngleUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is SolidAngleUnit))
+                throw new ArgumentException("The given unit is not of type SolidAngleUnit.", nameof(unit));
+
+            return ToUnit((SolidAngleUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((SolidAngleUnit) unit);
+        IQuantity<SolidAngleUnit> IQuantity<SolidAngleUnit>.ToUnit(SolidAngleUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.NetFramework.g.cs
@@ -546,15 +546,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is SolidAngleUnit))
-                throw new ArgumentException("The given unit is not of type SolidAngleUnit.", nameof(unit));
-
-            return As((SolidAngleUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -566,6 +557,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SolidAngleUnit unitAsSolidAngleUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SolidAngleUnit)} is supported.", nameof(unit));
+
+            return As(unitAsSolidAngleUnit);
         }
 
         /// <summary>
@@ -581,10 +581,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is SolidAngleUnit))
-                throw new ArgumentException("The given unit is not of type SolidAngleUnit.", nameof(unit));
+            if(!(unit is SolidAngleUnit unitAsSolidAngleUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SolidAngleUnit)} is supported.", nameof(unit));
 
-            return ToUnit((SolidAngleUnit)unit);
+            return ToUnit(unitAsSolidAngleUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
@@ -666,7 +666,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((SpecificEnergyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificEnergyUnit))
+                throw new ArgumentException("The given unit is not of type SpecificEnergyUnit.", nameof(unit));
+
+            return As((SpecificEnergyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -681,9 +688,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((SpecificEnergyUnit) unit);
-
         /// <summary>
         ///     Converts this SpecificEnergy to another SpecificEnergy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -694,10 +698,17 @@ namespace UnitsNet
             return new SpecificEnergy(convertedValue, unit);
         }
 
-        IQuantity<SpecificEnergyUnit> IQuantity<SpecificEnergyUnit>.ToUnit(SpecificEnergyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is SpecificEnergyUnit))
+                throw new ArgumentException("The given unit is not of type SpecificEnergyUnit.", nameof(unit));
+
+            return ToUnit((SpecificEnergyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((SpecificEnergyUnit) unit);
+        IQuantity<SpecificEnergyUnit> IQuantity<SpecificEnergyUnit>.ToUnit(SpecificEnergyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.NetFramework.g.cs
@@ -666,15 +666,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is SpecificEnergyUnit))
-                throw new ArgumentException("The given unit is not of type SpecificEnergyUnit.", nameof(unit));
-
-            return As((SpecificEnergyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -686,6 +677,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificEnergyUnit unitAsSpecificEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificEnergyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsSpecificEnergyUnit);
         }
 
         /// <summary>
@@ -701,10 +701,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is SpecificEnergyUnit))
-                throw new ArgumentException("The given unit is not of type SpecificEnergyUnit.", nameof(unit));
+            if(!(unit is SpecificEnergyUnit unitAsSpecificEnergyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificEnergyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((SpecificEnergyUnit)unit);
+            return ToUnit(unitAsSpecificEnergyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
@@ -648,15 +648,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is SpecificEntropyUnit))
-                throw new ArgumentException("The given unit is not of type SpecificEntropyUnit.", nameof(unit));
-
-            return As((SpecificEntropyUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -668,6 +659,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificEntropyUnit unitAsSpecificEntropyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificEntropyUnit)} is supported.", nameof(unit));
+
+            return As(unitAsSpecificEntropyUnit);
         }
 
         /// <summary>
@@ -683,10 +683,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is SpecificEntropyUnit))
-                throw new ArgumentException("The given unit is not of type SpecificEntropyUnit.", nameof(unit));
+            if(!(unit is SpecificEntropyUnit unitAsSpecificEntropyUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificEntropyUnit)} is supported.", nameof(unit));
 
-            return ToUnit((SpecificEntropyUnit)unit);
+            return ToUnit(unitAsSpecificEntropyUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.NetFramework.g.cs
@@ -648,7 +648,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((SpecificEntropyUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificEntropyUnit))
+                throw new ArgumentException("The given unit is not of type SpecificEntropyUnit.", nameof(unit));
+
+            return As((SpecificEntropyUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -663,9 +670,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((SpecificEntropyUnit) unit);
-
         /// <summary>
         ///     Converts this SpecificEntropy to another SpecificEntropy with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -676,10 +680,17 @@ namespace UnitsNet
             return new SpecificEntropy(convertedValue, unit);
         }
 
-        IQuantity<SpecificEntropyUnit> IQuantity<SpecificEntropyUnit>.ToUnit(SpecificEntropyUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is SpecificEntropyUnit))
+                throw new ArgumentException("The given unit is not of type SpecificEntropyUnit.", nameof(unit));
+
+            return ToUnit((SpecificEntropyUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((SpecificEntropyUnit) unit);
+        IQuantity<SpecificEntropyUnit> IQuantity<SpecificEntropyUnit>.ToUnit(SpecificEntropyUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
@@ -573,15 +573,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is SpecificVolumeUnit))
-                throw new ArgumentException("The given unit is not of type SpecificVolumeUnit.", nameof(unit));
-
-            return As((SpecificVolumeUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -593,6 +584,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificVolumeUnit unitAsSpecificVolumeUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificVolumeUnit)} is supported.", nameof(unit));
+
+            return As(unitAsSpecificVolumeUnit);
         }
 
         /// <summary>
@@ -608,10 +608,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is SpecificVolumeUnit))
-                throw new ArgumentException("The given unit is not of type SpecificVolumeUnit.", nameof(unit));
+            if(!(unit is SpecificVolumeUnit unitAsSpecificVolumeUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificVolumeUnit)} is supported.", nameof(unit));
 
-            return ToUnit((SpecificVolumeUnit)unit);
+            return ToUnit(unitAsSpecificVolumeUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.NetFramework.g.cs
@@ -573,7 +573,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((SpecificVolumeUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificVolumeUnit))
+                throw new ArgumentException("The given unit is not of type SpecificVolumeUnit.", nameof(unit));
+
+            return As((SpecificVolumeUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -588,9 +595,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((SpecificVolumeUnit) unit);
-
         /// <summary>
         ///     Converts this SpecificVolume to another SpecificVolume with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -601,10 +605,17 @@ namespace UnitsNet
             return new SpecificVolume(convertedValue, unit);
         }
 
-        IQuantity<SpecificVolumeUnit> IQuantity<SpecificVolumeUnit>.ToUnit(SpecificVolumeUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is SpecificVolumeUnit))
+                throw new ArgumentException("The given unit is not of type SpecificVolumeUnit.", nameof(unit));
+
+            return ToUnit((SpecificVolumeUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((SpecificVolumeUnit) unit);
+        IQuantity<SpecificVolumeUnit> IQuantity<SpecificVolumeUnit>.ToUnit(SpecificVolumeUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
@@ -786,7 +786,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((SpecificWeightUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificWeightUnit))
+                throw new ArgumentException("The given unit is not of type SpecificWeightUnit.", nameof(unit));
+
+            return As((SpecificWeightUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -801,9 +808,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((SpecificWeightUnit) unit);
-
         /// <summary>
         ///     Converts this SpecificWeight to another SpecificWeight with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -814,10 +818,17 @@ namespace UnitsNet
             return new SpecificWeight(convertedValue, unit);
         }
 
-        IQuantity<SpecificWeightUnit> IQuantity<SpecificWeightUnit>.ToUnit(SpecificWeightUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is SpecificWeightUnit))
+                throw new ArgumentException("The given unit is not of type SpecificWeightUnit.", nameof(unit));
+
+            return ToUnit((SpecificWeightUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((SpecificWeightUnit) unit);
+        IQuantity<SpecificWeightUnit> IQuantity<SpecificWeightUnit>.ToUnit(SpecificWeightUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.NetFramework.g.cs
@@ -786,15 +786,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is SpecificWeightUnit))
-                throw new ArgumentException("The given unit is not of type SpecificWeightUnit.", nameof(unit));
-
-            return As((SpecificWeightUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -806,6 +797,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpecificWeightUnit unitAsSpecificWeightUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificWeightUnit)} is supported.", nameof(unit));
+
+            return As(unitAsSpecificWeightUnit);
         }
 
         /// <summary>
@@ -821,10 +821,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is SpecificWeightUnit))
-                throw new ArgumentException("The given unit is not of type SpecificWeightUnit.", nameof(unit));
+            if(!(unit is SpecificWeightUnit unitAsSpecificWeightUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpecificWeightUnit)} is supported.", nameof(unit));
 
-            return ToUnit((SpecificWeightUnit)unit);
+            return ToUnit(unitAsSpecificWeightUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
@@ -1008,7 +1008,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((SpeedUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpeedUnit))
+                throw new ArgumentException("The given unit is not of type SpeedUnit.", nameof(unit));
+
+            return As((SpeedUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1023,9 +1030,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((SpeedUnit) unit);
-
         /// <summary>
         ///     Converts this Speed to another Speed with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1036,10 +1040,17 @@ namespace UnitsNet
             return new Speed(convertedValue, unit);
         }
 
-        IQuantity<SpeedUnit> IQuantity<SpeedUnit>.ToUnit(SpeedUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is SpeedUnit))
+                throw new ArgumentException("The given unit is not of type SpeedUnit.", nameof(unit));
+
+            return ToUnit((SpeedUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((SpeedUnit) unit);
+        IQuantity<SpeedUnit> IQuantity<SpeedUnit>.ToUnit(SpeedUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.NetFramework.g.cs
@@ -1008,15 +1008,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is SpeedUnit))
-                throw new ArgumentException("The given unit is not of type SpeedUnit.", nameof(unit));
-
-            return As((SpeedUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1028,6 +1019,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is SpeedUnit unitAsSpeedUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpeedUnit)} is supported.", nameof(unit));
+
+            return As(unitAsSpeedUnit);
         }
 
         /// <summary>
@@ -1043,10 +1043,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is SpeedUnit))
-                throw new ArgumentException("The given unit is not of type SpeedUnit.", nameof(unit));
+            if(!(unit is SpeedUnit unitAsSpeedUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(SpeedUnit)} is supported.", nameof(unit));
 
-            return ToUnit((SpeedUnit)unit);
+            return ToUnit(unitAsSpeedUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
@@ -602,15 +602,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is TemperatureUnit))
-                throw new ArgumentException("The given unit is not of type TemperatureUnit.", nameof(unit));
-
-            return As((TemperatureUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -622,6 +613,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TemperatureUnit unitAsTemperatureUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TemperatureUnit)} is supported.", nameof(unit));
+
+            return As(unitAsTemperatureUnit);
         }
 
         /// <summary>
@@ -637,10 +637,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is TemperatureUnit))
-                throw new ArgumentException("The given unit is not of type TemperatureUnit.", nameof(unit));
+            if(!(unit is TemperatureUnit unitAsTemperatureUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TemperatureUnit)} is supported.", nameof(unit));
 
-            return ToUnit((TemperatureUnit)unit);
+            return ToUnit(unitAsTemperatureUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.NetFramework.g.cs
@@ -602,7 +602,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((TemperatureUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TemperatureUnit))
+                throw new ArgumentException("The given unit is not of type TemperatureUnit.", nameof(unit));
+
+            return As((TemperatureUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -617,9 +624,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((TemperatureUnit) unit);
-
         /// <summary>
         ///     Converts this Temperature to another Temperature with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -630,10 +634,17 @@ namespace UnitsNet
             return new Temperature(convertedValue, unit);
         }
 
-        IQuantity<TemperatureUnit> IQuantity<TemperatureUnit>.ToUnit(TemperatureUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is TemperatureUnit))
+                throw new ArgumentException("The given unit is not of type TemperatureUnit.", nameof(unit));
+
+            return ToUnit((TemperatureUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((TemperatureUnit) unit);
+        IQuantity<TemperatureUnit> IQuantity<TemperatureUnit>.ToUnit(TemperatureUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
@@ -678,15 +678,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is TemperatureChangeRateUnit))
-                throw new ArgumentException("The given unit is not of type TemperatureChangeRateUnit.", nameof(unit));
-
-            return As((TemperatureChangeRateUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -698,6 +689,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TemperatureChangeRateUnit unitAsTemperatureChangeRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TemperatureChangeRateUnit)} is supported.", nameof(unit));
+
+            return As(unitAsTemperatureChangeRateUnit);
         }
 
         /// <summary>
@@ -713,10 +713,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is TemperatureChangeRateUnit))
-                throw new ArgumentException("The given unit is not of type TemperatureChangeRateUnit.", nameof(unit));
+            if(!(unit is TemperatureChangeRateUnit unitAsTemperatureChangeRateUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TemperatureChangeRateUnit)} is supported.", nameof(unit));
 
-            return ToUnit((TemperatureChangeRateUnit)unit);
+            return ToUnit(unitAsTemperatureChangeRateUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.NetFramework.g.cs
@@ -678,7 +678,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((TemperatureChangeRateUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TemperatureChangeRateUnit))
+                throw new ArgumentException("The given unit is not of type TemperatureChangeRateUnit.", nameof(unit));
+
+            return As((TemperatureChangeRateUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -693,9 +700,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((TemperatureChangeRateUnit) unit);
-
         /// <summary>
         ///     Converts this TemperatureChangeRate to another TemperatureChangeRate with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -706,10 +710,17 @@ namespace UnitsNet
             return new TemperatureChangeRate(convertedValue, unit);
         }
 
-        IQuantity<TemperatureChangeRateUnit> IQuantity<TemperatureChangeRateUnit>.ToUnit(TemperatureChangeRateUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is TemperatureChangeRateUnit))
+                throw new ArgumentException("The given unit is not of type TemperatureChangeRateUnit.", nameof(unit));
+
+            return ToUnit((TemperatureChangeRateUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((TemperatureChangeRateUnit) unit);
+        IQuantity<TemperatureChangeRateUnit> IQuantity<TemperatureChangeRateUnit>.ToUnit(TemperatureChangeRateUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
@@ -648,15 +648,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is TemperatureDeltaUnit))
-                throw new ArgumentException("The given unit is not of type TemperatureDeltaUnit.", nameof(unit));
-
-            return As((TemperatureDeltaUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -668,6 +659,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TemperatureDeltaUnit unitAsTemperatureDeltaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TemperatureDeltaUnit)} is supported.", nameof(unit));
+
+            return As(unitAsTemperatureDeltaUnit);
         }
 
         /// <summary>
@@ -683,10 +683,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is TemperatureDeltaUnit))
-                throw new ArgumentException("The given unit is not of type TemperatureDeltaUnit.", nameof(unit));
+            if(!(unit is TemperatureDeltaUnit unitAsTemperatureDeltaUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TemperatureDeltaUnit)} is supported.", nameof(unit));
 
-            return ToUnit((TemperatureDeltaUnit)unit);
+            return ToUnit(unitAsTemperatureDeltaUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.NetFramework.g.cs
@@ -648,7 +648,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((TemperatureDeltaUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TemperatureDeltaUnit))
+                throw new ArgumentException("The given unit is not of type TemperatureDeltaUnit.", nameof(unit));
+
+            return As((TemperatureDeltaUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -663,9 +670,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((TemperatureDeltaUnit) unit);
-
         /// <summary>
         ///     Converts this TemperatureDelta to another TemperatureDelta with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -676,10 +680,17 @@ namespace UnitsNet
             return new TemperatureDelta(convertedValue, unit);
         }
 
-        IQuantity<TemperatureDeltaUnit> IQuantity<TemperatureDeltaUnit>.ToUnit(TemperatureDeltaUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is TemperatureDeltaUnit))
+                throw new ArgumentException("The given unit is not of type TemperatureDeltaUnit.", nameof(unit));
+
+            return ToUnit((TemperatureDeltaUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((TemperatureDeltaUnit) unit);
+        IQuantity<TemperatureDeltaUnit> IQuantity<TemperatureDeltaUnit>.ToUnit(TemperatureDeltaUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
@@ -561,15 +561,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ThermalConductivityUnit))
-                throw new ArgumentException("The given unit is not of type ThermalConductivityUnit.", nameof(unit));
-
-            return As((ThermalConductivityUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -581,6 +572,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ThermalConductivityUnit unitAsThermalConductivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ThermalConductivityUnit)} is supported.", nameof(unit));
+
+            return As(unitAsThermalConductivityUnit);
         }
 
         /// <summary>
@@ -596,10 +596,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ThermalConductivityUnit))
-                throw new ArgumentException("The given unit is not of type ThermalConductivityUnit.", nameof(unit));
+            if(!(unit is ThermalConductivityUnit unitAsThermalConductivityUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ThermalConductivityUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ThermalConductivityUnit)unit);
+            return ToUnit(unitAsThermalConductivityUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.NetFramework.g.cs
@@ -561,7 +561,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ThermalConductivityUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ThermalConductivityUnit))
+                throw new ArgumentException("The given unit is not of type ThermalConductivityUnit.", nameof(unit));
+
+            return As((ThermalConductivityUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -576,9 +583,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ThermalConductivityUnit) unit);
-
         /// <summary>
         ///     Converts this ThermalConductivity to another ThermalConductivity with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -589,10 +593,17 @@ namespace UnitsNet
             return new ThermalConductivity(convertedValue, unit);
         }
 
-        IQuantity<ThermalConductivityUnit> IQuantity<ThermalConductivityUnit>.ToUnit(ThermalConductivityUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ThermalConductivityUnit))
+                throw new ArgumentException("The given unit is not of type ThermalConductivityUnit.", nameof(unit));
+
+            return ToUnit((ThermalConductivityUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ThermalConductivityUnit) unit);
+        IQuantity<ThermalConductivityUnit> IQuantity<ThermalConductivityUnit>.ToUnit(ThermalConductivityUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
@@ -603,15 +603,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is ThermalResistanceUnit))
-                throw new ArgumentException("The given unit is not of type ThermalResistanceUnit.", nameof(unit));
-
-            return As((ThermalResistanceUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -623,6 +614,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ThermalResistanceUnit unitAsThermalResistanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ThermalResistanceUnit)} is supported.", nameof(unit));
+
+            return As(unitAsThermalResistanceUnit);
         }
 
         /// <summary>
@@ -638,10 +638,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is ThermalResistanceUnit))
-                throw new ArgumentException("The given unit is not of type ThermalResistanceUnit.", nameof(unit));
+            if(!(unit is ThermalResistanceUnit unitAsThermalResistanceUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(ThermalResistanceUnit)} is supported.", nameof(unit));
 
-            return ToUnit((ThermalResistanceUnit)unit);
+            return ToUnit(unitAsThermalResistanceUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.NetFramework.g.cs
@@ -603,7 +603,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((ThermalResistanceUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is ThermalResistanceUnit))
+                throw new ArgumentException("The given unit is not of type ThermalResistanceUnit.", nameof(unit));
+
+            return As((ThermalResistanceUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -618,9 +625,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((ThermalResistanceUnit) unit);
-
         /// <summary>
         ///     Converts this ThermalResistance to another ThermalResistance with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -631,10 +635,17 @@ namespace UnitsNet
             return new ThermalResistance(convertedValue, unit);
         }
 
-        IQuantity<ThermalResistanceUnit> IQuantity<ThermalResistanceUnit>.ToUnit(ThermalResistanceUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is ThermalResistanceUnit))
+                throw new ArgumentException("The given unit is not of type ThermalResistanceUnit.", nameof(unit));
+
+            return ToUnit((ThermalResistanceUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((ThermalResistanceUnit) unit);
+        IQuantity<ThermalResistanceUnit> IQuantity<ThermalResistanceUnit>.ToUnit(ThermalResistanceUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
@@ -843,15 +843,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is TorqueUnit))
-                throw new ArgumentException("The given unit is not of type TorqueUnit.", nameof(unit));
-
-            return As((TorqueUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -863,6 +854,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TorqueUnit unitAsTorqueUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TorqueUnit)} is supported.", nameof(unit));
+
+            return As(unitAsTorqueUnit);
         }
 
         /// <summary>
@@ -878,10 +878,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is TorqueUnit))
-                throw new ArgumentException("The given unit is not of type TorqueUnit.", nameof(unit));
+            if(!(unit is TorqueUnit unitAsTorqueUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(TorqueUnit)} is supported.", nameof(unit));
 
-            return ToUnit((TorqueUnit)unit);
+            return ToUnit(unitAsTorqueUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.NetFramework.g.cs
@@ -843,7 +843,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((TorqueUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is TorqueUnit))
+                throw new ArgumentException("The given unit is not of type TorqueUnit.", nameof(unit));
+
+            return As((TorqueUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -858,9 +865,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((TorqueUnit) unit);
-
         /// <summary>
         ///     Converts this Torque to another Torque with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -871,10 +875,17 @@ namespace UnitsNet
             return new Torque(convertedValue, unit);
         }
 
-        IQuantity<TorqueUnit> IQuantity<TorqueUnit>.ToUnit(TorqueUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is TorqueUnit))
+                throw new ArgumentException("The given unit is not of type TorqueUnit.", nameof(unit));
+
+            return ToUnit((TorqueUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((TorqueUnit) unit);
+        IQuantity<TorqueUnit> IQuantity<TorqueUnit>.ToUnit(TorqueUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
@@ -543,15 +543,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is VitaminAUnit))
-                throw new ArgumentException("The given unit is not of type VitaminAUnit.", nameof(unit));
-
-            return As((VitaminAUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -563,6 +554,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is VitaminAUnit unitAsVitaminAUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VitaminAUnit)} is supported.", nameof(unit));
+
+            return As(unitAsVitaminAUnit);
         }
 
         /// <summary>
@@ -578,10 +578,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is VitaminAUnit))
-                throw new ArgumentException("The given unit is not of type VitaminAUnit.", nameof(unit));
+            if(!(unit is VitaminAUnit unitAsVitaminAUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VitaminAUnit)} is supported.", nameof(unit));
 
-            return ToUnit((VitaminAUnit)unit);
+            return ToUnit(unitAsVitaminAUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.NetFramework.g.cs
@@ -543,7 +543,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((VitaminAUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is VitaminAUnit))
+                throw new ArgumentException("The given unit is not of type VitaminAUnit.", nameof(unit));
+
+            return As((VitaminAUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -558,9 +565,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((VitaminAUnit) unit);
-
         /// <summary>
         ///     Converts this VitaminA to another VitaminA with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -571,10 +575,17 @@ namespace UnitsNet
             return new VitaminA(convertedValue, unit);
         }
 
-        IQuantity<VitaminAUnit> IQuantity<VitaminAUnit>.ToUnit(VitaminAUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is VitaminAUnit))
+                throw new ArgumentException("The given unit is not of type VitaminAUnit.", nameof(unit));
+
+            return ToUnit((VitaminAUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((VitaminAUnit) unit);
+        IQuantity<VitaminAUnit> IQuantity<VitaminAUnit>.ToUnit(VitaminAUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
@@ -1203,15 +1203,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is VolumeUnit))
-                throw new ArgumentException("The given unit is not of type VolumeUnit.", nameof(unit));
-
-            return As((VolumeUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1223,6 +1214,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is VolumeUnit unitAsVolumeUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VolumeUnit)} is supported.", nameof(unit));
+
+            return As(unitAsVolumeUnit);
         }
 
         /// <summary>
@@ -1238,10 +1238,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is VolumeUnit))
-                throw new ArgumentException("The given unit is not of type VolumeUnit.", nameof(unit));
+            if(!(unit is VolumeUnit unitAsVolumeUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VolumeUnit)} is supported.", nameof(unit));
 
-            return ToUnit((VolumeUnit)unit);
+            return ToUnit(unitAsVolumeUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.NetFramework.g.cs
@@ -1203,7 +1203,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((VolumeUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is VolumeUnit))
+                throw new ArgumentException("The given unit is not of type VolumeUnit.", nameof(unit));
+
+            return As((VolumeUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1218,9 +1225,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((VolumeUnit) unit);
-
         /// <summary>
         ///     Converts this Volume to another Volume with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1231,10 +1235,17 @@ namespace UnitsNet
             return new Volume(convertedValue, unit);
         }
 
-        IQuantity<VolumeUnit> IQuantity<VolumeUnit>.ToUnit(VolumeUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is VolumeUnit))
+                throw new ArgumentException("The given unit is not of type VolumeUnit.", nameof(unit));
+
+            return ToUnit((VolumeUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((VolumeUnit) unit);
+        IQuantity<VolumeUnit> IQuantity<VolumeUnit>.ToUnit(VolumeUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
@@ -1248,15 +1248,6 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is VolumeFlowUnit))
-                throw new ArgumentException("The given unit is not of type VolumeFlowUnit.", nameof(unit));
-
-            return As((VolumeFlowUnit)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1268,6 +1259,15 @@ namespace UnitsNet
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is VolumeFlowUnit unitAsVolumeFlowUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VolumeFlowUnit)} is supported.", nameof(unit));
+
+            return As(unitAsVolumeFlowUnit);
         }
 
         /// <summary>
@@ -1283,10 +1283,10 @@ namespace UnitsNet
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is VolumeFlowUnit))
-                throw new ArgumentException("The given unit is not of type VolumeFlowUnit.", nameof(unit));
+            if(!(unit is VolumeFlowUnit unitAsVolumeFlowUnit))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof(VolumeFlowUnit)} is supported.", nameof(unit));
 
-            return ToUnit((VolumeFlowUnit)unit);
+            return ToUnit(unitAsVolumeFlowUnit);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.NetFramework.g.cs
@@ -1248,7 +1248,14 @@ namespace UnitsNet
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As((VolumeFlowUnit)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is VolumeFlowUnit))
+                throw new ArgumentException("The given unit is not of type VolumeFlowUnit.", nameof(unit));
+
+            return As((VolumeFlowUnit)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -1263,9 +1270,6 @@ namespace UnitsNet
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As((VolumeFlowUnit) unit);
-
         /// <summary>
         ///     Converts this VolumeFlow to another VolumeFlow with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -1276,10 +1280,17 @@ namespace UnitsNet
             return new VolumeFlow(convertedValue, unit);
         }
 
-        IQuantity<VolumeFlowUnit> IQuantity<VolumeFlowUnit>.ToUnit(VolumeFlowUnit unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is VolumeFlowUnit))
+                throw new ArgumentException("The given unit is not of type VolumeFlowUnit.", nameof(unit));
+
+            return ToUnit((VolumeFlowUnit)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit((VolumeFlowUnit) unit);
+        IQuantity<VolumeFlowUnit> IQuantity<VolumeFlowUnit>.ToUnit(VolumeFlowUnit unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -969,15 +969,6 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
 
         #region Conversion Methods
 
-        /// <inheritdoc />
-        double IQuantity.As(Enum unit)
-        {
-            if(!(unit is $unitEnumName))
-                throw new ArgumentException("The given unit is not of type $unitEnumName.", nameof(unit));
-
-            return As(($unitEnumName)unit);
-        }
-
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
         /// </summary>
@@ -989,6 +980,15 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
 
             var converted = GetValueAs(unit);
             return Convert.ToDouble(converted);
+        }
+
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is $unitEnumName unitAs$unitEnumName))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof($unitEnumName)} is supported.", nameof(unit));
+
+            return As(unitAs$unitEnumName);
         }
 
         /// <summary>
@@ -1004,10 +1004,10 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
         /// <inheritdoc />
         IQuantity IQuantity.ToUnit(Enum unit)
         {
-            if(!(unit is $unitEnumName))
-                throw new ArgumentException("The given unit is not of type $unitEnumName.", nameof(unit));
+            if(!(unit is $unitEnumName unitAs$unitEnumName))
+                throw new ArgumentException($"The given unit is of type {unit.GetType()}. Only {typeof($unitEnumName)} is supported.", nameof(unit));
 
-            return ToUnit(($unitEnumName)unit);
+            return ToUnit(unitAs$unitEnumName);
         }
 
         /// <inheritdoc />

--- a/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
+++ b/UnitsNet/Scripts/Include-GenerateQuantitySourceCode.ps1
@@ -969,7 +969,14 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
 
         #region Conversion Methods
 
-        double IQuantity.As(Enum unit) => As(($unitEnumName)unit);
+        /// <inheritdoc />
+        double IQuantity.As(Enum unit)
+        {
+            if(!(unit is $unitEnumName))
+                throw new ArgumentException("The given unit is not of type $unitEnumName.", nameof(unit));
+
+            return As(($unitEnumName)unit);
+        }
 
         /// <summary>
         ///     Convert to the unit representation <paramref name="unit" />.
@@ -984,9 +991,6 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
             return Convert.ToDouble(converted);
         }
 
-        /// <inheritdoc />
-        public double As(Enum unit) => As(($unitEnumName) unit);
-
         /// <summary>
         ///     Converts this $quantityName to another $quantityName with the unit representation <paramref name="unit" />.
         /// </summary>
@@ -997,10 +1001,17 @@ function GenerateConversionMethods([GeneratorArgs]$genArgs)
             return new $quantityName(convertedValue, unit);
         }
 
-        IQuantity<$unitEnumName> IQuantity<$unitEnumName>.ToUnit($unitEnumName unit) => ToUnit(unit);
+        /// <inheritdoc />
+        IQuantity IQuantity.ToUnit(Enum unit)
+        {
+            if(!(unit is $unitEnumName))
+                throw new ArgumentException("The given unit is not of type $unitEnumName.", nameof(unit));
+
+            return ToUnit(($unitEnumName)unit);
+        }
 
         /// <inheritdoc />
-        public IQuantity ToUnit(Enum unit) => ToUnit(($unitEnumName) unit);
+        IQuantity<$unitEnumName> IQuantity<$unitEnumName>.ToUnit($unitEnumName unit) => ToUnit(unit);
 
         /// <summary>
         ///     Converts the current value + unit to the base unit.


### PR DESCRIPTION
IQuantity As/ToUnit methods would blindly cast an Enum to the unit type, even if it was the wrong unit type. Throwing an exception for wrong type.