### PR TITLE
QuantityFormatterTests: Formatting the 'expected' values using the CurrentUICulture

### DIFF
--- a/UnitsNet.Tests/QuantityFormatterTests.cs
+++ b/UnitsNet.Tests/QuantityFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System.Globalization;
 using Xunit;
 
 namespace UnitsNet.Tests
@@ -108,7 +109,7 @@ namespace UnitsNet.Tests
         {
             var length = Length.FromMeters(123456789.987654321);
 
-            var expected = string.Format($"{{0:{format}}} {{1:a}}", length.Value, length);
+            var expected = string.Format(CultureInfo.CurrentUICulture, $"{{0:{format}}} {{1:a}}", length.Value, length);
             Assert.Equal(expected, QuantityFormatter.Format(length, format));
         }
 
@@ -132,7 +133,7 @@ namespace UnitsNet.Tests
         {
             var length = Length.FromMeters(123456789.987654321);
 
-            var expected = string.Format($"{{0:{format}}} {{1:a}}", length.Value, length);
+            var expected = string.Format(CultureInfo.CurrentUICulture, $"{{0:{format}}} {{1:a}}", length.Value, length);
             Assert.Equal(expected, QuantityFormatter.Format(length, format));
         }
     }


### PR DESCRIPTION
- var expected = string.Format(CultureInfo.CurrentUICulture, ...) as per the defaultCulture of the [QuantityFormatter.Format](https://github.com/angularsen/UnitsNet/blob/ca373f75d51604f7e8918f2aafb5f2fc380b757e/UnitsNet/QuantityFormatter.cs#L72) method overload

PS This might have to get reverted after #795 is merged, but I suggest updating this so that it is consistent with the currently tested behavior (there are currently 17 tests failing on my machine)