### PR TITLE
Add revolutions per second squared unit to rotational acceleration

### DIFF
--- a/Common/UnitDefinitions/RotationalAcceleration.json
+++ b/Common/UnitDefinitions/RotationalAcceleration.json
@@ -41,6 +41,18 @@
           "Abbreviations": [ "rpm/s" ]
         }
       ]
+    },
+    {
+      "SingularName": "RevolutionPerSecondPerSecond",
+      "PluralName": "RevolutionsPerSecondPerSecond",
+      "FromUnitToBaseFunc": "(2*Math.PI)*x",
+      "FromBaseToUnitFunc": "(1/(2*Math.PI))*x",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "r/s²" ]
+        }
+      ]
     }
   ]
 }

--- a/Common/UnitDefinitions/RotationalAcceleration.json
+++ b/Common/UnitDefinitions/RotationalAcceleration.json
@@ -43,8 +43,8 @@
       ]
     },
     {
-      "SingularName": "RevolutionPerSecondPerSecond",
-      "PluralName": "RevolutionsPerSecondPerSecond",
+      "SingularName": "RevolutionPerSecondSquared",
+      "PluralName": "RevolutionsPerSecondSquared",
       "FromUnitToBaseFunc": "(2*Math.PI)*x",
       "FromBaseToUnitFunc": "(1/(2*Math.PI))*x",
       "Localization": [

--- a/UnitsNet.Tests/CustomCode/RotationalAccelerationTests.cs
+++ b/UnitsNet.Tests/CustomCode/RotationalAccelerationTests.cs
@@ -30,5 +30,6 @@ namespace UnitsNet.Tests.CustomCode
         protected override double DegreesPerSecondSquaredInOneRadianPerSecondSquared => 180 / Math.PI;
         protected override double RadiansPerSecondSquaredInOneRadianPerSecondSquared => 1;
         protected override double RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared => 9.549296586;
+        protected override double RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared => 1 / (2 * Math.PI);
     }
 }

--- a/UnitsNet.Tests/CustomCode/RotationalAccelerationTests.cs
+++ b/UnitsNet.Tests/CustomCode/RotationalAccelerationTests.cs
@@ -30,6 +30,6 @@ namespace UnitsNet.Tests.CustomCode
         protected override double DegreesPerSecondSquaredInOneRadianPerSecondSquared => 180 / Math.PI;
         protected override double RadiansPerSecondSquaredInOneRadianPerSecondSquared => 1;
         protected override double RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared => 9.549296586;
-        protected override double RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared => 1 / (2 * Math.PI);
+        protected override double RevolutionsPerSecondSquaredInOneRadianPerSecondSquared=> 0.159154943091895;
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
@@ -37,13 +37,13 @@ namespace UnitsNet.Tests
         protected abstract double DegreesPerSecondSquaredInOneRadianPerSecondSquared { get; }
         protected abstract double RadiansPerSecondSquaredInOneRadianPerSecondSquared { get; }
         protected abstract double RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared { get; }
-        protected abstract double RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared { get; }
+        protected abstract double RevolutionsPerSecondSquaredInOneRadianPerSecondSquared { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double DegreesPerSecondSquaredTolerance { get { return 1e-5; } }
         protected virtual double RadiansPerSecondSquaredTolerance { get { return 1e-5; } }
         protected virtual double RevolutionsPerMinutePerSecondTolerance { get { return 1e-5; } }
-        protected virtual double RevolutionsPerSecondPerSecondTolerance { get { return 1e-5; } }
+        protected virtual double RevolutionsPerSecondSquaredTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
@@ -72,7 +72,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DegreesPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.DegreesPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RadiansPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared, radianpersecondsquared.RevolutionsPerMinutePerSecond, RevolutionsPerMinutePerSecondTolerance);
-            AssertEx.EqualTolerance(RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared, radianpersecondsquared.RevolutionsPerSecondPerSecond, RevolutionsPerSecondPerSecondTolerance);
+            AssertEx.EqualTolerance(RevolutionsPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.RevolutionsPerSecondSquared, RevolutionsPerSecondSquaredTolerance);
         }
 
         [Fact]
