### PR TITLE
Add pound per foot second

### DIFF
--- a/Common/UnitDefinitions/DynamicViscosity.json
+++ b/Common/UnitDefinitions/DynamicViscosity.json
@@ -82,6 +82,18 @@
           "Abbreviations": [ "lbf·s/ft²" ]
         }
       ]
+    },
+    {
+      "SingularName": "PoundPerFootSecond",
+      "PluralName": "PoundPerFootSecond",
+      "FromUnitToBaseFunc": "x * 1.4881639",
+      "FromBaseToUnitFunc": "x / 1.4881639",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "lb/ft·s" ]
+        }
+      ]
     }
   ]
 }

--- a/Common/UnitDefinitions/DynamicViscosity.json
+++ b/Common/UnitDefinitions/DynamicViscosity.json
@@ -85,7 +85,7 @@
     },
     {
       "SingularName": "PoundPerFootSecond",
-      "PluralName": "PoundPerFootSecond",
+      "PluralName": "PoundsPerFootSecond",
       "FromUnitToBaseFunc": "x * 1.4881639",
       "FromBaseToUnitFunc": "x / 1.4881639",
       "Localization": [

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToDynamicViscosityExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToDynamicViscosityExtensionsTest.g.cs
@@ -57,6 +57,10 @@ namespace UnitsNet.Tests
             Assert.Equal(DynamicViscosity.FromPoundsForceSecondPerSquareInch(2), 2.PoundsForceSecondPerSquareInch());
 
         [Fact]
+        public void NumberToPoundPerFootSecondTest() =>
+            Assert.Equal(DynamicViscosity.FromPoundPerFootSecond(2), 2.PoundPerFootSecond());
+
+        [Fact]
         public void NumberToReynsTest() =>
             Assert.Equal(DynamicViscosity.FromReyns(2), 2.Reyns());
 

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToDynamicViscosityExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToDynamicViscosityExtensionsTest.g.cs
@@ -57,8 +57,8 @@ namespace UnitsNet.Tests
             Assert.Equal(DynamicViscosity.FromPoundsForceSecondPerSquareInch(2), 2.PoundsForceSecondPerSquareInch());
 
         [Fact]
-        public void NumberToPoundPerFootSecondTest() =>
-            Assert.Equal(DynamicViscosity.FromPoundPerFootSecond(2), 2.PoundPerFootSecond());
+        public void NumberToPoundsPerFootSecondTest() =>
+            Assert.Equal(DynamicViscosity.FromPoundsPerFootSecond(2), 2.PoundsPerFootSecond());
 
         [Fact]
         public void NumberToReynsTest() =>

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToDynamicViscosityExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToDynamicViscosityExtensions.g.cs
@@ -60,6 +60,10 @@ namespace UnitsNet.NumberExtensions.NumberToDynamicViscosity
         public static DynamicViscosity PoundsForceSecondPerSquareInch<T>(this T value) =>
             DynamicViscosity.FromPoundsForceSecondPerSquareInch(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="DynamicViscosity.FromPoundPerFootSecond(UnitsNet.QuantityValue)" />
+        public static DynamicViscosity PoundPerFootSecond<T>(this T value) =>
+            DynamicViscosity.FromPoundPerFootSecond(Convert.ToDouble(value));
+
         /// <inheritdoc cref="DynamicViscosity.FromReyns(UnitsNet.QuantityValue)" />
         public static DynamicViscosity Reyns<T>(this T value) =>
             DynamicViscosity.FromReyns(Convert.ToDouble(value));

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToDynamicViscosityExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToDynamicViscosityExtensions.g.cs
@@ -60,9 +60,9 @@ namespace UnitsNet.NumberExtensions.NumberToDynamicViscosity
         public static DynamicViscosity PoundsForceSecondPerSquareInch<T>(this T value) =>
             DynamicViscosity.FromPoundsForceSecondPerSquareInch(Convert.ToDouble(value));
 
-        /// <inheritdoc cref="DynamicViscosity.FromPoundPerFootSecond(UnitsNet.QuantityValue)" />
-        public static DynamicViscosity PoundPerFootSecond<T>(this T value) =>
-            DynamicViscosity.FromPoundPerFootSecond(Convert.ToDouble(value));
+        /// <inheritdoc cref="DynamicViscosity.FromPoundsPerFootSecond(UnitsNet.QuantityValue)" />
+        public static DynamicViscosity PoundsPerFootSecond<T>(this T value) =>
+            DynamicViscosity.FromPoundsPerFootSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="DynamicViscosity.FromReyns(UnitsNet.QuantityValue)" />
         public static DynamicViscosity Reyns<T>(this T value) =>

--- a/UnitsNet.Tests/CustomCode/DynamicViscosityTests.cs
+++ b/UnitsNet.Tests/CustomCode/DynamicViscosityTests.cs
@@ -14,6 +14,7 @@ namespace UnitsNet.Tests.CustomCode
         protected override double NewtonSecondsPerMeterSquaredInOneNewtonSecondPerMeterSquared => 1;
         protected override double PascalSecondsInOneNewtonSecondPerMeterSquared => 1;
         protected override double PoiseInOneNewtonSecondPerMeterSquared => 10;
+        protected override double PoundsPerFootSecondInOneNewtonSecondPerMeterSquared => 0.671968994813;
         protected override double ReynsInOneNewtonSecondPerMeterSquared => 1.4503773773020922e-4;
         protected override double PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared => 1.4503773773020922e-4;
         protected override double PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared => 2.0885434233150127e-2;

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
@@ -44,7 +44,7 @@ namespace UnitsNet.Tests
         protected abstract double PoiseInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared { get; }
-        protected abstract double PoundPerFootSecondInOneNewtonSecondPerMeterSquared { get; }
+        protected abstract double PoundsPerFootSecondInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double ReynsInOneNewtonSecondPerMeterSquared { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
@@ -56,7 +56,7 @@ namespace UnitsNet.Tests
         protected virtual double PoiseTolerance { get { return 1e-5; } }
         protected virtual double PoundsForceSecondPerSquareFootTolerance { get { return 1e-5; } }
         protected virtual double PoundsForceSecondPerSquareInchTolerance { get { return 1e-5; } }
-        protected virtual double PoundPerFootSecondTolerance { get { return 1e-5; } }
+        protected virtual double PoundsPerFootSecondTolerance { get { return 1e-5; } }
         protected virtual double ReynsTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
@@ -127,7 +127,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.Poise, PoiseTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsForceSecondPerSquareFoot, PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsForceSecondPerSquareInch, PoundsForceSecondPerSquareInchTolerance);
-            AssertEx.EqualTolerance(PoundPerFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundPerFootSecond, PoundPerFootSecondTolerance);
+            AssertEx.EqualTolerance(PoundsPerFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsPerFootSecond, PoundsPerFootSecondTolerance);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.Reyns, ReynsTolerance);
         }
 
@@ -167,7 +167,7 @@ namespace UnitsNet.Tests
             Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareInch, quantity07.Unit);
 
             var quantity08 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundPerFootSecond);
