### PR TITLE
Add 'Per Second' Unit to Frequency

### DIFF
--- a/Common/UnitDefinitions/Frequency.json
+++ b/Common/UnitDefinitions/Frequency.json
@@ -67,6 +67,18 @@
           "Abbreviations": [ "bpm" ]
         }
       ]
+    },
+    {
+      "SingularName": "PerSecond",
+      "PluralName": "PerSecond",
+      "FromUnitToBaseFunc": "x",
+      "FromBaseToUnitFunc": "x",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "s⁻¹" ]
+        }
+      ]
     }
   ]
 }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToFrequencyExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToFrequencyExtensionsTest.g.cs
@@ -53,6 +53,10 @@ namespace UnitsNet.Tests
             Assert.Equal(Frequency.FromMegahertz(2), 2.Megahertz());
 
         [Fact]
+        public void NumberToPerSecondTest() =>
+            Assert.Equal(Frequency.FromPerSecond(2), 2.PerSecond());
+
+        [Fact]
         public void NumberToRadiansPerSecondTest() =>
             Assert.Equal(Frequency.FromRadiansPerSecond(2), 2.RadiansPerSecond());
 

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToFrequencyExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToFrequencyExtensions.g.cs
@@ -54,6 +54,10 @@ namespace UnitsNet.NumberExtensions.NumberToFrequency
         public static Frequency Megahertz<T>(this T value) =>
             Frequency.FromMegahertz(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Frequency.FromPerSecond(UnitsNet.QuantityValue)" />
+        public static Frequency PerSecond<T>(this T value) =>
+            Frequency.FromPerSecond(Convert.ToDouble(value));
+
         /// <inheritdoc cref="Frequency.FromRadiansPerSecond(UnitsNet.QuantityValue)" />
         public static Frequency RadiansPerSecond<T>(this T value) =>
             Frequency.FromRadiansPerSecond(Convert.ToDouble(value));

--- a/UnitsNet.Tests/CustomCode/FrequencyTests.cs
+++ b/UnitsNet.Tests/CustomCode/FrequencyTests.cs
@@ -17,6 +17,8 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double TerahertzInOneHertz => 1e-12;
 
+        protected override double PerSecondInOneHertz => 1;
+
         protected override double CyclesPerHourInOneHertz => 3600;
 
         protected override double CyclesPerMinuteInOneHertz => 60;

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
@@ -43,6 +43,7 @@ namespace UnitsNet.Tests
         protected abstract double HertzInOneHertz { get; }
         protected abstract double KilohertzInOneHertz { get; }
         protected abstract double MegahertzInOneHertz { get; }
+        protected abstract double PerSecondInOneHertz { get; }
         protected abstract double RadiansPerSecondInOneHertz { get; }
         protected abstract double TerahertzInOneHertz { get; }
 
@@ -54,6 +55,7 @@ namespace UnitsNet.Tests
         protected virtual double HertzTolerance { get { return 1e-5; } }
         protected virtual double KilohertzTolerance { get { return 1e-5; } }
         protected virtual double MegahertzTolerance { get { return 1e-5; } }
+        protected virtual double PerSecondTolerance { get { return 1e-5; } }
         protected virtual double RadiansPerSecondTolerance { get { return 1e-5; } }
         protected virtual double TerahertzTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
@@ -124,6 +126,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(HertzInOneHertz, hertz.Hertz, HertzTolerance);
             AssertEx.EqualTolerance(KilohertzInOneHertz, hertz.Kilohertz, KilohertzTolerance);
             AssertEx.EqualTolerance(MegahertzInOneHertz, hertz.Megahertz, MegahertzTolerance);
+            AssertEx.EqualTolerance(PerSecondInOneHertz, hertz.PerSecond, PerSecondTolerance);
             AssertEx.EqualTolerance(RadiansPerSecondInOneHertz, hertz.RadiansPerSecond, RadiansPerSecondTolerance);
             AssertEx.EqualTolerance(TerahertzInOneHertz, hertz.Terahertz, TerahertzTolerance);
         }