@@ -81,7 +81,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.DegreePerSecondSquared).DegreesPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RadianPerSecondSquared).RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RevolutionPerMinutePerSecond).RevolutionsPerMinutePerSecond, RevolutionsPerMinutePerSecondTolerance);
-            AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RevolutionPerSecondPerSecond).RevolutionsPerSecondPerSecond, RevolutionsPerSecondPerSecondTolerance);
+            AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RevolutionPerSecondSquared).RevolutionsPerSecondSquared, RevolutionsPerSecondSquaredTolerance);
         }
 
         [Fact]
@@ -104,7 +104,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DegreesPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.DegreePerSecondSquared), DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RadiansPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RadianPerSecondSquared), RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RevolutionPerMinutePerSecond), RevolutionsPerMinutePerSecondTolerance);
-            AssertEx.EqualTolerance(RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RevolutionPerSecondPerSecond), RevolutionsPerSecondPerSecondTolerance);
+            AssertEx.EqualTolerance(RevolutionsPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RevolutionPerSecondSquared), RevolutionsPerSecondSquaredTolerance);
         }
 
         [Fact]
@@ -124,9 +124,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared, (double)revolutionperminutepersecondQuantity.Value, RevolutionsPerMinutePerSecondTolerance);
             Assert.Equal(RotationalAccelerationUnit.RevolutionPerMinutePerSecond, revolutionperminutepersecondQuantity.Unit);
 
-            var revolutionpersecondpersecondQuantity = radianpersecondsquared.ToUnit(RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
-            AssertEx.EqualTolerance(RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared, (double)revolutionpersecondpersecondQuantity.Value, RevolutionsPerSecondPerSecondTolerance);
-            Assert.Equal(RotationalAccelerationUnit.RevolutionPerSecondPerSecond, revolutionpersecondpersecondQuantity.Unit);
+            var revolutionpersecondsquaredQuantity = radianpersecondsquared.ToUnit(RotationalAccelerationUnit.RevolutionPerSecondSquared);
+            AssertEx.EqualTolerance(RevolutionsPerSecondSquaredInOneRadianPerSecondSquared, (double)revolutionpersecondsquaredQuantity.Value, RevolutionsPerSecondSquaredTolerance);
+            Assert.Equal(RotationalAccelerationUnit.RevolutionPerSecondSquared, revolutionpersecondsquaredQuantity.Unit);
         }
 
         [Fact]
@@ -136,7 +136,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalAcceleration.FromDegreesPerSecondSquared(radianpersecondsquared.DegreesPerSecondSquared).RadiansPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.FromRadiansPerSecondSquared(radianpersecondsquared.RadiansPerSecondSquared).RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.FromRevolutionsPerMinutePerSecond(radianpersecondsquared.RevolutionsPerMinutePerSecond).RadiansPerSecondSquared, RevolutionsPerMinutePerSecondTolerance);
-            AssertEx.EqualTolerance(1, RotationalAcceleration.FromRevolutionsPerSecondPerSecond(radianpersecondsquared.RevolutionsPerSecondPerSecond).RadiansPerSecondSquared, RevolutionsPerSecondPerSecondTolerance);
+            AssertEx.EqualTolerance(1, RotationalAcceleration.FromRevolutionsPerSecondSquared(radianpersecondsquared.RevolutionsPerSecondSquared).RadiansPerSecondSquared, RevolutionsPerSecondSquaredTolerance);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/RotationalAccelerationTestsBase.g.cs
@@ -37,11 +37,13 @@ namespace UnitsNet.Tests
         protected abstract double DegreesPerSecondSquaredInOneRadianPerSecondSquared { get; }
         protected abstract double RadiansPerSecondSquaredInOneRadianPerSecondSquared { get; }
         protected abstract double RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared { get; }
