### PR TITLE
 UnitMath extension methods (Min, Max, Sum, Average)

### DIFF
--- a/UnitsNet.Tests/UnitMathTests.cs
+++ b/UnitsNet.Tests/UnitMathTests.cs
@@ -16,7 +16,7 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void AverageOfEmpySourceThrowsException()
+        public void AverageOfEmptySourceThrowsException()
         {
             var units = new Length[] { };
 
@@ -70,7 +70,7 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void MaxOfEmpySourceThrowsException()
+        public void MaxOfEmptySourceThrowsException()
         {
             var units = new Length[] { };
 
@@ -124,7 +124,7 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void MinOfEmpySourceThrowsException()
+        public void MinOfEmptySourceThrowsException()
         {
             var units = new Length[] { };
 
@@ -178,7 +178,7 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void SumOfEmpySourceReturnsZero()
+        public void SumOfEmptySourceReturnsZero()
         {
             var units = new Length[] { };
 

--- a/UnitsNet.Tests/UnitMathTests.cs
+++ b/UnitsNet.Tests/UnitMathTests.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections.Generic;
+using UnitsNet.Units;
+using Xunit;
+
+namespace UnitsNet.Tests
+{
+    public class UnitMathTests
+    {
+        [Fact]
+        public void AverageOfDifferentUnitsThrowsException()
+        {
+            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
+
+            Assert.Throws<ArgumentException>(() => units.Average(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void AverageOfEmpySourceThrowsException()
+        {
+            var units = new Length[] { };
+
+            Assert.Throws<InvalidOperationException>(() => units.Average(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void AverageOfLengthsCalculatesCorrectly()
+        {
+            var units = new[] {Length.FromMeters(1), Length.FromCentimeters(50)};
+
+            Length average = units.Average(LengthUnit.Centimeter);
+
+            Assert.Equal(75, average.Value);
+            Assert.Equal(LengthUnit.Centimeter, average.Unit);
+        }
+
+        [Fact]
+        public void AverageOfLengthsWithNullSelectorThrowsException()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Assert.Throws<ArgumentNullException>(() => units.Average((Func<KeyValuePair<string, Length>, Length>) null, LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void AverageOfLengthsWithSelectorCalculatesCorrectly()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Length average = units.Average(x => x.Value, LengthUnit.Centimeter);
+
+            Assert.Equal(75, average.Value);
+            Assert.Equal(LengthUnit.Centimeter, average.Unit);
+        }
+
+        [Fact]
+        public void MaxOfDifferentUnitsThrowsException()
+        {
+            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
+
+            Assert.Throws<ArgumentException>(() => units.Max(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void MaxOfEmpySourceThrowsException()
+        {
+            var units = new Length[] { };
+
+            Assert.Throws<InvalidOperationException>(() => units.Max(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void MaxOfLengthsCalculatesCorrectly()
+        {
+            var units = new[] {Length.FromMeters(1), Length.FromCentimeters(50)};
+
+            Length max = units.Max(LengthUnit.Centimeter);
+
+            Assert.Equal(100, max.Value);
+            Assert.Equal(LengthUnit.Centimeter, max.Unit);
+        }
+
+        [Fact]
+        public void MaxOfLengthsWithNullSelectorThrowsException()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Assert.Throws<ArgumentNullException>(() => units.Max((Func<KeyValuePair<string, Length>, Length>) null, LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void MaxOfLengthsWithSelectorCalculatesCorrectly()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Length max = units.Max(x => x.Value, LengthUnit.Centimeter);
+
+            Assert.Equal(100, max.Value);
+            Assert.Equal(LengthUnit.Centimeter, max.Unit);
+        }
+
+        [Fact]
+        public void MinOfDifferentUnitsThrowsException()
+        {
+            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
+
+            Assert.Throws<ArgumentException>(() => units.Min(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void MinOfEmpySourceThrowsException()
+        {
+            var units = new Length[] { };
+
+            Assert.Throws<InvalidOperationException>(() => units.Min(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void MinOfLengthsCalculatesCorrectly()
+        {
+            var units = new[] {Length.FromMeters(1), Length.FromCentimeters(50)};
+
+            Length min = units.Min(LengthUnit.Centimeter);
+
+            Assert.Equal(50, min.Value);
+            Assert.Equal(LengthUnit.Centimeter, min.Unit);
+        }
+
+        [Fact]
+        public void MinOfLengthsWithNullSelectorThrowsException()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Assert.Throws<ArgumentNullException>(() => units.Min((Func<KeyValuePair<string, Length>, Length>) null, LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void MinOfLengthsWithSelectorCalculatesCorrectly()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Length min = units.Min(x => x.Value, LengthUnit.Centimeter);
+
+            Assert.Equal(50, min.Value);
+            Assert.Equal(LengthUnit.Centimeter, min.Unit);
+        }
+
+        [Fact]
+        public void SumOfDifferentUnitsThrowsException()
+        {
+            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
+
+            Assert.Throws<ArgumentException>(() => units.Sum(LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void SumOfEmpySourceReturnsZero()
+        {
+            var units = new Length[] { };
+
+            Length sum = units.Sum(Length.BaseUnit);
+
+            Assert.Equal(Length.Zero, sum);
+        }
+
+        [Fact]
+        public void SumOfLengthsCalculatesCorrectly()
+        {
+            var units = new[] {Length.FromMeters(1), Length.FromCentimeters(50)};
+
+            Length sum = units.Sum(LengthUnit.Centimeter);
+
+            Assert.Equal(150, sum.Value);
+            Assert.Equal(LengthUnit.Centimeter, sum.Unit);
+        }
+
+        [Fact]
+        public void SumOfLengthsWithNullSelectorThrowsException()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Assert.Throws<ArgumentNullException>(() => units.Sum((Func<KeyValuePair<string, Length>, Length>) null, LengthUnit.Centimeter));
+        }
+
+        [Fact]
+        public void SumOfLengthsWithSelectorCalculatesCorrectly()
+        {
+            var units = new[]
+            {
+                new KeyValuePair<string, Length>("1", Length.FromMeters(1)),
+                new KeyValuePair<string, Length>("2", Length.FromCentimeters(50))
+            };
+
+            Length sum = units.Sum(x => x.Value, LengthUnit.Centimeter);
+
+            Assert.Equal(150, sum.Value);
+            Assert.Equal(LengthUnit.Centimeter, sum.Unit);
+        }
+    }
+}

--- a/UnitsNet/UnitMath.cs
+++ b/UnitsNet/UnitMath.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UnitsNet
+{
+    /// <summary>
+    ///     A set of extension methods for some of the most common Math operations, such as Min, Max, Sum and Average
+    /// </summary>
+    public static class UnitMath
+    {
+        /// <summary>Computes the sum of a sequence of <typeparamref name="TQuantity" /> values.</summary>
+        /// <param name="source">A sequence of <typeparamref name="TQuantity" /> values to calculate the sum of.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <returns>The sum of the values in the sequence, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Sum<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return (TQuantity) Quantity.From(source.Sum(x => x.As(unitType)), unitType);
+        }
+
+        /// <summary>
+        ///     Computes the sum of the sequence of <typeparamref name="TQuantity" /> values that are obtained by invoking a
+        ///     transform function on each element of the input sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values that are used to calculate a sum.</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <returns>The sum of the projected values, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Sum<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return source.Select(selector).Sum(unitType);
+        }
+
+        /// <summary>Computes the min of a sequence of <typeparamref name="TQuantity" /> values.</summary>
+        /// <param name="source">A sequence of <typeparamref name="TQuantity" /> values to calculate the min of.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <returns>The min of the values in the sequence, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> is null.
+        /// </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="source">source</paramref> contains no elements.</exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Min<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return (TQuantity) Quantity.From(source.Min(x => x.As(unitType)), unitType);
+        }
+
+        /// <summary>
+        ///     Computes the min of the sequence of <typeparamref name="TQuantity" /> values that are obtained by invoking a
+        ///     transform function on each element of the input sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values that are used to calculate a min.</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <returns>The min of the projected values, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
+        /// </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="source">source</paramref> contains no elements.</exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Min<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return source.Select(selector).Min(unitType);
+        }
+
+        /// <summary>Computes the max of a sequence of <typeparamref name="TQuantity" /> values.</summary>
+        /// <param name="source">A sequence of <typeparamref name="TQuantity" /> values to calculate the max of.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <returns>The max of the values in the sequence, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> is null.
+        /// </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="source">source</paramref> contains no elements.</exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Max<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return (TQuantity) Quantity.From(source.Max(x => x.As(unitType)), unitType);
+        }
+
+        /// <summary>
+        ///     Computes the max of the sequence of <typeparamref name="TQuantity" /> values that are obtained by invoking a
+        ///     transform function on each element of the input sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values that are used to calculate a max.</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <returns>The max of the projected values, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
+        /// </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="source">source</paramref> contains no elements.</exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Max<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return source.Select(selector).Max(unitType);
+        }
+
+        /// <summary>Computes the average of a sequence of <typeparamref name="TQuantity" /> values.</summary>
+        /// <param name="source">A sequence of <typeparamref name="TQuantity" /> values to calculate the average of.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <returns>The average of the values in the sequence, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> is null.
+        /// </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="source">source</paramref> contains no elements.</exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Average<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return (TQuantity) Quantity.From(source.Average(x => x.As(unitType)), unitType);
+        }
+
+        /// <summary>
+        ///     Computes the average of the sequence of <typeparamref name="TQuantity" /> values that are obtained by invoking
+        ///     a transform function on each element of the input sequence.
+        /// </summary>
+        /// <param name="source">A sequence of values that are used to calculate an average.</param>
+        /// <param name="selector">A transform function to apply to each element.</param>
+        /// <param name="unitType">The desired unit type for the resulting quantity</param>
+        /// <typeparam name="TSource">The type of the elements of source.</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <returns>The average of the projected values, represented in the specified unit type.</returns>
+        /// <exception cref="T:System.ArgumentNullException">
+        ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
+        /// </exception>
+        /// <exception cref="T:System.InvalidOperationException"><paramref name="source">source</paramref> contains no elements.</exception>
+        /// <exception cref="ArgumentException">
+        ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
+        /// </exception>
+        public static TQuantity Average<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
+            where TQuantity : IQuantity
+        {
+            return source.Select(selector).Average(unitType);
+        }
+    }
+}


### PR DESCRIPTION
Added a set of extension methods for some of the most common Math operations, such as Min, Max, Sum and Average (with selector overloads)