### PR TITLE
Added kilopound-force imperial variant to force

### DIFF
--- a/Common/UnitDefinitions/Force.json
+++ b/Common/UnitDefinitions/Force.json
@@ -147,6 +147,22 @@
           "Abbreviations": [ "ozf" ]
         }
       ]
+    },
+    {
+      "SingularName": "KilopoundForce",
+      "PluralName": "KilopoundsForce",
+      "FromUnitToBaseFunc": "x*4448.2216152605095551842641431421",
+      "FromBaseToUnitFunc": "x/4448.2216152605095551842641431421",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "kipf" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "кипф" ]
+        }
+      ]
     }
   ]
 }

--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -12,6 +12,7 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double KilogramsForceInOneNewton => 0.101972;
 
+        protected override double KilopoundsForceInOneNewton => 0.22481e-3;
         protected override double MeganewtonsInOneNewton => 1E-6;
         protected override double KilonewtonsInOneNewton => 1E-3;
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
@@ -41,6 +41,7 @@ namespace UnitsNet.Tests
         protected abstract double KilogramsForceInOneNewton { get; }
         protected abstract double KilonewtonsInOneNewton { get; }
         protected abstract double KiloPondsInOneNewton { get; }
+        protected abstract double KilopoundsForceInOneNewton { get; }
         protected abstract double MeganewtonsInOneNewton { get; }
         protected abstract double MicronewtonsInOneNewton { get; }
         protected abstract double MillinewtonsInOneNewton { get; }
@@ -56,6 +57,7 @@ namespace UnitsNet.Tests
         protected virtual double KilogramsForceTolerance { get { return 1e-5; } }
         protected virtual double KilonewtonsTolerance { get { return 1e-5; } }
         protected virtual double KiloPondsTolerance { get { return 1e-5; } }
+        protected virtual double KilopoundsForceTolerance { get { return 1e-5; } }
         protected virtual double MeganewtonsTolerance { get { return 1e-5; } }
         protected virtual double MicronewtonsTolerance { get { return 1e-5; } }
         protected virtual double MillinewtonsTolerance { get { return 1e-5; } }
@@ -130,6 +132,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(KilogramsForceInOneNewton, newton.KilogramsForce, KilogramsForceTolerance);
             AssertEx.EqualTolerance(KilonewtonsInOneNewton, newton.Kilonewtons, KilonewtonsTolerance);
             AssertEx.EqualTolerance(KiloPondsInOneNewton, newton.KiloPonds, KiloPondsTolerance);
+            AssertEx.EqualTolerance(KilopoundsForceInOneNewton, newton.KilopoundsForce, KilopoundsForceTolerance);
             AssertEx.EqualTolerance(MeganewtonsInOneNewton, newton.Meganewtons, MeganewtonsTolerance);
             AssertEx.EqualTolerance(MicronewtonsInOneNewton, newton.Micronewtons, MicronewtonsTolerance);
             AssertEx.EqualTolerance(MillinewtonsInOneNewton, newton.Millinewtons, MillinewtonsTolerance);
@@ -163,37 +166,41 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity04.KiloPonds, KiloPondsTolerance);
             Assert.Equal(ForceUnit.KiloPond, quantity04.Unit);
 
-            var quantity05 = Force.From(1, ForceUnit.Meganewton);
-            AssertEx.EqualTolerance(1, quantity05.Meganewtons, MeganewtonsTolerance);
-            Assert.Equal(ForceUnit.Meganewton, quantity05.Unit);
+            var quantity05 = Force.From(1, ForceUnit.KilopoundForce);
+            AssertEx.EqualTolerance(1, quantity05.KilopoundsForce, KilopoundsForceTolerance);
+            Assert.Equal(ForceUnit.KilopoundForce, quantity05.Unit);
 
-            var quantity06 = Force.From(1, ForceUnit.Micronewton);
-            AssertEx.EqualTolerance(1, quantity06.Micronewtons, MicronewtonsTolerance);
-            Assert.Equal(ForceUnit.Micronewton, quantity06.Unit);
+            var quantity06 = Force.From(1, ForceUnit.Meganewton);
+            AssertEx.EqualTolerance(1, quantity06.Meganewtons, MeganewtonsTolerance);
+            Assert.Equal(ForceUnit.Meganewton, quantity06.Unit);
 
