### PR TITLE
Fix codegen for obsolete attributes

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/NumberExtensionsGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/NumberExtensionsGenerator.cs
@@ -52,9 +52,9 @@ namespace UnitsNet.NumberExtensions.NumberTo{_quantityName}
             return Writer.ToString();
         }
 
-        private string GetObsoleteAttributeOrNull(string obsoleteText) =>
+        private static string? GetObsoleteAttributeOrNull(string obsoleteText) =>
             string.IsNullOrWhiteSpace(obsoleteText) ?
             null :
-            $"[System.Obsolete({obsoleteText})]";
+            $"[System.Obsolete(\"{obsoleteText}\")]";
     }
 }

--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -1157,6 +1157,6 @@ namespace UnitsNet
         /// </summary>
         private static string GetObsoleteAttributeOrNull(string obsoleteText) => string.IsNullOrWhiteSpace(obsoleteText)
             ? null
-            : $"[System.Obsolete({obsoleteText})]";
+            : $"[System.Obsolete(\"{obsoleteText}\")]";
     }
 }

--- a/CodeGen/Generators/UnitsNetWrcGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetWrcGen/QuantityGenerator.cs
@@ -734,17 +734,17 @@ namespace UnitsNet
         }
 
         /// <inheritdoc cref="GetObsoleteAttributeOrNull(string)"/>
-        internal static string GetObsoleteAttributeOrNull(Quantity quantity) => GetObsoleteAttributeOrNull(quantity.ObsoleteText);
+        internal static string? GetObsoleteAttributeOrNull(Quantity quantity) => GetObsoleteAttributeOrNull(quantity.ObsoleteText);
 
         /// <inheritdoc cref="GetObsoleteAttributeOrNull(string)"/>
-        internal static string GetObsoleteAttributeOrNull(Unit unit) => GetObsoleteAttributeOrNull(unit.ObsoleteText);
+        internal static string? GetObsoleteAttributeOrNull(Unit unit) => GetObsoleteAttributeOrNull(unit.ObsoleteText);
 
         /// <summary>
         /// Returns the Obsolete attribute if ObsoleteText has been defined on the JSON input - otherwise returns empty string
         /// It is up to the consumer to wrap any padding/new lines in order to keep to correct indentation formats
         /// </summary>
-        private static string GetObsoleteAttributeOrNull(string obsoleteText) => string.IsNullOrWhiteSpace(obsoleteText)
+        private static string? GetObsoleteAttributeOrNull(string obsoleteText) => string.IsNullOrWhiteSpace(obsoleteText)
             ? null
-            : $"[System.Obsolete({obsoleteText})]";
+            : $"[System.Obsolete(\"{obsoleteText}\")]";
     }
 }


### PR DESCRIPTION
It was missing double quotes around the string.

- Add missing double-quotes around obsolete message in c# code
- Fix nearby nullability issues