### PR TITLE
Extendable json serialisation

### DIFF
--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\UnitsNet.Tests\UnitsNet.Tests.csproj" />
     <ProjectReference Include="..\UnitsNet\UnitsNet.csproj" />
   </ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Security.Cryptography;
 using Newtonsoft.Json;
 
 namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
@@ -22,7 +21,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
             Info = new QuantityInfo<HowMuchUnit>
             (
                 QuantityType.Ratio,
-                new UnitInfo<HowMuchUnit>[]
+                new[]
                 {
                     new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
                     new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
@@ -35,11 +34,11 @@ namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
 
         }
 
-        public double As(HowMuchUnit unit)
+        double IQuantity<HowMuchUnit>.As(HowMuchUnit unit)
         {
             return As(unit);
         }
-        
+
         QuantityInfo<HowMuchUnit> IQuantity<HowMuchUnit>.QuantityInfo => Info;
 
         public HowMuchUnit Unit { get; }
@@ -50,9 +49,9 @@ namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
             return new HowMuch((double)value,fromUnit);
         }
 
-        public static HowMuchUnit BaseUnit { get; } 
+        public static HowMuchUnit BaseUnit { get; }
         public static HowMuch Zero { get; } = new HowMuch(0, BaseUnit);
-        
+
 
         public QuantityType Type => QuantityType.Ratio;
         public static BaseDimensions BaseDimensions => BaseDimensions.Dimensionless;

--- a/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Security.Cryptography;
+using Newtonsoft.Json;
 
 namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
 {
@@ -6,40 +8,76 @@ namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
     /// <summary>
     /// Example of a custom/third-party quantity implementation, for plugging in quantities and units at runtime.
     /// </summary>
-    public struct HowMuch : IQuantity
+    public struct HowMuch : IQuantity<HowMuchUnit>
     {
         public HowMuch(double value, Enum unit) : this()
         {
-            Unit = unit;
+            Unit = (HowMuchUnit)unit;
             Value = value;
         }
 
-        public Enum Unit { get; }
+        static HowMuch()
+        {
+            BaseUnit = HowMuchUnit.Some;
+            Info = new QuantityInfo<HowMuchUnit>
+            (
+                QuantityType.Ratio,
+                new UnitInfo<HowMuchUnit>[]
+                {
+                    new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
+                    new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
+                    new UnitInfo<HowMuchUnit>(HowMuchUnit.AShitTon, BaseUnits.Undefined),
+                },
+                BaseUnit,
+                Zero,
+                BaseDimensions
+            );
+
+        }
+
+        public double As(HowMuchUnit unit)
+        {
+            return As(unit);
+        }
+        
+        QuantityInfo<HowMuchUnit> IQuantity<HowMuchUnit>.QuantityInfo => Info;
+
+        public HowMuchUnit Unit { get; }
         public double Value { get; }
 
-        #region Crud to satisfy IQuantity, but not really used for anything
+        public static HowMuch From(QuantityValue value, HowMuchUnit fromUnit)
+        {
+            return new HowMuch((double)value,fromUnit);
+        }
 
-        private static readonly HowMuch Zero = new HowMuch(0, HowMuchUnit.Some);
+        public static HowMuchUnit BaseUnit { get; } 
+        public static HowMuch Zero { get; } = new HowMuch(0, BaseUnit);
+        
 
         public QuantityType Type => QuantityType.Ratio;
-        public BaseDimensions Dimensions => BaseDimensions.Dimensionless;
+        public static BaseDimensions BaseDimensions => BaseDimensions.Dimensionless;
+        public BaseDimensions Dimensions => BaseDimensions;
+        [JsonIgnore]
+        public QuantityInfo QuantityInfo => Info;
 
-        public QuantityInfo QuantityInfo => new QuantityInfo(Type,
-            new UnitInfo[]
-            {
-                new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
-                new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
-                new UnitInfo<HowMuchUnit>(HowMuchUnit.AShitTon, BaseUnits.Undefined),
-            },
-            HowMuchUnit.Some,
-            Zero,
-            BaseDimensions.Dimensionless);
+        public static QuantityInfo<HowMuchUnit> Info { get; }
 
         public double As(Enum unit) => Convert.ToDouble(unit);
 
+        #region Crud to satisfy IQuantity, but not really used for anything
         public double As(UnitSystem unitSystem) => throw new NotImplementedException();
+        Enum IQuantity.Unit => Unit;
 
         public IQuantity ToUnit(Enum unit) => new HowMuch(As(unit), unit);
+        IQuantity<HowMuchUnit> IQuantity<HowMuchUnit>.ToUnit(UnitSystem unitSystem)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQuantity<HowMuchUnit> ToUnit(HowMuchUnit unit)
+        {
+            throw new NotImplementedException();
+        }
 
         public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
 

--- a/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
@@ -1,0 +1,53 @@
+﻿using System;
+
+namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
+{
+    /// <inheritdoc cref="IQuantity"/>
+    /// <summary>
+    /// Example of a custom/third-party quantity implementation, for plugging in quantities and units at runtime.
+    /// </summary>
+    public struct HowMuch : IQuantity
+    {
+        public HowMuch(double value, Enum unit) : this()
+        {
+            Unit = unit;
+            Value = value;
+        }
+
+        public Enum Unit { get; }
+        public double Value { get; }
+
+        #region Crud to satisfy IQuantity, but not really used for anything
+
+        private static readonly HowMuch Zero = new HowMuch(0, HowMuchUnit.Some);
+
+        public QuantityType Type => QuantityType.Ratio;
+        public BaseDimensions Dimensions => BaseDimensions.Dimensionless;
+
+        public QuantityInfo QuantityInfo => new QuantityInfo(Type,
+            new UnitInfo[]
+            {
+                new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
+                new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
+                new UnitInfo<HowMuchUnit>(HowMuchUnit.AShitTon, BaseUnits.Undefined),
+            },
+            HowMuchUnit.Some,
+            Zero,
+            BaseDimensions.Dimensionless);
+
+        public double As(Enum unit) => Convert.ToDouble(unit);
+
+        public double As(UnitSystem unitSystem) => throw new NotImplementedException();
+
+        public IQuantity ToUnit(Enum unit) => new HowMuch(As(unit), unit);
+
+        public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
+
+        public string ToString(string format, IFormatProvider formatProvider) => $"HowMuch ({format}, {formatProvider})";
+        public string ToString(IFormatProvider provider) => $"HowMuch ({provider})";
+        public string ToString(IFormatProvider provider, int significantDigitsAfterRadix) => $"HowMuch ({provider}, {significantDigitsAfterRadix})";
+        public string ToString(IFormatProvider provider, string format, params object[] args) => $"HowMuch ({provider}, {string.Join(", ", args)})";
+
+        #endregion
+    }
+}

--- a/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuch.cs
@@ -29,9 +29,38 @@ namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
                 },
                 BaseUnit,
                 Zero,
-                BaseDimensions
+                BaseDimensions,
+                new CustomQuantityOptions(TryParse, TryCreate)
             );
+        }
 
+        private static bool TryParse(IFormatProvider formatProvider, string str, out IQuantity quantity)
+        {
+            // Dummy implementation
+            if (str == "a ton")
+            {
+                quantity = From(1, HowMuchUnit.ATon);
+                return true;
+            }
+            else
+            {
+                quantity = default;
+                return false;
+            }
+        }
+
+        private static bool TryCreate(QuantityValue value, Enum unit, out IQuantity quantity)
+        {
+            if (Enum.IsDefined(typeof(HowMuchUnit), unit))
+            {
+                quantity = From(value, (HowMuchUnit)unit);
+                return true;
+            }
+            else
+            {
+                quantity = default;
+                return false;
+            }
         }
 
         double IQuantity<HowMuchUnit>.As(HowMuchUnit unit)

--- a/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuchUnit.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/CustomQuantities/HowMuchUnit.cs
@@ -1,0 +1,12 @@
+﻿namespace UnitsNet.Serialization.JsonNet.Tests.CustomQuantities
+{
+    /// <summary>
+    /// Example of a custom/third-party quantity implementation, for plugging in quantities and units at runtime.
+    /// </summary>
+    public enum HowMuchUnit
+    {
+        Some,
+        ATon,
+        AShitTon
+    }
+}

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -20,7 +20,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             return SerializeObject(obj, QuantityFactory.Default);
         }
 
-        private string SerializeObject(object obj,QuantityFactory qtyFactory)
+        private string SerializeObject(object obj, QuantityFactory qtyFactory)
         {
             var jsonSerializerSettings = new JsonSerializerSettings { Formatting = Formatting.Indented };
             jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(qtyFactory));

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
@@ -22,7 +22,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
         private string SerializeObject(object obj, QuantityFactory qtyFactory)
         {
-            var jsonSerializerSettings = new JsonSerializerSettings { Formatting = Formatting.Indented };
+            var jsonSerializerSettings = new JsonSerializerSettings {Formatting = Formatting.Indented};
             jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(qtyFactory));
             return JsonConvert.SerializeObject(obj, jsonSerializerSettings).Replace("\r\n", "\n");
         }
