### PR TITLE
Support case insensitive parsing of quantities

### DIFF
--- a/UnitsNet.Tests/QuantityParserTests.cs
+++ b/UnitsNet.Tests/QuantityParserTests.cs
@@ -9,6 +9,53 @@ namespace UnitsNet.Tests
     public class QuantityParserTests
     {
         [Fact]
+        public void Parse_WithSingleCaseInsensitiveMatch_ParsesWithMatchedUnit()
+        {
+            var unitAbbreviationsCache = new UnitAbbreviationsCache();
+            unitAbbreviationsCache.MapUnitToAbbreviation(HowMuchUnit.Some, "foo");
+            var quantityParser = new QuantityParser(unitAbbreviationsCache);
+
+            HowMuch q = quantityParser.Parse<HowMuch, HowMuchUnit>("1 FOO",
+                null,
+                (value, unit) => new HowMuch((double) value, unit));
+
+            Assert.Equal(HowMuchUnit.Some, q.Unit);
+            Assert.Equal(1, q.Value);
+        }
+
+        [Fact]
+        public void Parse_WithOneCaseInsensitiveMatchAndOneExactMatch_ParsesWithTheExactMatchUnit()
+        {
+            var unitAbbreviationsCache = new UnitAbbreviationsCache();
+            unitAbbreviationsCache.MapUnitToAbbreviation(HowMuchUnit.Some, "foo");
+            unitAbbreviationsCache.MapUnitToAbbreviation(HowMuchUnit.ATon, "FOO");
+            var quantityParser = new QuantityParser(unitAbbreviationsCache);
+
+            HowMuch q = quantityParser.Parse<HowMuch, HowMuchUnit>("1 FOO",
+                null,
+                (value, unit) => new HowMuch((double) value, unit));
+
+            Assert.Equal(HowMuchUnit.ATon, q.Unit);
+            Assert.Equal(1, q.Value);
+        }
+
+        [Fact]
+        public void Parse_WithMultipleCaseInsensitiveMatchesButNoExactMatches_ThrowsUnitNotFoundException()
+        {
+            var unitAbbreviationsCache = new UnitAbbreviationsCache();
+            unitAbbreviationsCache.MapUnitToAbbreviation(HowMuchUnit.Some, "foo");
+            unitAbbreviationsCache.MapUnitToAbbreviation(HowMuchUnit.ATon, "FOO");
+            var quantityParser = new QuantityParser(unitAbbreviationsCache);
+
+            void Act()
+            {
+                quantityParser.Parse<HowMuch, HowMuchUnit>("1 Foo", null, (value, unit) => new HowMuch((double) value, unit));
+            }
+
+            Assert.Throws<UnitNotFoundException>(Act);
+        }
+
+        [Fact]
         public void Parse_MappedCustomUnit()
         {
             var unitAbbreviationsCache = new UnitAbbreviationsCache();

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -222,7 +222,7 @@ namespace UnitsNet
         private Regex CreateRegexForQuantity<TUnitType>([CanBeNull] IFormatProvider formatProvider) where TUnitType : Enum
         {
             var pattern = CreateRegexPatternForQuantity<TUnitType>(formatProvider);
-            return new Regex(pattern, RegexOptions.Singleline);
+            return new Regex(pattern, RegexOptions.Singleline | RegexOptions.IgnoreCase);
         }
     }
 }


### PR DESCRIPTION
## Motivation
Make it easier to define unit abbreviations in order for `Parse()` to work for all variations of upper/lowercase in the unit abbreviation.

This was already supported for `UnitParser` and even though `QuantityParser` builds on top of `UnitParser`, it failed due to a regex it computes based on the list of unit abbreviations.

## Design
- Case insensitive parsing should "just work" if it matches exactly one abbreviation
- If case insensitive parsing matches multiple units, then only an exact match on casing will succeed. Otherwise it already throws `UnitNotFoundException` in `UnitParser`.

## Examples
- `Volume.Parse("1 L")` currently fails, because only lowercase `l` is defined in JSON. There are no other volume units with the same lowercase abbreviation.

## Changes
- Add ignore case flag to regex in `QuantityParser`
- Add tests for happy and sad cases