### PR TITLE
Revert "Replace MIT-0 with MIT to fix nuget push"

### DIFF
--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>UnitsNet Extensions NumberToExtensions NumberToUnitsExtensions NumberExtensions NumberToUnits convert conversion parse</PackageTags>
   </PropertyGroup>

--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -2,7 +2,7 @@
   <!-- NuGet properties -->
   <PropertyGroup>
     <PackageId>UnitsNet.NumberExtensions</PackageId>
-    <Version>4.81.0</Version>
+    <Version>4.81.1</Version>
     <Authors>Andreas Gullberg Larsen, Lu Li, Jon Suda</Authors>
     <Title>Units.NET NumberExtensions</Title>
     <Description>Adds extension methods to number types to more easily create quantities, such as 5.Meters() instead of Length.FromMeters(5).</Description>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>unit units measurement json Json.NET Newtonsoft serialize deserialize serialization deserialization</PackageTags>
     <PackageReleaseNotes>Upgrade JSON.NET to 12.0.3. Support arrays.</PackageReleaseNotes>

--- a/UnitsNet.WindowsRuntimeComponent/Properties/AssemblyInfo.cs
+++ b/UnitsNet.WindowsRuntimeComponent/Properties/AssemblyInfo.cs
@@ -17,6 +17,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("")]
-[assembly: AssemblyVersion("4.81.0")]
-[assembly: AssemblyFileVersion("4.81.0")]
+[assembly: AssemblyVersion("4.81.1")]
+[assembly: AssemblyFileVersion("4.81.1")]
 [assembly: InternalsVisibleTo("UnitsNet.WindowsRuntimeComponent.Tests")]

--- a/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.nuspec
+++ b/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET - Windows Runtime Component</title>
     <authors>Andreas Gullberg Larsen</authors>
     <owners>Andreas Gullberg Larsen</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>For C#/VB Universal Windows code (UWP), use UnitsNet instead. This is a Windows Runtime Component with reduced functionality to support all UWP languages, such as JavaScript and C++, and other runtime components.</description>

--- a/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.nuspec
+++ b/UnitsNet.WindowsRuntimeComponent/UnitsNet.WindowsRuntimeComponent.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>UnitsNet.WindowsRuntimeComponent</id>
-    <version>4.81.0</version>
+    <version>4.81.1</version>
     <title>Units.NET - Windows Runtime Component</title>
     <authors>Andreas Gullberg Larsen</authors>
     <owners>Andreas Gullberg Larsen</owners>

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -2,7 +2,7 @@
   <!-- NuGet properties -->
   <PropertyGroup>
     <PackageId>UnitsNet</PackageId>
-    <Version>4.81.0</Version>
+    <Version>4.81.1</Version>
     <Authors>Andreas Gullberg Larsen</Authors>
     <Title>Units.NET</Title>
     <Description>Get all the common units of measurement and the conversions between them. It is light-weight and thoroughly tested.</Description>

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
Fixes #853
This reverts commit c3b1297388ce209986c3b842deaa039b6b22b11d.

It was temporarily changed to `MIT` due to issues pushing nuget packages, rejected by nuget.org API.
Hopefully it was just a temporary fluke.

- Change nuget license from `MIT` to `MIT-0`
- Bump nuget versions to test if it works