### PR TITLE
Add PackageIcon to nugets

### DIFF
--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
+    <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
     <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
@@ -38,6 +39,11 @@
   <!-- Project references, will also generate the corresponding nuget dependencies -->
   <ItemGroup>
     <ProjectReference Include="..\UnitsNet\UnitsNet.csproj" />
+  </ItemGroup>
+
+  <!-- Files to include in nuget package -->
+  <ItemGroup>
+    <None Include="Docs/Images/logo-32.png" Pack="true" PackagePath="/"/>
   </ItemGroup>
 
 </Project>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
+    <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
     <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
@@ -50,6 +51,11 @@
   <!-- Project references, will also generate the corresponding nuget dependencies -->
   <ItemGroup>
     <ProjectReference Include="..\UnitsNet\UnitsNet.csproj" />
+  </ItemGroup>
+
+  <!-- Files to include in nuget package -->
+  <ItemGroup>
+    <None Include="Docs/Images/logo-32.png" Pack="true" PackagePath="/"/>
   </ItemGroup>
 
 </Project>

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -9,6 +9,7 @@
     <Copyright>Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com).</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/angularsen/UnitsNet</RepositoryUrl>
+    <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
     <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
@@ -39,7 +40,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyName>UnitsNet</AssemblyName>
   </PropertyGroup>
-  
+
   <!-- NuGet references that work for both signed and unsigned -->
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="All" />
@@ -57,5 +58,9 @@
     <None Remove="UnitDefinitions\**" />
   </ItemGroup>
 
+  <!-- Files to include in nuget package -->
+  <ItemGroup>
+    <None Include="Docs/Images/logo-32.png" Pack="true" PackagePath="/"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes deprecation warning for PackageIconUrl.
Need both elements for a time until most users have switched to Visual Studio 16.3 or higher.