-            AssertEx.EqualTolerance(1, quantity08.PoundPerFootSecond, PoundPerFootSecondTolerance);
+            AssertEx.EqualTolerance(1, quantity08.PoundsPerFootSecond, PoundsPerFootSecondTolerance);
             Assert.Equal(DynamicViscosityUnit.PoundPerFootSecond, quantity08.Unit);
 
             var quantity09 = DynamicViscosity.From(1, DynamicViscosityUnit.Reyn);
@@ -201,7 +201,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.Poise), PoiseTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundForceSecondPerSquareFoot), PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundForceSecondPerSquareInch), PoundsForceSecondPerSquareInchTolerance);
-            AssertEx.EqualTolerance(PoundPerFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundPerFootSecond), PoundPerFootSecondTolerance);
+            AssertEx.EqualTolerance(PoundsPerFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundPerFootSecond), PoundsPerFootSecondTolerance);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.Reyn), ReynsTolerance);
         }
 
@@ -243,7 +243,7 @@ namespace UnitsNet.Tests
             Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareInch, poundforcesecondpersquareinchQuantity.Unit);
 
             var poundperfootsecondQuantity = newtonsecondpermetersquared.ToUnit(DynamicViscosityUnit.PoundPerFootSecond);
-            AssertEx.EqualTolerance(PoundPerFootSecondInOneNewtonSecondPerMeterSquared, (double)poundperfootsecondQuantity.Value, PoundPerFootSecondTolerance);
+            AssertEx.EqualTolerance(PoundsPerFootSecondInOneNewtonSecondPerMeterSquared, (double)poundperfootsecondQuantity.Value, PoundsPerFootSecondTolerance);
             Assert.Equal(DynamicViscosityUnit.PoundPerFootSecond, poundperfootsecondQuantity.Unit);
 
             var reynQuantity = newtonsecondpermetersquared.ToUnit(DynamicViscosityUnit.Reyn);
