### PR TITLE
Fix TryParseFeetInches when current locale uses ' as number separator

### DIFF
--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -65,6 +65,9 @@ namespace UnitsNet.Tests
             Assert.Equal(expected, length.ToString(sFormatString, NumberFormatInfo.InvariantInfo));
         }
 
+        /// <summary>
+        /// This verifies that the culture is correctly considered when formatting objects with an explicit culture.
+        /// </summary>
         [Fact]
         public void FormattingUsesSuppliedLocale()
         {
@@ -72,6 +75,23 @@ namespace UnitsNet.Tests
             CultureInfo c = CultureInfo.CreateSpecificCulture("de-CH");
             string formatted = string.Format(c, "{0:g}", t);
             Assert.Equal("2'012.12 °C", formatted);
+        }
+
+        /// <summary>
+        /// This verifies that the culture is correctly considered when using <see cref="FormattableString.ToString(IFormatProvider)"/>
+        /// </summary>
+        [Fact]
+        public void FormatStringWorksWithSuppliedLocale()
+        {
+            Temperature t = Temperature.FromDegreesCelsius(2012.1234);
+            CultureInfo c = CultureInfo.CreateSpecificCulture("de-CH");
+
+            FormattableString f = $"{t:g}";
+            Assert.Equal("2'012.12 °C", f.ToString(c));
+
+            // This does not work. Looks like a compiler bug to me.
+            // string f2 = $"{t:g}".ToString(c);
+            // Assert.Equal("2'012.12 °C", f2.ToString(c)); // Actual value is formatted according to CurrentUiCulture.
         }
 
         [Fact]

--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -72,9 +72,10 @@ namespace UnitsNet.Tests
         public void FormattingUsesSuppliedLocale()
         {
             Temperature t = Temperature.FromDegreesCelsius(2012.1234);
-            CultureInfo c = CultureInfo.CreateSpecificCulture("de-CH");
+            CultureInfo c = new CultureInfo("de-CH", false);
             string formatted = string.Format(c, "{0:g}", t);
-            Assert.Equal("2'012.12 °C", formatted);
+            // Let's be very explicit here
+            Assert.Equal("2" + c.NumberFormat.NumberGroupSeparator + "012" + c.NumberFormat.NumberDecimalSeparator + "12 °C", formatted);
         }
 
         /// <summary>
