### PR TITLE
Added Square Nautical Mile to Area Units.

### DIFF
--- a/Common/UnitDefinitions/Area.json
+++ b/Common/UnitDefinitions/Area.json
@@ -234,6 +234,18 @@
           "Abbreviations": [ "ha" ]
         }
       ]
+    },
+    {
+      "SingularName": "SquareNauticalMile",
+      "PluralName": "SquareNauticalMiles",
+      "FromUnitToBaseFunc": "x*3429904",
+      "FromBaseToUnitFunc": "x/3429904",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": ["nmi²"]
+        }
+      ]
     }
   ]
 }

--- a/UnitsNet.Tests/CustomCode/AreaTests.cs
+++ b/UnitsNet.Tests/CustomCode/AreaTests.cs
@@ -35,6 +35,8 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double UsSurveySquareFeetInOneSquareMeter => 10.76386736111121;
 
+        protected override double SquareNauticalMilesInOneSquareMeter => 0.00000029155335;
+
         [Fact]
         public void AreaDividedByLengthEqualsLength()
         {

--- a/UnitsNet.Tests/GeneratedCode/AreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/AreaTestsBase.g.cs
@@ -45,6 +45,7 @@ namespace UnitsNet.Tests
         protected abstract double SquareMicrometersInOneSquareMeter { get; }
         protected abstract double SquareMilesInOneSquareMeter { get; }
         protected abstract double SquareMillimetersInOneSquareMeter { get; }
+        protected abstract double SquareNauticalMilesInOneSquareMeter { get; }
         protected abstract double SquareYardsInOneSquareMeter { get; }
         protected abstract double UsSurveySquareFeetInOneSquareMeter { get; }
 
@@ -60,6 +61,7 @@ namespace UnitsNet.Tests
         protected virtual double SquareMicrometersTolerance { get { return 1e-5; } }
         protected virtual double SquareMilesTolerance { get { return 1e-5; } }
         protected virtual double SquareMillimetersTolerance { get { return 1e-5; } }
+        protected virtual double SquareNauticalMilesTolerance { get { return 1e-5; } }
         protected virtual double SquareYardsTolerance { get { return 1e-5; } }
         protected virtual double UsSurveySquareFeetTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
@@ -98,6 +100,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(SquareMicrometersInOneSquareMeter, squaremeter.SquareMicrometers, SquareMicrometersTolerance);
             AssertEx.EqualTolerance(SquareMilesInOneSquareMeter, squaremeter.SquareMiles, SquareMilesTolerance);
             AssertEx.EqualTolerance(SquareMillimetersInOneSquareMeter, squaremeter.SquareMillimeters, SquareMillimetersTolerance);
+            AssertEx.EqualTolerance(SquareNauticalMilesInOneSquareMeter, squaremeter.SquareNauticalMiles, SquareNauticalMilesTolerance);
             AssertEx.EqualTolerance(SquareYardsInOneSquareMeter, squaremeter.SquareYards, SquareYardsTolerance);
             AssertEx.EqualTolerance(UsSurveySquareFeetInOneSquareMeter, squaremeter.UsSurveySquareFeet, UsSurveySquareFeetTolerance);
         }
@@ -116,6 +119,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareMicrometer).SquareMicrometers, SquareMicrometersTolerance);
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareMile).SquareMiles, SquareMilesTolerance);
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareMillimeter).SquareMillimeters, SquareMillimetersTolerance);
+            AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareNauticalMile).SquareNauticalMiles, SquareNauticalMilesTolerance);
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.SquareYard).SquareYards, SquareYardsTolerance);
             AssertEx.EqualTolerance(1, Area.From(1, AreaUnit.UsSurveySquareFoot).UsSurveySquareFeet, UsSurveySquareFeetTolerance);
         }
@@ -148,6 +152,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(SquareMicrometersInOneSquareMeter, squaremeter.As(AreaUnit.SquareMicrometer), SquareMicrometersTolerance);
             AssertEx.EqualTolerance(SquareMilesInOneSquareMeter, squaremeter.As(AreaUnit.SquareMile), SquareMilesTolerance);
             AssertEx.EqualTolerance(SquareMillimetersInOneSquareMeter, squaremeter.As(AreaUnit.SquareMillimeter), SquareMillimetersTolerance);
+            AssertEx.EqualTolerance(SquareNauticalMilesInOneSquareMeter, squaremeter.As(AreaUnit.SquareNauticalMile), SquareNauticalMilesTolerance);
             AssertEx.EqualTolerance(SquareYardsInOneSquareMeter, squaremeter.As(AreaUnit.SquareYard), SquareYardsTolerance);
             AssertEx.EqualTolerance(UsSurveySquareFeetInOneSquareMeter, squaremeter.As(AreaUnit.UsSurveySquareFoot), UsSurveySquareFeetTolerance);
         }
@@ -201,6 +206,10 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(SquareMillimetersInOneSquareMeter, (double)squaremillimeterQuantity.Value, SquareMillimetersTolerance);
             Assert.Equal(AreaUnit.SquareMillimeter, squaremillimeterQuantity.Unit);
 
