### PR TITLE
codegen: Make abbreviations for prefixes explicit

### DIFF
--- a/CodeGen/Generators/UnitsNetGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGenerator.cs
@@ -10,7 +10,6 @@ using CodeGen.Generators.UnitsNetGen;
 using CodeGen.Helpers;
 using CodeGen.JsonTypes;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Serilog;
 
 namespace CodeGen.Generators
@@ -57,11 +56,18 @@ namespace CodeGen.Generators
 
         private static Quantity ParseQuantityFile(string jsonFile)
         {
-            var quantity = JsonConvert.DeserializeObject<Quantity>(File.ReadAllText(jsonFile, Encoding.UTF8), JsonSerializerSettings);
-            AddPrefixUnits(quantity);
-            FixConversionFunctionsForDecimalValueTypes(quantity);
-            OrderUnitsByName(quantity);
-            return quantity;
+            try
+            {
+                var quantity = JsonConvert.DeserializeObject<Quantity>(File.ReadAllText(jsonFile, Encoding.UTF8), JsonSerializerSettings);
+                AddPrefixUnits(quantity);
+                FixConversionFunctionsForDecimalValueTypes(quantity);
+                OrderUnitsByName(quantity);
+                return quantity;
+            }
+            catch (Exception e)
+            {
+                throw new Exception($"Error parsing quantity JSON file: {jsonFile}", e);
+            }
         }
 
         private static void GenerateUnitTestClassIfNotExists(StringBuilder sb, Quantity quantity, string filePath)
@@ -144,124 +150,61 @@ namespace CodeGen.Generators
             foreach (Unit unit in quantity.Units)
             {
                 // "Kilo", "Nano" etc.
-                for (var prefixIndex = 0; prefixIndex < unit.Prefixes.Length; prefixIndex++)
+                foreach (Prefix prefix in unit.Prefixes)
                 {
-                    Prefix prefix = unit.Prefixes[prefixIndex];
-                    PrefixInfo prefixInfo = PrefixInfo.Entries[prefix];
-
-                    unitsToAdd.Add(new Unit
+                    try
                     {
-                        SingularName = $"{prefix}{unit.SingularName.ToCamelCase()}", // "Kilo" + "NewtonPerMeter" => "KilonewtonPerMeter"
-                        PluralName = $"{prefix}{unit.PluralName.ToCamelCase()}",     // "Kilo" + "NewtonsPerMeter" => "KilonewtonsPerMeter"
-                        BaseUnits = null, // Can we determine this somehow?
-                        FromBaseToUnitFunc = $"({unit.FromBaseToUnitFunc}) / {prefixInfo.Factor}",
-                        FromUnitToBaseFunc = $"({unit.FromUnitToBaseFunc}) * {prefixInfo.Factor}",
-                        Localization = GetLocalizationForPrefixUnit(unit, prefixIndex, prefixInfo, quantity.Name),
-                    });
+                        PrefixInfo prefixInfo = PrefixInfo.Entries[prefix];
+
+                        unitsToAdd.Add(new Unit
+                        {
+                            SingularName = $"{prefix}{unit.SingularName.ToCamelCase()}", // "Kilo" + "NewtonPerMeter" => "KilonewtonPerMeter"
+                            PluralName = $"{prefix}{unit.PluralName.ToCamelCase()}", // "Kilo" + "NewtonsPerMeter" => "KilonewtonsPerMeter"
+                            BaseUnits = null, // Can we determine this somehow?
+                            FromBaseToUnitFunc = $"({unit.FromBaseToUnitFunc}) / {prefixInfo.Factor}",
+                            FromUnitToBaseFunc = $"({unit.FromUnitToBaseFunc}) * {prefixInfo.Factor}",
+                            Localization = GetLocalizationForPrefixUnit(unit.Localization, prefixInfo),
+                        });
+                    }
+                    catch (Exception e)
+                    {
+                        throw new Exception($"Error parsing prefix {prefix} for unit {quantity.Name}.{unit.SingularName}.", e);
+                    }
                 }
             }
 
             quantity.Units = quantity.Units.Concat(unitsToAdd).ToArray();
         }
 
