### PR TITLE
Use HowMuchUnit instead of Enum in HowMuch quantity

### DIFF
--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -49,6 +49,7 @@ namespace UnitsNet.Tests.CustomQuantities
 
         public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
 
+        public override string ToString() => $"{Value} {Unit}";
         public string ToString(string format, IFormatProvider formatProvider) => $"HowMuch ({format}, {formatProvider})";
         public string ToString(IFormatProvider provider) => $"HowMuch ({provider})";
         public string ToString(IFormatProvider provider, int significantDigitsAfterRadix) => $"HowMuch ({provider}, {significantDigitsAfterRadix})";

--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -8,7 +8,7 @@ namespace UnitsNet.Tests.CustomQuantities
     /// </summary>
     public struct HowMuch : IQuantity
     {
-        public HowMuch(double value, HowMuchUnit unit) : this()
+        public HowMuch(double value, HowMuchUnit unit)
         {
             Unit = unit;
             Value = value;

--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -8,16 +8,18 @@ namespace UnitsNet.Tests.CustomQuantities
     /// </summary>
     public struct HowMuch : IQuantity
     {
-        public HowMuch(double value, Enum unit) : this()
+        public HowMuch(double value, HowMuchUnit unit) : this()
         {
             Unit = unit;
             Value = value;
         }
 
-        public Enum Unit { get; }
+        Enum IQuantity.Unit => Unit;
+        public HowMuchUnit Unit { get; }
+
         public double Value { get; }
 
-        #region Crud to satisfy IQuantity, but not really used for anything
+        #region IQuantity
 
         private static readonly HowMuch Zero = new HowMuch(0, HowMuchUnit.Some);
 
@@ -39,7 +41,11 @@ namespace UnitsNet.Tests.CustomQuantities
 
         public double As(UnitSystem unitSystem) => throw new NotImplementedException();
 
-        public IQuantity ToUnit(Enum unit) => new HowMuch(As(unit), unit);
+        public IQuantity ToUnit(Enum unit)
+        {
+            if (unit is HowMuchUnit howMuchUnit) return new HowMuch(As(unit), howMuchUnit);
+            throw new ArgumentException("Must be of type HowMuchUnit.", nameof(unit));
+        }
 
         public IQuantity ToUnit(UnitSystem unitSystem) => throw new NotImplementedException();
 

--- a/UnitsNet.Tests/UnitConverterTest.cs
+++ b/UnitsNet.Tests/UnitConverterTest.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
-using System;
 using UnitsNet.Tests.CustomQuantities;
 using UnitsNet.Units;
 using Xunit;
@@ -96,7 +95,7 @@ namespace UnitsNet.Tests
         [InlineData(1, HowMuchUnit.Some, HowMuchUnit.Some, 1)]
         [InlineData(1, HowMuchUnit.Some, HowMuchUnit.ATon, 2)]
         [InlineData(1, HowMuchUnit.Some, HowMuchUnit.AShitTon, 10)]
-        public void ConversionForUnitsOfCustomQuantity(double fromValue, Enum fromUnit, Enum toUnit, double expectedValue)
+        public void ConversionForUnitsOfCustomQuantity(double fromValue, HowMuchUnit fromUnit, HowMuchUnit toUnit, double expectedValue)
         {
             // Intentionally don't map conversion Some->Some, it is not necessary
             var unitConverter = new UnitConverter();


### PR DESCRIPTION
Minor improvement in test code that also serves as example code for custom quantities.