### PR TITLE
Chain length measure unit

### DIFF
--- a/Common/UnitDefinitions/Length.json
+++ b/Common/UnitDefinitions/Length.json
@@ -351,6 +351,21 @@
           "Abbreviations": [ "R⊙" ]
         }
       ]
+    },
+    {
+      "SingularName": "Chain",
+      "PluralName": "Chains",
+      "BaseUnits": {
+        "L": "Chain"
+      },
+      "FromUnitToBaseFunc": "x*20.1168",
+      "FromBaseToUnitFunc": "x/20.1168",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "ch" ]
+        }
+      ]
     }
   ]
 }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToLengthExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToLengthExtensionsTest.g.cs
@@ -33,6 +33,10 @@ namespace UnitsNet.Tests
             Assert.Equal(Length.FromCentimeters(2), 2.Centimeters());
 
         [Fact]
+        public void NumberToChainsTest() =>
+            Assert.Equal(Length.FromChains(2), 2.Chains());
+
+        [Fact]
         public void NumberToDecimetersTest() =>
             Assert.Equal(Length.FromDecimeters(2), 2.Decimeters());
 

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToLengthExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToLengthExtensions.g.cs
@@ -34,6 +34,10 @@ namespace UnitsNet.NumberExtensions.NumberToLength
         public static Length Centimeters<T>(this T value) =>
             Length.FromCentimeters(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Length.FromChains(UnitsNet.QuantityValue)" />
+        public static Length Chains<T>(this T value) =>
+            Length.FromChains(Convert.ToDouble(value));
+
         /// <inheritdoc cref="Length.FromDecimeters(UnitsNet.QuantityValue)" />
         public static Length Decimeters<T>(this T value) =>
             Length.FromDecimeters(Convert.ToDouble(value));

--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -73,6 +73,8 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double SolarRadiusesInOneMeter => 1.43779384911791000E-09;
 
+        protected override double ChainsInOneMeter => 0.0497096953789867;
+
         [ Fact]
         public void AreaTimesLengthEqualsVolume()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
@@ -38,6 +38,7 @@ namespace UnitsNet.Tests
     {
         protected abstract double AstronomicalUnitsInOneMeter { get; }
         protected abstract double CentimetersInOneMeter { get; }
+        protected abstract double ChainsInOneMeter { get; }
         protected abstract double DecimetersInOneMeter { get; }
         protected abstract double DtpPicasInOneMeter { get; }
         protected abstract double DtpPointsInOneMeter { get; }
@@ -72,6 +73,7 @@ namespace UnitsNet.Tests
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double AstronomicalUnitsTolerance { get { return 1e-5; } }
         protected virtual double CentimetersTolerance { get { return 1e-5; } }
+        protected virtual double ChainsTolerance { get { return 1e-5; } }
         protected virtual double DecimetersTolerance { get { return 1e-5; } }
         protected virtual double DtpPicasTolerance { get { return 1e-5; } }
         protected virtual double DtpPointsTolerance { get { return 1e-5; } }
@@ -165,6 +167,7 @@ namespace UnitsNet.Tests
             Length meter = Length.FromMeters(1);
             AssertEx.EqualTolerance(AstronomicalUnitsInOneMeter, meter.AstronomicalUnits, AstronomicalUnitsTolerance);
             AssertEx.EqualTolerance(CentimetersInOneMeter, meter.Centimeters, CentimetersTolerance);
+            AssertEx.EqualTolerance(ChainsInOneMeter, meter.Chains, ChainsTolerance);
             AssertEx.EqualTolerance(DecimetersInOneMeter, meter.Decimeters, DecimetersTolerance);
             AssertEx.EqualTolerance(DtpPicasInOneMeter, meter.DtpPicas, DtpPicasTolerance);
             AssertEx.EqualTolerance(DtpPointsInOneMeter, meter.DtpPoints, DtpPointsTolerance);
@@ -208,125 +211,129 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity01.Centimeters, CentimetersTolerance);
             Assert.Equal(LengthUnit.Centimeter, quantity01.Unit);
 
-            var quantity02 = Length.From(1, LengthUnit.Decimeter);
-            AssertEx.EqualTolerance(1, quantity02.Decimeters, DecimetersTolerance);
-            Assert.Equal(LengthUnit.Decimeter, quantity02.Unit);
+            var quantity02 = Length.From(1, LengthUnit.Chain);
+            AssertEx.EqualTolerance(1, quantity02.Chains, ChainsTolerance);
+            Assert.Equal(LengthUnit.Chain, quantity02.Unit);
 
-            var quantity03 = Length.From(1, LengthUnit.DtpPica);
-            AssertEx.EqualTolerance(1, quantity03.DtpPicas, DtpPicasTolerance);
-            Assert.Equal(LengthUnit.DtpPica, quantity03.Unit);
+            var quantity03 = Length.From(1, LengthUnit.Decimeter);
+            AssertEx.EqualTolerance(1, quantity03.Decimeters, DecimetersTolerance);
+            Assert.Equal(LengthUnit.Decimeter, quantity03.Unit);
 
-            var quantity04 = Length.From(1, LengthUnit.DtpPoint);
-            AssertEx.EqualTolerance(1, quantity04.DtpPoints, DtpPointsTolerance);
-            Assert.Equal(LengthUnit.DtpPoint, quantity04.Unit);
+            var quantity04 = Length.From(1, LengthUnit.DtpPica);
+            AssertEx.EqualTolerance(1, quantity04.DtpPicas, DtpPicasTolerance);
+            Assert.Equal(LengthUnit.DtpPica, quantity04.Unit);
 
-            var quantity05 = Length.From(1, LengthUnit.Fathom);
-            AssertEx.EqualTolerance(1, quantity05.Fathoms, FathomsTolerance);
-            Assert.Equal(LengthUnit.Fathom, quantity05.Unit);
+            var quantity05 = Length.From(1, LengthUnit.DtpPoint);
+            AssertEx.EqualTolerance(1, quantity05.DtpPoints, DtpPointsTolerance);
+            Assert.Equal(LengthUnit.DtpPoint, quantity05.Unit);
 
-            var quantity06 = Length.From(1, LengthUnit.Foot);
-            AssertEx.EqualTolerance(1, quantity06.Feet, FeetTolerance);
-            Assert.Equal(LengthUnit.Foot, quantity06.Unit);
+            var quantity06 = Length.From(1, LengthUnit.Fathom);
+            AssertEx.EqualTolerance(1, quantity06.Fathoms, FathomsTolerance);
+            Assert.Equal(LengthUnit.Fathom, quantity06.Unit);
 
-            var quantity07 = Length.From(1, LengthUnit.Hand);
-            AssertEx.EqualTolerance(1, quantity07.Hands, HandsTolerance);
-            Assert.Equal(LengthUnit.Hand, quantity07.Unit);
+            var quantity07 = Length.From(1, LengthUnit.Foot);
+            AssertEx.EqualTolerance(1, quantity07.Feet, FeetTolerance);
+            Assert.Equal(LengthUnit.Foot, quantity07.Unit);
 
-            var quantity08 = Length.From(1, LengthUnit.Hectometer);
-            AssertEx.EqualTolerance(1, quantity08.Hectometers, HectometersTolerance);
-            Assert.Equal(LengthUnit.Hectometer, quantity08.Unit);
+            var quantity08 = Length.From(1, LengthUnit.Hand);
+            AssertEx.EqualTolerance(1, quantity08.Hands, HandsTolerance);
+            Assert.Equal(LengthUnit.Hand, quantity08.Unit);
 
-            var quantity09 = Length.From(1, LengthUnit.Inch);
-            AssertEx.EqualTolerance(1, quantity09.Inches, InchesTolerance);
-            Assert.Equal(LengthUnit.Inch, quantity09.Unit);
+            var quantity09 = Length.From(1, LengthUnit.Hectometer);
+            AssertEx.EqualTolerance(1, quantity09.Hectometers, HectometersTolerance);
+            Assert.Equal(LengthUnit.Hectometer, quantity09.Unit);
 
-            var quantity10 = Length.From(1, LengthUnit.KilolightYear);
-            AssertEx.EqualTolerance(1, quantity10.KilolightYears, KilolightYearsTolerance);
-            Assert.Equal(LengthUnit.KilolightYear, quantity10.Unit);
+            var quantity10 = Length.From(1, LengthUnit.Inch);
+            AssertEx.EqualTolerance(1, quantity10.Inches, InchesTolerance);
+            Assert.Equal(LengthUnit.Inch, quantity10.Unit);
 
-            var quantity11 = Length.From(1, LengthUnit.Kilometer);
-            AssertEx.EqualTolerance(1, quantity11.Kilometers, KilometersTolerance);
-            Assert.Equal(LengthUnit.Kilometer, quantity11.Unit);
+            var quantity11 = Length.From(1, LengthUnit.KilolightYear);
+            AssertEx.EqualTolerance(1, quantity11.KilolightYears, KilolightYearsTolerance);
+            Assert.Equal(LengthUnit.KilolightYear, quantity11.Unit);
 
-            var quantity12 = Length.From(1, LengthUnit.Kiloparsec);
-            AssertEx.EqualTolerance(1, quantity12.Kiloparsecs, KiloparsecsTolerance);
-            Assert.Equal(LengthUnit.Kiloparsec, quantity12.Unit);
+            var quantity12 = Length.From(1, LengthUnit.Kilometer);
+            AssertEx.EqualTolerance(1, quantity12.Kilometers, KilometersTolerance);
+            Assert.Equal(LengthUnit.Kilometer, quantity12.Unit);
 
-            var quantity13 = Length.From(1, LengthUnit.LightYear);
-            AssertEx.EqualTolerance(1, quantity13.LightYears, LightYearsTolerance);
-            Assert.Equal(LengthUnit.LightYear, quantity13.Unit);
+            var quantity13 = Length.From(1, LengthUnit.Kiloparsec);
+            AssertEx.EqualTolerance(1, quantity13.Kiloparsecs, KiloparsecsTolerance);
+            Assert.Equal(LengthUnit.Kiloparsec, quantity13.Unit);
 
-            var quantity14 = Length.From(1, LengthUnit.MegalightYear);
-            AssertEx.EqualTolerance(1, quantity14.MegalightYears, MegalightYearsTolerance);
-            Assert.Equal(LengthUnit.MegalightYear, quantity14.Unit);
+            var quantity14 = Length.From(1, LengthUnit.LightYear);
+            AssertEx.EqualTolerance(1, quantity14.LightYears, LightYearsTolerance);
+            Assert.Equal(LengthUnit.LightYear, quantity14.Unit);
 
-            var quantity15 = Length.From(1, LengthUnit.Megaparsec);
-            AssertEx.EqualTolerance(1, quantity15.Megaparsecs, MegaparsecsTolerance);
-            Assert.Equal(LengthUnit.Megaparsec, quantity15.Unit);
+            var quantity15 = Length.From(1, LengthUnit.MegalightYear);
+            AssertEx.EqualTolerance(1, quantity15.MegalightYears, MegalightYearsTolerance);
+            Assert.Equal(LengthUnit.MegalightYear, quantity15.Unit);
 
-            var quantity16 = Length.From(1, LengthUnit.Meter);
-            AssertEx.EqualTolerance(1, quantity16.Meters, MetersTolerance);
-            Assert.Equal(LengthUnit.Meter, quantity16.Unit);
+            var quantity16 = Length.From(1, LengthUnit.Megaparsec);
+            AssertEx.EqualTolerance(1, quantity16.Megaparsecs, MegaparsecsTolerance);
+            Assert.Equal(LengthUnit.Megaparsec, quantity16.Unit);
 
-            var quantity17 = Length.From(1, LengthUnit.Microinch);
-            AssertEx.EqualTolerance(1, quantity17.Microinches, MicroinchesTolerance);
-            Assert.Equal(LengthUnit.Microinch, quantity17.Unit);
+            var quantity17 = Length.From(1, LengthUnit.Meter);
+            AssertEx.EqualTolerance(1, quantity17.Meters, MetersTolerance);
+            Assert.Equal(LengthUnit.Meter, quantity17.Unit);
 
-            var quantity18 = Length.From(1, LengthUnit.Micrometer);
-            AssertEx.EqualTolerance(1, quantity18.Micrometers, MicrometersTolerance);
-            Assert.Equal(LengthUnit.Micrometer, quantity18.Unit);
+            var quantity18 = Length.From(1, LengthUnit.Microinch);
+            AssertEx.EqualTolerance(1, quantity18.Microinches, MicroinchesTolerance);
+            Assert.Equal(LengthUnit.Microinch, quantity18.Unit);
 
-            var quantity19 = Length.From(1, LengthUnit.Mil);
-            AssertEx.EqualTolerance(1, quantity19.Mils, MilsTolerance);
-            Assert.Equal(LengthUnit.Mil, quantity19.Unit);
+            var quantity19 = Length.From(1, LengthUnit.Micrometer);
+            AssertEx.EqualTolerance(1, quantity19.Micrometers, MicrometersTolerance);
+            Assert.Equal(LengthUnit.Micrometer, quantity19.Unit);
 
-            var quantity20 = Length.From(1, LengthUnit.Mile);
-            AssertEx.EqualTolerance(1, quantity20.Miles, MilesTolerance);
-            Assert.Equal(LengthUnit.Mile, quantity20.Unit);
+            var quantity20 = Length.From(1, LengthUnit.Mil);
+            AssertEx.EqualTolerance(1, quantity20.Mils, MilsTolerance);
+            Assert.Equal(LengthUnit.Mil, quantity20.Unit);
 
-            var quantity21 = Length.From(1, LengthUnit.Millimeter);
-            AssertEx.EqualTolerance(1, quantity21.Millimeters, MillimetersTolerance);
-            Assert.Equal(LengthUnit.Millimeter, quantity21.Unit);
+            var quantity21 = Length.From(1, LengthUnit.Mile);
+            AssertEx.EqualTolerance(1, quantity21.Miles, MilesTolerance);
+            Assert.Equal(LengthUnit.Mile, quantity21.Unit);
 
-            var quantity22 = Length.From(1, LengthUnit.Nanometer);
-            AssertEx.EqualTolerance(1, quantity22.Nanometers, NanometersTolerance);
-            Assert.Equal(LengthUnit.Nanometer, quantity22.Unit);
+            var quantity22 = Length.From(1, LengthUnit.Millimeter);
+            AssertEx.EqualTolerance(1, quantity22.Millimeters, MillimetersTolerance);
+            Assert.Equal(LengthUnit.Millimeter, quantity22.Unit);
 
-            var quantity23 = Length.From(1, LengthUnit.NauticalMile);
-            AssertEx.EqualTolerance(1, quantity23.NauticalMiles, NauticalMilesTolerance);
-            Assert.Equal(LengthUnit.NauticalMile, quantity23.Unit);
+            var quantity23 = Length.From(1, LengthUnit.Nanometer);
+            AssertEx.EqualTolerance(1, quantity23.Nanometers, NanometersTolerance);
+            Assert.Equal(LengthUnit.Nanometer, quantity23.Unit);
 
-            var quantity24 = Length.From(1, LengthUnit.Parsec);
-            AssertEx.EqualTolerance(1, quantity24.Parsecs, ParsecsTolerance);
-            Assert.Equal(LengthUnit.Parsec, quantity24.Unit);
+            var quantity24 = Length.From(1, LengthUnit.NauticalMile);
+            AssertEx.EqualTolerance(1, quantity24.NauticalMiles, NauticalMilesTolerance);
+            Assert.Equal(LengthUnit.NauticalMile, quantity24.Unit);
 
-            var quantity25 = Length.From(1, LengthUnit.PrinterPica);
-            AssertEx.EqualTolerance(1, quantity25.PrinterPicas, PrinterPicasTolerance);
-            Assert.Equal(LengthUnit.PrinterPica, quantity25.Unit);
+            var quantity25 = Length.From(1, LengthUnit.Parsec);
+            AssertEx.EqualTolerance(1, quantity25.Parsecs, ParsecsTolerance);
+            Assert.Equal(LengthUnit.Parsec, quantity25.Unit);
 
-            var quantity26 = Length.From(1, LengthUnit.PrinterPoint);
-            AssertEx.EqualTolerance(1, quantity26.PrinterPoints, PrinterPointsTolerance);
-            Assert.Equal(LengthUnit.PrinterPoint, quantity26.Unit);
+            var quantity26 = Length.From(1, LengthUnit.PrinterPica);
+            AssertEx.EqualTolerance(1, quantity26.PrinterPicas, PrinterPicasTolerance);
+            Assert.Equal(LengthUnit.PrinterPica, quantity26.Unit);
 
-            var quantity27 = Length.From(1, LengthUnit.Shackle);
-            AssertEx.EqualTolerance(1, quantity27.Shackles, ShacklesTolerance);
-            Assert.Equal(LengthUnit.Shackle, quantity27.Unit);
+            var quantity27 = Length.From(1, LengthUnit.PrinterPoint);
+            AssertEx.EqualTolerance(1, quantity27.PrinterPoints, PrinterPointsTolerance);
+            Assert.Equal(LengthUnit.PrinterPoint, quantity27.Unit);
 
-            var quantity28 = Length.From(1, LengthUnit.SolarRadius);
-            AssertEx.EqualTolerance(1, quantity28.SolarRadiuses, SolarRadiusesTolerance);
-            Assert.Equal(LengthUnit.SolarRadius, quantity28.Unit);
+            var quantity28 = Length.From(1, LengthUnit.Shackle);
+            AssertEx.EqualTolerance(1, quantity28.Shackles, ShacklesTolerance);
+            Assert.Equal(LengthUnit.Shackle, quantity28.Unit);
 
-            var quantity29 = Length.From(1, LengthUnit.Twip);
-            AssertEx.EqualTolerance(1, quantity29.Twips, TwipsTolerance);
-            Assert.Equal(LengthUnit.Twip, quantity29.Unit);
+            var quantity29 = Length.From(1, LengthUnit.SolarRadius);
+            AssertEx.EqualTolerance(1, quantity29.SolarRadiuses, SolarRadiusesTolerance);
+            Assert.Equal(LengthUnit.SolarRadius, quantity29.Unit);
 
-            var quantity30 = Length.From(1, LengthUnit.UsSurveyFoot);
-            AssertEx.EqualTolerance(1, quantity30.UsSurveyFeet, UsSurveyFeetTolerance);
-            Assert.Equal(LengthUnit.UsSurveyFoot, quantity30.Unit);
+            var quantity30 = Length.From(1, LengthUnit.Twip);
+            AssertEx.EqualTolerance(1, quantity30.Twips, TwipsTolerance);
+            Assert.Equal(LengthUnit.Twip, quantity30.Unit);
 
-            var quantity31 = Length.From(1, LengthUnit.Yard);
-            AssertEx.EqualTolerance(1, quantity31.Yards, YardsTolerance);
-            Assert.Equal(LengthUnit.Yard, quantity31.Unit);
+            var quantity31 = Length.From(1, LengthUnit.UsSurveyFoot);
+            AssertEx.EqualTolerance(1, quantity31.UsSurveyFeet, UsSurveyFeetTolerance);
+            Assert.Equal(LengthUnit.UsSurveyFoot, quantity31.Unit);
+
+            var quantity32 = Length.From(1, LengthUnit.Yard);
+            AssertEx.EqualTolerance(1, quantity32.Yards, YardsTolerance);
+            Assert.Equal(LengthUnit.Yard, quantity32.Unit);
 
         }
 