@@ -263,7 +263,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoise(newtonsecondpermetersquared.Poise).NewtonSecondsPerMeterSquared, PoiseTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsForceSecondPerSquareFoot(newtonsecondpermetersquared.PoundsForceSecondPerSquareFoot).NewtonSecondsPerMeterSquared, PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsForceSecondPerSquareInch(newtonsecondpermetersquared.PoundsForceSecondPerSquareInch).NewtonSecondsPerMeterSquared, PoundsForceSecondPerSquareInchTolerance);
-            AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundPerFootSecond(newtonsecondpermetersquared.PoundPerFootSecond).NewtonSecondsPerMeterSquared, PoundPerFootSecondTolerance);
+            AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsPerFootSecond(newtonsecondpermetersquared.PoundsPerFootSecond).NewtonSecondsPerMeterSquared, PoundsPerFootSecondTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromReyns(newtonsecondpermetersquared.Reyns).NewtonSecondsPerMeterSquared, ReynsTolerance);
         }
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
@@ -44,6 +44,7 @@ namespace UnitsNet.Tests
         protected abstract double PoiseInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared { get; }
+        protected abstract double PoundPerFootSecondInOneNewtonSecondPerMeterSquared { get; }
         protected abstract double ReynsInOneNewtonSecondPerMeterSquared { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
@@ -55,6 +56,7 @@ namespace UnitsNet.Tests
         protected virtual double PoiseTolerance { get { return 1e-5; } }
         protected virtual double PoundsForceSecondPerSquareFootTolerance { get { return 1e-5; } }
         protected virtual double PoundsForceSecondPerSquareInchTolerance { get { return 1e-5; } }
+        protected virtual double PoundPerFootSecondTolerance { get { return 1e-5; } }
         protected virtual double ReynsTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
@@ -125,6 +127,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.Poise, PoiseTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsForceSecondPerSquareFoot, PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundsForceSecondPerSquareInch, PoundsForceSecondPerSquareInchTolerance);
+            AssertEx.EqualTolerance(PoundPerFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.PoundPerFootSecond, PoundPerFootSecondTolerance);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.Reyns, ReynsTolerance);
         }
 
@@ -163,9 +166,13 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity07.PoundsForceSecondPerSquareInch, PoundsForceSecondPerSquareInchTolerance);
             Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareInch, quantity07.Unit);
 
-            var quantity08 = DynamicViscosity.From(1, DynamicViscosityUnit.Reyn);
-            AssertEx.EqualTolerance(1, quantity08.Reyns, ReynsTolerance);
-            Assert.Equal(DynamicViscosityUnit.Reyn, quantity08.Unit);
+            var quantity08 = DynamicViscosity.From(1, DynamicViscosityUnit.PoundPerFootSecond);
+            AssertEx.EqualTolerance(1, quantity08.PoundPerFootSecond, PoundPerFootSecondTolerance);
+            Assert.Equal(DynamicViscosityUnit.PoundPerFootSecond, quantity08.Unit);
+
+            var quantity09 = DynamicViscosity.From(1, DynamicViscosityUnit.Reyn);
+            AssertEx.EqualTolerance(1, quantity09.Reyns, ReynsTolerance);
+            Assert.Equal(DynamicViscosityUnit.Reyn, quantity09.Unit);
 
         }
 
@@ -194,6 +201,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(PoiseInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.Poise), PoiseTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareFootInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundForceSecondPerSquareFoot), PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundForceSecondPerSquareInch), PoundsForceSecondPerSquareInchTolerance);
+            AssertEx.EqualTolerance(PoundPerFootSecondInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.PoundPerFootSecond), PoundPerFootSecondTolerance);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, newtonsecondpermetersquared.As(DynamicViscosityUnit.Reyn), ReynsTolerance);
         }
 
@@ -234,6 +242,10 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(PoundsForceSecondPerSquareInchInOneNewtonSecondPerMeterSquared, (double)poundforcesecondpersquareinchQuantity.Value, PoundsForceSecondPerSquareInchTolerance);
             Assert.Equal(DynamicViscosityUnit.PoundForceSecondPerSquareInch, poundforcesecondpersquareinchQuantity.Unit);
 