@@ -34,7 +34,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
         private T DeserializeObject<T>(string json, QuantityFactory qtyFactory)
         {
-            var jsonSerializerSettings = new JsonSerializerSettings { Formatting = Formatting.Indented };
+            var jsonSerializerSettings = new JsonSerializerSettings {Formatting = Formatting.Indented};
             jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(qtyFactory));
             return JsonConvert.DeserializeObject<T>(json, jsonSerializerSettings);
         }
@@ -67,12 +67,12 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             public void Custom_ExpectConstructedValueAndUnit()
             {
                 var quantityFactory = new QuantityFactory();
-                quantityFactory.AddUnit(typeof(HowMuch),typeof(HowMuchUnit));
+                quantityFactory.AddUnit(typeof(HowMuch), typeof(HowMuchUnit));
 
-                var howMuch = new HowMuch(3.1415,HowMuchUnit.ATon);
+                var howMuch = new HowMuch(3.1415, HowMuchUnit.ATon);
                 var expectedJson = "{\n  \"Unit\": \"HowMuchUnit.ATon\",\n  \"Value\": 3.1415\n}";
 
-                string json = SerializeObject(howMuch,quantityFactory);
+                string json = SerializeObject(howMuch, quantityFactory);
 
                 Assert.Equal(expectedJson, json);
             }
@@ -108,6 +108,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                     NullableFrequency = Frequency.FromHertz(10),
                     NonNullableFrequency = Frequency.FromHertz(10)
                 };
+
                 // Ugly manually formatted JSON string is used because string literals with newlines are rendered differently
                 //  on the build server (i.e. the build server uses '\r' instead of '\n')
                 string expectedJson = "{\n" +
@@ -147,7 +148,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void ArrayValue_ExpectJsonArray()
             {
-                Frequency[] testObj = { Frequency.FromHertz(10), Frequency.FromHertz(10) };
+                Frequency[] testObj = {Frequency.FromHertz(10), Frequency.FromHertz(10)};
 
                 string expectedJson = "[\n" +
                                       "  {\n" +
@@ -204,11 +205,11 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             public void Custom_ExpectJsonCorrectlyDeserialized()
             {
                 var qtyFactory = new QuantityFactory();
-                qtyFactory.AddUnit(typeof(HowMuch),typeof(HowMuchUnit));
-                HowMuch originalHowMuch = new HowMuch(2.71,HowMuchUnit.AShitTon);
-                string json = SerializeObject(originalHowMuch,qtyFactory);
+                qtyFactory.AddUnit(typeof(HowMuch), typeof(HowMuchUnit));
+                HowMuch originalHowMuch = new HowMuch(2.71, HowMuchUnit.AShitTon);
+                string json = SerializeObject(originalHowMuch, qtyFactory);
 
-                var deserializedHowMuch = DeserializeObject<HowMuch>(json,qtyFactory);
+                var deserializedHowMuch = DeserializeObject<HowMuch>(json, qtyFactory);
 
                 Assert.Equal(originalHowMuch, deserializedHowMuch);
             }
@@ -232,6 +233,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                     NullableFrequency = Frequency.FromHertz(10),
                     NonNullableFrequency = Frequency.FromHertz(10)
                 };
+
                 string json = SerializeObject(testObj);
 
                 var deserializedTestObj = DeserializeObject<TestObj>(json);
@@ -256,6 +258,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                     NullableFrequency = null,
                     NonNullableFrequency = Frequency.FromHertz(10)
                 };
+
                 string json = SerializeObject(testObj);
 
                 var deserializedTestObj = DeserializeObject<TestObj>(json);
@@ -282,7 +285,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void UnitInIComparable_ExpectUnitCorrectlyDeserialized()
             {
-                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable()
+                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable
                 {
                     Value = Power.FromWatts(10)
                 };
@@ -290,16 +293,16 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
                 string json = JsonConvert.SerializeObject(testObjWithIComparable, jsonSerializerSettings);
 
-                var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json,jsonSerializerSettings);
+                var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json, jsonSerializerSettings);
 
                 Assert.Equal(typeof(Power), deserializedTestObject.Value.GetType());
-                Assert.Equal(Power.FromWatts(10), (Power)deserializedTestObject.Value);
+                Assert.Equal(Power.FromWatts(10), (Power) deserializedTestObject.Value);
             }
 
             [Fact]
             public void DoubleInIComparable_ExpectUnitCorrectlyDeserialized()
             {
-                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable()
+                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable
                 {
                     Value = 10.0
                 };
@@ -310,15 +313,15 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 var deserializedTestObject = JsonConvert.DeserializeObject<TestObjWithIComparable>(json, jsonSerializerSettings);
 
                 Assert.Equal(typeof(double), deserializedTestObject.Value.GetType());
-                Assert.Equal(10d, (double)deserializedTestObject.Value);
+                Assert.Equal(10d, (double) deserializedTestObject.Value);
             }
 
             [Fact]
             public void ClassInIComparable_ExpectUnitCorrectlyDeserialized()
             {
-                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable()
+                TestObjWithIComparable testObjWithIComparable = new TestObjWithIComparable
                 {
-                    Value = new ComparableClass() { Value = 10 }
+                    Value = new ComparableClass {Value = 10}
                 };
                 JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
@@ -332,10 +335,10 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void OtherObjectWithUnitAndValue_ExpectCorrectResturnValues()
             {
-                TestObjWithValueAndUnit testObjWithValueAndUnit = new TestObjWithValueAndUnit()
+                TestObjWithValueAndUnit testObjWithValueAndUnit = new TestObjWithValueAndUnit
                 {
-                   Value = 5,
-                   Unit = "Test",
+                    Value = 5,
+                    Unit = "Test",
                 };
                 JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
@@ -350,11 +353,11 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void ThreeObjectsInIComparableWithDifferentValues_ExpectAllCorrectlyDeserialized()
             {
-                TestObjWithThreeIComparable testObjWithIComparable = new TestObjWithThreeIComparable()
+                TestObjWithThreeIComparable testObjWithIComparable = new TestObjWithThreeIComparable
                 {
                     Value1 = 10.0,
                     Value2 = Power.FromWatts(19),
-                    Value3 = new ComparableClass() { Value = 10 },
+                    Value3 = new ComparableClass {Value = 10},
                 };
                 JsonSerializerSettings jsonSerializerSettings = CreateJsonSerializerSettings();
 
@@ -372,20 +375,20 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void ArrayOfUnits_ExpectCorrectlyDeserialized()
             {
-                Frequency[] expected = { Frequency.FromHertz(10), Frequency.FromHertz(10) };
+                Frequency[] expected = {Frequency.FromHertz(10), Frequency.FromHertz(10)};
 
                 string json = "[\n" +
-                                      "  {\n" +
-                                      "    \"Unit\": \"FrequencyUnit.Hertz\",\n" +
-                                      "    \"Value\": 10.0\n" +
-                                      "  },\n" +
-                                      "  {\n" +
-                                      "    \"Unit\": \"FrequencyUnit.Hertz\",\n" +
-                                      "    \"Value\": 10.0\n" +
-                                      "  }\n" +
-                                      "]";
+                              "  {\n" +
+                              "    \"Unit\": \"FrequencyUnit.Hertz\",\n" +
+                              "    \"Value\": 10.0\n" +
+                              "  },\n" +
+                              "  {\n" +
+                              "    \"Unit\": \"FrequencyUnit.Hertz\",\n" +
+                              "    \"Value\": 10.0\n" +
+                              "  }\n" +
+                              "]";
 
-                Frequency[] result  = DeserializeObject<Frequency[]>(json);
+                Frequency[] result = DeserializeObject<Frequency[]>(json);
 
                 Assert.Equal(expected, result);
             }
@@ -402,7 +405,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
             private static JsonSerializerSettings CreateJsonSerializerSettings()
             {
-                var jsonSerializerSettings = new JsonSerializerSettings()
+                var jsonSerializerSettings = new JsonSerializerSettings
                 {
                     Formatting = Formatting.Indented,
                     TypeNameHandling = TypeNameHandling.Auto
@@ -425,16 +428,17 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
             public int CompareTo(object obj)
             {
-                return ((IComparable)Value).CompareTo(obj);
+                return ((IComparable) Value).CompareTo(obj);
             }
         }
 
         private class ComparableClass : IComparable
         {
             public int Value { get; set; }
+
             public int CompareTo(object obj)
             {
-                return ((IComparable)Value).CompareTo(obj);
+                return ((IComparable) Value).CompareTo(obj);
             }
 
             // Needed for virfying that the deserialized object is the same, should not affect the serilization code
@@ -444,7 +448,8 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 {
                     return false;
                 }
-                return Value.Equals(((ComparableClass)obj).Value);
+
+                return Value.Equals(((ComparableClass) obj).Value);
             }
 
             public override int GetHashCode()

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -14,16 +14,15 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         {
         }
 
-
         private string SerializeObject(object obj)
         {
             return SerializeObject(obj, QuantityFactory.Default);
         }
 
-        private string SerializeObject(object obj, QuantityFactory qtyFactory)
+        private string SerializeObject(object obj, QuantityFactory quantityFactory)
         {
             var jsonSerializerSettings = new JsonSerializerSettings {Formatting = Formatting.Indented};
-            jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(qtyFactory));
+            jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(quantityFactory));
             return JsonConvert.SerializeObject(obj, jsonSerializerSettings).Replace("\r\n", "\n");
         }
 
@@ -32,10 +31,10 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             return DeserializeObject<T>(json, QuantityFactory.Default);
         }
 
-        private T DeserializeObject<T>(string json, QuantityFactory qtyFactory)
+        private T DeserializeObject<T>(string json, QuantityFactory quantityFactory)
         {
             var jsonSerializerSettings = new JsonSerializerSettings {Formatting = Formatting.Indented};
-            jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(qtyFactory));
+            jsonSerializerSettings.Converters.Add(new UnitsNetJsonConverter(quantityFactory));
             return JsonConvert.DeserializeObject<T>(json, jsonSerializerSettings);
         }
 