@@ -349,6 +356,7 @@ namespace UnitsNet.Tests
             var meter = Length.FromMeters(1);
             AssertEx.EqualTolerance(AstronomicalUnitsInOneMeter, meter.As(LengthUnit.AstronomicalUnit), AstronomicalUnitsTolerance);
             AssertEx.EqualTolerance(CentimetersInOneMeter, meter.As(LengthUnit.Centimeter), CentimetersTolerance);
+            AssertEx.EqualTolerance(ChainsInOneMeter, meter.As(LengthUnit.Chain), ChainsTolerance);
             AssertEx.EqualTolerance(DecimetersInOneMeter, meter.As(LengthUnit.Decimeter), DecimetersTolerance);
             AssertEx.EqualTolerance(DtpPicasInOneMeter, meter.As(LengthUnit.DtpPica), DtpPicasTolerance);
             AssertEx.EqualTolerance(DtpPointsInOneMeter, meter.As(LengthUnit.DtpPoint), DtpPointsTolerance);
@@ -393,6 +401,10 @@ namespace UnitsNet.Tests
             var centimeterQuantity = meter.ToUnit(LengthUnit.Centimeter);
             AssertEx.EqualTolerance(CentimetersInOneMeter, (double)centimeterQuantity.Value, CentimetersTolerance);
             Assert.Equal(LengthUnit.Centimeter, centimeterQuantity.Unit);
