### PR TITLE
Add benchmarks for UnitSystem methods

### DIFF
--- a/UnitsNet.Benchmark/Program.cs
+++ b/UnitsNet.Benchmark/Program.cs
@@ -14,6 +14,9 @@ namespace UnitsNet.Benchmark
         public Length Constructor() => new Length(3.0, LengthUnit.Meter);
 
         [Benchmark]
+        public Length Constructor_SI() => new Length(3.0, UnitSystem.SI);
+
+        [Benchmark]
         public Length FromMethod() => Length.FromMeters(3.0);
 
         [Benchmark]
@@ -23,7 +26,13 @@ namespace UnitsNet.Benchmark
         public double As() => length.As(LengthUnit.Centimeter);
 
         [Benchmark]
+        public double As_SI() => length.As(UnitSystem.SI);
+
+        [Benchmark]
         public Length ToUnit() => length.ToUnit(LengthUnit.Centimeter);
+
+        [Benchmark]
+        public Length ToUnit_SI() => length.ToUnit(UnitSystem.SI);
 
         [Benchmark]
         public string ToStringTest() => length.ToString();
@@ -42,6 +51,9 @@ namespace UnitsNet.Benchmark
 
         [Benchmark]
         public double IQuantity_As() => lengthIQuantity.As(LengthUnit.Centimeter);
+
+        [Benchmark]
+        public double IQuantity_As_SI() => lengthIQuantity.As(UnitSystem.SI);
 
         [Benchmark]
         public IQuantity IQuantity_ToUnit() => lengthIQuantity.ToUnit(LengthUnit.Centimeter);


### PR DESCRIPTION
Added benchmarks for UnitSystem methods (UnitSystem.SI) in order to use as base line for comparison (I see there is a [tool](https://github.com/dotnet/performance/tree/master/src/tools/ResultsComparer) for that) with the modifications envisioned in #651 