@@ -67,7 +66,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             public void Custom_ExpectConstructedValueAndUnit()
             {
                 var quantityFactory = new QuantityFactory();
-                quantityFactory.AddUnit(typeof(HowMuch), typeof(HowMuchUnit));
+                quantityFactory.AddUnit(HowMuch.Info);
 
                 var howMuch = new HowMuch(3.1415, HowMuchUnit.ATon);
                 var expectedJson = "{\n  \"Unit\": \"HowMuchUnit.ATon\",\n  \"Value\": 3.1415\n}";
@@ -204,12 +203,13 @@ namespace UnitsNet.Serialization.JsonNet.Tests
             [Fact]
             public void Custom_ExpectJsonCorrectlyDeserialized()
             {
-                var qtyFactory = new QuantityFactory();
-                qtyFactory.AddUnit(typeof(HowMuch), typeof(HowMuchUnit));
-                HowMuch originalHowMuch = new HowMuch(2.71, HowMuchUnit.AShitTon);
-                string json = SerializeObject(originalHowMuch, qtyFactory);
+                var quantityFactory = new QuantityFactory();
+                quantityFactory.AddUnit(HowMuch.Info);
 
-                var deserializedHowMuch = DeserializeObject<HowMuch>(json, qtyFactory);
+                HowMuch originalHowMuch = new HowMuch(2.71, HowMuchUnit.AShitTon);
+                string json = SerializeObject(originalHowMuch, quantityFactory);
+
+                var deserializedHowMuch = DeserializeObject<HowMuch>(json, quantityFactory);
 
                 Assert.Equal(originalHowMuch, deserializedHowMuch);
             }

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonConverterTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using Newtonsoft.Json;
+using UnitsNet.Serialization.JsonNet.Tests.CustomQuantities;
 using Xunit;
 
 namespace UnitsNet.Serialization.JsonNet.Tests
@@ -47,6 +48,19 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 var expectedJson = "{\n  \"Unit\": \"MassUnit.Pound\",\n  \"Value\": 200.0\n}";
 
                 string json = SerializeObject(mass);
+
+                Assert.Equal(expectedJson, json);
+            }
+
+            [Fact]
+            public void Custom_ExpectConstructedValueAndUnit()
+            {
+                Quantity.AddUnit(typeof(HowMuch),typeof(HowMuchUnit));
+
+                var howMuch = new HowMuch(3.1415,HowMuchUnit.ATon);
+                var expectedJson = "{\n  \"Unit\": \"HowMuchUnit.ATon\",\n  \"Value\": 3.1415\n}";
+
+                string json = SerializeObject(howMuch);
 
                 Assert.Equal(expectedJson, json);
             }
@@ -172,6 +186,18 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 var deserializedMass = DeserializeObject<Mass>(json);
 
                 Assert.Equal(originalMass, deserializedMass);
+            }
+
+            [Fact]
+            public void Custom_ExpectJsonCorrectlyDeserialized()
+            {
+                Quantity.AddUnit(typeof(HowMuch),typeof(HowMuchUnit));
+                HowMuch originalHowMuch = new HowMuch(2.71,HowMuchUnit.AShitTon);
+                string json = SerializeObject(originalHowMuch);
+
+                var deserializedHowMuch = DeserializeObject<HowMuch>(json);
+
+                Assert.Equal(originalHowMuch, deserializedHowMuch);
             }
 
             [Fact]

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -72,11 +72,12 @@ namespace UnitsNet.Serialization.JsonNet
             // "MassUnit.Kilogram" => "MassUnit" and "Kilogram"
             string unitEnumTypeName = vu.Unit.Split('.')[0];
             string unitEnumValue = vu.Unit.Split('.')[1];
+            string quantityTypeName = unitEnumTypeName.Remove(unitEnumTypeName.Length - 4);
 
             Type unitEnumType;
