### PR TITLE
Add pound/foot-second in DynamicViscosity

### DIFF
--- a/Common/UnitDefinitions/DynamicViscosity.json
+++ b/Common/UnitDefinitions/DynamicViscosity.json
@@ -17,7 +17,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "Ns/m²" ]
+          "Abbreviations": ["Ns/m²"]
         }
       ]
     },
@@ -26,11 +26,11 @@
       "PluralName": "PascalSeconds",
       "FromUnitToBaseFunc": "x",
       "FromBaseToUnitFunc": "x",
-      "Prefixes": [ "Milli", "Micro" ],
+      "Prefixes": ["Milli", "Micro"],
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "Pa·s", "PaS" ]
+          "Abbreviations": ["Pa·s", "PaS"]
         }
       ]
     },
@@ -39,11 +39,11 @@
       "PluralName": "Poise",
       "FromUnitToBaseFunc": "x/10",
       "FromBaseToUnitFunc": "x*10",
-      "Prefixes": [ "Centi" ],
+      "Prefixes": ["Centi"],
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "P" ]
+          "Abbreviations": ["P"]
         }
       ]
     },
@@ -55,7 +55,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "reyn" ]
+          "Abbreviations": ["reyn"]
         }
       ]
     },
@@ -67,7 +67,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lbf·s/in²" ]
+          "Abbreviations": ["lbf·s/in²"]
         }
       ]
     },
@@ -79,7 +79,19 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lbf·s/ft²" ]
+          "Abbreviations": ["lbf·s/ft²"]
+        }
+      ]
+    },
+    {
+      "SingularName": "PoundFootSecond",
+      "PluralName": "PoundsFootSecond",
+      "FromUnitToBaseFunc": "x * 1.4881639",
+      "FromBaseToUnitFunc": "x / 1.4881639",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "lb/ft-s" ]
         }
       ]
     }

--- a/UnitsNet.Tests/CustomCode/DynamicViscosityTests.cs
+++ b/UnitsNet.Tests/CustomCode/DynamicViscosityTests.cs
@@ -14,6 +14,7 @@ namespace UnitsNet.Tests.CustomCode
         protected override double NewtonSecondsPerMeterSquaredInOneNewtonSecondPerMeterSquared => 1;
         protected override double PascalSecondsInOneNewtonSecondPerMeterSquared => 1;
         protected override double PoiseInOneNewtonSecondPerMeterSquared => 10;
+        protected override double PoundsFootSecondInOneNewtonSecondPerMeterSquared => 0.671968994813;
         protected override double ReynsInOneNewtonSecondPerMeterSquared => 1.4503773773020922e-4;
         protected override double PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared => 1.4503773773020922e-4;
         protected override double PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared => 2.0885434233150127e-2;

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet.Tests
         protected abstract double NewtonSecondsPerMeterSquaredInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PascalSecondsInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoiseInOneNewtonSecondPerMeterSquared { get; }
+        protected abstract double PoundsFootSecondInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double ReynsInOneNewtonSecondPerMeterSquared { get; }
@@ -53,6 +54,7 @@ namespace UnitsNet.Tests
         protected virtual double NewtonSecondsPerMeterSquaredTolerance { get { return 1e-5; } }
         protected virtual double PascalSecondsTolerance { get { return 1e-5; } }
         protected virtual double PoiseTolerance { get { return 1e-5; } }
+        protected virtual double PoundsFootSecondTolerance { get { return 1e-5; } }
         protected virtual double PoundsForceSecondPerSquareFootTolerance { get { return 1e-5; } }
         protected virtual double PoundsForceSecondPerSquareInchTolerance { get { return 1e-5; } }
         protected virtual double ReynsTolerance { get { return 1e-5; } }
@@ -123,6 +125,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(NewtonSecondsPerMeterSquaredInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.NewtonSecondsPerMeterSquared, NewtonSecondsPerMeterSquaredTolerance);
             AssertEx.EqualTolerance(PascalSecondsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PascalSeconds, PascalSecondsTolerance);
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.Poise, PoiseTolerance);
+            AssertEx.EqualTolerance(PoundsFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsFootSecond, PoundsFootSecondTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsForceSecondPerSquareFoot, PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsForceSecondPerSquareInch, PoundsForceSecondPerSquareInchTolerance);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.Reyns, ReynsTolerance);
@@ -155,17 +158,21 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity05.Poise, PoiseTolerance);
             Assert.Equal(DynamicViscosityUnit.Poise, quantity05.Unit);
 