-            var quantity07 = Force.From(1, ForceUnit.Millinewton);
-            AssertEx.EqualTolerance(1, quantity07.Millinewtons, MillinewtonsTolerance);
-            Assert.Equal(ForceUnit.Millinewton, quantity07.Unit);
+            var quantity07 = Force.From(1, ForceUnit.Micronewton);
+            AssertEx.EqualTolerance(1, quantity07.Micronewtons, MicronewtonsTolerance);
+            Assert.Equal(ForceUnit.Micronewton, quantity07.Unit);
 
-            var quantity08 = Force.From(1, ForceUnit.Newton);
-            AssertEx.EqualTolerance(1, quantity08.Newtons, NewtonsTolerance);
-            Assert.Equal(ForceUnit.Newton, quantity08.Unit);
+            var quantity08 = Force.From(1, ForceUnit.Millinewton);
+            AssertEx.EqualTolerance(1, quantity08.Millinewtons, MillinewtonsTolerance);
+            Assert.Equal(ForceUnit.Millinewton, quantity08.Unit);
 
-            var quantity09 = Force.From(1, ForceUnit.OunceForce);
-            AssertEx.EqualTolerance(1, quantity09.OunceForce, OunceForceTolerance);
-            Assert.Equal(ForceUnit.OunceForce, quantity09.Unit);
+            var quantity09 = Force.From(1, ForceUnit.Newton);
+            AssertEx.EqualTolerance(1, quantity09.Newtons, NewtonsTolerance);
+            Assert.Equal(ForceUnit.Newton, quantity09.Unit);
 
-            var quantity10 = Force.From(1, ForceUnit.Poundal);
-            AssertEx.EqualTolerance(1, quantity10.Poundals, PoundalsTolerance);
-            Assert.Equal(ForceUnit.Poundal, quantity10.Unit);
+            var quantity10 = Force.From(1, ForceUnit.OunceForce);
+            AssertEx.EqualTolerance(1, quantity10.OunceForce, OunceForceTolerance);
+            Assert.Equal(ForceUnit.OunceForce, quantity10.Unit);
 
-            var quantity11 = Force.From(1, ForceUnit.PoundForce);
-            AssertEx.EqualTolerance(1, quantity11.PoundsForce, PoundsForceTolerance);
-            Assert.Equal(ForceUnit.PoundForce, quantity11.Unit);
+            var quantity11 = Force.From(1, ForceUnit.Poundal);
+            AssertEx.EqualTolerance(1, quantity11.Poundals, PoundalsTolerance);
+            Assert.Equal(ForceUnit.Poundal, quantity11.Unit);
 
-            var quantity12 = Force.From(1, ForceUnit.TonneForce);
-            AssertEx.EqualTolerance(1, quantity12.TonnesForce, TonnesForceTolerance);
-            Assert.Equal(ForceUnit.TonneForce, quantity12.Unit);
+            var quantity12 = Force.From(1, ForceUnit.PoundForce);
+            AssertEx.EqualTolerance(1, quantity12.PoundsForce, PoundsForceTolerance);
+            Assert.Equal(ForceUnit.PoundForce, quantity12.Unit);
+
+            var quantity13 = Force.From(1, ForceUnit.TonneForce);
+            AssertEx.EqualTolerance(1, quantity13.TonnesForce, TonnesForceTolerance);
+            Assert.Equal(ForceUnit.TonneForce, quantity13.Unit);
 
         }
 
@@ -219,6 +226,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(KilogramsForceInOneNewton, newton.As(ForceUnit.KilogramForce), KilogramsForceTolerance);
             AssertEx.EqualTolerance(KilonewtonsInOneNewton, newton.As(ForceUnit.Kilonewton), KilonewtonsTolerance);
             AssertEx.EqualTolerance(KiloPondsInOneNewton, newton.As(ForceUnit.KiloPond), KiloPondsTolerance);
+            AssertEx.EqualTolerance(KilopoundsForceInOneNewton, newton.As(ForceUnit.KilopoundForce), KilopoundsForceTolerance);
             AssertEx.EqualTolerance(MeganewtonsInOneNewton, newton.As(ForceUnit.Meganewton), MeganewtonsTolerance);
             AssertEx.EqualTolerance(MicronewtonsInOneNewton, newton.As(ForceUnit.Micronewton), MicronewtonsTolerance);
             AssertEx.EqualTolerance(MillinewtonsInOneNewton, newton.As(ForceUnit.Millinewton), MillinewtonsTolerance);