-            if (Quantity.ExternalQuantities.ContainsKey(unitEnumTypeName))
+            if (Quantity.ExternalQuantities.ContainsKey(quantityTypeName))
             {
-                unitEnumType = Quantity.ExternalQuantities[unitEnumTypeName].UnitEnumType;
+                unitEnumType = Quantity.ExternalQuantities[quantityTypeName].UnitEnumType;
             }
             else
             {
@@ -172,11 +173,17 @@ namespace UnitsNet.Serialization.JsonNet
 
         private static ValueUnit ToValueUnit(IQuantity value)
         {
+            string unitTypeName = value.QuantityInfo.UnitType.Name;
+            if (Quantity.ExternalQuantities.ContainsKey(value.GetType().Name))
+            {
+                unitTypeName = value.Unit.GetType().Name;
+            }
+
             return new ValueUnit
             {
                 // See ValueUnit about precision loss for quantities using decimal type.
                 Value = value.Value,
-                Unit = $"{value.QuantityInfo.UnitType.Name}.{value.Unit}"
+                Unit = $"{unitTypeName}.{value.Unit}"
             };
         }
 
@@ -212,6 +219,7 @@ namespace UnitsNet.Serialization.JsonNet
 
             return objectType.Namespace != null &&
                 (objectType.Namespace.Equals(nameof(UnitsNet)) ||
+                 Quantity.ExternalQuantities.ContainsKey(objectType.Name) ||
                 objectType == typeof(ValueUnit) ||
                 // All unit types implement IComparable
                 objectType == typeof(IComparable));

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -74,9 +74,9 @@ namespace UnitsNet.Serialization.JsonNet
             string unitEnumValue = vu.Unit.Split('.')[1];
 
             Type unitEnumType;
-            if (Quantity.KnownQuantities.ContainsKey(unitEnumTypeName))
+            if (Quantity.ExternalQuantities.ContainsKey(unitEnumTypeName))
             {
-                unitEnumType = Quantity.KnownQuantities[unitEnumTypeName].UnitEnumType;
+                unitEnumType = Quantity.ExternalQuantities[unitEnumTypeName].UnitEnumType;
             }
             else
             {

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -201,7 +201,7 @@ namespace UnitsNet.Serialization.JsonNet
                 return CanConvertNullable(objectType);
 
             return objectType.Namespace != null &&
-                (_quantityFactory.IsQuantityTypeConfigured(objectType) ||
+                (_quantityFactory.CanCreate(objectType) ||
                 objectType == typeof(ValueUnit) ||
                 // All unit types implement IComparable
                 objectType == typeof(IComparable));

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -2,6 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -67,21 +68,30 @@ namespace UnitsNet.Serialization.JsonNet
         }
 
         private static IQuantity ParseValueUnit(ValueUnit vu)
-        {
+        { 
             // "MassUnit.Kilogram" => "MassUnit" and "Kilogram"
             string unitEnumTypeName = vu.Unit.Split('.')[0];
             string unitEnumValue = vu.Unit.Split('.')[1];
 
-            // "UnitsNet.Units.MassUnit,UnitsNet"
-            string unitEnumTypeAssemblyQualifiedName = "UnitsNet.Units." + unitEnumTypeName + ",UnitsNet";
-
-            // -- see http://stackoverflow.com/a/6465096/1256096 for details
-            Type unitEnumType = Type.GetType(unitEnumTypeAssemblyQualifiedName);
-            if (unitEnumType == null)
+            Type unitEnumType;
+            if (Quantity.KnownQuantities.ContainsKey(unitEnumTypeName))
             {
-                var ex = new UnitsNetException("Unable to find enum type.");
-                ex.Data["type"] = unitEnumTypeAssemblyQualifiedName;
-                throw ex;
+                unitEnumType = Quantity.KnownQuantities[unitEnumTypeName].UnitEnumType;
+            }
+            else
+            {
+
+                // "UnitsNet.Units.MassUnit,UnitsNet"
+                string unitEnumTypeAssemblyQualifiedName = "UnitsNet.Units." + unitEnumTypeName + ",UnitsNet";
+
+                // -- see http://stackoverflow.com/a/6465096/1256096 for details
+                unitEnumType = Type.GetType(unitEnumTypeAssemblyQualifiedName);
+                if (unitEnumType == null)
+                {
+                    var ex = new UnitsNetException("Unable to find enum type.");
+                    ex.Data["type"] = unitEnumTypeAssemblyQualifiedName;
+                    throw ex;
+                }
             }
 
             double value = vu.Value;

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -2,7 +2,6 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using JetBrains.Annotations;
 using Newtonsoft.Json;
@@ -24,10 +23,10 @@ namespace UnitsNet.Serialization.JsonNet
     /// </remarks>
     public class UnitsNetJsonConverter : JsonConverter
     {
-        private QuantityFactory _quantityFactory;
+        private readonly QuantityFactory _quantityFactory;
 
         /// <summary>
-        /// Creates a JSON converter using the default Quantity Factory.
+        /// Creates a JSON converter using the default <see cref="QuantityFactory"/>.
         /// </summary>
         public UnitsNetJsonConverter() : this(QuantityFactory.Default)
         {
@@ -35,12 +34,12 @@ namespace UnitsNet.Serialization.JsonNet
         }
 
         /// <summary>
-        /// Creates a JSON converter using a supplied quantity factory.
+        /// Creates a JSON converter using the given quantity factory.
         /// </summary>
-        /// <param name="quantityFactory">The quantity factory to use in generating IQuantity types.</param>
+        /// <param name="quantityFactory">The quantity factory to use when constructing IQuantity objects.</param>
         public UnitsNetJsonConverter(QuantityFactory quantityFactory)
         {
-            this._quantityFactory = quantityFactory;
+            _quantityFactory = quantityFactory;
         }
 
         /// <summary>
@@ -88,7 +87,7 @@ namespace UnitsNet.Serialization.JsonNet
 
         private IQuantity ParseValueUnit(ValueUnit vu)
         {
-            return _quantityFactory.FromValueAndUnit(vu.Value,vu.Unit);
+            return _quantityFactory.FromValueAndUnit(vu.Value, vu.Unit);
         }
 
         private object TryDeserializeIComparable(JsonReader reader, JsonSerializer serializer)
@@ -161,15 +160,16 @@ namespace UnitsNet.Serialization.JsonNet
             }
         }
 
-        private ValueUnit ToValueUnit(IQuantity value)
+        private static ValueUnit ToValueUnit(IQuantity value)
         {
-            string unitTypeName = _quantityFactory.UnitTypeName(value);
+            // Example: "Length"
+            var quantityName = value.QuantityInfo.Name;
 
             return new ValueUnit
             {
                 // See ValueUnit about precision loss for quantities using decimal type.
                 Value = value.Value,
-                Unit = $"{unitTypeName}Unit.{value.Unit}"
+                Unit = $"{quantityName}Unit.{value.Unit}"
             };
         }
 
@@ -204,7 +204,7 @@ namespace UnitsNet.Serialization.JsonNet
                 return CanConvertNullable(objectType);
 
             return objectType.Namespace != null &&
-                (_quantityFactory.CanBuild(objectType) ||
+                (_quantityFactory.IsQuantityTypeConfigured(objectType) ||
                 objectType == typeof(ValueUnit) ||
                 // All unit types implement IComparable
                 objectType == typeof(IComparable));

--- a/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetJsonConverter.cs
@@ -162,14 +162,11 @@ namespace UnitsNet.Serialization.JsonNet
 
         private static ValueUnit ToValueUnit(IQuantity value)
         {
-            // Example: "Length"
-            var quantityName = value.QuantityInfo.Name;
-
             return new ValueUnit
             {
                 // See ValueUnit about precision loss for quantities using decimal type.
                 Value = value.Value,
-                Unit = $"{quantityName}Unit.{value.Unit}"
+                Unit = $"{value.QuantityInfo.UnitType.Name}.{value.Unit}"
             };
         }
 

--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using Newtonsoft.Json;
 
 namespace UnitsNet.Tests.CustomQuantities
 {
@@ -6,40 +7,75 @@ namespace UnitsNet.Tests.CustomQuantities
     /// <summary>
     /// Example of a custom/third-party quantity implementation, for plugging in quantities and units at runtime.
     /// </summary>
-    public struct HowMuch : IQuantity
+    public struct HowMuch : IQuantity<HowMuchUnit>
     {
+        public HowMuchUnit Unit { get; }
+        public double Value { get; }
+
         public HowMuch(double value, Enum unit) : this()
         {
-            Unit = unit;
+            Unit = (HowMuchUnit)unit;
             Value = value;
         }
 
-        public Enum Unit { get; }
-        public double Value { get; }
+        static HowMuch()
+        {
+            BaseUnit = HowMuchUnit.Some;
+            Info = new QuantityInfo<HowMuchUnit>
+            (
+                QuantityType.Ratio,
+                new UnitInfo<HowMuchUnit>[]
+                {
+                    new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
+                    new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
+                    new UnitInfo<HowMuchUnit>(HowMuchUnit.AShitTon, BaseUnits.Undefined),
+                },
+                BaseUnit,
+                Zero,
+                BaseDimensions
+            );
 
-        #region Crud to satisfy IQuantity, but not really used for anything
+        }
 
-        private static readonly HowMuch Zero = new HowMuch(0, HowMuchUnit.Some);
+        public double As(HowMuchUnit unit)
+        {
+            return Value;
+        }
+        
+        QuantityInfo<HowMuchUnit> IQuantity<HowMuchUnit>.QuantityInfo => Info;
 
-        public QuantityType Type => QuantityType.Undefined;
-        public BaseDimensions Dimensions => BaseDimensions.Dimensionless;
+        public static HowMuch From(QuantityValue value, HowMuchUnit fromUnit)
+        {
+            return new HowMuch((double)value,fromUnit);
+        }
 
-        public QuantityInfo QuantityInfo => new QuantityInfo(Type,
-            new UnitInfo[]
-            {
-                new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
-                new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
-                new UnitInfo<HowMuchUnit>(HowMuchUnit.AShitTon, BaseUnits.Undefined),
-            },
-            HowMuchUnit.Some,
-            Zero,
-            BaseDimensions.Dimensionless);
+        public static HowMuchUnit BaseUnit { get; } 
+        public static HowMuch Zero { get; } = new HowMuch(0, BaseUnit);
+        
+        public QuantityType Type => QuantityType.Ratio;
+        public static BaseDimensions BaseDimensions => BaseDimensions.Dimensionless;
+        public BaseDimensions Dimensions => BaseDimensions;
+        [JsonIgnore]
+        public QuantityInfo QuantityInfo => Info;
+
+        public static QuantityInfo<HowMuchUnit> Info { get; }
 
         public double As(Enum unit) => Convert.ToDouble(unit);
 
+        #region Crud to satisfy IQuantity, but not really used for anything
         public double As(UnitSystem unitSystem) => throw new NotImplementedException();
+        Enum IQuantity.Unit => Unit;
 
         public IQuantity ToUnit(Enum unit) => new HowMuch(As(unit), unit);
+        IQuantity<HowMuchUnit> IQuantity<HowMuchUnit>.ToUnit(UnitSystem unitSystem)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IQuantity<HowMuchUnit> ToUnit(HowMuchUnit unit)
+        {
+            throw new NotImplementedException();
+        }
 
         public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
 

--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -32,9 +32,38 @@ namespace UnitsNet.Tests.CustomQuantities
                 },
                 BaseUnit,
                 Zero,
-                BaseDimensions
+                BaseDimensions,
+                new CustomQuantityOptions(TryParse, TryCreate)
             );
+        }
 
+        private static bool TryParse(IFormatProvider formatProvider, string str, out IQuantity quantity)
+        {
+            // Dummy implementation
+            if (str == "a ton")
+            {
+                quantity = From(1, HowMuchUnit.ATon);
+                return true;
+            }
+            else
+            {
+                quantity = default;
+                return false;
+            }
+        }
+
+        private static bool TryCreate(QuantityValue value, Enum unit, out IQuantity quantity)
+        {
+            if (Enum.IsDefined(typeof(HowMuchUnit), unit))
+            {
+                quantity = From(value, (HowMuchUnit)unit);
+                return true;
+            }
+            else
+            {
+                quantity = default;
+                return false;
+            }
         }
 
         public double As(HowMuchUnit unit)

--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -24,7 +24,7 @@ namespace UnitsNet.Tests.CustomQuantities
             Info = new QuantityInfo<HowMuchUnit>
             (
                 QuantityType.Ratio,
-                new UnitInfo<HowMuchUnit>[]
+                new[]
                 {
                     new UnitInfo<HowMuchUnit>(HowMuchUnit.Some, BaseUnits.Undefined),
                     new UnitInfo<HowMuchUnit>(HowMuchUnit.ATon, BaseUnits.Undefined),
@@ -41,7 +41,7 @@ namespace UnitsNet.Tests.CustomQuantities
         {
             return Value;
         }
-        
+
         QuantityInfo<HowMuchUnit> IQuantity<HowMuchUnit>.QuantityInfo => Info;
 
         public static HowMuch From(QuantityValue value, HowMuchUnit fromUnit)
@@ -49,9 +49,9 @@ namespace UnitsNet.Tests.CustomQuantities
             return new HowMuch((double)value,fromUnit);
         }
 
-        public static HowMuchUnit BaseUnit { get; } 
+        public static HowMuchUnit BaseUnit { get; }
         public static HowMuch Zero { get; } = new HowMuch(0, BaseUnit);
-        
+
         public QuantityType Type => QuantityType.Ratio;
         public static BaseDimensions BaseDimensions => BaseDimensions.Dimensionless;
         public BaseDimensions Dimensions => BaseDimensions;

--- a/UnitsNet.Tests/CustomQuantities/HowMuchUnit.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuchUnit.cs
@@ -1,4 +1,4 @@
-namespace UnitsNet.Tests.CustomQuantities
+﻿namespace UnitsNet.Tests.CustomQuantities
 {
     /// <summary>
     /// Example of a custom/third-party quantity implementation, for plugging in quantities and units at runtime.

--- a/UnitsNet.Tests/QuantityTest.cs
+++ b/UnitsNet.Tests/QuantityTest.cs
@@ -14,7 +14,7 @@ namespace UnitsNet.Tests
     public class QuantityTest
     {
         // Exclude Undefined value
-        private int QuantityCount => Enum.GetValues(typeof(QuantityType)).Length - 1 + Quantity.ExternalQuantities.Count;
+        private int QuantityCount => Enum.GetValues(typeof(QuantityType)).Length - 1;
         private int TypeCount => Enum.GetValues(typeof(QuantityType)).Length - 1;
 
         [Theory]
@@ -42,13 +42,6 @@ namespace UnitsNet.Tests
             Assert.Equal(Length.FromCentimeters(3), Quantity.From(3, LengthUnit.Centimeter));
             Assert.Equal(Mass.FromTonnes(3), Quantity.From(3, MassUnit.Tonne));
             Assert.Equal(Pressure.FromMegabars(3), Quantity.From(3, PressureUnit.Megabar));
-        }
-
-        [Fact]
-        public void From_GivenValueAndUnit_ReturnsCustomQuantity()
-        {
-            Quantity.AddUnit(typeof(HowMuch),typeof(HowMuchUnit));
-            Assert.Equal(new HowMuch(42,HowMuchUnit.Some), Quantity.From(42, HowMuchUnit.Some));
         }
 
         [Fact]

--- a/UnitsNet.Tests/QuantityTest.cs
+++ b/UnitsNet.Tests/QuantityTest.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Linq;
 using JetBrains.Annotations;
+using UnitsNet.Tests.CustomQuantities;
 using UnitsNet.Units;
 using Xunit;
 
@@ -40,6 +41,13 @@ namespace UnitsNet.Tests
             Assert.Equal(Length.FromCentimeters(3), Quantity.From(3, LengthUnit.Centimeter));
             Assert.Equal(Mass.FromTonnes(3), Quantity.From(3, MassUnit.Tonne));
             Assert.Equal(Pressure.FromMegabars(3), Quantity.From(3, PressureUnit.Megabar));
+        }
+
+        [Fact]
+        public void From_GivenValueAndUnit_ReturnsCustomQuantity()
+        {
+            Quantity.AddUnit(typeof(HowMuch),typeof(HowMuchUnit));
+            Assert.Equal(new HowMuch(42,HowMuchUnit.Some), Quantity.From(42, HowMuchUnit.Some));
         }
 
         [Fact]

--- a/UnitsNet.Tests/QuantityTest.cs
+++ b/UnitsNet.Tests/QuantityTest.cs
@@ -14,7 +14,8 @@ namespace UnitsNet.Tests
     public class QuantityTest
     {
         // Exclude Undefined value
-        private static readonly int QuantityCount = Enum.GetValues(typeof(QuantityType)).Length - 1;
+        private int QuantityCount => Enum.GetValues(typeof(QuantityType)).Length - 1 + Quantity.ExternalQuantities.Count;
+        private int TypeCount => Enum.GetValues(typeof(QuantityType)).Length - 1;
 
         [Theory]
         [InlineData(double.NaN)]
@@ -185,7 +186,7 @@ namespace UnitsNet.Tests
             var types = Quantity.Types;
 
             Assert.Superset(knownQuantities.ToHashSet(), types.ToHashSet());
-            Assert.Equal(QuantityCount, types.Length);
+            Assert.Equal(TypeCount, types.Length);
         }
 
         [Fact]

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -49,7 +49,6 @@ namespace UnitsNet
         public static IQuantity From(QuantityValue value, Enum unit)
         {
             return QuantityFactory.Default.From(value, unit);
-
         }
 
         /// <inheritdoc cref="TryFrom(QuantityValue,System.Enum,out UnitsNet.IQuantity)"/>
@@ -79,8 +78,7 @@ namespace UnitsNet
         {
             return QuantityFactory.Default.TryParse(quantityType, quantityString, out quantity);
         }
-
-
+        
         /// <summary>
         ///     Get information about the given quantity type.
         /// </summary>

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -44,7 +44,6 @@ namespace UnitsNet
                 throw ex;
             }
             KnownQuantities.Add(quantityType.Name, new KnownQuantityInfo() {QuantityType = quantityType, UnitEnumType = unitEnumType});
-            Names = Names.Append(quantityType.Name).ToArray();
         }
 
         private static readonly Lazy<QuantityInfo[]> InfosLazy;
@@ -54,9 +53,7 @@ namespace UnitsNet
 
         static Quantity()
         {
-            var quantityTypes = Enum.GetValues(typeof(QuantityType)).Cast<QuantityType>().Except(new[] {QuantityType.Undefined}).ToArray();
-            Types = quantityTypes;
-            Names = quantityTypes.Select(qt => qt.ToString()).ToArray();
+            _quantityTypes = Enum.GetValues(typeof(QuantityType)).Cast<QuantityType>().Except(new[] {QuantityType.Undefined}).ToList();
 
             InfosLazy = new Lazy<QuantityInfo[]>(() => Types
                 .Select(quantityType => FromQuantityType(quantityType, 0.0).QuantityInfo)
@@ -64,15 +61,17 @@ namespace UnitsNet
                 .ToArray());
         }
 
+        private static readonly List<QuantityType> _quantityTypes;
+
         /// <summary>
         /// All enum values of <see cref="QuantityType"/>, such as <see cref="QuantityType.Length"/> and <see cref="QuantityType.Mass"/>.
         /// </summary>
-        public static QuantityType[] Types { get; }
+        public static QuantityType[] Types => _quantityTypes.ToArray();
 
         /// <summary>
         /// All enum value names of <see cref="QuantityType"/>, such as "Length" and "Mass".
         /// </summary>
-        public static string[] Names { get; private set; }
+        public static string[] Names => _quantityTypes.Select(qt => qt.ToString()).Concat(KnownQuantities.Keys).ToArray();
 
         /// <summary>
         /// All quantity information objects, such as <see cref="Length.Info"/> and <see cref="Mass.Info"/>.

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -43,7 +43,8 @@ namespace UnitsNet
                 ex.Data["type"] = quantityType.Name;
                 throw ex;
             }
-            ExternalQuantities.Add(quantityType.Name, new ExternalQuantityInfo() {QuantityType = quantityType, UnitEnumType = unitEnumType});
+
+            ExternalQuantities[quantityType.Name] = new ExternalQuantityInfo() {QuantityType = quantityType, UnitEnumType = unitEnumType};
         }
 
         private static readonly Lazy<QuantityInfo[]> InfosLazy;

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -100,8 +100,25 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">Unit value is not a know unit enum type.</exception>
         public static IQuantity From(QuantityValue value, Enum unit)
         {
+            var unitTypeName = unit.GetType().Name;
+            var quantityName = unitTypeName.Substring(0,unitTypeName.Length - "Unit".Length);
+            if (ExternalQuantities.ContainsKey(quantityName))
+            {
+                object[] parameters = new object[2];
+                parameters[0] = (double) value;
+                parameters[1] = (Enum) unit;
+
+                return (IQuantity)Activator.CreateInstance
+                    (
+                    ExternalQuantities[quantityName].QuantityType,
+                    parameters
+                    );
+            }
+
             if (TryFrom(value, unit, out IQuantity quantity))
+            {
                 return quantity;
+            }
 
             throw new ArgumentException(
                 $"Unit value {unit} of type {unit.GetType()} is not a known unit enum type. Expected types like UnitsNet.Units.LengthUnit. Did you pass in a third-party enum type defined outside UnitsNet library?");

--- a/UnitsNet/CustomCode/QuantityFactory.cs
+++ b/UnitsNet/CustomCode/QuantityFactory.cs
@@ -110,10 +110,7 @@ namespace UnitsNet
                 return false;
             }
 