+            var poundperfootsecondQuantity = newtonsecondpermetersquared.ToUnit(DynamicViscosityUnit.PoundPerFootSecond);
+            AssertEx.EqualTolerance(PoundPerFootSecondInOneNewtonSecondPerMeterSquared, (double)poundperfootsecondQuantity.Value, PoundPerFootSecondTolerance);
+            Assert.Equal(DynamicViscosityUnit.PoundPerFootSecond, poundperfootsecondQuantity.Unit);
+
             var reynQuantity = newtonsecondpermetersquared.ToUnit(DynamicViscosityUnit.Reyn);
             AssertEx.EqualTolerance(ReynsInOneNewtonSecondPerMeterSquared, (double)reynQuantity.Value, ReynsTolerance);
             Assert.Equal(DynamicViscosityUnit.Reyn, reynQuantity.Unit);
@@ -251,6 +263,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoise(newtonsecondpermetersquared.Poise).NewtonSecondsPerMeterSquared, PoiseTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsForceSecondPerSquareFoot(newtonsecondpermetersquared.PoundsForceSecondPerSquareFoot).NewtonSecondsPerMeterSquared, PoundsForceSecondPerSquareFootTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundsForceSecondPerSquareInch(newtonsecondpermetersquared.PoundsForceSecondPerSquareInch).NewtonSecondsPerMeterSquared, PoundsForceSecondPerSquareInchTolerance);
+            AssertEx.EqualTolerance(1, DynamicViscosity.FromPoundPerFootSecond(newtonsecondpermetersquared.PoundPerFootSecond).NewtonSecondsPerMeterSquared, PoundPerFootSecondTolerance);
             AssertEx.EqualTolerance(1, DynamicViscosity.FromReyns(newtonsecondpermetersquared.Reyns).NewtonSecondsPerMeterSquared, ReynsTolerance);
         }
 