@@ -159,13 +162,17 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity06.Megahertz, MegahertzTolerance);
             Assert.Equal(FrequencyUnit.Megahertz, quantity06.Unit);
 
-            var quantity07 = Frequency.From(1, FrequencyUnit.RadianPerSecond);
-            AssertEx.EqualTolerance(1, quantity07.RadiansPerSecond, RadiansPerSecondTolerance);
-            Assert.Equal(FrequencyUnit.RadianPerSecond, quantity07.Unit);
+            var quantity07 = Frequency.From(1, FrequencyUnit.PerSecond);
+            AssertEx.EqualTolerance(1, quantity07.PerSecond, PerSecondTolerance);
+            Assert.Equal(FrequencyUnit.PerSecond, quantity07.Unit);
 
-            var quantity08 = Frequency.From(1, FrequencyUnit.Terahertz);
-            AssertEx.EqualTolerance(1, quantity08.Terahertz, TerahertzTolerance);
-            Assert.Equal(FrequencyUnit.Terahertz, quantity08.Unit);
+            var quantity08 = Frequency.From(1, FrequencyUnit.RadianPerSecond);
+            AssertEx.EqualTolerance(1, quantity08.RadiansPerSecond, RadiansPerSecondTolerance);
+            Assert.Equal(FrequencyUnit.RadianPerSecond, quantity08.Unit);
+
+            var quantity09 = Frequency.From(1, FrequencyUnit.Terahertz);
+            AssertEx.EqualTolerance(1, quantity09.Terahertz, TerahertzTolerance);
+            Assert.Equal(FrequencyUnit.Terahertz, quantity09.Unit);
 
         }
 
@@ -193,6 +200,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(HertzInOneHertz, hertz.As(FrequencyUnit.Hertz), HertzTolerance);
             AssertEx.EqualTolerance(KilohertzInOneHertz, hertz.As(FrequencyUnit.Kilohertz), KilohertzTolerance);
             AssertEx.EqualTolerance(MegahertzInOneHertz, hertz.As(FrequencyUnit.Megahertz), MegahertzTolerance);
+            AssertEx.EqualTolerance(PerSecondInOneHertz, hertz.As(FrequencyUnit.PerSecond), PerSecondTolerance);
             AssertEx.EqualTolerance(RadiansPerSecondInOneHertz, hertz.As(FrequencyUnit.RadianPerSecond), RadiansPerSecondTolerance);
             AssertEx.EqualTolerance(TerahertzInOneHertz, hertz.As(FrequencyUnit.Terahertz), TerahertzTolerance);
         }
@@ -230,6 +238,10 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(MegahertzInOneHertz, (double)megahertzQuantity.Value, MegahertzTolerance);
             Assert.Equal(FrequencyUnit.Megahertz, megahertzQuantity.Unit);
 
+            var persecondQuantity = hertz.ToUnit(FrequencyUnit.PerSecond);
+            AssertEx.EqualTolerance(PerSecondInOneHertz, (double)persecondQuantity.Value, PerSecondTolerance);
+            Assert.Equal(FrequencyUnit.PerSecond, persecondQuantity.Unit);
+
             var radianpersecondQuantity = hertz.ToUnit(FrequencyUnit.RadianPerSecond);
             AssertEx.EqualTolerance(RadiansPerSecondInOneHertz, (double)radianpersecondQuantity.Value, RadiansPerSecondTolerance);
             Assert.Equal(FrequencyUnit.RadianPerSecond, radianpersecondQuantity.Unit);
@@ -250,6 +262,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Frequency.FromHertz(hertz.Hertz).Hertz, HertzTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromKilohertz(hertz.Kilohertz).Hertz, KilohertzTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromMegahertz(hertz.Megahertz).Hertz, MegahertzTolerance);
+            AssertEx.EqualTolerance(1, Frequency.FromPerSecond(hertz.PerSecond).Hertz, PerSecondTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromRadiansPerSecond(hertz.RadiansPerSecond).Hertz, RadiansPerSecondTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromTerahertz(hertz.Terahertz).Hertz, TerahertzTolerance);
         }
