### PR TITLE
Code cleanup in JSON code

### DIFF
--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNetJsonConverterTests.cs
@@ -5,7 +5,7 @@ using System;
 using Newtonsoft.Json;
 using Xunit;
 
-namespace UnitsNet.Serialization.JsonNet.Tests
+namespace UnitsNet.Serialization.JsonNet.CompatibilityTests
 {
     public class UnitsNetJsonConverterTests
     {

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -121,7 +121,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void ArrayValue_ExpectJsonArray()
             {
-                Frequency[] testObj = new Frequency[] { Frequency.FromHertz(10), Frequency.FromHertz(10) };
+                Frequency[] testObj = { Frequency.FromHertz(10), Frequency.FromHertz(10) };
 
                 string expectedJson = "[\n" +
                                       "  {\n" +
@@ -333,7 +333,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void ArrayOfUnits_ExpectCorrectlyDeserialized()
             {
-                Frequency[] expected = new Frequency[] { Frequency.FromHertz(10), Frequency.FromHertz(10) };
+                Frequency[] expected = { Frequency.FromHertz(10), Frequency.FromHertz(10) };
 
                 string json = "[\n" +
                                       "  {\n" +


### PR DESCRIPTION
Found during PR review #712. Addressed separately.

- Remove redundant list allocations
- Use C#7 `is` operator for more readable type casting
- Minor syntax fixes
- Extract code for reuse
- Pass type instead of `object` where applicable