-        private static Localization[] GetLocalizationForPrefixUnit(Unit unit, int prefixIndex, PrefixInfo prefixInfo, string quantityName)
+        /// <summary>
+        /// Create unit abbreviations for a prefix unit, given a unit and the prefix.
+        /// The unit abbreviations are either prefixed with the SI prefix or an explicitly configured abbreviation via <see cref="AbbreviationsForPrefixes"/>.
+        /// </summary>
+        private static Localization[] GetLocalizationForPrefixUnit(IEnumerable<Localization> localizations, PrefixInfo prefixInfo)
         {
-            string[] GetUnitAbbreviationsForPrefix(Localization loc)
+            return localizations.Select(loc =>
             {
-                // If no custom abbreviations are specified, prepend the default prefix to each unit abbreviation: kilo ("k") + meter ("m") => kilometer ("km")
-                if (loc.AbbreviationsWithPrefixes == null || !loc.AbbreviationsWithPrefixes.Any())
+                if (loc.TryGetAbbreviationsForPrefix(prefixInfo.Prefix, out string[] unitAbbreviationsForPrefix))
                 {
-                    string prefix = prefixInfo.Abbreviation;
-                    return loc.Abbreviations.Select(unitAbbreviation => $"{prefix}{unitAbbreviation}").ToArray();
+                    // Use explicitly defined prefix unit abbreviations
+                    return new Localization
+                    {
+                        Culture = loc.Culture,
+                        Abbreviations = unitAbbreviationsForPrefix,
+                    };
                 }
 
-                /*
-                 Prepend prefix to all abbreviations of a unit.
-                 Some languages, like Russian, you can't simply prepend "k" for kilo prefix, so the prefix abbreviations must be explicitly defined
-                 with AbbreviationsWithPrefixes.
-
-                 Example 1 - Torque.Newtonmeter has only a single abbreviation in Russian, so AbbreviationsWithPrefixes is an array of strings mapped to each prefix
-
-    {
-      "SingularName": "NewtonMeter",
-      "PluralName": "NewtonMeters",
-      "FromUnitToBaseFunc": "x",
-      "FromBaseToUnitFunc": "x",
-      "Prefixes": [ "Kilo", "Mega" ],
-      "Localization": [
-        {
-          "Culture": "en-US",
-          "Abbreviations": [ "N·m" ]
-        },
-        {
-          "Culture": "ru-RU",
-          "Abbreviations": [ "Н·м" ],
-          "AbbreviationsWithPrefixes": [ "кН·м", "МН·м" ]
-        }
-      ]
-    },
-
-                Example 2 - Duration.Second has 3 prefixes and 2 abbreviations in Russian, so AbbreviationsWithPrefixes is an array of 3 items where each
-                represents the unit abbreviations for that prefix - typically a variant of those in "Abbreviations", but the counts don't have to match.
-
-    {
-      "SingularName": "Second",
-      "PluralName": "Seconds",
-      "BaseUnits": {
-        "T": "Second"
-      },
-      "FromUnitToBaseFunc": "x",
-      "FromBaseToUnitFunc": "x",
-      "Prefixes": [ "Nano", "Micro", "Milli" ],
-      "Localization": [
-        {
-          "Culture": "en-US",
-          "Abbreviations": [ "s", "sec", "secs", "second", "seconds" ]
-        },
-        {
-          "Culture": "ru-RU",
-          "Abbreviations": [ "с", "сек" ],
-          "AbbreviationsWithPrefixes": [ ["нс", "нсек"], ["мкс", "мксек"], ["мс", "мсек"] ]
-        }
-      ]
-    }
-                 */
-
-                EnsureValidAbbreviationsWithPrefixes(loc, unit, quantityName);
-                JToken abbreviationsForPrefix = loc.AbbreviationsWithPrefixes[prefixIndex];
-                switch (abbreviationsForPrefix.Type)
-                {
-                    case JTokenType.Array:
-                        return abbreviationsForPrefix.ToObject<string[]>();
-                    case JTokenType.String:
-                        return new[] {abbreviationsForPrefix.ToObject<string>()};
-                    default:
-                        throw new NotSupportedException("Expect AbbreviationsWithPrefixes to be an array of strings or string arrays.");
-                }
-            }
-
-            Localization WithPrefixes(Localization loc)
-            {
-                string[] unitAbbreviationsForPrefix = GetUnitAbbreviationsForPrefix(loc);
+                // No prefix unit abbreviations are specified, so fall back to prepending the default SI prefix to each unit abbreviation:
+                // kilo ("k") + meter ("m") => kilometer ("km")
+                string prefix = prefixInfo.Abbreviation;
+                unitAbbreviationsForPrefix = loc.Abbreviations.Select(unitAbbreviation => $"{prefix}{unitAbbreviation}").ToArray();
 
                 return new Localization
                 {
                     Culture = loc.Culture,
                     Abbreviations = unitAbbreviationsForPrefix,
                 };
-            }
-
-            return unit.Localization.Select(WithPrefixes).ToArray();
-        }
-
-        private static void EnsureValidAbbreviationsWithPrefixes(Localization localization, Unit unit, string quantityName)
-        {
-            if (localization.AbbreviationsWithPrefixes.Length > 0 &&
-                localization.AbbreviationsWithPrefixes.Length != unit.Prefixes.Length)
-            {
-                throw new InvalidDataException(
-                    $"The Prefixes array length {unit.Prefixes.Length} does not match Localization.AbbreviationsWithPrefixes array length {localization.AbbreviationsWithPrefixes.Length} for {quantityName}.{unit.SingularName}");
-            }
+            }).ToArray();
         }
     }
 }