@@ -253,6 +261,10 @@ namespace UnitsNet.Tests
             var kilopondQuantity = newton.ToUnit(ForceUnit.KiloPond);
             AssertEx.EqualTolerance(KiloPondsInOneNewton, (double)kilopondQuantity.Value, KiloPondsTolerance);
             Assert.Equal(ForceUnit.KiloPond, kilopondQuantity.Unit);
+
+            var kilopoundforceQuantity = newton.ToUnit(ForceUnit.KilopoundForce);
+            AssertEx.EqualTolerance(KilopoundsForceInOneNewton, (double)kilopoundforceQuantity.Value, KilopoundsForceTolerance);
+            Assert.Equal(ForceUnit.KilopoundForce, kilopoundforceQuantity.Unit);
 
             var meganewtonQuantity = newton.ToUnit(ForceUnit.Meganewton);
             AssertEx.EqualTolerance(MeganewtonsInOneNewton, (double)meganewtonQuantity.Value, MeganewtonsTolerance);
@@ -296,6 +308,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Force.FromKilogramsForce(newton.KilogramsForce).Newtons, KilogramsForceTolerance);
             AssertEx.EqualTolerance(1, Force.FromKilonewtons(newton.Kilonewtons).Newtons, KilonewtonsTolerance);
             AssertEx.EqualTolerance(1, Force.FromKiloPonds(newton.KiloPonds).Newtons, KiloPondsTolerance);
+            AssertEx.EqualTolerance(1, Force.FromKilopoundsForce(newton.KilopoundsForce).Newtons, KilopoundsForceTolerance);
             AssertEx.EqualTolerance(1, Force.FromMeganewtons(newton.Meganewtons).Newtons, MeganewtonsTolerance);
             AssertEx.EqualTolerance(1, Force.FromMicronewtons(newton.Micronewtons).Newtons, MicronewtonsTolerance);
             AssertEx.EqualTolerance(1, Force.FromMillinewtons(newton.Millinewtons).Newtons, MillinewtonsTolerance);
@@ -448,6 +461,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 kgf", new Force(1, ForceUnit.KilogramForce).ToString());
                 Assert.Equal("1 kN", new Force(1, ForceUnit.Kilonewton).ToString());
                 Assert.Equal("1 kp", new Force(1, ForceUnit.KiloPond).ToString());
+                Assert.Equal("1 kipf", new Force(1, ForceUnit.KilopoundForce).ToString());
                 Assert.Equal("1 MN", new Force(1, ForceUnit.Meganewton).ToString());
                 Assert.Equal("1 µN", new Force(1, ForceUnit.Micronewton).ToString());
                 Assert.Equal("1 mN", new Force(1, ForceUnit.Millinewton).ToString());
@@ -474,6 +488,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 kgf", new Force(1, ForceUnit.KilogramForce).ToString(swedishCulture));
             Assert.Equal("1 kN", new Force(1, ForceUnit.Kilonewton).ToString(swedishCulture));
             Assert.Equal("1 kp", new Force(1, ForceUnit.KiloPond).ToString(swedishCulture));
+            Assert.Equal("1 kipf", new Force(1, ForceUnit.KilopoundForce).ToString(swedishCulture));
             Assert.Equal("1 MN", new Force(1, ForceUnit.Meganewton).ToString(swedishCulture));
             Assert.Equal("1 µN", new Force(1, ForceUnit.Micronewton).ToString(swedishCulture));
             Assert.Equal("1 mN", new Force(1, ForceUnit.Millinewton).ToString(swedishCulture));

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.g.cs
@@ -181,6 +181,11 @@ namespace UnitsNet
         public double KiloPonds => As(ForceUnit.KiloPond);
 
         /// <summary>
+        ///     Get Force in KilopoundsForce.
+        /// </summary>
+        public double KilopoundsForce => As(ForceUnit.KilopoundForce);
+
+        /// <summary>
         ///     Get Force in Meganewtons.
         /// </summary>
         public double Meganewtons => As(ForceUnit.Meganewton);
@@ -299,6 +304,16 @@ namespace UnitsNet
         {
             double value = (double) kiloponds;
             return new Force(value, ForceUnit.KiloPond);
+        }
+        /// <summary>
+        ///     Get Force from KilopoundsForce.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Force FromKilopoundsForce(double kilopoundsforce)
+        {
+            double value = (double) kilopoundsforce;
+            return new Force(value, ForceUnit.KilopoundForce);
         }
         /// <summary>
         ///     Get Force from Meganewtons.
