### PR TITLE
Use auto properties where possible

### DIFF
--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -9,22 +9,22 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 {
     public class UnitsNetJsonConverterTests
     {
-        private readonly JsonSerializerSettings _jsonSerializerSettings;
+        private JsonSerializerSettings JsonSerializerSettings { get; }
 
         protected UnitsNetJsonConverterTests()
         {
-            _jsonSerializerSettings = new JsonSerializerSettings {Formatting = Formatting.Indented};
-            _jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter());
+            JsonSerializerSettings = new JsonSerializerSettings {Formatting = Formatting.Indented};
+            JsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter());
         }
 
         private string SerializeObject(object obj)
         {
-            return JsonConvert.SerializeObject(obj, _jsonSerializerSettings).Replace("\r\n", "\n");
+            return JsonConvert.SerializeObject(obj, JsonSerializerSettings).Replace("\r\n", "\n");
         }
 
         private T DeserializeObject<T>(string json)
         {
-            return JsonConvert.DeserializeObject<T>(json, _jsonSerializerSettings);
+            return JsonConvert.DeserializeObject<T>(json, JsonSerializerSettings);
         }
 
         public class Serialize : UnitsNetJsonConverterTests

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -7,7 +7,7 @@ namespace UnitsNet
 {
     public partial class Quantity
     {
-        private static readonly Lazy<QuantityInfo[]> InfosLazy;
+        private static Lazy<QuantityInfo[]> InfosLazy { get; }
 
         static Quantity()
         {

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -24,15 +24,15 @@ namespace UnitsNet
         /// </summary>
         private const NumberStyles ParseNumberStyles = NumberStyles.Number | NumberStyles.Float | NumberStyles.AllowExponent;
 
-        private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
-        private UnitParser _unitParser;
+        private UnitAbbreviationsCache UnitAbbreviationsCache { get; }
+        private UnitParser UnitParser { get; }
 
         public static QuantityParser Default { get; }
 
         public QuantityParser(UnitAbbreviationsCache unitAbbreviationsCache)
         {
-            _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
-            _unitParser = new UnitParser(_unitAbbreviationsCache);
+            UnitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
+            UnitParser = new UnitParser(UnitAbbreviationsCache);
         }
 
         static QuantityParser()
@@ -124,7 +124,7 @@ namespace UnitsNet
             bool matchEntireString = true)
             where TUnitType : Enum
         {
-            var unitAbbreviations = _unitAbbreviationsCache.GetUnitAbbreviations(unit, formatProvider);
+            var unitAbbreviations = UnitAbbreviationsCache.GetUnitAbbreviations(unit, formatProvider);
             var pattern = GetRegexPatternForUnitAbbreviations(unitAbbreviations);
             return matchEntireString ? $"^{pattern}$" : pattern;
         }
@@ -152,7 +152,7 @@ namespace UnitsNet
             where TUnitType : Enum
         {
             var value = double.Parse(valueString, ParseNumberStyles, formatProvider);
-            var parsedUnit = _unitParser.Parse<TUnitType>(unitString, formatProvider);
+            var parsedUnit = UnitParser.Parse<TUnitType>(unitString, formatProvider);
             return fromDelegate(value, parsedUnit);
         }
 
@@ -173,7 +173,7 @@ namespace UnitsNet
             if (!double.TryParse(valueString, ParseNumberStyles, formatProvider, out var value))
                     return false;
 
-            if (!_unitParser.TryParse<TUnitType>(unitString, formatProvider, out var parsedUnit))
+            if (!UnitParser.TryParse<TUnitType>(unitString, formatProvider, out var parsedUnit))
                     return false;
 
             result = fromDelegate(value, parsedUnit);
@@ -201,7 +201,7 @@ namespace UnitsNet
 
         private string CreateRegexPatternForQuantity<TUnitType>(IFormatProvider formatProvider) where TUnitType : Enum
         {
-            var unitAbbreviations = _unitAbbreviationsCache.GetAllUnitAbbreviationsForQuantity(typeof(TUnitType), formatProvider);
+            var unitAbbreviations = UnitAbbreviationsCache.GetAllUnitAbbreviationsForQuantity(typeof(TUnitType), formatProvider);
             var pattern = GetRegexPatternForUnitAbbreviations(unitAbbreviations);
 
             // Match entire string exactly

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -20,7 +20,7 @@ namespace UnitsNet
     /// </summary>
     public sealed partial class UnitAbbreviationsCache
     {
-        private readonly Dictionary<IFormatProvider, UnitTypeToLookup> _lookupsForCulture;
+        private Dictionary<IFormatProvider, UnitTypeToLookup> LookupsForCulture { get; }
 
         /// <summary>
         ///     Fallback culture used by <see cref="GetUnitAbbreviations{TUnitType}" /> and <see cref="GetDefaultAbbreviation{TUnitType}" />
@@ -31,7 +31,7 @@ namespace UnitsNet
         ///     culture, but no translation is defined, so we return the US English definition as a last resort. If it's not
         ///     defined there either, an exception is thrown.
         /// </example>
-        private static readonly CultureInfo FallbackCulture = new CultureInfo("en-US");
+        private static CultureInfo FallbackCulture { get; } = new CultureInfo("en-US");
 
         /// <summary>
         ///     The static instance used internally for ToString() and Parse() of quantities and units.
@@ -43,7 +43,7 @@ namespace UnitsNet
         /// </summary>
         public UnitAbbreviationsCache()
         {
-            _lookupsForCulture = new Dictionary<IFormatProvider, UnitTypeToLookup>();
+            LookupsForCulture = new Dictionary<IFormatProvider, UnitTypeToLookup>();
 
             LoadGeneratedAbbreviations();
         }
@@ -171,8 +171,8 @@ namespace UnitsNet
 
             formatProvider = formatProvider ?? CultureInfo.CurrentUICulture;
 
-            if (!_lookupsForCulture.TryGetValue(formatProvider, out var quantitiesForProvider))
-                quantitiesForProvider = _lookupsForCulture[formatProvider] = new UnitTypeToLookup();
+            if (!LookupsForCulture.TryGetValue(formatProvider, out var quantitiesForProvider))
+                quantitiesForProvider = LookupsForCulture[formatProvider] = new UnitTypeToLookup();
 
             if (!quantitiesForProvider.TryGetValue(unitType, out var unitToAbbreviations))
                 unitToAbbreviations = quantitiesForProvider[unitType] = new UnitValueAbbreviationLookup();
@@ -306,7 +306,7 @@ namespace UnitsNet
 
             formatProvider = formatProvider ?? CultureInfo.CurrentUICulture;
 
-            if(!_lookupsForCulture.TryGetValue(formatProvider, out var quantitiesForProvider))
+            if(!LookupsForCulture.TryGetValue(formatProvider, out var quantitiesForProvider))
                 return formatProvider != FallbackCulture ? TryGetUnitValueAbbreviationLookup(unitType, FallbackCulture, out unitToAbbreviations) : false;
 
             if(!quantitiesForProvider.TryGetValue(unitType, out unitToAbbreviations))

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -17,7 +17,7 @@ namespace UnitsNet
     /// </summary>
     public sealed class UnitParser
     {
-        private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
+        private UnitAbbreviationsCache UnitAbbreviationsCache { get; }
 
         /// <summary>
         ///     The default static instance used internally to parse quantities and units using the
@@ -31,7 +31,7 @@ namespace UnitsNet
         /// <param name="unitAbbreviationsCache"></param>
         public UnitParser(UnitAbbreviationsCache unitAbbreviationsCache)
         {
-            _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
+            UnitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
         }
 
         static UnitParser()
@@ -72,7 +72,7 @@ namespace UnitsNet
             if (unitAbbreviation == null) throw new ArgumentNullException(nameof(unitAbbreviation));
             unitAbbreviation = unitAbbreviation.Trim();
 
-            if(!_unitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
+            if(!UnitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
                 throw new UnitNotFoundException($"No abbreviations defined for unit type [{unitType}] for culture [{formatProvider}].");
 
             var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation, ignoreCase: true);
@@ -160,7 +160,7 @@ namespace UnitsNet
             unitAbbreviation = unitAbbreviation.Trim();
             unit = default;
 
-            if(!_unitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
+            if(!UnitAbbreviationsCache.TryGetUnitValueAbbreviationLookup(unitType, formatProvider, out var abbreviations))
                 return false;
 
             var unitIntValues = abbreviations.GetUnitsForAbbreviation(unitAbbreviation, ignoreCase: true);

--- a/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
+++ b/UnitsNet/CustomCode/UnitValueAbbreviationLookup.cs
@@ -1,4 +1,4 @@
-// Licensed under MIT No Attribution, see LICENSE file at the root.
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
@@ -12,13 +12,13 @@ namespace UnitsNet
 {
     internal class UnitValueAbbreviationLookup
     {
-        private readonly UnitToAbbreviationMap unitToAbbreviationMap = new UnitToAbbreviationMap();
-        private readonly AbbreviationToUnitMap abbreviationToUnitMap = new AbbreviationToUnitMap();
-        private readonly AbbreviationToUnitMap lowerCaseAbbreviationToUnitMap = new AbbreviationToUnitMap();
+        private UnitToAbbreviationMap UnitToAbbreviationMap { get; } = new UnitToAbbreviationMap();
+        private AbbreviationToUnitMap AbbreviationToUnitMap { get; } = new AbbreviationToUnitMap();
+        private AbbreviationToUnitMap LowerCaseAbbreviationToUnitMap { get; } = new AbbreviationToUnitMap();
 
         internal string[] GetAllUnitAbbreviationsForQuantity()
         {
-            return unitToAbbreviationMap.Values.SelectMany((abbreviations) =>
+            return UnitToAbbreviationMap.Values.SelectMany((abbreviations) =>
             {
                 return abbreviations;
             } ).Distinct().ToArray();
@@ -31,8 +31,8 @@ namespace UnitsNet
 
         internal List<string> GetAbbreviationsForUnit(int unit)
         {
-            if(!unitToAbbreviationMap.TryGetValue(unit, out var abbreviations))
-                unitToAbbreviationMap[unit] = abbreviations = new List<string>();
+            if(!UnitToAbbreviationMap.TryGetValue(unit, out var abbreviations))
+                UnitToAbbreviationMap[unit] = abbreviations = new List<string>();
 
             return abbreviations.Distinct().ToList();
         }
@@ -41,7 +41,7 @@ namespace UnitsNet
         {
             var lowerCaseAbbreviation = abbreviation.ToLower();
             var key = ignoreCase ? lowerCaseAbbreviation : abbreviation;
-            var map = ignoreCase ? lowerCaseAbbreviationToUnitMap : abbreviationToUnitMap;
+            var map = ignoreCase ? LowerCaseAbbreviationToUnitMap : AbbreviationToUnitMap;
 
             if(!map.TryGetValue(key, out List<int> units))
                 map[key] = units = new List<int>();
@@ -53,14 +53,14 @@ namespace UnitsNet
         {
             var lowerCaseAbbreviation = abbreviation.ToLower();
 
-            if(!unitToAbbreviationMap.TryGetValue(unit, out var abbreviationsForUnit))
-                abbreviationsForUnit = unitToAbbreviationMap[unit] = new List<string>();
+            if(!UnitToAbbreviationMap.TryGetValue(unit, out var abbreviationsForUnit))
+                abbreviationsForUnit = UnitToAbbreviationMap[unit] = new List<string>();
 
-            if(!abbreviationToUnitMap.TryGetValue(abbreviation, out var unitsForAbbreviation))
-                abbreviationToUnitMap[abbreviation] = unitsForAbbreviation = new List<int>();
+            if(!AbbreviationToUnitMap.TryGetValue(abbreviation, out var unitsForAbbreviation))
+                AbbreviationToUnitMap[abbreviation] = unitsForAbbreviation = new List<int>();
 
-            if(!lowerCaseAbbreviationToUnitMap.TryGetValue(lowerCaseAbbreviation, out var unitsForLowerCaseAbbreviation))
-                lowerCaseAbbreviationToUnitMap[lowerCaseAbbreviation] = unitsForLowerCaseAbbreviation = new List<int>();
+            if(!LowerCaseAbbreviationToUnitMap.TryGetValue(lowerCaseAbbreviation, out var unitsForLowerCaseAbbreviation))
+                LowerCaseAbbreviationToUnitMap[lowerCaseAbbreviation] = unitsForLowerCaseAbbreviation = new List<int>();
 
             unitsForLowerCaseAbbreviation.Remove(unit);
             unitsForLowerCaseAbbreviation.Add(unit);

--- a/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
+++ b/UnitsNet/InternalHelpers/ReflectionBridgeExtensions.cs
@@ -22,31 +22,31 @@ namespace UnitsNet.InternalHelpers
 {
     internal struct TypeWrapper
     {
-        private readonly Type _type;
+        private Type Type { get; }
 
         public TypeWrapper(Type type)
         {
-            _type = type;
+            Type = type;
         }
 
-        internal Assembly Assembly => _type.ToUniformType().Assembly;
-        internal bool IsEnum => _type.ToUniformType().IsEnum;
-        internal bool IsClass => _type.ToUniformType().IsClass;
-        internal bool IsAssignableFrom(Type other) => _type.ToUniformType().IsAssignableFrom(other.ToUniformType());
-        internal bool IsValueType => _type.ToUniformType().IsValueType;
+        internal Assembly Assembly => Type.ToUniformType().Assembly;
+        internal bool IsEnum => Type.ToUniformType().IsEnum;
+        internal bool IsClass => Type.ToUniformType().IsClass;
+        internal bool IsAssignableFrom(Type other) => Type.ToUniformType().IsAssignableFrom(other.ToUniformType());
+        internal bool IsValueType => Type.ToUniformType().IsValueType;
 
         internal PropertyInfo GetProperty(string name)
         {
 #if NET40 || NET35 || NET20 || SILVERLIGHT
-            return _type.GetProperty(name);
+            return Type.GetProperty(name);
 #else
-            return _type.GetTypeInfo().GetDeclaredProperty(name);
+            return Type.GetTypeInfo().GetDeclaredProperty(name);
 #endif
         }
 
         internal IEnumerable<MethodInfo> GetDeclaredMethods()
         {
-            var t = _type.ToUniformType();
+            var t = Type.ToUniformType();
             while (t != null)
             {
 #if NET40 || NET35 || NET20 || SILVERLIGHT

--- a/UnitsNet/QuantityInfo.cs
+++ b/UnitsNet/QuantityInfo.cs
@@ -20,9 +20,9 @@ namespace UnitsNet
     /// </remarks>
     public class QuantityInfo
     {
-        private static readonly string UnitEnumNamespace = typeof(LengthUnit).Namespace;
+        private static string UnitEnumNamespace { get; } = typeof(LengthUnit).Namespace;
 
-        private static readonly Type[] UnitEnumTypes = typeof(Length)
+        private static Type[] UnitEnumTypes { get; } = typeof(Length)
             .Wrap()
             .Assembly
             .GetExportedTypes()

--- a/UnitsNet/QuantityValue.cs
+++ b/UnitsNet/QuantityValue.cs
@@ -25,25 +25,25 @@ namespace UnitsNet
         ///     Value assigned when implicitly casting from all numeric types except <see cref="decimal" />, since
         ///     <see cref="double" /> has the greatest range and is 64 bits versus 128 bits for <see cref="decimal"/>.
         /// </summary>
-        private readonly double? _value;
+        private double? Value { get; }
 
         /// <summary>
         ///     Value assigned when implicitly casting from <see cref="decimal" /> type, since it has a greater precision than
         ///     <see cref="double"/> and we want to preserve that when constructing quantities that use <see cref="decimal"/>
         ///     as their value type.
         /// </summary>
-        private readonly decimal? _valueDecimal;
+        private decimal? ValueDecimal { get; }
 
         private QuantityValue(double val)
         {
-            _value = Guard.EnsureValidNumber(val, nameof(val));
-            _valueDecimal = null;
+            Value = Guard.EnsureValidNumber(val, nameof(val));
+            ValueDecimal = null;
         }
 
         private QuantityValue(decimal val)
         {
-            _valueDecimal = val;
-            _value = null;
+            ValueDecimal = val;
+            Value = null;
         }
 
         #region To QuantityValue
@@ -76,7 +76,7 @@ namespace UnitsNet
         public static explicit operator double(QuantityValue number)
         {
             // double -> decimal -> zero (since we can't implement the default struct ctor)
-            return number._value ?? (double) number._valueDecimal.GetValueOrDefault();
+            return number.Value ?? (double) number.ValueDecimal.GetValueOrDefault();
         }
 
         #endregion
@@ -87,7 +87,7 @@ namespace UnitsNet
         public static explicit operator decimal(QuantityValue number)
         {
             // decimal -> double -> zero (since we can't implement the default struct ctor)
-            return number._valueDecimal ?? (decimal) number._value.GetValueOrDefault();
+            return number.ValueDecimal ?? (decimal) number.Value.GetValueOrDefault();
         }
 
         #endregion
@@ -95,7 +95,7 @@ namespace UnitsNet
         /// <summary>Returns the string representation of the numeric value.</summary>
         public override string ToString()
         {
-            return _value.HasValue ? _value.ToString() : _valueDecimal.ToString();
+            return Value.HasValue ? Value.ToString() : ValueDecimal.ToString();
         }
     }
 }

--- a/UnitsNet/UnitSystem.cs
+++ b/UnitsNet/UnitSystem.cs
@@ -93,7 +93,7 @@ namespace UnitsNet
         /// </summary>
         public BaseUnits BaseUnits{ get; }
 
-        private static readonly BaseUnits SIBaseUnits = new BaseUnits(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second,
+        private static BaseUnits SIBaseUnits { get; } = new BaseUnits(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second,
             ElectricCurrentUnit.Ampere, TemperatureUnit.Kelvin, AmountOfSubstanceUnit.Mole, LuminousIntensityUnit.Candela);
 
         /// <summary>


### PR DESCRIPTION
Just to match the rest of the library where we use them heavily.

I wish I could do the quantity classes (_value), but the old json still uses reflection to get it. Now that reflection is gone we could make the change but have to update the json and break forward compatibility.