+            var squarenauticalmileQuantity = squaremeter.ToUnit(AreaUnit.SquareNauticalMile);
+            AssertEx.EqualTolerance(SquareNauticalMilesInOneSquareMeter, (double)squarenauticalmileQuantity.Value, SquareNauticalMilesTolerance);
+            Assert.Equal(AreaUnit.SquareNauticalMile, squarenauticalmileQuantity.Unit);
+
             var squareyardQuantity = squaremeter.ToUnit(AreaUnit.SquareYard);
             AssertEx.EqualTolerance(SquareYardsInOneSquareMeter, (double)squareyardQuantity.Value, SquareYardsTolerance);
             Assert.Equal(AreaUnit.SquareYard, squareyardQuantity.Unit);
@@ -225,6 +234,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Area.FromSquareMicrometers(squaremeter.SquareMicrometers).SquareMeters, SquareMicrometersTolerance);
             AssertEx.EqualTolerance(1, Area.FromSquareMiles(squaremeter.SquareMiles).SquareMeters, SquareMilesTolerance);
             AssertEx.EqualTolerance(1, Area.FromSquareMillimeters(squaremeter.SquareMillimeters).SquareMeters, SquareMillimetersTolerance);
+            AssertEx.EqualTolerance(1, Area.FromSquareNauticalMiles(squaremeter.SquareNauticalMiles).SquareMeters, SquareNauticalMilesTolerance);
             AssertEx.EqualTolerance(1, Area.FromSquareYards(squaremeter.SquareYards).SquareMeters, SquareYardsTolerance);
             AssertEx.EqualTolerance(1, Area.FromUsSurveySquareFeet(squaremeter.UsSurveySquareFeet).SquareMeters, UsSurveySquareFeetTolerance);
         }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.g.cs
@@ -211,6 +211,11 @@ namespace UnitsNet
         public double SquareMillimeters => As(AreaUnit.SquareMillimeter);
 
         /// <summary>
+        ///     Get Area in SquareNauticalMiles.
+        /// </summary>
+        public double SquareNauticalMiles => As(AreaUnit.SquareNauticalMile);
+
+        /// <summary>
         ///     Get Area in SquareYards.
         /// </summary>
         public double SquareYards => As(AreaUnit.SquareYard);
@@ -359,6 +364,16 @@ namespace UnitsNet
         {
             double value = (double) squaremillimeters;
             return new Area(value, AreaUnit.SquareMillimeter);
+        }
+        /// <summary>
+        ///     Get Area from SquareNauticalMiles.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Area FromSquareNauticalMiles(double squarenauticalmiles)
+        {
+            double value = (double) squarenauticalmiles;
+            return new Area(value, AreaUnit.SquareNauticalMile);
         }
         /// <summary>
         ///     Get Area from SquareYards.
@@ -682,6 +697,7 @@ namespace UnitsNet
                 case AreaUnit.SquareMicrometer: return _value*1e-12;
                 case AreaUnit.SquareMile: return _value*2.59e6;
                 case AreaUnit.SquareMillimeter: return _value*1e-6;
+                case AreaUnit.SquareNauticalMile: return _value*3429904;
                 case AreaUnit.SquareYard: return _value*0.836127;
                 case AreaUnit.UsSurveySquareFoot: return _value*0.09290341161;
                 default:
@@ -709,6 +725,7 @@ namespace UnitsNet
                 case AreaUnit.SquareMicrometer: return baseUnitValue/1e-12;
                 case AreaUnit.SquareMile: return baseUnitValue/2.59e6;
                 case AreaUnit.SquareMillimeter: return baseUnitValue/1e-6;
+                case AreaUnit.SquareNauticalMile: return baseUnitValue/3429904;
                 case AreaUnit.SquareYard: return baseUnitValue/0.836127;
                 case AreaUnit.UsSurveySquareFoot: return baseUnitValue/0.09290341161;
                 default:

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -114,6 +114,7 @@ namespace UnitsNet
                 ("ru-RU", typeof(AreaUnit), (int)AreaUnit.SquareMile, new string[]{"миля²"}),
                 ("en-US", typeof(AreaUnit), (int)AreaUnit.SquareMillimeter, new string[]{"mm²"}),
                 ("ru-RU", typeof(AreaUnit), (int)AreaUnit.SquareMillimeter, new string[]{"мм²"}),
