### PR TITLE
Fix a typo in VolumeFlow.json ("sm³/min" to "cm³/min")

### DIFF
--- a/Common/UnitDefinitions/VolumeFlow.json
+++ b/Common/UnitDefinitions/VolumeFlow.json
@@ -471,7 +471,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "sm³/min" ]
+          "Abbreviations": [ "cm³/min" ]
         },
         {
           "Culture": "ru-RU",

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
@@ -1066,7 +1066,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 cl/day", new VolumeFlow(1, VolumeFlowUnit.CentiliterPerDay).ToString());
                 Assert.Equal("1 cL/min", new VolumeFlow(1, VolumeFlowUnit.CentiliterPerMinute).ToString());
                 Assert.Equal("1 cL/s", new VolumeFlow(1, VolumeFlowUnit.CentiliterPerSecond).ToString());
-                Assert.Equal("1 sm³/min", new VolumeFlow(1, VolumeFlowUnit.CubicCentimeterPerMinute).ToString());
+                Assert.Equal("1 cm³/min", new VolumeFlow(1, VolumeFlowUnit.CubicCentimeterPerMinute).ToString());
                 Assert.Equal("1 dm³/min", new VolumeFlow(1, VolumeFlowUnit.CubicDecimeterPerMinute).ToString());
                 Assert.Equal("1 ft³/h", new VolumeFlow(1, VolumeFlowUnit.CubicFootPerHour).ToString());
                 Assert.Equal("1 ft³/min", new VolumeFlow(1, VolumeFlowUnit.CubicFootPerMinute).ToString());
@@ -1135,7 +1135,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 cl/day", new VolumeFlow(1, VolumeFlowUnit.CentiliterPerDay).ToString(swedishCulture));
             Assert.Equal("1 cL/min", new VolumeFlow(1, VolumeFlowUnit.CentiliterPerMinute).ToString(swedishCulture));
             Assert.Equal("1 cL/s", new VolumeFlow(1, VolumeFlowUnit.CentiliterPerSecond).ToString(swedishCulture));
-            Assert.Equal("1 sm³/min", new VolumeFlow(1, VolumeFlowUnit.CubicCentimeterPerMinute).ToString(swedishCulture));
+            Assert.Equal("1 cm³/min", new VolumeFlow(1, VolumeFlowUnit.CubicCentimeterPerMinute).ToString(swedishCulture));
             Assert.Equal("1 dm³/min", new VolumeFlow(1, VolumeFlowUnit.CubicDecimeterPerMinute).ToString(swedishCulture));
             Assert.Equal("1 ft³/h", new VolumeFlow(1, VolumeFlowUnit.CubicFootPerHour).ToString(swedishCulture));
             Assert.Equal("1 ft³/min", new VolumeFlow(1, VolumeFlowUnit.CubicFootPerMinute).ToString(swedishCulture));

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -1518,7 +1518,7 @@ namespace UnitsNet
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CentiliterPerMinute, new string[]{"сл/мин"}),
                 ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CentiliterPerSecond, new string[]{"cL/s", "cLPS"}),
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CentiliterPerSecond, new string[]{"сл/c"}),
-                ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicCentimeterPerMinute, new string[]{"sm³/min"}),
+                ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicCentimeterPerMinute, new string[]{"cm³/min"}),
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicCentimeterPerMinute, new string[]{"см³/мин"}),
                 ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicDecimeterPerMinute, new string[]{"dm³/min"}),
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicDecimeterPerMinute, new string[]{"дм³/мин"}),

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -1518,7 +1518,7 @@ namespace UnitsNet
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CentiliterPerMinute, new string[]{"сл/мин"}),
                 ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CentiliterPerSecond, new string[]{"cL/s", "cLPS"}),
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CentiliterPerSecond, new string[]{"сл/c"}),
-                ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicCentimeterPerMinute, new string[]{"sm³/min"}),
+                ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicCentimeterPerMinute, new string[]{"cm³/min"}),
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicCentimeterPerMinute, new string[]{"см³/мин"}),
                 ("en-US", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicDecimeterPerMinute, new string[]{"dm³/min"}),
                 ("ru-RU", typeof(VolumeFlowUnit), (int)VolumeFlowUnit.CubicDecimeterPerMinute, new string[]{"дм³/мин"}),


### PR DESCRIPTION
I assume the abbreviation of CubicCentimeterPerMinute is wrong.