@@ -84,10 +85,10 @@ namespace UnitsNet.Tests
         public void FormatStringWorksWithSuppliedLocale()
         {
             Temperature t = Temperature.FromDegreesCelsius(2012.1234);
-            CultureInfo c = CultureInfo.CreateSpecificCulture("de-CH");
+            CultureInfo c = new CultureInfo("de-CH", false);
 
             FormattableString f = $"{t:g}";
-            Assert.Equal("2'012.12 °C", f.ToString(c));
+            Assert.Equal("2" + c.NumberFormat.NumberGroupSeparator + "012" + c.NumberFormat.NumberDecimalSeparator + "12 °C", f.ToString(c));
 
             // This does not work. Looks like a compiler bug to me.
             // string f2 = $"{t:g}".ToString(c);

--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -66,6 +66,15 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void FormattingUsesSuppliedLocale()
+        {
+            Temperature t = Temperature.FromDegreesCelsius(2012.1234);
+            CultureInfo c = CultureInfo.CreateSpecificCulture("de-CH");
+            string formatted = string.Format(c, "{0:g}", t);
+            Assert.Equal("2'012.12 °C", formatted);
+        }
+
+        [Fact]
         public void UFormatEqualsUnitToString()
         {
             Assert.Equal(length.Unit.ToString(), length.ToString("u"));

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -60,6 +60,27 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Try to parse a string with one or two quantities of the format "&lt;quantity&gt; &lt;unit&gt;".
+        /// </summary>
+        /// <param name="str">String to parse. Typically in the form: {number} {unit}</param>
+        /// <param name="provider">Format to use when parsing number and unit. Defaults to <see cref="CultureInfo.CurrentUICulture" /> if null.</param>
+        /// <param name="allowedNumberStyles">Allowed number styles</param>
+        /// <param name="result">Resulting unit quantity if successful.</param>
+        /// <returns>True if successful, otherwise false.</returns>
+        /// <example>
+        ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
+        /// </example>
+        private static bool TryParse([CanBeNull] string str, [CanBeNull] IFormatProvider provider, NumberStyles allowedNumberStyles, out Length result)
+        {
+            return QuantityParser.Default.TryParse<Length, LengthUnit>(
+                str,
+                provider,
+                From,
+                allowedNumberStyles,
+                out result);
+        }
+
+        /// <summary>
         /// Special parsing of feet/inches strings, commonly used.
         /// 2 feet 4 inches is sometimes denoted as 2′−4″, 2′ 4″, 2′4″, 2 ft 4 in.
         /// The apostrophe can be ′ and '.
@@ -80,7 +101,8 @@ namespace UnitsNet
             str = str.Trim();
 
             // This succeeds if only feet or inches are given, not both
-            if (TryParse(str, formatProvider, out result))
+            // Do not allow thousands separator here, since it may be equal to the unit abbreviation (').
+            if (TryParse(str, formatProvider, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, out result))
                 return true;
 
             var quantityParser = QuantityParser.Default;

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -102,7 +102,7 @@ namespace UnitsNet
 
             // This succeeds if only feet or inches are given, not both
             // Do not allow thousands separator here, since it may be equal to the unit abbreviation (').
-            if (TryParse(str, formatProvider, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, out result))
+            if (TryParse(str, formatProvider, NumberStyles.Float, out result))
                 return true;
 
             var quantityParser = QuantityParser.Default;

--- a/UnitsNet/CustomCode/Quantities/Length.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Length.extra.cs
@@ -70,7 +70,7 @@ namespace UnitsNet
         /// <example>
         ///     Length.Parse("5.5 m", new CultureInfo("en-US"));
         /// </example>
-        private static bool TryParse([CanBeNull] string str, [CanBeNull] IFormatProvider provider, NumberStyles allowedNumberStyles, out Length result)
+        private static bool TryParse(string? str, IFormatProvider? provider, NumberStyles allowedNumberStyles, out Length result)
         {
             return QuantityParser.Default.TryParse<Length, LengthUnit>(
                 str,

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -69,12 +69,12 @@ namespace UnitsNet
             return ParseWithRegex(valueString!, unitString!, fromDelegate, formatProvider);
         }
 
-        internal bool TryParse<TQuantity, TUnitType>([NotNull] string str,
-            [CanBeNull] IFormatProvider formatProvider,
+        internal bool TryParse<TQuantity, TUnitType>(string? str,
+            IFormatProvider? formatProvider,
             [NotNull] QuantityFromDelegate<TQuantity, TUnitType> fromDelegate,
             out TQuantity result)
-            where TQuantity : IQuantity
-            where TUnitType : Enum
+            where TQuantity : struct, IQuantity
+            where TUnitType : struct, Enum
         {
             return TryParse(str, formatProvider, fromDelegate, ParseNumberStyles, out result);
         }
@@ -112,7 +112,7 @@ namespace UnitsNet
         ///     Workaround for C# not allowing to pass on 'out' param from type Length to IQuantity, even though the are compatible.
         /// </summary>
         [SuppressMessage("ReSharper", "UseStringInterpolation")]
-        internal bool TryParse<TQuantity, TUnitType>([NotNull] string str,
+        internal bool TryParse<TQuantity, TUnitType>(string? str,
             IFormatProvider? formatProvider,
             [NotNull] QuantityFromDelegate<TQuantity, TUnitType> fromDelegate,
             NumberStyles allowedNumberStyles,
@@ -133,12 +133,12 @@ namespace UnitsNet
         /// <summary>
         ///     Workaround for C# not allowing to pass on 'out' param from type Length to IQuantity, even though the are compatible.
         /// </summary>
-        internal bool TryParse<TQuantity, TUnitType>([NotNull] string str,
-            [CanBeNull] IFormatProvider formatProvider,
+        internal bool TryParse<TQuantity, TUnitType>(string? str,
+            IFormatProvider? formatProvider,
             [NotNull] QuantityFromDelegate<TQuantity, TUnitType> fromDelegate,
-            out IQuantity result)
-            where TQuantity : IQuantity
-            where TUnitType : Enum
+            out IQuantity? result)
+            where TQuantity : struct, IQuantity
+            where TUnitType : struct, Enum
         {
             return TryParse(str, formatProvider, fromDelegate, ParseNumberStyles, out result);
         }


### PR DESCRIPTION
My current locale (de-CH) uses ' (an apostrophe) as thousands separator. This broke the unit test for the `TryParseFeetInches` method, because the input string `1'1"` is ambiguous. Therefore I now removed the separator as valid input in a feet-inches combination. It's pretty unlikely that someone will need to parse `1,345'21"`. 