+                ("en-US", typeof(AreaUnit), (int)AreaUnit.SquareNauticalMile, new string[]{"nmi²"}),
                 ("en-US", typeof(AreaUnit), (int)AreaUnit.SquareYard, new string[]{"yd²"}),
                 ("ru-RU", typeof(AreaUnit), (int)AreaUnit.SquareYard, new string[]{"ярд²"}),
                 ("en-US", typeof(AreaUnit), (int)AreaUnit.UsSurveySquareFoot, new string[]{"ft² (US)"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/AreaUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/AreaUnit.g.cs
@@ -37,6 +37,7 @@ namespace UnitsNet.Units
         SquareMicrometer,
         SquareMile,
         SquareMillimeter,
+        SquareNauticalMile,
         SquareYard,
         UsSurveySquareFoot,
     }

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -61,6 +61,7 @@ namespace UnitsNet
                     new UnitInfo<AreaUnit>(AreaUnit.SquareMicrometer, new BaseUnits(length: LengthUnit.Micrometer)),
                     new UnitInfo<AreaUnit>(AreaUnit.SquareMile, new BaseUnits(length: LengthUnit.Mile)),
                     new UnitInfo<AreaUnit>(AreaUnit.SquareMillimeter, new BaseUnits(length: LengthUnit.Millimeter)),
+                    new UnitInfo<AreaUnit>(AreaUnit.SquareNauticalMile, BaseUnits.Undefined),
                     new UnitInfo<AreaUnit>(AreaUnit.SquareYard, new BaseUnits(length: LengthUnit.Yard)),
                     new UnitInfo<AreaUnit>(AreaUnit.UsSurveySquareFoot, new BaseUnits(length: LengthUnit.UsSurveyFoot)),
                 },
@@ -231,6 +232,11 @@ namespace UnitsNet
         public double SquareMillimeters => As(AreaUnit.SquareMillimeter);
 
         /// <summary>
+        ///     Get Area in SquareNauticalMiles.
+        /// </summary>
+        public double SquareNauticalMiles => As(AreaUnit.SquareNauticalMile);
+
+        /// <summary>
         ///     Get Area in SquareYards.
         /// </summary>
         public double SquareYards => As(AreaUnit.SquareYard);
@@ -367,6 +373,15 @@ namespace UnitsNet
         {
             double value = (double) squaremillimeters;
             return new Area(value, AreaUnit.SquareMillimeter);
+        }
+        /// <summary>
+        ///     Get Area from SquareNauticalMiles.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Area FromSquareNauticalMiles(QuantityValue squarenauticalmiles)
+        {
+            double value = (double) squarenauticalmiles;
+            return new Area(value, AreaUnit.SquareNauticalMile);
         }
         /// <summary>
         ///     Get Area from SquareYards.
@@ -826,6 +841,7 @@ namespace UnitsNet
                 case AreaUnit.SquareMicrometer: return _value*1e-12;
                 case AreaUnit.SquareMile: return _value*2.59e6;
                 case AreaUnit.SquareMillimeter: return _value*1e-6;
+                case AreaUnit.SquareNauticalMile: return _value*3429904;
                 case AreaUnit.SquareYard: return _value*0.836127;
                 case AreaUnit.UsSurveySquareFoot: return _value*0.09290341161;
                 default:
@@ -853,6 +869,7 @@ namespace UnitsNet
                 case AreaUnit.SquareMicrometer: return baseUnitValue/1e-12;
                 case AreaUnit.SquareMile: return baseUnitValue/2.59e6;
                 case AreaUnit.SquareMillimeter: return baseUnitValue/1e-6;
+                case AreaUnit.SquareNauticalMile: return baseUnitValue/3429904;
                 case AreaUnit.SquareYard: return baseUnitValue/0.836127;
                 case AreaUnit.UsSurveySquareFoot: return baseUnitValue/0.09290341161;
                 default:

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -114,6 +114,7 @@ namespace UnitsNet
                 ("ru-RU", typeof(AreaUnit), (int)AreaUnit.SquareMile, new string[]{"миля²"}),
                 ("en-US", typeof(AreaUnit), (int)AreaUnit.SquareMillimeter, new string[]{"mm²"}),
                 ("ru-RU", typeof(AreaUnit), (int)AreaUnit.SquareMillimeter, new string[]{"мм²"}),
+                ("en-US", typeof(AreaUnit), (int)AreaUnit.SquareNauticalMile, new string[]{"nmi²"}),
                 ("en-US", typeof(AreaUnit), (int)AreaUnit.SquareYard, new string[]{"yd²"}),
                 ("ru-RU", typeof(AreaUnit), (int)AreaUnit.SquareYard, new string[]{"ярд²"}),
                 ("en-US", typeof(AreaUnit), (int)AreaUnit.UsSurveySquareFoot, new string[]{"ft² (US)"}),

--- a/UnitsNet/GeneratedCode/Units/AreaUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AreaUnit.g.cs
@@ -37,6 +37,7 @@ namespace UnitsNet.Units
         SquareMicrometer,
         SquareMile,
         SquareMillimeter,
+        SquareNauticalMile,
         SquareYard,
         UsSurveySquareFoot,
     }


### PR DESCRIPTION
Conversion to square meters is an exact number (1852^2, or 3429904). Conversion back to 8 significant figures (2.9155335e-7). Followed the UnitsNet Wiki guidelines for adding the unit. Thanks for this extensive library, a square nautical mile unit would be very useful for my line of work.