@@ -676,6 +691,7 @@ namespace UnitsNet
                 case ForceUnit.KilogramForce: return _value*9.80665002864;
                 case ForceUnit.Kilonewton: return (_value) * 1e3d;
                 case ForceUnit.KiloPond: return _value*9.80665002864;
+                case ForceUnit.KilopoundForce: return _value*4448.2216152605095551842641431421;
                 case ForceUnit.Meganewton: return (_value) * 1e6d;
                 case ForceUnit.Micronewton: return (_value) * 1e-6d;
                 case ForceUnit.Millinewton: return (_value) * 1e-3d;
@@ -703,6 +719,7 @@ namespace UnitsNet
                 case ForceUnit.KilogramForce: return baseUnitValue/9.80665002864;
                 case ForceUnit.Kilonewton: return (baseUnitValue) / 1e3d;
                 case ForceUnit.KiloPond: return baseUnitValue/9.80665002864;
+                case ForceUnit.KilopoundForce: return baseUnitValue/4448.2216152605095551842641431421;
                 case ForceUnit.Meganewton: return (baseUnitValue) / 1e6d;
                 case ForceUnit.Micronewton: return (baseUnitValue) / 1e-6d;
                 case ForceUnit.Millinewton: return (baseUnitValue) / 1e-3d;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -366,6 +366,8 @@ namespace UnitsNet
                 ("ru-RU", typeof(ForceUnit), (int)ForceUnit.Kilonewton, new string[]{"кН"}),
                 ("en-US", typeof(ForceUnit), (int)ForceUnit.KiloPond, new string[]{"kp"}),
                 ("ru-RU", typeof(ForceUnit), (int)ForceUnit.KiloPond, new string[]{"кгс"}),