+
+            var chainQuantity = meter.ToUnit(LengthUnit.Chain);
+            AssertEx.EqualTolerance(ChainsInOneMeter, (double)chainQuantity.Value, ChainsTolerance);
+            Assert.Equal(LengthUnit.Chain, chainQuantity.Unit);
 
             var decimeterQuantity = meter.ToUnit(LengthUnit.Decimeter);
             AssertEx.EqualTolerance(DecimetersInOneMeter, (double)decimeterQuantity.Value, DecimetersTolerance);
@@ -521,6 +533,7 @@ namespace UnitsNet.Tests
             Length meter = Length.FromMeters(1);
             AssertEx.EqualTolerance(1, Length.FromAstronomicalUnits(meter.AstronomicalUnits).Meters, AstronomicalUnitsTolerance);
             AssertEx.EqualTolerance(1, Length.FromCentimeters(meter.Centimeters).Meters, CentimetersTolerance);
+            AssertEx.EqualTolerance(1, Length.FromChains(meter.Chains).Meters, ChainsTolerance);
             AssertEx.EqualTolerance(1, Length.FromDecimeters(meter.Decimeters).Meters, DecimetersTolerance);
             AssertEx.EqualTolerance(1, Length.FromDtpPicas(meter.DtpPicas).Meters, DtpPicasTolerance);
             AssertEx.EqualTolerance(1, Length.FromDtpPoints(meter.DtpPoints).Meters, DtpPointsTolerance);