--- a/CodeGen/JsonTypes/Localization.cs
+++ b/CodeGen/JsonTypes/Localization.cs
@@ -12,10 +12,47 @@ namespace CodeGen.JsonTypes
 #pragma warning disable 0649
 
         public string[] Abbreviations = Array.Empty<string>();
-        public JToken[] AbbreviationsWithPrefixes;
+
+        /// <summary>
+        /// Unit abbreviations for prefixes of a unit.
+        /// Typically, this is used for languages or units abbreviations where the default SI prefix ("k" for kilo etc) cannot simply be prepended
+        /// to the abbreviations defined in <see cref="Localization.Abbreviations"/>.
+        /// </summary>
+        /// <example>
+        /// Duration.Second unit for Russian culture has "Abbreviations": [ "с", "сек" ] and "AbbreviationsForPrefixes": { "Nano": ["нс", "нсек"], "Micro": ["мкс", "мксек"], "Milli": ["мс", "мсек"] }
+        /// </example>
+        /// <remarks>One or more of properties with <see cref="Prefix"/> names should be assigned a string or a string[].</remarks>
+        public JObject AbbreviationsForPrefixes;
+
         public string Culture;
 
         // 0649 Field is never assigned to
 #pragma warning restore 0649
+
+        public bool TryGetAbbreviationsForPrefix(Prefix prefix, out string[] unitAbbreviations)
+        {
+            if (AbbreviationsForPrefixes == null ||
+                !AbbreviationsForPrefixes.TryGetValue(prefix.ToString(), out JToken value))
+            {
+                unitAbbreviations = default;
+                return false;
+            }
+
+            switch (value.Type)
+            {
+                case JTokenType.String:
+                {
+                    unitAbbreviations = new[] {value.ToObject<string>()};
+                    return true;
+                }
+                case JTokenType.Array:
+                {
+                    unitAbbreviations = value.ToObject<string[]>();
+                    return true;
+                }
+                default:
+                    throw new NotSupportedException($"Expected AbbreviationsForPrefixes.{prefix} to be a string or an array of strings.");
+            }
+        }
     }
 }

--- a/CodeGen/PrefixInfo.cs
+++ b/CodeGen/PrefixInfo.cs
@@ -1,5 +1,5 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using CodeGen.JsonTypes;
 
 namespace CodeGen