+                ("en-US", typeof(ForceUnit), (int)ForceUnit.KilopoundForce, new string[]{"kipf"}),
+                ("ru-RU", typeof(ForceUnit), (int)ForceUnit.KilopoundForce, new string[]{"кипф"}),
                 ("en-US", typeof(ForceUnit), (int)ForceUnit.Meganewton, new string[]{"MN"}),
                 ("ru-RU", typeof(ForceUnit), (int)ForceUnit.Meganewton, new string[]{"МН"}),
                 ("en-US", typeof(ForceUnit), (int)ForceUnit.Micronewton, new string[]{"µN"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/ForceUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/ForceUnit.g.cs
@@ -31,6 +31,7 @@ namespace UnitsNet.Units
         KilogramForce,
         Kilonewton,
         KiloPond,
+        KilopoundForce,
         Meganewton,
         Micronewton,
         Millinewton,

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -55,6 +55,7 @@ namespace UnitsNet
                     new UnitInfo<ForceUnit>(ForceUnit.KilogramForce, BaseUnits.Undefined),
                     new UnitInfo<ForceUnit>(ForceUnit.Kilonewton, BaseUnits.Undefined),
                     new UnitInfo<ForceUnit>(ForceUnit.KiloPond, BaseUnits.Undefined),
+                    new UnitInfo<ForceUnit>(ForceUnit.KilopoundForce, BaseUnits.Undefined),
                     new UnitInfo<ForceUnit>(ForceUnit.Meganewton, BaseUnits.Undefined),
                     new UnitInfo<ForceUnit>(ForceUnit.Micronewton, BaseUnits.Undefined),
                     new UnitInfo<ForceUnit>(ForceUnit.Millinewton, BaseUnits.Undefined),
@@ -201,6 +202,11 @@ namespace UnitsNet
         public double KiloPonds => As(ForceUnit.KiloPond);
 
         /// <summary>
+        ///     Get Force in KilopoundsForce.
+        /// </summary>
+        public double KilopoundsForce => As(ForceUnit.KilopoundForce);
+
+        /// <summary>
         ///     Get Force in Meganewtons.
         /// </summary>
         public double Meganewtons => As(ForceUnit.Meganewton);
@@ -313,6 +319,15 @@ namespace UnitsNet
         {
             double value = (double) kiloponds;
             return new Force(value, ForceUnit.KiloPond);
+        }
+        /// <summary>
+        ///     Get Force from KilopoundsForce.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Force FromKilopoundsForce(QuantityValue kilopoundsforce)
+        {
+            double value = (double) kilopoundsforce;
+            return new Force(value, ForceUnit.KilopoundForce);
         }
         /// <summary>
         ///     Get Force from Meganewtons.
@@ -820,6 +835,7 @@ namespace UnitsNet
                 case ForceUnit.KilogramForce: return _value*9.80665002864;
                 case ForceUnit.Kilonewton: return (_value) * 1e3d;
                 case ForceUnit.KiloPond: return _value*9.80665002864;
+                case ForceUnit.KilopoundForce: return _value*4448.2216152605095551842641431421;
                 case ForceUnit.Meganewton: return (_value) * 1e6d;
                 case ForceUnit.Micronewton: return (_value) * 1e-6d;
                 case ForceUnit.Millinewton: return (_value) * 1e-3d;
@@ -858,6 +874,7 @@ namespace UnitsNet
                 case ForceUnit.KilogramForce: return baseUnitValue/9.80665002864;
                 case ForceUnit.Kilonewton: return (baseUnitValue) / 1e3d;
                 case ForceUnit.KiloPond: return baseUnitValue/9.80665002864;
+                case ForceUnit.KilopoundForce: return baseUnitValue/4448.2216152605095551842641431421;
                 case ForceUnit.Meganewton: return (baseUnitValue) / 1e6d;
                 case ForceUnit.Micronewton: return (baseUnitValue) / 1e-6d;
                 case ForceUnit.Millinewton: return (baseUnitValue) / 1e-3d;

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -366,6 +366,8 @@ namespace UnitsNet
                 ("ru-RU", typeof(ForceUnit), (int)ForceUnit.Kilonewton, new string[]{"кН"}),
                 ("en-US", typeof(ForceUnit), (int)ForceUnit.KiloPond, new string[]{"kp"}),
                 ("ru-RU", typeof(ForceUnit), (int)ForceUnit.KiloPond, new string[]{"кгс"}),
+                ("en-US", typeof(ForceUnit), (int)ForceUnit.KilopoundForce, new string[]{"kipf"}),
+                ("ru-RU", typeof(ForceUnit), (int)ForceUnit.KilopoundForce, new string[]{"кипф"}),
                 ("en-US", typeof(ForceUnit), (int)ForceUnit.Meganewton, new string[]{"MN"}),
                 ("ru-RU", typeof(ForceUnit), (int)ForceUnit.Meganewton, new string[]{"МН"}),
                 ("en-US", typeof(ForceUnit), (int)ForceUnit.Micronewton, new string[]{"µN"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -558,6 +558,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Force>(ForceUnit.Kilonewton, Force.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Force>(Force.BaseUnit, ForceUnit.KiloPond, q => q.ToUnit(ForceUnit.KiloPond));
             unitConverter.SetConversionFunction<Force>(ForceUnit.KiloPond, Force.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<Force>(Force.BaseUnit, ForceUnit.KilopoundForce, q => q.ToUnit(ForceUnit.KilopoundForce));
+            unitConverter.SetConversionFunction<Force>(ForceUnit.KilopoundForce, Force.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Force>(Force.BaseUnit, ForceUnit.Meganewton, q => q.ToUnit(ForceUnit.Meganewton));
             unitConverter.SetConversionFunction<Force>(ForceUnit.Meganewton, Force.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Force>(Force.BaseUnit, ForceUnit.Micronewton, q => q.ToUnit(ForceUnit.Micronewton));

--- a/UnitsNet/GeneratedCode/Units/ForceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ForceUnit.g.cs
@@ -31,6 +31,7 @@ namespace UnitsNet.Units
         KilogramForce,
         Kilonewton,
         KiloPond,
+        KilopoundForce,
         Meganewton,
         Micronewton,
         Millinewton,


### PR DESCRIPTION
We were missing the imperial variant of kilonewtons, being Kilopound-force.
Up untill now, we've worked around it in our code using an extension method:

![image](https://user-images.githubusercontent.com/6634696/73851976-b0cad600-482e-11ea-8db6-b966c47f3273.png)

So i'm adding it to the library so others can use it too.

Due to the difference in abbreviation (lbf vs kipf), i couldn't simply add the "Kilo" prefix to Kilopound-force (which I initially tried)

Converter used: https://www.unitconverters.net/force/kilopound-force-to-newton.htm