-            var quantity06 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundForceSecondPerSquareFoot);
-            AssertEx.EqualTolerance(1, quantity06.PoundsForceSecondPerSquareFoot, PoundsForceSecondPerSquareFootTolerance);
-            Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, quantity06.Unit);
+            var quantity06 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundFootSecond);
+            AssertEx.EqualTolerance(1, quantity06.PoundsFootSecond, PoundsFootSecondTolerance);
+            Assert.Equal(DynamicViscosityUnit.PoundFootSecond, quantity06.Unit);
 
-            var quantity07 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundForceSecondPerSquareInch);
-            AssertEx.EqualTolerance(1, quantity07.PoundsForceSecondPerSquareInch, PoundsForceSecondPerSquareInchTolerance);
-            Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareInch, quantity07.Unit);
+            var quantity07 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundForceSecondPerSquareFoot);
+            AssertEx.EqualTolerance(1, quantity07.PoundsForceSecondPerSquareFoot, PoundsForceSecondPerSquareFootTolerance);
+            Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, quantity07.Unit);
 
-            var quantity08 = DynamicViscosity.From(1, DynamicViscosityUnit.Reyn);
-            AssertEx.EqualTolerance(1, quantity08.Reyns, ReynsTolerance);
-            Assert.Equal(DynamicViscosityUnit.Reyn, quantity08.Unit);
+            var quantity08 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundForceSecondPerSquareInch);
+            AssertEx.EqualTolerance(1, quantity08.PoundsForceSecondPerSquareInch, PoundsForceSecondPerSquareInchTolerance);
+            Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareInch, quantity08.Unit);
+
+            var quantity09 = DynamicViscosity.From(1, DynamicViscosityUnit.Reyn);
+            AssertEx.EqualTolerance(1, quantity09.Reyns, ReynsTolerance);
+            Assert.Equal(DynamicViscosityUnit.Reyn, quantity09.Unit);
 
         }
 
@@ -192,6 +199,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(NewtonSecondsPerMeterSquaredInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.NewtonSecondPerMeterSquared), NewtonSecondsPerMeterSquaredTolerance);
             AssertEx.EqualTolerance(PascalSecondsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PascalSecond), PascalSecondsTolerance);
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.Poise), PoiseTolerance);
+            AssertEx.EqualTolerance(PoundsFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundFootSecond), PoundsFootSecondTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundForceSecondPerSquareFoot), PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundForceSecondPerSquareInch), PoundsForceSecondPerSquareInchTolerance);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.Reyn), ReynsTolerance);
@@ -226,6 +234,10 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, (double)poiseQuantity.Value, PoiseTolerance);
             Assert.Equal(DynamicViscosityUnit.Poise, poiseQuantity.Unit);
 
+            var poundfootsecondQuantity = newtonsecondpermetersquared.ToUnit(DynamicViscosityUnit.PoundFootSecond);
+            AssertEx.EqualTolerance(PoundsFootSecondInOneNewtonSecondPerMeterSquared, (double)poundfootsecondQuantity.Value, PoundsFootSecondTolerance);
+            Assert.Equal(DynamicViscosityUnit.PoundFootSecond, poundfootsecondQuantity.Unit);
+
             var poundforcesecondpersquarefootQuantity = newtonsecondpermetersquared.ToUnit(DynamicViscosityUnit.PoundForceSecondPerSquareFoot);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, (double)poundforcesecondpersquarefootQuantity.Value, PoundsForceSecondPerSquareFootTolerance);
             Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, poundforcesecondpersquarefootQuantity.Unit);
@@ -249,6 +261,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, DynamicViscosity.FromNewtonSecondsPerMeterSquared(newtonsecondpermetersquared.NewtonSecondsPerMeterSquared).NewtonSecondsPerMeterSquared, NewtonSecondsPerMeterSquaredTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPascalSeconds(newtonsecondpermetersquared.PascalSeconds).NewtonSecondsPerMeterSquared, PascalSecondsTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoise(newtonsecondpermetersquared.Poise).NewtonSecondsPerMeterSquared, PoiseTolerance);
+            AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsFootSecond(newtonsecondpermetersquared.PoundsFootSecond).NewtonSecondsPerMeterSquared, PoundsFootSecondTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsForceSecondPerSquareFoot(newtonsecondpermetersquared.PoundsForceSecondPerSquareFoot).NewtonSecondsPerMeterSquared, PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsForceSecondPerSquareInch(newtonsecondpermetersquared.PoundsForceSecondPerSquareInch).NewtonSecondsPerMeterSquared, PoundsForceSecondPerSquareInchTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromReyns(newtonsecondpermetersquared.Reyns).NewtonSecondsPerMeterSquared, ReynsTolerance);
@@ -397,6 +410,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 Ns/m²", new DynamicViscosity(1, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString());
                 Assert.Equal("1 Pa·s", new DynamicViscosity(1, DynamicViscosityUnit.PascalSecond).ToString());
                 Assert.Equal("1 P", new DynamicViscosity(1, DynamicViscosityUnit.Poise).ToString());
