### PR TITLE
Fix #652 - Parse fails with custom formatprovider

### DIFF
--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -143,5 +143,71 @@ namespace UnitsNet.Tests.CustomCode
             bool actual = Length.TryParse(s, usEnglish, out Length _);
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData("1 ng", "en-US", 1, MassUnit.Nanogram)]
+        [InlineData("1 нг", "ru-RU", 1, MassUnit.Nanogram)]
+        [InlineData("1 g", "en-US", 1, MassUnit.Gram)]
+        [InlineData("1 г", "ru-RU", 1, MassUnit.Gram)]
+        [InlineData("1 kg", "en-US", 1, MassUnit.Kilogram)]
+        [InlineData("1 кг", "ru-RU", 1, MassUnit.Kilogram)]
+        public void ParseMassWithPrefixUnits_GivenCulture_ReturnsQuantityWithSameUnitAndValue(string str, string cultureName, double expectedValue, Enum expectedUnit)
+        {
+            var actual = Mass.Parse(str, new CultureInfo(cultureName));
+
+            Assert.Equal(expectedUnit, actual.Unit);
+            Assert.Equal(expectedValue, actual.Value);
+        }
+
+        [Theory]
+        [InlineData("1 nm", "en-US", 1, LengthUnit.Nanometer)]
+        [InlineData("1 нм", "ru-RU", 1, LengthUnit.Nanometer)]
+        [InlineData("1 m", "en-US", 1, LengthUnit.Meter)]
+        [InlineData("1 м", "ru-RU", 1, LengthUnit.Meter)]
+        [InlineData("1 km", "en-US", 1, LengthUnit.Kilometer)]
+        [InlineData("1 км", "ru-RU", 1, LengthUnit.Kilometer)]
+        public void ParseLengthWithPrefixUnits_GivenCulture_ReturnsQuantityWithSameUnitAndValue(string str, string cultureName, double expectedValue, Enum expectedUnit)
+        {
+            var actual = Length.Parse(str, new CultureInfo(cultureName));
+
+            Assert.Equal(expectedUnit, actual.Unit);
+            Assert.Equal(expectedValue, actual.Value);
+        }
+
+        [Theory]
+        [InlineData("1 µN", "en-US", 1, ForceUnit.Micronewton)]
+        [InlineData("1 нН", "ru-RU", 1, ForceUnit.Micronewton)]
+        [InlineData("1 N", "en-US", 1, ForceUnit.Newton)]
+        [InlineData("1 Н", "ru-RU", 1, ForceUnit.Newton)]
+        [InlineData("1 kN", "en-US", 1, ForceUnit.Kilonewton)]
+        [InlineData("1 кН", "ru-RU", 1, ForceUnit.Kilonewton)]
+        public void ParseForceWithPrefixUnits_GivenCulture_ReturnsQuantityWithSameUnitAndValue(string str, string cultureName, double expectedValue, Enum expectedUnit)
+        {
+            var actual = Force.Parse(str, new CultureInfo(cultureName));
+
+            Assert.Equal(expectedUnit, actual.Unit);
+            Assert.Equal(expectedValue, actual.Value);
+        }
+
+        [Theory]
+        [InlineData("1 b", "en-US", 1, InformationUnit.Bit)]
+        [InlineData("1 b", "ru-RU", 1, InformationUnit.Bit)]
+        [InlineData("1 B", "en-US", 1, InformationUnit.Byte)]
+        [InlineData("1 B", "ru-RU", 1, InformationUnit.Byte)]
+        [InlineData("1 Mb", "en-US", 1, InformationUnit.Megabit)]
+        [InlineData("1 Mb", "ru-RU", 1, InformationUnit.Megabit)]
+        [InlineData("1 Mib", "en-US", 1, InformationUnit.Mebibit)]
+        [InlineData("1 Mib", "ru-RU", 1, InformationUnit.Mebibit)]
+        [InlineData("1 MB", "en-US", 1, InformationUnit.Megabyte)]
+        [InlineData("1 MB", "ru-RU", 1, InformationUnit.Megabyte)]
+        [InlineData("1 MiB", "en-US", 1, InformationUnit.Mebibyte)]
+        [InlineData("1 MiB", "ru-RU", 1, InformationUnit.Mebibyte)]
+        public void ParseInformationWithPrefixUnits_GivenCulture_ReturnsQuantityWithSameUnitAndValue(string str, string cultureName, decimal expectedValue, Enum expectedUnit)
+        {
+            var actual = Information.Parse(str, new CultureInfo(cultureName));
+
+            Assert.Equal(expectedUnit, actual.Unit);
+            Assert.Equal(expectedValue, actual.Value);
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -176,7 +176,7 @@ namespace UnitsNet.Tests.CustomCode
 
         [Theory]
         [InlineData("1 µN", "en-US", 1, ForceUnit.Micronewton)]
-        [InlineData("1 нН", "ru-RU", 1, ForceUnit.Micronewton)]
+        [InlineData("1 мкН", "ru-RU", 1, ForceUnit.Micronewton)]
         [InlineData("1 N", "en-US", 1, ForceUnit.Newton)]
         [InlineData("1 Н", "ru-RU", 1, ForceUnit.Newton)]
         [InlineData("1 kN", "en-US", 1, ForceUnit.Kilonewton)]

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System;
+using System.Globalization;
 using UnitsNet.Units;
 using Xunit;
 
@@ -130,6 +132,18 @@ namespace UnitsNet.Tests
             // Assert
             Assert.Equal("Cannot parse \"pt\" since it could be either of these: DtpPoint, PrinterPoint", exception1.Message);
             Assert.Equal("Cannot parse \"pt\" since it could be either of these: DtpPoint, PrinterPoint", exception2.Message);
+        }
+
+        [Theory]
+        [InlineData("ng", "en-US", MassUnit.Nanogram)]
+        [InlineData("нг", "ru-RU", MassUnit.Nanogram)]
+        [InlineData("g", "en-US", MassUnit.Gram)]
+        [InlineData("г", "ru-RU", MassUnit.Gram)]
+        [InlineData("kg", "en-US", MassUnit.Kilogram)]
+        [InlineData("кг", "ru-RU", MassUnit.Kilogram)]
+        public void ParseMassUnit_GivenCulture(string str, string cultureName, Enum expectedUnit)
+        {
+            Assert.Equal(expectedUnit, UnitParser.Default.Parse<MassUnit>(str, new CultureInfo(cultureName)));
         }
     }
 }

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -50,7 +50,7 @@ namespace UnitsNet
         [PublicAPI]
         public TUnitType Parse<TUnitType>(string unitAbbreviation, [CanBeNull] IFormatProvider formatProvider = null) where TUnitType : Enum
         {
-            return (TUnitType)Parse(unitAbbreviation, typeof(TUnitType));
+            return (TUnitType)Parse(unitAbbreviation, typeof(TUnitType), formatProvider);
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #652 

Format provider was accidentally not forwarded in one of the `UnitParser.Parse()` methods.
Add failing tests and then fix them.
Add tests for the most common quantities.