@@ -416,6 +429,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 P", new DynamicViscosity(1, DynamicViscosityUnit.Poise).ToString());
                 Assert.Equal("1 lbf·s/ft²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareFoot).ToString());
                 Assert.Equal("1 lbf·s/in²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareInch).ToString());
+                Assert.Equal("1 lb/ft·s", new DynamicViscosity(1, DynamicViscosityUnit.PoundPerFootSecond).ToString());
                 Assert.Equal("1 reyn", new DynamicViscosity(1, DynamicViscosityUnit.Reyn).ToString());
             }
             finally
@@ -438,6 +452,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 P", new DynamicViscosity(1, DynamicViscosityUnit.Poise).ToString(swedishCulture));
             Assert.Equal("1 lbf·s/ft²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareFoot).ToString(swedishCulture));
             Assert.Equal("1 lbf·s/in²", new DynamicViscosity(1, DynamicViscosityUnit.PoundForceSecondPerSquareInch).ToString(swedishCulture));
+            Assert.Equal("1 lb/ft·s", new DynamicViscosity(1, DynamicViscosityUnit.PoundPerFootSecond).ToString(swedishCulture));
             Assert.Equal("1 reyn", new DynamicViscosity(1, DynamicViscosityUnit.Reyn).ToString(swedishCulture));
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -199,9 +199,9 @@ namespace UnitsNet
         public double PoundsForceSecondPerSquareInch => As(DynamicViscosityUnit.PoundForceSecondPerSquareInch);
 
         /// <summary>
-        ///     Get DynamicViscosity in PoundPerFootSecond.
+        ///     Get DynamicViscosity in PoundsPerFootSecond.
         /// </summary>
-        public double PoundPerFootSecond => As(DynamicViscosityUnit.PoundPerFootSecond);
+        public double PoundsPerFootSecond => As(DynamicViscosityUnit.PoundPerFootSecond);
 
         /// <summary>
         ///     Get DynamicViscosity in Reyns.
@@ -319,13 +319,13 @@ namespace UnitsNet
             return new DynamicViscosity(value, DynamicViscosityUnit.PoundForceSecondPerSquareInch);
         }
         /// <summary>
-        ///     Get DynamicViscosity from PoundPerFootSecond.
+        ///     Get DynamicViscosity from PoundsPerFootSecond.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         [Windows.Foundation.Metadata.DefaultOverload]
-        public static DynamicViscosity FromPoundPerFootSecond(double poundperfootsecond)
+        public static DynamicViscosity FromPoundsPerFootSecond(double poundsperfootsecond)
         {
-            double value = (double) poundperfootsecond;
+            double value = (double) poundsperfootsecond;
             return new DynamicViscosity(value, DynamicViscosityUnit.PoundPerFootSecond);
         }
         /// <summary>

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -199,6 +199,11 @@ namespace UnitsNet
         public double PoundsForceSecondPerSquareInch => As(DynamicViscosityUnit.PoundForceSecondPerSquareInch);
 
         /// <summary>
+        ///     Get DynamicViscosity in PoundPerFootSecond.
+        /// </summary>
+        public double PoundPerFootSecond => As(DynamicViscosityUnit.PoundPerFootSecond);
+
+        /// <summary>
         ///     Get DynamicViscosity in Reyns.
         /// </summary>
         public double Reyns => As(DynamicViscosityUnit.Reyn);
@@ -312,6 +317,16 @@ namespace UnitsNet
         {
             double value = (double) poundsforcesecondpersquareinch;
             return new DynamicViscosity(value, DynamicViscosityUnit.PoundForceSecondPerSquareInch);
+        }
+        /// <summary>
+        ///     Get DynamicViscosity from PoundPerFootSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static DynamicViscosity FromPoundPerFootSecond(double poundperfootsecond)
+        {
+            double value = (double) poundperfootsecond;
+            return new DynamicViscosity(value, DynamicViscosityUnit.PoundPerFootSecond);
         }
         /// <summary>
         ///     Get DynamicViscosity from Reyns.
@@ -622,6 +637,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.Poise: return _value/10;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return _value * 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return _value * 6.8947572931683613e3;
+                case DynamicViscosityUnit.PoundPerFootSecond: return _value * 1.4881639;
                 case DynamicViscosityUnit.Reyn: return _value * 6.8947572931683613e3;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
@@ -645,6 +661,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.Poise: return baseUnitValue*10;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return baseUnitValue / 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return baseUnitValue / 6.8947572931683613e3;
+                case DynamicViscosityUnit.PoundPerFootSecond: return baseUnitValue / 1.4881639;
                 case DynamicViscosityUnit.Reyn: return baseUnitValue / 6.8947572931683613e3;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -253,6 +253,7 @@ namespace UnitsNet
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Poise, new string[]{"P"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareFoot, new string[]{"lbf·s/ft²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareInch, new string[]{"lbf·s/in²"}),
+                ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundPerFootSecond, new string[]{"lb/ft·s"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Reyn, new string[]{"reyn"}),
                 ("en-US", typeof(ElectricAdmittanceUnit), (int)ElectricAdmittanceUnit.Microsiemens, new string[]{"µS"}),
                 ("en-US", typeof(ElectricAdmittanceUnit), (int)ElectricAdmittanceUnit.Millisiemens, new string[]{"mS"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/DynamicViscosityUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/DynamicViscosityUnit.g.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Units
         Poise,
         PoundForceSecondPerSquareFoot,
         PoundForceSecondPerSquareInch,
+        PoundPerFootSecond,
         Reyn,
     }
 

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -218,9 +218,9 @@ namespace UnitsNet
         public double PoundsForceSecondPerSquareInch => As(DynamicViscosityUnit.PoundForceSecondPerSquareInch);
 
         /// <summary>
-        ///     Get DynamicViscosity in PoundPerFootSecond.
+        ///     Get DynamicViscosity in PoundsPerFootSecond.
         /// </summary>
-        public double PoundPerFootSecond => As(DynamicViscosityUnit.PoundPerFootSecond);
+        public double PoundsPerFootSecond => As(DynamicViscosityUnit.PoundPerFootSecond);
 
         /// <summary>
         ///     Get DynamicViscosity in Reyns.
@@ -329,12 +329,12 @@ namespace UnitsNet
             return new DynamicViscosity(value, DynamicViscosityUnit.PoundForceSecondPerSquareInch);
         }
         /// <summary>
-        ///     Get DynamicViscosity from PoundPerFootSecond.
+        ///     Get DynamicViscosity from PoundsPerFootSecond.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static DynamicViscosity FromPoundPerFootSecond(QuantityValue poundperfootsecond)
+        public static DynamicViscosity FromPoundsPerFootSecond(QuantityValue poundsperfootsecond)
         {
-            double value = (double) poundperfootsecond;
+            double value = (double) poundsperfootsecond;
             return new DynamicViscosity(value, DynamicViscosityUnit.PoundPerFootSecond);
         }
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -63,6 +63,7 @@ namespace UnitsNet
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.Poise, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PoundForceSecondPerSquareInch, BaseUnits.Undefined),
+                    new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.PoundPerFootSecond, BaseUnits.Undefined),
                     new UnitInfo<DynamicViscosityUnit>(DynamicViscosityUnit.Reyn, BaseUnits.Undefined),
                 },
                 BaseUnit, Zero, BaseDimensions);