@@ -9,6 +9,11 @@ namespace CodeGen
     /// </summary>
     internal class PrefixInfo
     {
+        /// <summary>
+        /// The unit prefix.
+        /// </summary>
+        public Prefix Prefix { get; }
+
         /// <summary>
         /// The unit prefix abbreviation, such as "k" for kilo or "m" for milli.
         /// </summary>
@@ -20,44 +25,45 @@ namespace CodeGen
         /// <example>Kilo has "1e3" in order to multiply by 1000.</example>
         public string Factor { get; }
 
-        public static readonly IReadOnlyDictionary<Prefix, PrefixInfo> Entries = new Dictionary<Prefix, PrefixInfo>
+        public static readonly IReadOnlyDictionary<Prefix, PrefixInfo> Entries = new[]
         {
-            // NOTE: Need to append 'd' suffix for double in order to later search/replace "d" with "m"
+            // Need to append 'd' suffix for double in order to later search/replace "d" with "m"
             // when creating decimal conversion functions in CodeGen.Generator.FixConversionFunctionsForDecimalValueTypes.
 
             // SI prefixes
-            { Prefix.Yocto, new PrefixInfo("y", "1e-24d") },
-            { Prefix.Zepto, new PrefixInfo("z", "1e-21d") },
-            { Prefix.Atto, new PrefixInfo("a", "1e-18d") },
-            { Prefix.Femto, new PrefixInfo("f", "1e-15d") },
-            { Prefix.Pico, new PrefixInfo("p", "1e-12d") },
-            { Prefix.Nano, new PrefixInfo("n", "1e-9d") },
-            { Prefix.Micro, new PrefixInfo("µ", "1e-6d") },
-            { Prefix.Milli, new PrefixInfo("m", "1e-3d") },
-            { Prefix.Centi, new PrefixInfo("c", "1e-2d") },
-            { Prefix.Deci, new PrefixInfo("d", "1e-1d") },
-            { Prefix.Deca, new PrefixInfo("da", "1e1d") },
-            { Prefix.Hecto, new PrefixInfo("h", "1e2d") },
-            { Prefix.Kilo, new PrefixInfo("k", "1e3d") },
-            { Prefix.Mega, new PrefixInfo("M", "1e6d") },
-            { Prefix.Giga, new PrefixInfo("G", "1e9d") },
-            { Prefix.Tera, new PrefixInfo("T", "1e12d") },
-            { Prefix.Peta, new PrefixInfo("P", "1e15d") },
-            { Prefix.Exa, new PrefixInfo("E", "1e18d") },
-            { Prefix.Zetta, new PrefixInfo("Z", "1e21d") },
-            { Prefix.Yotta, new PrefixInfo("Y", "1e24d") },
+            new PrefixInfo(Prefix.Yocto, "y", "1e-24d"),
+            new PrefixInfo(Prefix.Zepto, "z", "1e-21d"),
+            new PrefixInfo(Prefix.Atto, "a", "1e-18d"),
+            new PrefixInfo(Prefix.Femto, "f", "1e-15d"),
+            new PrefixInfo(Prefix.Pico, "p", "1e-12d"),
+            new PrefixInfo(Prefix.Nano, "n", "1e-9d"),
+            new PrefixInfo(Prefix.Micro, "µ", "1e-6d"),
+            new PrefixInfo(Prefix.Milli, "m", "1e-3d"),
+            new PrefixInfo(Prefix.Centi, "c", "1e-2d"),
+            new PrefixInfo(Prefix.Deci, "d", "1e-1d"),
+            new PrefixInfo(Prefix.Deca, "da", "1e1d"),
+            new PrefixInfo(Prefix.Hecto, "h", "1e2d"),
+            new PrefixInfo(Prefix.Kilo, "k", "1e3d"),
+            new PrefixInfo(Prefix.Mega, "M", "1e6d"),
+            new PrefixInfo(Prefix.Giga, "G", "1e9d"),
+            new PrefixInfo(Prefix.Tera, "T", "1e12d"),
+            new PrefixInfo(Prefix.Peta, "P", "1e15d"),
+            new PrefixInfo(Prefix.Exa, "E", "1e18d"),
+            new PrefixInfo(Prefix.Zetta, "Z", "1e21d"),
+            new PrefixInfo(Prefix.Yotta, "Y", "1e24d"),
 
             // Binary prefixes
-            { Prefix.Kibi, new PrefixInfo("Ki", $"1024d") },
-            { Prefix.Mebi, new PrefixInfo("Mi", $"(1024d * 1024)") },
-            { Prefix.Gibi, new PrefixInfo("Gi", $"(1024d * 1024 * 1024)") },
-            { Prefix.Tebi, new PrefixInfo("Ti", $"(1024d * 1024 * 1024 * 1024)") },
-            { Prefix.Pebi, new PrefixInfo("Pi", $"(1024d * 1024 * 1024 * 1024 * 1024)") },
-            { Prefix.Exbi, new PrefixInfo("Ei", $"(1024d * 1024 * 1024 * 1024 * 1024 * 1024)") },
-        };
+            new PrefixInfo(Prefix.Kibi, "Ki", $"1024d"),
+            new PrefixInfo(Prefix.Mebi, "Mi", $"(1024d * 1024)"),
+            new PrefixInfo(Prefix.Gibi, "Gi", $"(1024d * 1024 * 1024)"),
+            new PrefixInfo(Prefix.Tebi, "Ti", $"(1024d * 1024 * 1024 * 1024)"),
+            new PrefixInfo(Prefix.Pebi, "Pi", $"(1024d * 1024 * 1024 * 1024 * 1024)"),
+            new PrefixInfo(Prefix.Exbi, "Ei", $"(1024d * 1024 * 1024 * 1024 * 1024 * 1024)"),
+        }.ToDictionary(prefixInfo => prefixInfo.Prefix);
 