+        protected abstract double RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double DegreesPerSecondSquaredTolerance { get { return 1e-5; } }
         protected virtual double RadiansPerSecondSquaredTolerance { get { return 1e-5; } }
         protected virtual double RevolutionsPerMinutePerSecondTolerance { get { return 1e-5; } }
+        protected virtual double RevolutionsPerSecondPerSecondTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
@@ -70,6 +72,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DegreesPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.DegreesPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RadiansPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared, radianpersecondsquared.RevolutionsPerMinutePerSecond, RevolutionsPerMinutePerSecondTolerance);
+            AssertEx.EqualTolerance(RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared, radianpersecondsquared.RevolutionsPerSecondPerSecond, RevolutionsPerSecondPerSecondTolerance);
         }
 
         [Fact]
@@ -78,6 +81,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.DegreePerSecondSquared).DegreesPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RadianPerSecondSquared).RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RevolutionPerMinutePerSecond).RevolutionsPerMinutePerSecond, RevolutionsPerMinutePerSecondTolerance);
+            AssertEx.EqualTolerance(1, RotationalAcceleration.From(1, RotationalAccelerationUnit.RevolutionPerSecondPerSecond).RevolutionsPerSecondPerSecond, RevolutionsPerSecondPerSecondTolerance);
         }
 
         [Fact]
@@ -100,6 +104,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DegreesPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.DegreePerSecondSquared), DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RadiansPerSecondSquaredInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RadianPerSecondSquared), RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RevolutionPerMinutePerSecond), RevolutionsPerMinutePerSecondTolerance);
+            AssertEx.EqualTolerance(RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared, radianpersecondsquared.As(RotationalAccelerationUnit.RevolutionPerSecondPerSecond), RevolutionsPerSecondPerSecondTolerance);
         }
 
         [Fact]
@@ -118,6 +123,10 @@ namespace UnitsNet.Tests
             var revolutionperminutepersecondQuantity = radianpersecondsquared.ToUnit(RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
             AssertEx.EqualTolerance(RevolutionsPerMinutePerSecondInOneRadianPerSecondSquared, (double)revolutionperminutepersecondQuantity.Value, RevolutionsPerMinutePerSecondTolerance);
             Assert.Equal(RotationalAccelerationUnit.RevolutionPerMinutePerSecond, revolutionperminutepersecondQuantity.Unit);
+
+            var revolutionpersecondpersecondQuantity = radianpersecondsquared.ToUnit(RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+            AssertEx.EqualTolerance(RevolutionsPerSecondPerSecondInOneRadianPerSecondSquared, (double)revolutionpersecondpersecondQuantity.Value, RevolutionsPerSecondPerSecondTolerance);
+            Assert.Equal(RotationalAccelerationUnit.RevolutionPerSecondPerSecond, revolutionpersecondpersecondQuantity.Unit);
         }
 
         [Fact]
@@ -127,6 +136,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, RotationalAcceleration.FromDegreesPerSecondSquared(radianpersecondsquared.DegreesPerSecondSquared).RadiansPerSecondSquared, DegreesPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.FromRadiansPerSecondSquared(radianpersecondsquared.RadiansPerSecondSquared).RadiansPerSecondSquared, RadiansPerSecondSquaredTolerance);
             AssertEx.EqualTolerance(1, RotationalAcceleration.FromRevolutionsPerMinutePerSecond(radianpersecondsquared.RevolutionsPerMinutePerSecond).RadiansPerSecondSquared, RevolutionsPerMinutePerSecondTolerance);