@@ -692,6 +705,7 @@ namespace UnitsNet.Tests
             try {
                 Assert.Equal("1 au", new Length(1, LengthUnit.AstronomicalUnit).ToString());
                 Assert.Equal("1 cm", new Length(1, LengthUnit.Centimeter).ToString());
+                Assert.Equal("1 ch", new Length(1, LengthUnit.Chain).ToString());
                 Assert.Equal("1 dm", new Length(1, LengthUnit.Decimeter).ToString());
                 Assert.Equal("1 pica", new Length(1, LengthUnit.DtpPica).ToString());
                 Assert.Equal("1 pt", new Length(1, LengthUnit.DtpPoint).ToString());
@@ -737,6 +751,7 @@ namespace UnitsNet.Tests
 
             Assert.Equal("1 au", new Length(1, LengthUnit.AstronomicalUnit).ToString(swedishCulture));
             Assert.Equal("1 cm", new Length(1, LengthUnit.Centimeter).ToString(swedishCulture));
+            Assert.Equal("1 ch", new Length(1, LengthUnit.Chain).ToString(swedishCulture));
             Assert.Equal("1 dm", new Length(1, LengthUnit.Decimeter).ToString(swedishCulture));
             Assert.Equal("1 pica", new Length(1, LengthUnit.DtpPica).ToString(swedishCulture));
             Assert.Equal("1 pt", new Length(1, LengthUnit.DtpPoint).ToString(swedishCulture));

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.g.cs
@@ -166,6 +166,11 @@ namespace UnitsNet
         public double Centimeters => As(LengthUnit.Centimeter);
 
         /// <summary>
+        ///     Get Length in Chains.
+        /// </summary>
+        public double Chains => As(LengthUnit.Chain);
+
+        /// <summary>
         ///     Get Length in Decimeters.
         /// </summary>
         public double Decimeters => As(LengthUnit.Decimeter);
@@ -364,6 +369,16 @@ namespace UnitsNet
         {
             double value = (double) centimeters;
             return new Length(value, LengthUnit.Centimeter);
+        }
+        /// <summary>
+        ///     Get Length from Chains.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Length FromChains(double chains)
+        {
+            double value = (double) chains;
+            return new Length(value, LengthUnit.Chain);
         }
         /// <summary>
         ///     Get Length from Decimeters.
@@ -958,6 +973,7 @@ namespace UnitsNet
             {
                 case LengthUnit.AstronomicalUnit: return _value * 1.4959787070e11;
                 case LengthUnit.Centimeter: return (_value) * 1e-2d;
+                case LengthUnit.Chain: return _value*20.1168;
                 case LengthUnit.Decimeter: return (_value) * 1e-1d;
                 case LengthUnit.DtpPica: return _value/236.220472441;
                 case LengthUnit.DtpPoint: return (_value/72)*2.54e-2;
@@ -1004,6 +1020,7 @@ namespace UnitsNet
             {
                 case LengthUnit.AstronomicalUnit: return baseUnitValue / 1.4959787070e11;
                 case LengthUnit.Centimeter: return (baseUnitValue) / 1e-2d;
+                case LengthUnit.Chain: return baseUnitValue/20.1168;
                 case LengthUnit.Decimeter: return (baseUnitValue) / 1e-1d;
                 case LengthUnit.DtpPica: return baseUnitValue*236.220472441;
                 case LengthUnit.DtpPoint: return (baseUnitValue/2.54e-2)*72;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -533,6 +533,7 @@ namespace UnitsNet
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.AstronomicalUnit, new string[]{"au", "ua"}),
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.Centimeter, new string[]{"cm"}),
                 ("ru-RU", typeof(LengthUnit), (int)LengthUnit.Centimeter, new string[]{"см"}),
+                ("en-US", typeof(LengthUnit), (int)LengthUnit.Chain, new string[]{"ch"}),
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.Decimeter, new string[]{"dm"}),
                 ("ru-RU", typeof(LengthUnit), (int)LengthUnit.Decimeter, new string[]{"дм"}),
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.DtpPica, new string[]{"pica"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/LengthUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/LengthUnit.g.cs
@@ -33,6 +33,7 @@ namespace UnitsNet.Units
         /// <remarks>https://en.wikipedia.org/wiki/Astronomical_unit</remarks>
         AstronomicalUnit,
         Centimeter,
+        Chain,
         Decimeter,
         DtpPica,
         DtpPoint,

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -52,6 +52,7 @@ namespace UnitsNet
                 new UnitInfo<LengthUnit>[] {
                     new UnitInfo<LengthUnit>(LengthUnit.AstronomicalUnit, BaseUnits.Undefined),
                     new UnitInfo<LengthUnit>(LengthUnit.Centimeter, BaseUnits.Undefined),
+                    new UnitInfo<LengthUnit>(LengthUnit.Chain, new BaseUnits(length: LengthUnit.Chain)),
                     new UnitInfo<LengthUnit>(LengthUnit.Decimeter, BaseUnits.Undefined),
                     new UnitInfo<LengthUnit>(LengthUnit.DtpPica, new BaseUnits(length: LengthUnit.DtpPica)),
                     new UnitInfo<LengthUnit>(LengthUnit.DtpPoint, new BaseUnits(length: LengthUnit.DtpPoint)),
@@ -203,6 +204,11 @@ namespace UnitsNet
         ///     Get Length in Centimeters.
         /// </summary>
         public double Centimeters => As(LengthUnit.Centimeter);
+
+        /// <summary>
+        ///     Get Length in Chains.
+        /// </summary>
+        public double Chains => As(LengthUnit.Chain);
 
         /// <summary>
         ///     Get Length in Decimeters.
@@ -400,6 +406,15 @@ namespace UnitsNet
         {
             double value = (double) centimeters;
             return new Length(value, LengthUnit.Centimeter);
+        }
+        /// <summary>
+        ///     Get Length from Chains.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Length FromChains(QuantityValue chains)
+        {
+            double value = (double) chains;
+            return new Length(value, LengthUnit.Chain);
         }
         /// <summary>
         ///     Get Length from Decimeters.
@@ -1102,6 +1117,7 @@ namespace UnitsNet
             {
                 case LengthUnit.AstronomicalUnit: return _value * 1.4959787070e11;
                 case LengthUnit.Centimeter: return (_value) * 1e-2d;
+                case LengthUnit.Chain: return _value*20.1168;
                 case LengthUnit.Decimeter: return (_value) * 1e-1d;
                 case LengthUnit.DtpPica: return _value/236.220472441;
                 case LengthUnit.DtpPoint: return (_value/72)*2.54e-2;
@@ -1159,6 +1175,7 @@ namespace UnitsNet
             {
                 case LengthUnit.AstronomicalUnit: return baseUnitValue / 1.4959787070e11;
                 case LengthUnit.Centimeter: return (baseUnitValue) / 1e-2d;
+                case LengthUnit.Chain: return baseUnitValue/20.1168;
                 case LengthUnit.Decimeter: return (baseUnitValue) / 1e-1d;
                 case LengthUnit.DtpPica: return baseUnitValue*236.220472441;
                 case LengthUnit.DtpPoint: return (baseUnitValue/2.54e-2)*72;

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -533,6 +533,7 @@ namespace UnitsNet
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.AstronomicalUnit, new string[]{"au", "ua"}),
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.Centimeter, new string[]{"cm"}),
                 ("ru-RU", typeof(LengthUnit), (int)LengthUnit.Centimeter, new string[]{"см"}),
+                ("en-US", typeof(LengthUnit), (int)LengthUnit.Chain, new string[]{"ch"}),
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.Decimeter, new string[]{"dm"}),
                 ("ru-RU", typeof(LengthUnit), (int)LengthUnit.Decimeter, new string[]{"дм"}),
                 ("en-US", typeof(LengthUnit), (int)LengthUnit.DtpPica, new string[]{"pica"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -823,6 +823,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Length>(LengthUnit.AstronomicalUnit, Length.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Length>(Length.BaseUnit, LengthUnit.Centimeter, q => q.ToUnit(LengthUnit.Centimeter));
             unitConverter.SetConversionFunction<Length>(LengthUnit.Centimeter, Length.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<Length>(Length.BaseUnit, LengthUnit.Chain, q => q.ToUnit(LengthUnit.Chain));
+            unitConverter.SetConversionFunction<Length>(LengthUnit.Chain, Length.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Length>(Length.BaseUnit, LengthUnit.Decimeter, q => q.ToUnit(LengthUnit.Decimeter));
             unitConverter.SetConversionFunction<Length>(LengthUnit.Decimeter, Length.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Length>(Length.BaseUnit, LengthUnit.DtpPica, q => q.ToUnit(LengthUnit.DtpPica));

--- a/UnitsNet/GeneratedCode/Units/LengthUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/LengthUnit.g.cs
@@ -33,6 +33,7 @@ namespace UnitsNet.Units
         /// <remarks>https://en.wikipedia.org/wiki/Astronomical_unit</remarks>
         AstronomicalUnit,
         Centimeter,
+        Chain,
         Decimeter,
         DtpPica,
         DtpPoint,


### PR DESCRIPTION
This PR adds the Chain length measure unit.
[Wiki](https://en.wikipedia.org/wiki/Chain_(unit)) about this measure unit.

The abbreviation is "ch", according to this [source](https://m.measurementconversions.org/lengths/abbreviations.htm).