-            var (parsedQuantity, parseSuccess) = quantityInfo.TryFrom(value, unit);
-
-            quantity = parsedQuantity;
-            return parseSuccess;
+            return quantityInfo.TryFrom(value, unit, out quantity);
         }
 
         /// <inheritdoc cref="Parse(IFormatProvider, System.Type,string)" />
@@ -176,10 +173,7 @@ namespace UnitsNet
                 return false;
             }
 
-            var (parsedQuantity, parseSuccess) = quantityInfo.TryParse(formatProvider, quantityString);
-            quantity = parsedQuantity;
-
-            return parseSuccess;
+            return quantityInfo.TryParse(formatProvider, quantityString, out quantity);
         }
 
         /// <summary>

--- a/UnitsNet/CustomCode/QuantityFactory.cs
+++ b/UnitsNet/CustomCode/QuantityFactory.cs
@@ -2,21 +2,21 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection;
 using JetBrains.Annotations;
 using UnitsNet.InternalHelpers;
 
 namespace UnitsNet
 {
     /// <summary>
-    /// A class that can be used to construct standard are custom Quantity types.
+    ///     Factory to construct <see cref="IQuantity" /> objects from built-in or externally configured
+    ///     quantity types and unit enum types.
     /// </summary>
     public class QuantityFactory
     {
         /// <summary>
-        /// A default instance of a QuantityFactory.  Can construct all of the types defined in the core UnitsNet.
+        ///     A dictionary of info structs for each known type.
         /// </summary>
-        public static QuantityFactory Default { get; }
+        private readonly Dictionary<string, QuantityInfo> _configuredQuantities;
 
         static QuantityFactory()
         {
@@ -24,76 +24,59 @@ namespace UnitsNet
         }
 
         /// <summary>
-        /// Default constructor.  Uses a list of types from the Quantity object.
+        ///     Default constructor. Uses a list of types from the Quantity object.
         /// </summary>
         public QuantityFactory()
         {
-            KnownQuantities = Quantity.Infos.ToDictionary(x => x.Name, x => x);
+            _configuredQuantities = Quantity.Infos.ToDictionary(x => x.Name, x => x);
         }
 
         /// <summary>
-        /// A dictionary of info structs for each known type.
+        ///     A default instance of a QuantityFactory.  Can construct all of the types defined in the core UnitsNet.
         /// </summary>
-        public Dictionary<string, QuantityInfo> KnownQuantities;
+        public static QuantityFactory Default { get; }
 
         /// <summary>
-        ///     Adds a type defined in an external assembly for serialisation.
+        ///     A dictionary of info structs for each known type.
         /// </summary>
-        /// <param name="quantityType">The quantity type.</param>
-        /// <param name="unitType">The unit type for the quantity.</param>
-        public void AddUnit(Type quantityType,Type unitType)
+        public IReadOnlyDictionary<string, QuantityInfo> ConfiguredQuantities => _configuredQuantities;
+
+        /// <summary>
+        ///     Configures a new quantity type and its corresponding unit enum type.
+        /// </summary>
+        /// <example>
+        ///     This can be useful to support serializing and deserializing third-party quantity types that implement <see cref="IQuantity"/>.
+        /// </example>
+        /// <param name="quantityInfo">Description of the quantity.</param>
+        public void AddUnit(QuantityInfo quantityInfo)
         {
-            var quantityInfoProperty = quantityType.GetProperty("QuantityInfo");
-            if (quantityInfoProperty == null)
-            {
-                throw new UnitsNetException($"Invalid type registration {quantityType.Name}. Type must implement IQuantity.");
-            }
-
-            var baseUnit = Enum.ToObject(unitType, 1);
-
-            var parameters = new[] {1.0, baseUnit};
-            var instance = (IQuantity)Activator.CreateInstance
-            (
-                quantityType,
-                BindingFlags.CreateInstance,
-                null,
-                parameters,
-                CultureInfo.InvariantCulture
-            );
-            var info = (QuantityInfo)(quantityInfoProperty.GetValue(instance, null));
-
-            KnownQuantities[info.ValueType.Name] = info;
+            var quantityName = quantityInfo.Name;
+            _configuredQuantities[quantityName] = quantityInfo;
         }
 
         /// <summary>
-        ///     Dynamically construct a quantity.
+        ///     Dynamically construct a quantity from a number and a unit enum.
         /// </summary>
         /// <param name="value">Numeric value.</param>
         /// <param name="unit">Unit enum value.</param>
-        /// <returns>An <see cref="IQuantity"/> object.</returns>
+        /// <returns>An <see cref="IQuantity" /> object.</returns>
         /// <exception cref="ArgumentException">Unit value is not a know unit enum type.</exception>
         public IQuantity From(QuantityValue value, Enum unit)
         {
-            var unitTypeName = unit.GetType().Name;
-            var quantityName = unitTypeName.Substring(0, unitTypeName.Length - "Unit".Length);
-            if (!KnownQuantities.ContainsKey(quantityName))
-            {
-                throw new UnitsNetException($"Unknown unit type {unit.GetType().Name}");
-            }
+            var unitEnumType = unit.GetType();
+            EnsureQuantityForUnitEnumIsConfigured(unitEnumType);
 
-            var success = TryFrom(value, unit, out IQuantity quantity);
-
+            var success = TryFrom(value, unit, out var quantity);
             if (!success)
             {
-                throw new UnitsNetException($"Unable to create IQuantity with unit {Enum.GetName(unit.GetType(),unit)}.");
+                throw new UnitsNetException($"Unable to create IQuantity with unit {Enum.GetName(unitEnumType, unit)}.");
             }
 
             return quantity;
         }
 
-
         /// <summary>
-        /// Try to create an IQuantity based on a value and a unit
+        ///     Try to create an IQuantity based on a value and a unit
         /// </summary>
         /// <param name="value">The number of the quantity.</param>
         /// <param name="unit">The unit of measure for the quantity.</param>
@@ -111,56 +94,63 @@ namespace UnitsNet
         }
 
 
-        /// <inheritdoc cref = "Parse(IFormatProvider, System.Type,string)" />
+        /// <inheritdoc cref="Parse(IFormatProvider, System.Type,string)" />
         public bool TryFrom(QuantityValue value, Enum unit, out IQuantity quantity)
         {
             var unitTypeName = unit.GetType().Name;
             var quantityTypeName = unitTypeName.Remove(unitTypeName.Length - "Unit".Length);
-            if (!KnownQuantities.ContainsKey(quantityTypeName))
+            if (!_configuredQuantities.TryGetValue(quantityTypeName, out QuantityInfo quantityInfo))
             {
                 quantity = default;
                 return false;
             }
 
-            var result = KnownQuantities[quantityTypeName].TryFrom(value, unit);
-            quantity = result.Item1;
-            return result.Item2;
+            var (parsedQuantity, parseSuccess) = quantityInfo.TryFrom(value, unit);
+
+            quantity = parsedQuantity;
+            return parseSuccess;
         }
 
-        /// <inheritdoc cref="Parse(IFormatProvider, System.Type,string)"/>
+        /// <inheritdoc cref="Parse(IFormatProvider, System.Type,string)" />
         public IQuantity Parse(Type quantityType, string quantityString) => Parse(null, quantityType, quantityString);
 
         /// <summary>
         ///     Dynamically parse a quantity string representation.
         /// </summary>
-        /// <param name="formatProvider">The format provider to use for lookup. Defaults to <see cref="CultureInfo.CurrentUICulture" /> if null.</param>
-        /// <param name="quantityType">Type of quantity, such as <see cref="Length"/>.</param>
-        /// <param name="quantityString">Quantity string representation, such as "1.5 kg". Must be compatible with given quantity type.</param>
+        /// <param name="formatProvider">
+        ///     The format provider to use for lookup. Defaults to
+        ///     <see cref="CultureInfo.CurrentUICulture" /> if null.
+        /// </param>
+        /// <param name="quantityType">Type of quantity, such as <see cref="Length" />.</param>
+        /// <param name="quantityString">
+        ///     Quantity string representation, such as "1.5 kg". Must be compatible with given quantity
+        ///     type.
+        /// </param>
         /// <returns>The parsed quantity.</returns>
         /// <exception cref="ArgumentException">Type must be of type UnitsNet.IQuantity -or- Type is not a known quantity type.</exception>
         public IQuantity Parse([CanBeNull] IFormatProvider formatProvider, Type quantityType, string quantityString)
         {
             if (!typeof(IQuantity).Wrap().IsAssignableFrom(quantityType))
             {
-                throw new ArgumentException($"Type {quantityType} must be of type UnitsNet.IQuantity.");
+                throw new ArgumentException($"Type {quantityType.FullName} must be of type UnitsNet.IQuantity.");
             }
 
-            if (TryParse(formatProvider, quantityType, quantityString, out IQuantity quantity))
+            if (TryParse(formatProvider, quantityType, quantityString, out var quantity))
             {
                 return quantity;
             }
 
-            throw new ArgumentException($"Quantity string could not be parsed to quantity {quantityType}.");
+            throw new ArgumentException($"Quantity string could not be parsed to quantity {quantityType.FullName}.");
         }
 
-        /// <inheritdoc cref="TryParse(IFormatProvider, System.Type,string,out IQuantity)"/>
+        /// <inheritdoc cref="TryParse(IFormatProvider, System.Type,string,out IQuantity)" />
         public bool TryParse(Type quantityType, string quantityString, out IQuantity quantity)
         {
             return TryParse(null, quantityType, quantityString, out quantity);
         }
 
         /// <summary>
-        /// Attempt to parse a Quantity from a type and a string consisting of value and unit.
+        ///     Attempt to parse a Quantity from a type and a string consisting of value and unit.
         /// </summary>
         /// <param name="formatProvider">Language format</param>
         /// <param name="quantityType">The type of quantity to create</param>
@@ -169,78 +159,71 @@ namespace UnitsNet
         /// <returns>True is parsing succeeded</returns>
         public bool TryParse([CanBeNull] IFormatProvider formatProvider, Type quantityType, string quantityString, out IQuantity quantity)
         {
-            if (!KnownQuantities.ContainsKey(quantityType.Name))
+            if (!typeof(IQuantity).Wrap().IsAssignableFrom(quantityType))
             {
                 quantity = default;
                 return false;
             }
 
-            quantity = default;
-
-            if (!typeof(IQuantity).Wrap().IsAssignableFrom(quantityType))
+            if (!_configuredQuantities.TryGetValue(quantityType.Name, out QuantityInfo quantityInfo))
             {
+                quantity = default;
                 return false;
             }
 
-            var result = KnownQuantities[quantityType.Name].TryParse(formatProvider,quantityString);
+            var (parsedQuantity, parseSuccess) = quantityInfo.TryParse(formatProvider, quantityString);
+            quantity = parsedQuantity;
 
-            if (result.Item2) quantity = result.Item1;
-
-            return result.Item2;
+            return parseSuccess;
         }
 
         /// <summary>
-        /// Gets the name of a unit type base on a Quantity value.
-        /// </summary>
-        /// <param name="value">The value for which to get the unit name.</param>
-        /// <returns>A unit type name (Mass, Length, etc).</returns>
-        public string UnitTypeName(IQuantity value)
-        {
-            var typeName = value.GetType().Name;
-            if (!KnownQuantities.ContainsKey(typeName))
-            {
-                throw new UnitsNetException($"Unknown type {typeName}");
-            }
-
-            return KnownQuantities[typeName].Name;
-            
-        }
-
-        /// <summary>
-        /// Produces a Quantity from a number as a QuantityValue and a unit as a string.
+        ///     Produces a Quantity from a number as a QuantityValue and a unit as a string.
         /// </summary>
         /// <param name="value">The number of units.</param>
         /// <param name="unit">The unit as a string - e.g "MassUnit.Kilogram"</param>
         /// <returns>An IQuantity.</returns>
-        public IQuantity FromValueAndUnit(QuantityValue value,string unit)
+        public IQuantity FromValueAndUnit(QuantityValue value, string unit)
         {
             // "MassUnit.Kilogram" => "MassUnit" and "Kilogram"
             string unitEnumTypeName = unit.Split('.')[0];
             string unitEnumValue = unit.Split('.')[1];
             string quantityTypeName = unitEnumTypeName.Remove(unitEnumTypeName.Length - 4);
 
-            if (!KnownQuantities.ContainsKey(quantityTypeName))
+            if (!_configuredQuantities.ContainsKey(quantityTypeName))
             {
                 throw new UnitsNetException($"Unit type {quantityTypeName} not known.");
             }
 
-            var unitEnumType = KnownQuantities[quantityTypeName].UnitType;
-            
-            Enum unitValue = (Enum)Enum.Parse(unitEnumType, unitEnumValue); // Ex: MassUnit.Kilogram
+            var unitEnumType = _configuredQuantities[quantityTypeName].UnitType;
+
+            var unitValue = (Enum) Enum.Parse(unitEnumType, unitEnumValue); // Ex: MassUnit.Kilogram
 
             return From(value, unitValue);
         }
 
         /// <summary>
-        /// A function to check if building a particular type is supported in this QuantityFactory.
+        ///     A function to check if building a particular type is supported in this QuantityFactory.
         /// </summary>
         /// <param name="objectType">The type of object to check.</param>
         /// <returns>True if the type is supported.</returns>
-        public bool CanBuild(Type objectType)
+        public bool IsQuantityTypeConfigured(Type objectType)
         {
-            return KnownQuantities.ContainsKey(objectType.Name);
+            return _configuredQuantities.ContainsKey(objectType.Name);
+        }
+
+        private void EnsureQuantityForUnitEnumIsConfigured(Type unitEnumType)
+        {
+            // "LengthUnit"
+            var unitTypeName = unitEnumType.Name;
+
+            // "LengthUnit" => "Length"
+            var quantityName = unitTypeName.Substring(0, unitTypeName.Length - "Unit".Length);
+
+            if (!_configuredQuantities.ContainsKey(quantityName))
+            {
+                throw new UnitsNetException($"No quantity is configured for unit enum type {unitEnumType.FullName}. Make sure to call AddUnit() first.");
+            }
         }
     }