+            AssertEx.EqualTolerance(1, RotationalAcceleration.FromRevolutionsPerSecondPerSecond(radianpersecondsquared.RevolutionsPerSecondPerSecond).RadiansPerSecondSquared, RevolutionsPerSecondPerSecondTolerance);
         }
 
         [Fact]

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -171,9 +171,9 @@ namespace UnitsNet
         public double RevolutionsPerMinutePerSecond => As(RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
 
         /// <summary>
-        ///     Get RotationalAcceleration in RevolutionsPerSecondPerSecond.
+        ///     Get RotationalAcceleration in RevolutionsPerSecondSquared.
         /// </summary>
-        public double RevolutionsPerSecondPerSecond => As(RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+        public double RevolutionsPerSecondSquared => As(RotationalAccelerationUnit.RevolutionPerSecondSquared);
 
         #endregion
 
@@ -236,14 +236,14 @@ namespace UnitsNet
             return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
         }
         /// <summary>
-        ///     Get RotationalAcceleration from RevolutionsPerSecondPerSecond.
+        ///     Get RotationalAcceleration from RevolutionsPerSecondSquared.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         [Windows.Foundation.Metadata.DefaultOverload]
-        public static RotationalAcceleration FromRevolutionsPerSecondPerSecond(double revolutionspersecondpersecond)
+        public static RotationalAcceleration FromRevolutionsPerSecondSquared(double revolutionspersecondsquared)
         {
-            double value = (double) revolutionspersecondpersecond;
-            return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+            double value = (double) revolutionspersecondsquared;
+            return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerSecondSquared);
         }
 
         /// <summary>
@@ -539,7 +539,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (Math.PI/180)*_value;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return _value;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return ((2*Math.PI)/60)*_value;
-                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (2*Math.PI)*_value;
+                case RotationalAccelerationUnit.RevolutionPerSecondSquared: return (2*Math.PI)*_value;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -557,7 +557,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (180/Math.PI)*baseUnitValue;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return baseUnitValue;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return (60/(2*Math.PI))*baseUnitValue;
-                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (1/(2*Math.PI))*baseUnitValue;
+                case RotationalAccelerationUnit.RevolutionPerSecondSquared: return (1/(2*Math.PI))*baseUnitValue;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -170,6 +170,11 @@ namespace UnitsNet
         /// </summary>
         public double RevolutionsPerMinutePerSecond => As(RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
 
+        /// <summary>
+        ///     Get RotationalAcceleration in RevolutionsPerSecondPerSecond.
+        /// </summary>
+        public double RevolutionsPerSecondPerSecond => As(RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+
         #endregion
 
         #region Static Methods
@@ -229,6 +234,16 @@ namespace UnitsNet
         {
             double value = (double) revolutionsperminutepersecond;
             return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
+        }
+        /// <summary>
+        ///     Get RotationalAcceleration from RevolutionsPerSecondPerSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static RotationalAcceleration FromRevolutionsPerSecondPerSecond(double revolutionspersecondpersecond)
+        {
+            double value = (double) revolutionspersecondpersecond;
+            return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
         }
 
         /// <summary>
@@ -524,6 +539,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (Math.PI/180)*_value;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return _value;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return ((2*Math.PI)/60)*_value;
+                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (2*Math.PI)*_value;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -541,6 +557,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (180/Math.PI)*baseUnitValue;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return baseUnitValue;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return (60/(2*Math.PI))*baseUnitValue;
+                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (1/(2*Math.PI))*baseUnitValue;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -920,6 +920,7 @@ namespace UnitsNet
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.DegreePerSecondSquared, new string[]{"°/s²", "deg/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RadianPerSecondSquared, new string[]{"rad/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerMinutePerSecond, new string[]{"rpm/s"}),
+                ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerSecondPerSecond, new string[]{"r/s²"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"crad/s"}),
                 ("ru-RU", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"срад/с"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.DeciradianPerSecond, new string[]{"drad/s"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -920,7 +920,7 @@ namespace UnitsNet
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.DegreePerSecondSquared, new string[]{"°/s²", "deg/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RadianPerSecondSquared, new string[]{"rad/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerMinutePerSecond, new string[]{"rpm/s"}),
-                ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerSecondPerSecond, new string[]{"r/s²"}),
+                ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerSecondSquared, new string[]{"r/s²"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"crad/s"}),
                 ("ru-RU", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"срад/с"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.DeciradianPerSecond, new string[]{"drad/s"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
@@ -29,7 +29,7 @@ namespace UnitsNet.Units
         DegreePerSecondSquared,
         RadianPerSecondSquared,
         RevolutionPerMinutePerSecond,
-        RevolutionPerSecondPerSecond,
+        RevolutionPerSecondSquared,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
@@ -29,6 +29,7 @@ namespace UnitsNet.Units
         DegreePerSecondSquared,
         RadianPerSecondSquared,
         RevolutionPerMinutePerSecond,
+        RevolutionPerSecondPerSecond,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -53,7 +53,7 @@ namespace UnitsNet
                     new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.DegreePerSecondSquared, BaseUnits.Undefined),
                     new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RadianPerSecondSquared, BaseUnits.Undefined),
                     new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RevolutionPerMinutePerSecond, BaseUnits.Undefined),