@@ -398,6 +411,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 Hz", new Frequency(1, FrequencyUnit.Hertz).ToString());
                 Assert.Equal("1 kHz", new Frequency(1, FrequencyUnit.Kilohertz).ToString());
                 Assert.Equal("1 MHz", new Frequency(1, FrequencyUnit.Megahertz).ToString());
+                Assert.Equal("1 s⁻¹", new Frequency(1, FrequencyUnit.PerSecond).ToString());
                 Assert.Equal("1 rad/s", new Frequency(1, FrequencyUnit.RadianPerSecond).ToString());
                 Assert.Equal("1 THz", new Frequency(1, FrequencyUnit.Terahertz).ToString());
             }
@@ -420,6 +434,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Hz", new Frequency(1, FrequencyUnit.Hertz).ToString(swedishCulture));
             Assert.Equal("1 kHz", new Frequency(1, FrequencyUnit.Kilohertz).ToString(swedishCulture));
             Assert.Equal("1 MHz", new Frequency(1, FrequencyUnit.Megahertz).ToString(swedishCulture));
+            Assert.Equal("1 s⁻¹", new Frequency(1, FrequencyUnit.PerSecond).ToString(swedishCulture));
             Assert.Equal("1 rad/s", new Frequency(1, FrequencyUnit.RadianPerSecond).ToString(swedishCulture));
             Assert.Equal("1 THz", new Frequency(1, FrequencyUnit.Terahertz).ToString(swedishCulture));
         }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.g.cs
@@ -191,6 +191,11 @@ namespace UnitsNet
         public double Megahertz => As(FrequencyUnit.Megahertz);
 
         /// <summary>
+        ///     Get Frequency in PerSecond.
+        /// </summary>
+        public double PerSecond => As(FrequencyUnit.PerSecond);
+
+        /// <summary>
         ///     Get Frequency in RadiansPerSecond.
         /// </summary>
         public double RadiansPerSecond => As(FrequencyUnit.RadianPerSecond);
@@ -299,6 +304,16 @@ namespace UnitsNet
         {
             double value = (double) megahertz;
             return new Frequency(value, FrequencyUnit.Megahertz);
+        }
+        /// <summary>
+        ///     Get Frequency from PerSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Frequency FromPerSecond(double persecond)
+        {
+            double value = (double) persecond;
+            return new Frequency(value, FrequencyUnit.PerSecond);
         }
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
@@ -618,6 +633,7 @@ namespace UnitsNet
                 case FrequencyUnit.Hertz: return _value;
                 case FrequencyUnit.Kilohertz: return (_value) * 1e3d;
                 case FrequencyUnit.Megahertz: return (_value) * 1e6d;
+                case FrequencyUnit.PerSecond: return _value;
                 case FrequencyUnit.RadianPerSecond: return _value/6.2831853072;
                 case FrequencyUnit.Terahertz: return (_value) * 1e12d;
                 default:
@@ -641,6 +657,7 @@ namespace UnitsNet
                 case FrequencyUnit.Hertz: return baseUnitValue;
                 case FrequencyUnit.Kilohertz: return (baseUnitValue) / 1e3d;
                 case FrequencyUnit.Megahertz: return (baseUnitValue) / 1e6d;