-
 }
-

--- a/UnitsNet/CustomCode/QuantityFactory.cs
+++ b/UnitsNet/CustomCode/QuantityFactory.cs
@@ -207,7 +207,7 @@ namespace UnitsNet
         /// </summary>
         /// <param name="objectType">The type of object to check.</param>
         /// <returns>True if the type is supported.</returns>
-        public bool IsQuantityTypeConfigured(Type objectType)
+        public bool CanCreate(Type objectType)
         {
             return _configuredQuantities.ContainsKey(objectType.Name);
         }

--- a/UnitsNet/CustomCode/QuantityFactory.cs
+++ b/UnitsNet/CustomCode/QuantityFactory.cs
@@ -1,0 +1,189 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using JetBrains.Annotations;
+using UnitsNet.InternalHelpers;
+
+namespace UnitsNet
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class QuantityFactory
+    {
+        /// <summary>
+        /// A default instance of a QuantityFactory.  Can construct all of the types defined in the core UnitsNet.
+        /// </summary>
+        public static QuantityFactory Default { get; }
+
+        static QuantityFactory()
+        {
+            Default = new QuantityFactory();
+        }
+
+        /// <summary>
+        /// Default constructor.  Uses a list of types from the Quantity object.
+        /// </summary>
+        public QuantityFactory()
+        {
+            KnownQuantities = Quantity.Infos.ToDictionary(x => x.Name, x => x);
+        }
+
+        /// <summary>
+        /// A dictionary of info structs for each known type.
+        /// </summary>
+        public Dictionary<string, QuantityInfo> KnownQuantities;
+
+        /// <summary>
+        ///     Adds a type defined in an external assembly for serialisation
+        /// </summary>
+        /// <param name="quantityType">The quantity type.</param>
+        public void AddUnit(Type quantityType)
+        {
+            var quantityInfoProperty = quantityType.GetProperty("QuantityInfo");
+            if (quantityInfoProperty == null)
+            {
+                throw new UnitsNetException($"Invalid type registration {quantityType.Name}. Type must implement IQuantity.");
+            }
+            var info = (QuantityInfo)(quantityInfoProperty.GetValue(null,null));
+
+            KnownQuantities[info.Name] = info;
+        }
+
+        /// <summary>
+        ///     Dynamically construct a quantity.
+        /// </summary>
+        /// <param name="value">Numeric value.</param>
+        /// <param name="unit">Unit enum value.</param>
+        /// <returns>An <see cref="IQuantity"/> object.</returns>
+        /// <exception cref="ArgumentException">Unit value is not a know unit enum type.</exception>
+        public IQuantity From(QuantityValue value, Enum unit)
+        {
+            var unitTypeName = unit.GetType().Name;
+            var quantityName = unitTypeName.Substring(0, unitTypeName.Length - "Unit".Length);
+            if (!KnownQuantities.ContainsKey(quantityName))
+            {
+                throw new UnitsNetException($"Unknown unit type {unit.GetType().Name}");
+            }
+
+            var success = TryFrom(value, unit, out IQuantity quantity);
+
+            if (!success)
+            {
+                throw new UnitsNetException($"Unable to create IQuantity with unit {Enum.GetName(unit.GetType(),unit)}.");
+            }
+
+            return quantity;
+        }
+
+
+        /// <summary>
+        /// Try to create an IQuantity based on a value and a unit
+        /// </summary>
+        /// <param name="value">The number of the quantity.</param>
+        /// <param name="unit">The unit of measure for the quantity.</param>
+        /// <param name="quantity">The value in which to return the IQuantity.</param>
+        /// <returns>True is creation of the IQuantity was successful.</returns>
+        public bool TryFrom(QuantityValue value, Enum unit, out IQuantity quantity)
+        {
+            // Implicit cast to QuantityValue would prevent TryFrom from being called,
+            // so we need to explicitly check this here for double arguments.
+            if (double.IsNaN((double)value) || double.IsInfinity((double)value))
+            {
+                quantity = default;
+                return false;
+            }
+
+            var unitTypeName = unit.GetType().Name;
+            if (!KnownQuantities.ContainsKey(unitTypeName))
+            {
+                quantity = default;
+                return false;
+            }
+
+            try
+            {
+                quantity = (IQuantity)Activator.CreateInstance
+                    (
+                    KnownQuantities[unitTypeName].UnitType,
+                    BindingFlags.CreateInstance,
+                    null,
+                    value,
+                    unit
+                    );
+                return quantity != null;
+            }
+            catch (Exception)
+            {
+                quantity = default;
+                return false;
+            }
+            
+        }
+
+        /// <inheritdoc cref="Parse(IFormatProvider, System.Type,string)"/>
+        public IQuantity Parse(Type quantityType, string quantityString) => Parse(null, quantityType, quantityString);
+
+        /// <summary>
+        ///     Dynamically parse a quantity string representation.
+        /// </summary>
+        /// <param name="formatProvider">The format provider to use for lookup. Defaults to <see cref="CultureInfo.CurrentUICulture" /> if null.</param>
+        /// <param name="quantityType">Type of quantity, such as <see cref="Length"/>.</param>
+        /// <param name="quantityString">Quantity string representation, such as "1.5 kg". Must be compatible with given quantity type.</param>
+        /// <returns>The parsed quantity.</returns>
+        /// <exception cref="ArgumentException">Type must be of type UnitsNet.IQuantity -or- Type is not a known quantity type.</exception>
+        public IQuantity Parse([CanBeNull] IFormatProvider formatProvider, Type quantityType, string quantityString)
+        {
+            if (!typeof(IQuantity).Wrap().IsAssignableFrom(quantityType))
+            {
+                throw new ArgumentException($"Type {quantityType} must be of type UnitsNet.IQuantity.");
+            }
+
+            if (TryParse(formatProvider, quantityType, quantityString, out IQuantity quantity))
+                return quantity;
+
+            throw new ArgumentException($"Quantity string could not be parsed to quantity {quantityType}.");
+        }
+
+        /// <inheritdoc cref="TryParse(IFormatProvider, System.Type,string,out IQuantity)"/>
+        public bool TryParse(Type quantityType, string quantityString, out IQuantity quantity)
+        {
+            return TryParse(null, quantityType, quantityString, out quantity);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="formatProvider"></param>
+        /// <param name="quantityType"></param>
+        /// <param name="quantityString"></param>
+        /// <param name="quantity"></param>
+        /// <returns></returns>
+        public bool TryParse([CanBeNull] IFormatProvider formatProvider, Type quantityType, string quantityString, out IQuantity quantity)
+        {
+            if (!KnownQuantities.ContainsKey(quantityType.Name))
+            {
+                quantity = default;
+                return false;
+            }
+
+            quantity = default;
+
+            if (!typeof(IQuantity).Wrap().IsAssignableFrom(quantityType))
+            {
+                return false;
+            }
+
+            var result = KnownQuantities[quantityType.Name].Builder(formatProvider,quantityString);
+
+            if (result.Item2) quantity = result.Item1;
+
+            return result.Item2;
+        }
+    }
+
+}
+