-        private PrefixInfo(string abbreviation, string factor)
+        private PrefixInfo(Prefix prefix, string abbreviation, string factor)
         {
+            Prefix = prefix;
             Abbreviation = abbreviation;
             Factor = factor;
         }

--- a/Common/UnitDefinitions/Density.json
+++ b/Common/UnitDefinitions/Density.json
@@ -77,7 +77,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lb/in³" ],
-          "AbbreviationsWithPrefixes": [ "kip/in³" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kip/in³" }
         }
       ]
     },
@@ -95,7 +95,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lb/ft³" ],
-          "AbbreviationsWithPrefixes": [ "kip/ft³" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kip/ft³" }
         }
       ]
     },

--- a/Common/UnitDefinitions/Duration.json
+++ b/Common/UnitDefinitions/Duration.json
@@ -137,7 +137,11 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "с", "сек" ],
-          "AbbreviationsWithPrefixes": [ ["нс", "нсек"], ["мкс", "мксек"], ["мс", "мсек"] ]
+          "AbbreviationsForPrefixes": {
+            "Nano": ["нс", "нсек"],
+            "Micro": ["мкс", "мксек"],
+            "Milli": ["мс", "мсек"]
+          }
         }
       ]
     }

--- a/Common/UnitDefinitions/Energy.json
+++ b/Common/UnitDefinitions/Energy.json
@@ -115,12 +115,12 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "th (E.C.)" ],
-          "AbbreviationsWithPrefixes": [ "Dth (E.C.)" ]
+          "AbbreviationsForPrefixes": { "Deca": "Dth (E.C.)" }
         },
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Европейский терм" ],
-          "AbbreviationsWithPrefixes": [ "Европейский декатерм" ]
+          "AbbreviationsForPrefixes": { "Deca": "Европейский декатерм" }
         }
       ]
     },
@@ -134,12 +134,12 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "th (U.S.)" ],
-          "AbbreviationsWithPrefixes": [ "Dth (U.S.)" ]
+          "AbbreviationsForPrefixes": { "Deca": "Dth (U.S.)" }
         },
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Американский терм" ],
-          "AbbreviationsWithPrefixes": [ "Американский декатерм" ]
+          "AbbreviationsForPrefixes": { "Deca": "Американский декатерм" }
         }
       ]
     },
@@ -153,12 +153,12 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "th (imp.)" ],
-          "AbbreviationsWithPrefixes": [ "Dth (imp.)" ]
+          "AbbreviationsForPrefixes": { "Deca": "Dth (imp.)" }
         },
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Английский терм" ],
-          "AbbreviationsWithPrefixes": [ "Английский декатерм" ]
+          "AbbreviationsForPrefixes": { "Deca": "Английский декатерм" }
         }
       ]
     }

--- a/Common/UnitDefinitions/Force.json
+++ b/Common/UnitDefinitions/Force.json
@@ -80,7 +80,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Н" ],
-          "AbbreviationsWithPrefixes": [ "мкН", "мН", "даН", "кН", "МН" ]
+          "AbbreviationsForPrefixes": { "Micro": "мкН", "Milli": "мН", "Deca": "даН", "Kilo": "кН", "Mega": "МН" }
         }
       ]
     },

--- a/Common/UnitDefinitions/KinematicViscosity.json
+++ b/Common/UnitDefinitions/KinematicViscosity.json
@@ -38,7 +38,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Ст" ],
-          "AbbreviationsWithPrefixes": [ "нСт", "мкСт", "мСт", "сСт", "дСт", "кСт" ]
+          "AbbreviationsForPrefixes": { "Nano": "нСт", "Micro": "мкСт", "Milli": "мСт", "Centi": "сСт", "Deci": "дСт", "Kilo": "кСт" }
         }
       ]
     }