+                case FrequencyUnit.PerSecond: return baseUnitValue;
                 case FrequencyUnit.RadianPerSecond: return baseUnitValue*6.2831853072;
                 case FrequencyUnit.Terahertz: return (baseUnitValue) / 1e12d;
                 default:

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -435,6 +435,7 @@ namespace UnitsNet
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Hertz, new string[]{"Hz"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Kilohertz, new string[]{"kHz"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Megahertz, new string[]{"MHz"}),
+                ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.PerSecond, new string[]{"s⁻¹"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.RadianPerSecond, new string[]{"rad/s"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Terahertz, new string[]{"THz"}),
                 ("en-US", typeof(FuelEfficiencyUnit), (int)FuelEfficiencyUnit.KilometerPerLiter, new string[]{"km/L"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -33,6 +33,7 @@ namespace UnitsNet.Units
         Hertz,
         Kilohertz,
         Megahertz,
+        PerSecond,
         RadianPerSecond,
         Terahertz,
     }

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -57,6 +57,7 @@ namespace UnitsNet
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.Hertz, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.Kilohertz, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.Megahertz, BaseUnits.Undefined),
+                    new UnitInfo<FrequencyUnit>(FrequencyUnit.PerSecond, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.RadianPerSecond, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.Terahertz, BaseUnits.Undefined),
                 },
@@ -207,6 +208,11 @@ namespace UnitsNet
         public double Megahertz => As(FrequencyUnit.Megahertz);
 
         /// <summary>
+        ///     Get Frequency in PerSecond.
+        /// </summary>
+        public double PerSecond => As(FrequencyUnit.PerSecond);
+
+        /// <summary>
         ///     Get Frequency in RadiansPerSecond.
         /// </summary>
         public double RadiansPerSecond => As(FrequencyUnit.RadianPerSecond);
@@ -307,6 +313,15 @@ namespace UnitsNet
         {
             double value = (double) megahertz;
             return new Frequency(value, FrequencyUnit.Megahertz);
+        }
+        /// <summary>
+        ///     Get Frequency from PerSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Frequency FromPerSecond(QuantityValue persecond)
+        {
+            double value = (double) persecond;
+            return new Frequency(value, FrequencyUnit.PerSecond);
         }
         /// <summary>
         ///     Get Frequency from RadiansPerSecond.
@@ -762,6 +777,7 @@ namespace UnitsNet
                 case FrequencyUnit.Hertz: return _value;
                 case FrequencyUnit.Kilohertz: return (_value) * 1e3d;
                 case FrequencyUnit.Megahertz: return (_value) * 1e6d;
+                case FrequencyUnit.PerSecond: return _value;
                 case FrequencyUnit.RadianPerSecond: return _value/6.2831853072;
                 case FrequencyUnit.Terahertz: return (_value) * 1e12d;
                 default:
@@ -796,6 +812,7 @@ namespace UnitsNet
                 case FrequencyUnit.Hertz: return baseUnitValue;
                 case FrequencyUnit.Kilohertz: return (baseUnitValue) / 1e3d;
                 case FrequencyUnit.Megahertz: return (baseUnitValue) / 1e6d;
+                case FrequencyUnit.PerSecond: return baseUnitValue;
                 case FrequencyUnit.RadianPerSecond: return baseUnitValue*6.2831853072;
                 case FrequencyUnit.Terahertz: return (baseUnitValue) / 1e12d;
                 default:

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -435,6 +435,7 @@ namespace UnitsNet
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Hertz, new string[]{"Hz"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Kilohertz, new string[]{"kHz"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Megahertz, new string[]{"MHz"}),
+                ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.PerSecond, new string[]{"s⁻¹"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.RadianPerSecond, new string[]{"rad/s"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Terahertz, new string[]{"THz"}),
                 ("en-US", typeof(FuelEfficiencyUnit), (int)FuelEfficiencyUnit.KilometerPerLiter, new string[]{"km/L"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -654,6 +654,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Kilohertz, Frequency.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.Megahertz, q => q.ToUnit(FrequencyUnit.Megahertz));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Megahertz, Frequency.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.PerSecond, q => q.ToUnit(FrequencyUnit.PerSecond));
+            unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.PerSecond, Frequency.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.RadianPerSecond, q => q.ToUnit(FrequencyUnit.RadianPerSecond));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.RadianPerSecond, Frequency.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.Terahertz, q => q.ToUnit(FrequencyUnit.Terahertz));

--- a/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -33,6 +33,7 @@ namespace UnitsNet.Units
         Hertz,
         Kilohertz,
         Megahertz,
+        PerSecond,
         RadianPerSecond,
         Terahertz,
     }


### PR DESCRIPTION
This PR adds a 'Per Second' unit to `Frequency` to support [inverse seconds](https://en.wikipedia.org/wiki/Inverse_second). This PR closes issue #753.