+                Assert.Equal("1 lb/ft-s", new DynamicViscosity(1, DynamicViscosityUnit.PoundFootSecond).ToString());
                 Assert.Equal("1 lbf·s/ft²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareFoot).ToString());
                 Assert.Equal("1 lbf·s/in²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareInch).ToString());
                 Assert.Equal("1 reyn", new DynamicViscosity(1, DynamicViscosityUnit.Reyn).ToString());
@@ -419,6 +433,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Ns/m²", new DynamicViscosity(1, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString(swedishCulture));
             Assert.Equal("1 Pa·s", new DynamicViscosity(1, DynamicViscosityUnit.PascalSecond).ToString(swedishCulture));
             Assert.Equal("1 P", new DynamicViscosity(1, DynamicViscosityUnit.Poise).ToString(swedishCulture));
+            Assert.Equal("1 lb/ft-s", new DynamicViscosity(1, DynamicViscosityUnit.PoundFootSecond).ToString(swedishCulture));
             Assert.Equal("1 lbf·s/ft²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareFoot).ToString(swedishCulture));
             Assert.Equal("1 lbf·s/in²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareInch).ToString(swedishCulture));
             Assert.Equal("1 reyn", new DynamicViscosity(1, DynamicViscosityUnit.Reyn).ToString(swedishCulture));

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -189,6 +189,11 @@ namespace UnitsNet
         public double Poise => As(DynamicViscosityUnit.Poise);
 
         /// <summary>
+        ///     Get DynamicViscosity in PoundsFootSecond.
+        /// </summary>
+        public double PoundsFootSecond => As(DynamicViscosityUnit.PoundFootSecond);
+
+        /// <summary>
         ///     Get DynamicViscosity in PoundsForceSecondPerSquareFoot.
         /// </summary>
         public double PoundsForceSecondPerSquareFoot => As(DynamicViscosityUnit.PoundForceSecondPerSquareFoot);
@@ -292,6 +297,16 @@ namespace UnitsNet
         {
             double value = (double) poise;
             return new DynamicViscosity(value, DynamicViscosityUnit.Poise);
+        }
+        /// <summary>
+        ///     Get DynamicViscosity from PoundsFootSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static DynamicViscosity FromPoundsFootSecond(double poundsfootsecond)
+        {
+            double value = (double) poundsfootsecond;
+            return new DynamicViscosity(value, DynamicViscosityUnit.PoundFootSecond);
         }
         /// <summary>
         ///     Get DynamicViscosity from PoundsForceSecondPerSquareFoot.
@@ -620,6 +635,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return _value;
                 case DynamicViscosityUnit.PascalSecond: return _value;
                 case DynamicViscosityUnit.Poise: return _value/10;
+                case DynamicViscosityUnit.PoundFootSecond: return _value * 1.4881639;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return _value * 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return _value * 6.8947572931683613e3;
                 case DynamicViscosityUnit.Reyn: return _value * 6.8947572931683613e3;
@@ -643,6 +659,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return baseUnitValue;
                 case DynamicViscosityUnit.PascalSecond: return baseUnitValue;
                 case DynamicViscosityUnit.Poise: return baseUnitValue*10;
+                case DynamicViscosityUnit.PoundFootSecond: return baseUnitValue / 1.4881639;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return baseUnitValue / 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return baseUnitValue / 6.8947572931683613e3;
                 case DynamicViscosityUnit.Reyn: return baseUnitValue / 6.8947572931683613e3;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -234,6 +234,7 @@ namespace UnitsNet
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.NewtonSecondPerMeterSquared, new string[]{"Ns/m²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PascalSecond, new string[]{"Pa·s", "PaS"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Poise, new string[]{"P"}),
+                ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundFootSecond, new string[]{"lb/ft-s"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareFoot, new string[]{"lbf·s/ft²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareInch, new string[]{"lbf·s/in²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Reyn, new string[]{"reyn"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/DynamicViscosityUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/DynamicViscosityUnit.g.cs
@@ -32,6 +32,7 @@ namespace UnitsNet.Units
         NewtonSecondPerMeterSquared,
         PascalSecond,
         Poise,
+        PoundFootSecond,
         PoundForceSecondPerSquareFoot,
         PoundForceSecondPerSquareInch,
         Reyn,

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -59,6 +59,7 @@ namespace UnitsNet
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.NewtonSecondPerMeterSquared, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PascalSecond, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.Poise, BaseUnits.Undefined),
+                    new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PoundFootSecond, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PoundForceSecondPerSquareInch, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.Reyn, BaseUnits.Undefined),
@@ -205,6 +206,11 @@ namespace UnitsNet
         public double Poise => As(DynamicViscosityUnit.Poise);
 
         /// <summary>
+        ///     Get DynamicViscosity in PoundsFootSecond.
+        /// </summary>
+        public double PoundsFootSecond => As(DynamicViscosityUnit.PoundFootSecond);
+
+        /// <summary>
         ///     Get DynamicViscosity in PoundsForceSecondPerSquareFoot.
         /// </summary>
         public double PoundsForceSecondPerSquareFoot => As(DynamicViscosityUnit.PoundForceSecondPerSquareFoot);
@@ -301,6 +307,15 @@ namespace UnitsNet
         {
             double value = (double) poise;
             return new DynamicViscosity(value, DynamicViscosityUnit.Poise);
+        }
+        /// <summary>
+        ///     Get DynamicViscosity from PoundsFootSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static DynamicViscosity FromPoundsFootSecond(QuantityValue poundsfootsecond)
+        {
+            double value = (double) poundsfootsecond;
+            return new DynamicViscosity(value, DynamicViscosityUnit.PoundFootSecond);
         }
         /// <summary>
         ///     Get DynamicViscosity from PoundsForceSecondPerSquareFoot.
@@ -764,6 +779,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return _value;
                 case DynamicViscosityUnit.PascalSecond: return _value;
                 case DynamicViscosityUnit.Poise: return _value/10;
+                case DynamicViscosityUnit.PoundFootSecond: return _value * 1.4881639;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return _value * 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return _value * 6.8947572931683613e3;
                 case DynamicViscosityUnit.Reyn: return _value * 6.8947572931683613e3;
@@ -798,6 +814,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.NewtonSecondPerMeterSquared: return baseUnitValue;
                 case DynamicViscosityUnit.PascalSecond: return baseUnitValue;
                 case DynamicViscosityUnit.Poise: return baseUnitValue*10;
+                case DynamicViscosityUnit.PoundFootSecond: return baseUnitValue / 1.4881639;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return baseUnitValue / 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return baseUnitValue / 6.8947572931683613e3;
                 case DynamicViscosityUnit.Reyn: return baseUnitValue / 6.8947572931683613e3;

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -234,6 +234,7 @@ namespace UnitsNet
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.NewtonSecondPerMeterSquared, new string[]{"Ns/m²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PascalSecond, new string[]{"Pa·s", "PaS"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Poise, new string[]{"P"}),
+                ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundFootSecond, new string[]{"lb/ft-s"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareFoot, new string[]{"lbf·s/ft²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareInch, new string[]{"lbf·s/in²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Reyn, new string[]{"reyn"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -354,6 +354,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.PascalSecond, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.Poise, q => q.ToUnit(DynamicViscosityUnit.Poise));
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.Poise, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.PoundFootSecond, q => q.ToUnit(DynamicViscosityUnit.PoundFootSecond));
+            unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.PoundFootSecond, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.PoundForceSecondPerSquareFoot, q => q.ToUnit(DynamicViscosityUnit.PoundForceSecondPerSquareFoot));
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.PoundForceSecondPerSquareInch, q => q.ToUnit(DynamicViscosityUnit.PoundForceSecondPerSquareInch));

--- a/UnitsNet/GeneratedCode/Units/DynamicViscosityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/DynamicViscosityUnit.g.cs
@@ -32,6 +32,7 @@ namespace UnitsNet.Units
         NewtonSecondPerMeterSquared,
         PascalSecond,
         Poise,
+        PoundFootSecond,
         PoundForceSecondPerSquareFoot,
         PoundForceSecondPerSquareInch,
         Reyn,


### PR DESCRIPTION
Add pound-foot-second in DynamicViscosity

Numbers are based on https://www.convertunits.com/info/lb/ft-s