--- a/Common/UnitDefinitions/Length.json
+++ b/Common/UnitDefinitions/Length.json
@@ -23,7 +23,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "м" ],
-          "AbbreviationsWithPrefixes": [ "нм", "мкм", "мм", "см", "дм", "гм", "км" ]
+          "AbbreviationsForPrefixes": { "Nano": "нм", "Micro": "мкм", "Milli": "мм", "Centi": "см", "Deci": "дм", "Hecto": "гм", "Kilo": "км" }
         }
       ]
     },

--- a/Common/UnitDefinitions/Mass.json
+++ b/Common/UnitDefinitions/Mass.json
@@ -23,7 +23,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "г" ],
-          "AbbreviationsWithPrefixes": [ "нг", "мкг", "мг", "сг", "дг", "даг", "гг", "кг" ]
+          "AbbreviationsForPrefixes": { "Nano": "нг", "Micro": "мкг", "Milli": "мг", "Centi": "сг", "Deci": "дг", "Deca": "даг", "Hecto": "гг", "Kilo": "кг" }
         }
       ]
     },
@@ -44,7 +44,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "т" ],
-          "AbbreviationsWithPrefixes": [ "кт", "Мт" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кт", "Mega": "Мт" }
         }
       ]
     },

--- a/Common/UnitDefinitions/MassConcentration.json
+++ b/Common/UnitDefinitions/MassConcentration.json
@@ -82,7 +82,7 @@
     },
     {
       "SingularName": "GramPerDeciliter",
-      "PluralName": "GramsPerDeciliter", 
+      "PluralName": "GramsPerDeciliter",
       "FromUnitToBaseFunc": "x/1e-1",
       "FromBaseToUnitFunc": "x*1e-1",
       "Prefixes": [ "Pico", "Nano", "Micro", "Milli", "Centi", "Deci" ],
@@ -95,7 +95,7 @@
     },
     {
       "SingularName": "GramPerLiter",
-      "PluralName": "GramsPerLiter",      
+      "PluralName": "GramsPerLiter",
       "BaseUnits": {
         "M": "Gram",
         "L": "Decimeter"
@@ -172,7 +172,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lb/in³" ],
-          "AbbreviationsWithPrefixes": [ "kip/in³" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kip/in³" }
         }
       ]
     },
@@ -190,7 +190,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lb/ft³" ],
-          "AbbreviationsWithPrefixes": [ "kip/ft³" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kip/ft³" }
         }
       ]
     },
@@ -212,7 +212,7 @@
     },
     {
       "SingularName": "PoundPerUSGallon",
-      "PluralName": "PoundsPerUSGallon",  
+      "PluralName": "PoundsPerUSGallon",
       "FromUnitToBaseFunc": "x*1.19826427e2",
       "FromBaseToUnitFunc": "x/1.19826427e2",
       "Localization": [

--- a/Common/UnitDefinitions/MassFlow.json
+++ b/Common/UnitDefinitions/MassFlow.json
@@ -99,7 +99,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lb/d" ],
-          "AbbreviationsWithPrefixes": [ "Mlb/d" ]
+          "AbbreviationsForPrefixes": { "Mega": "Mlb/d" }
         }
       ]
     },

--- a/Common/UnitDefinitions/MolarMass.json
+++ b/Common/UnitDefinitions/MolarMass.json
@@ -21,7 +21,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "г/моль" ],
-          "AbbreviationsWithPrefixes": [ "нг/моль", "мкг/моль", "мг/моль", "сг/моль", "дг/моль", "даг/моль", "гг/моль", "кг/моль" ]
+          "AbbreviationsForPrefixes": { "Nano": "нг/моль", "Micro": "мкг/моль", "Milli": "мг/моль", "Centi": "сг/моль", "Deci": "дг/моль", "Deca": "даг/моль", "Hecto": "гг/моль", "Kilo": "кг/моль" }
         }
       ]
     },