@@ -217,6 +218,11 @@ namespace UnitsNet
         public double PoundsForceSecondPerSquareInch => As(DynamicViscosityUnit.PoundForceSecondPerSquareInch);
 
         /// <summary>
+        ///     Get DynamicViscosity in PoundPerFootSecond.
+        /// </summary>
+        public double PoundPerFootSecond => As(DynamicViscosityUnit.PoundPerFootSecond);
+
+        /// <summary>
         ///     Get DynamicViscosity in Reyns.
         /// </summary>
         public double Reyns => As(DynamicViscosityUnit.Reyn);
@@ -321,6 +327,15 @@ namespace UnitsNet
         {
             double value = (double) poundsforcesecondpersquareinch;
             return new DynamicViscosity(value, DynamicViscosityUnit.PoundForceSecondPerSquareInch);
+        }
+        /// <summary>
+        ///     Get DynamicViscosity from PoundPerFootSecond.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static DynamicViscosity FromPoundPerFootSecond(QuantityValue poundperfootsecond)
+        {
+            double value = (double) poundperfootsecond;
+            return new DynamicViscosity(value, DynamicViscosityUnit.PoundPerFootSecond);
         }
         /// <summary>
         ///     Get DynamicViscosity from Reyns.
@@ -768,6 +783,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.Poise: return _value/10;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return _value * 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return _value * 6.8947572931683613e3;
+                case DynamicViscosityUnit.PoundPerFootSecond: return _value * 1.4881639;
                 case DynamicViscosityUnit.Reyn: return _value * 6.8947572931683613e3;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
@@ -802,6 +818,7 @@ namespace UnitsNet
                 case DynamicViscosityUnit.Poise: return baseUnitValue*10;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareFoot: return baseUnitValue / 4.7880258980335843e1;
                 case DynamicViscosityUnit.PoundForceSecondPerSquareInch: return baseUnitValue / 6.8947572931683613e3;
+                case DynamicViscosityUnit.PoundPerFootSecond: return baseUnitValue / 1.4881639;
                 case DynamicViscosityUnit.Reyn: return baseUnitValue / 6.8947572931683613e3;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -253,6 +253,7 @@ namespace UnitsNet
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Poise, new string[]{"P"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareFoot, new string[]{"lbf·s/ft²"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundForceSecondPerSquareInch, new string[]{"lbf·s/in²"}),
+                ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.PoundPerFootSecond, new string[]{"lb/ft·s"}),
                 ("en-US", typeof(DynamicViscosityUnit), (int)DynamicViscosityUnit.Reyn, new string[]{"reyn"}),
                 ("en-US", typeof(ElectricAdmittanceUnit), (int)ElectricAdmittanceUnit.Microsiemens, new string[]{"µS"}),
                 ("en-US", typeof(ElectricAdmittanceUnit), (int)ElectricAdmittanceUnit.Millisiemens, new string[]{"mS"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -358,6 +358,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.PoundForceSecondPerSquareFoot, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.PoundForceSecondPerSquareInch, q => q.ToUnit(DynamicViscosityUnit.PoundForceSecondPerSquareInch));
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.PoundForceSecondPerSquareInch, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.PoundPerFootSecond, q => q.ToUnit(DynamicViscosityUnit.PoundPerFootSecond));
+            unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.PoundPerFootSecond, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosity.BaseUnit, DynamicViscosityUnit.Reyn, q => q.ToUnit(DynamicViscosityUnit.Reyn));
             unitConverter.SetConversionFunction<DynamicViscosity>(DynamicViscosityUnit.Reyn, DynamicViscosity.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<ElectricAdmittance>(ElectricAdmittance.BaseUnit, ElectricAdmittanceUnit.Microsiemens, q => q.ToUnit(ElectricAdmittanceUnit.Microsiemens));

--- a/UnitsNet/GeneratedCode/Units/DynamicViscosityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/DynamicViscosityUnit.g.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Units
         Poise,
         PoundForceSecondPerSquareFoot,
         PoundForceSecondPerSquareInch,
+        PoundPerFootSecond,
         Reyn,
     }
 


### PR DESCRIPTION
Add pound-foot-second in DynamicViscosity

Numbers are based on https://www.convertunits.com/info/lb/ft-s