-                    new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RevolutionPerSecondPerSecond, BaseUnits.Undefined),
+                    new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RevolutionPerSecondSquared, BaseUnits.Undefined),
                 },
                 BaseUnit, Zero, BaseDimensions);
         }
@@ -182,9 +182,9 @@ namespace UnitsNet
         public double RevolutionsPerMinutePerSecond => As(RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
 
         /// <summary>
-        ///     Get RotationalAcceleration in RevolutionsPerSecondPerSecond.
+        ///     Get RotationalAcceleration in RevolutionsPerSecondSquared.
         /// </summary>
-        public double RevolutionsPerSecondPerSecond => As(RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+        public double RevolutionsPerSecondSquared => As(RotationalAccelerationUnit.RevolutionPerSecondSquared);
 
         #endregion
 
@@ -243,13 +243,13 @@ namespace UnitsNet
             return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
         }
         /// <summary>
-        ///     Get RotationalAcceleration from RevolutionsPerSecondPerSecond.
+        ///     Get RotationalAcceleration from RevolutionsPerSecondSquared.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static RotationalAcceleration FromRevolutionsPerSecondPerSecond(QuantityValue revolutionspersecondpersecond)
+        public static RotationalAcceleration FromRevolutionsPerSecondSquared(QuantityValue revolutionspersecondsquared)
         {
-            double value = (double) revolutionspersecondpersecond;
-            return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+            double value = (double) revolutionspersecondsquared;
+            return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerSecondSquared);
         }
 
         /// <summary>
@@ -683,7 +683,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (Math.PI/180)*_value;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return _value;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return ((2*Math.PI)/60)*_value;
-                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (2*Math.PI)*_value;
+                case RotationalAccelerationUnit.RevolutionPerSecondSquared: return (2*Math.PI)*_value;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -701,7 +701,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (180/Math.PI)*baseUnitValue;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return baseUnitValue;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return (60/(2*Math.PI))*baseUnitValue;
-                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (1/(2*Math.PI))*baseUnitValue;
+                case RotationalAccelerationUnit.RevolutionPerSecondSquared: return (1/(2*Math.PI))*baseUnitValue;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -53,6 +53,7 @@ namespace UnitsNet
                     new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.DegreePerSecondSquared, BaseUnits.Undefined),
                     new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RadianPerSecondSquared, BaseUnits.Undefined),
                     new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RevolutionPerMinutePerSecond, BaseUnits.Undefined),
+                    new UnitInfo<RotationalAccelerationUnit>(RotationalAccelerationUnit.RevolutionPerSecondPerSecond, BaseUnits.Undefined),
                 },
                 BaseUnit, Zero, BaseDimensions);
         }