--- a/Common/UnitDefinitions/Pressure.json
+++ b/Common/UnitDefinitions/Pressure.json
@@ -27,7 +27,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Па" ],
-          "AbbreviationsWithPrefixes": [ "мкПа", "ммПа", "даПа", "гПа", "кПа", "МПа", "ГПа" ]
+          "AbbreviationsForPrefixes": { "Micro": "мкПа", "Milli": "ммПа", "Deca": "даПа", "Hecto": "гПа", "Kilo": "кПа", "Mega": "МПа", "Giga": "ГПа" }
         }
       ]
     },
@@ -126,7 +126,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Н/м²" ],
-          "AbbreviationsWithPrefixes": [ "кН/м²", "Мн/м²" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кН/м²", "Mega": "Мн/м²" }
         }
       ]
     },
@@ -144,7 +144,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Н/см²" ],
-          "AbbreviationsWithPrefixes": [ "кН/см²" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кН/см²" }
         }
       ]
     },
@@ -162,7 +162,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Н/мм²" ],
-          "AbbreviationsWithPrefixes": [ "кН/мм²" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кН/мм²" }
         }
       ]
     },
@@ -208,7 +208,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "psi", "lb/in²" ],
-          "AbbreviationsWithPrefixes": [ "kipf/in²" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kipf/in²" }
         }
       ]
     },
@@ -222,7 +222,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lb/ft²" ],
-          "AbbreviationsWithPrefixes": [ "kipf/ft²" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kipf/ft²" }
         }
       ]
     },

--- a/Common/UnitDefinitions/PressureChangeRate.json
+++ b/Common/UnitDefinitions/PressureChangeRate.json
@@ -22,7 +22,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Па/с" ],
-          "AbbreviationsWithPrefixes": [ "кПа/с", "МПа/с" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кПа/с", "Mega": "МПа/с" }
         }
       ]
     },
@@ -40,7 +40,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Па/с" ],
-          "AbbreviationsWithPrefixes": [ "кПа/мин", "МПа/мин" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кПа/мин", "Mega": "МПа/мин" }
         }
       ]
     },

--- a/Common/UnitDefinitions/SpecificWeight.json
+++ b/Common/UnitDefinitions/SpecificWeight.json
@@ -94,7 +94,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lbf/in³" ],
-          "AbbreviationsWithPrefixes": [ "kipf/in³" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kipf/in³" }
         }
       ]
     },
@@ -108,7 +108,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lbf/ft³" ],
-          "AbbreviationsWithPrefixes": [ "kipf/ft³" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kipf/ft³" }
         }
       ]
     },

--- a/Common/UnitDefinitions/Torque.json
+++ b/Common/UnitDefinitions/Torque.json
@@ -48,7 +48,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "Н·м" ],
-          "AbbreviationsWithPrefixes": [ "кН·м", "МН·м" ]
+          "AbbreviationsForPrefixes": { "Kilo": "кН·м", "Mega": "МН·м" }
         }
       ]
     },
@@ -62,7 +62,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lbf·in" ],
-          "AbbreviationsWithPrefixes": [ "kipf·in", "Mlbf·in" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kipf·in", "Mega": "Mlbf·in" }
         }
       ]
     },
@@ -76,7 +76,7 @@
         {
           "Culture": "en-US",
           "Abbreviations": [ "lbf·ft" ],
-          "AbbreviationsWithPrefixes": [ "kipf·ft", "Mlbf·ft" ]
+          "AbbreviationsForPrefixes": { "Kilo": "kipf·ft", "Mega": "Mlbf·ft" }
         }
       ]
     },

--- a/Common/UnitDefinitions/Volume.json
+++ b/Common/UnitDefinitions/Volume.json
@@ -20,7 +20,7 @@
         {
           "Culture": "ru-RU",
           "Abbreviations": [ "л" ],
-          "AbbreviationsWithPrefixes": [ "мкл", "мл", "сл", "дл", "гл", "кл", "Mкл" ]
+          "AbbreviationsForPrefixes": {"Micro": "мкл", "Milli": "мл", "Centi": "сл", "Deci": "дл", "Hecto": "гл", "Kilo": "кл", "Mega": "Mкл" }
         }
       ]
     },


### PR DESCRIPTION
To avoid relying on exact same count and ordering of "Prefixes" in unit and "AbbreviationsWithPrefixes", which is bugprone when adding new prefixes.

- Rename AbbreviationsWithPrefixes to AbbreviationsForPrefixes
- Make AbbreviationsForPrefixes an object with prefixes as keys and string or string array as value
- Update JSON files