--- a/UnitsNet/CustomCode/QuantityFactory.cs
+++ b/UnitsNet/CustomCode/QuantityFactory.cs
@@ -39,7 +39,12 @@ namespace UnitsNet
         /// <summary>
         ///     A dictionary of info structs for each known type.
         /// </summary>
-        public IReadOnlyDictionary<string, QuantityInfo> ConfiguredQuantities => _configuredQuantities;
+#if (!NET40)
+        public IReadOnlyDictionary
+#else
+        public IDictionary
+#endif
+            <string, QuantityInfo> ConfiguredQuantities => _configuredQuantities;
 
         /// <summary>
         ///     Configures a new quantity type and its corresponding unit enum type.

--- a/UnitsNet/CustomCode/QuantityFactory.cs
+++ b/UnitsNet/CustomCode/QuantityFactory.cs
@@ -210,6 +210,12 @@ namespace UnitsNet
             
         }
 
+        /// <summary>
+        /// Produces a Quantity from a number as a QuantityValue and a unit as a string.
+        /// </summary>
+        /// <param name="value">The number of units.</param>
+        /// <param name="unit">The unit as a string - e.g "MassUnit.Kilogram"</param>
+        /// <returns>An IQuantity.</returns>
         public IQuantity FromValueAndUnit(QuantityValue value,string unit)
         {
             // "MassUnit.Kilogram" => "MassUnit" and "Kilogram"

--- a/UnitsNet/CustomQuantityOptions.cs
+++ b/UnitsNet/CustomQuantityOptions.cs
@@ -1,0 +1,48 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+using JetBrains.Annotations;
+
+namespace UnitsNet
+{
+    /// <summary>
+    /// Try to parse a quantity.
+    /// </summary>
+    /// <param name="formatProvider">The culture and localization to parse numbers and unit abbreviations.</param>
+    /// <param name="str">The string to parse.</param>
+    /// <param name="quantity">The resulting quantity.</param>
+    public delegate bool TryParseQuantity(IFormatProvider formatProvider, string str, out IQuantity quantity);
+
+    /// <summary>
+    /// Try to create a quantity given a number and a unit. Can fail if the unit enum value does not map to a quantity.
+    /// </summary>
+    /// <param name="value">Numeric value.</param>
+    /// <param name="unit">The unit.</param>
+    /// <param name="quantity">The resulting quantity.</param>
+    public delegate bool TryCreateQuantity(QuantityValue value, Enum unit, out IQuantity quantity);
+
+    /// <summary>
+    /// Options for constructing and parsing third-party quantities that are not handled by the generated code.
+    /// These quantities are typically added via <see cref="QuantityFactory"/>.<see cref="QuantityFactory.AddUnit"/>.
+    /// </summary>
+    public class CustomQuantityOptions
+    {
+        /// <inheritdoc cref="TryParseQuantity"/>
+        public TryParseQuantity TryParse { get; }
+
+        /// <inheritdoc cref="TryCreateQuantity"/>
+        public TryCreateQuantity TryCreate { get; }
+
+        /// <summary>
+        /// Create options for parsing and constructing custom quantities.
+        /// </summary>
+        /// <param name="tryParse">The parse function.</param>
+        /// <param name="tryCreate">The factory function.</param>
+        public CustomQuantityOptions([NotNull] TryParseQuantity tryParse, [NotNull] TryCreateQuantity tryCreate)
+        {
+            TryParse = tryParse ?? throw new ArgumentNullException(nameof(tryParse));
+            TryCreate = tryCreate ?? throw new ArgumentNullException(nameof(tryCreate));
+        }
+    }
+}

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -376,6 +376,7 @@ namespace UnitsNet
             decimal value = (decimal) exabits;
             return new Information(value, InformationUnit.Exabit);
         }