@@ -180,6 +181,11 @@ namespace UnitsNet
         /// </summary>
         public double RevolutionsPerMinutePerSecond => As(RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
 
+        /// <summary>
+        ///     Get RotationalAcceleration in RevolutionsPerSecondPerSecond.
+        /// </summary>
+        public double RevolutionsPerSecondPerSecond => As(RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
+
         #endregion
 
         #region Static Methods
@@ -235,6 +241,15 @@ namespace UnitsNet
         {
             double value = (double) revolutionsperminutepersecond;
             return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerMinutePerSecond);
+        }
+        /// <summary>
+        ///     Get RotationalAcceleration from RevolutionsPerSecondPerSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static RotationalAcceleration FromRevolutionsPerSecondPerSecond(QuantityValue revolutionspersecondpersecond)
+        {
+            double value = (double) revolutionspersecondpersecond;
+            return new RotationalAcceleration(value, RotationalAccelerationUnit.RevolutionPerSecondPerSecond);
         }
 
         /// <summary>
@@ -668,6 +683,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (Math.PI/180)*_value;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return _value;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return ((2*Math.PI)/60)*_value;
+                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (2*Math.PI)*_value;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -685,6 +701,7 @@ namespace UnitsNet
                 case RotationalAccelerationUnit.DegreePerSecondSquared: return (180/Math.PI)*baseUnitValue;
                 case RotationalAccelerationUnit.RadianPerSecondSquared: return baseUnitValue;
                 case RotationalAccelerationUnit.RevolutionPerMinutePerSecond: return (60/(2*Math.PI))*baseUnitValue;
+                case RotationalAccelerationUnit.RevolutionPerSecondPerSecond: return (1/(2*Math.PI))*baseUnitValue;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -920,6 +920,7 @@ namespace UnitsNet
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.DegreePerSecondSquared, new string[]{"°/s²", "deg/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RadianPerSecondSquared, new string[]{"rad/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerMinutePerSecond, new string[]{"rpm/s"}),
+                ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerSecondPerSecond, new string[]{"r/s²"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"crad/s"}),
                 ("ru-RU", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"срад/с"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.DeciradianPerSecond, new string[]{"drad/s"}),

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -920,7 +920,7 @@ namespace UnitsNet
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.DegreePerSecondSquared, new string[]{"°/s²", "deg/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RadianPerSecondSquared, new string[]{"rad/s²"}),
                 ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerMinutePerSecond, new string[]{"rpm/s"}),
-                ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerSecondPerSecond, new string[]{"r/s²"}),
+                ("en-US", typeof(RotationalAccelerationUnit), (int)RotationalAccelerationUnit.RevolutionPerSecondSquared, new string[]{"r/s²"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"crad/s"}),
                 ("ru-RU", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.CentiradianPerSecond, new string[]{"срад/с"}),
                 ("en-US", typeof(RotationalSpeedUnit), (int)RotationalSpeedUnit.DeciradianPerSecond, new string[]{"drad/s"}),

--- a/UnitsNet/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
@@ -29,7 +29,7 @@ namespace UnitsNet.Units
         DegreePerSecondSquared,
         RadianPerSecondSquared,
         RevolutionPerMinutePerSecond,
-        RevolutionPerSecondPerSecond,
+        RevolutionPerSecondSquared,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RotationalAccelerationUnit.g.cs
@@ -29,6 +29,7 @@ namespace UnitsNet.Units
         DegreePerSecondSquared,
         RadianPerSecondSquared,
         RevolutionPerMinutePerSecond,
+        RevolutionPerSecondPerSecond,
     }
 
     #pragma warning restore 1591


### PR DESCRIPTION
Add a unit of _revolutions per second squared_ to the [RotationalAcceleration](https://github.com/angularsen/UnitsNet/blob/master/Common/UnitDefinitions/RotationalAcceleration.json) quantity. Used same conventions as r/s unit in [RotationalSpeed](https://github.com/angularsen/UnitsNet/blob/master/Common/UnitDefinitions/RotationalSpeed.json)