+
         /// <summary>
         ///     Get Information from Exabytes.
         /// </summary>
@@ -385,6 +386,7 @@ namespace UnitsNet
             decimal value = (decimal) exabytes;
             return new Information(value, InformationUnit.Exabyte);
         }
+
         /// <summary>
         ///     Get Information from Exbibits.
         /// </summary>

--- a/UnitsNet/QuantityInfo.cs
+++ b/UnitsNet/QuantityInfo.cs
@@ -182,6 +182,7 @@ namespace UnitsNet
         public bool TryFrom(QuantityValue value, Enum unit, out IQuantity quantity)
         {
             var tryCreateFunc = _customQuantityOptions?.TryCreate;
+
             return tryCreateFunc != null
                 ? tryCreateFunc(value, unit, out quantity)
                 : Quantity.TryFrom(value, unit, out quantity);


### PR DESCRIPTION
Extensions to the Quantity class to allow the registration of classes implementing IQuantity from outside the UnitsNet library, and to support JSON serialisation and Quantity.From with this classes. 

I am a developer on v4 of the CumulusMX weather station software.  The weather measurements on this are a combination of measures that have units and simple scalars. To simplify the code, we have decided to implement the scalars as a custom IQuantity - but were finding that this prevented us effectively serialising and deserialising the state. By registering the custom type using the new functionality in this pull request we should resolve that.