### PR TITLE
Add B Units

### DIFF
--- a/Common/UnitDefinitions/Frequency.json
+++ b/Common/UnitDefinitions/Frequency.json
@@ -91,6 +91,18 @@
           "Abbreviations": [ "с⁻¹" ]
         }
       ]
+    },
+    {
+      "SingularName": "BUnit",
+      "PluralName": "BUnits",
+      "FromUnitToBaseFunc": "x * x * 1e-3",
+      "FromBaseToUnitFunc": "Math.Sqrt(x * 1e3)",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "B Units" ]
+        }
+      ]
     }
   ]
 }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToFrequencyExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToFrequencyExtensionsTest.g.cs
@@ -29,6 +29,10 @@ namespace UnitsNet.Tests
             Assert.Equal(Frequency.FromBeatsPerMinute(2), 2.BeatsPerMinute());
 
         [Fact]
+        public void NumberToBUnitsTest() =>
+            Assert.Equal(Frequency.FromBUnits(2), 2.BUnits());
+
+        [Fact]
         public void NumberToCyclesPerHourTest() =>
             Assert.Equal(Frequency.FromCyclesPerHour(2), 2.CyclesPerHour());
 

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToStandardVolumeFlowExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToStandardVolumeFlowExtensionsTest.g.cs
@@ -21,7 +21,7 @@ using UnitsNet.NumberExtensions.NumberToStandardVolumeFlow;
 using Xunit;
 
 namespace UnitsNet.Tests
-{    
+{
     public class NumberToStandardVolumeFlowExtensionsTests
     {
         [Fact]

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToFrequencyExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToFrequencyExtensions.g.cs
@@ -32,6 +32,10 @@ namespace UnitsNet.NumberExtensions.NumberToFrequency
         public static Frequency BeatsPerMinute<T>(this T value) =>
             Frequency.FromBeatsPerMinute(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Frequency.FromBUnits(UnitsNet.QuantityValue)" />
+        public static Frequency BUnits<T>(this T value) =>
+            Frequency.FromBUnits(Convert.ToDouble(value));
+
         /// <inheritdoc cref="Frequency.FromCyclesPerHour(UnitsNet.QuantityValue)" />
         public static Frequency CyclesPerHour<T>(this T value) =>
             Frequency.FromCyclesPerHour(Convert.ToDouble(value));

--- a/UnitsNet.Tests/CustomCode/FrequencyTests.cs
+++ b/UnitsNet.Tests/CustomCode/FrequencyTests.cs
@@ -28,6 +28,6 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double BeatsPerMinuteInOneHertz => 60;
 
-        protected override double BUnitsInOneHertz => Math.Sqrt(1000);
+        protected override double BUnitsInOneHertz => 31.622776601683793; // = Math.Sqrt(1000);
     }
 }

--- a/UnitsNet.Tests/CustomCode/FrequencyTests.cs
+++ b/UnitsNet.Tests/CustomCode/FrequencyTests.cs
@@ -24,8 +24,10 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double CyclesPerMinuteInOneHertz => 60;
 
-        protected override double RadiansPerSecondInOneHertz => 2*Math.PI;
+        protected override double RadiansPerSecondInOneHertz => 2 * Math.PI;
 
         protected override double BeatsPerMinuteInOneHertz => 60;
+
+        protected override double BUnitsInOneHertz => Math.Sqrt(1000);
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
@@ -38,6 +38,7 @@ namespace UnitsNet.Tests
     public abstract partial class FrequencyTestsBase : QuantityTestsBase
     {
         protected abstract double BeatsPerMinuteInOneHertz { get; }
+        protected abstract double BUnitsInOneHertz { get; }
         protected abstract double CyclesPerHourInOneHertz { get; }
         protected abstract double CyclesPerMinuteInOneHertz { get; }
         protected abstract double GigahertzInOneHertz { get; }
@@ -50,6 +51,7 @@ namespace UnitsNet.Tests
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double BeatsPerMinuteTolerance { get { return 1e-5; } }
+        protected virtual double BUnitsTolerance { get { return 1e-5; } }
         protected virtual double CyclesPerHourTolerance { get { return 1e-5; } }
         protected virtual double CyclesPerMinuteTolerance { get { return 1e-5; } }
         protected virtual double GigahertzTolerance { get { return 1e-5; } }
@@ -134,6 +136,7 @@ namespace UnitsNet.Tests
         {
             Frequency hertz = Frequency.FromHertz(1);
             AssertEx.EqualTolerance(BeatsPerMinuteInOneHertz, hertz.BeatsPerMinute, BeatsPerMinuteTolerance);
+            AssertEx.EqualTolerance(BUnitsInOneHertz, hertz.BUnits, BUnitsTolerance);
             AssertEx.EqualTolerance(CyclesPerHourInOneHertz, hertz.CyclesPerHour, CyclesPerHourTolerance);
             AssertEx.EqualTolerance(CyclesPerMinuteInOneHertz, hertz.CyclesPerMinute, CyclesPerMinuteTolerance);
             AssertEx.EqualTolerance(GigahertzInOneHertz, hertz.Gigahertz, GigahertzTolerance);
@@ -152,41 +155,45 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity00.BeatsPerMinute, BeatsPerMinuteTolerance);
             Assert.Equal(FrequencyUnit.BeatPerMinute, quantity00.Unit);
 
-            var quantity01 = Frequency.From(1, FrequencyUnit.CyclePerHour);
-            AssertEx.EqualTolerance(1, quantity01.CyclesPerHour, CyclesPerHourTolerance);
-            Assert.Equal(FrequencyUnit.CyclePerHour, quantity01.Unit);
+            var quantity01 = Frequency.From(1, FrequencyUnit.BUnit);
+            AssertEx.EqualTolerance(1, quantity01.BUnits, BUnitsTolerance);
+            Assert.Equal(FrequencyUnit.BUnit, quantity01.Unit);
 
-            var quantity02 = Frequency.From(1, FrequencyUnit.CyclePerMinute);
-            AssertEx.EqualTolerance(1, quantity02.CyclesPerMinute, CyclesPerMinuteTolerance);
-            Assert.Equal(FrequencyUnit.CyclePerMinute, quantity02.Unit);
+            var quantity02 = Frequency.From(1, FrequencyUnit.CyclePerHour);
+            AssertEx.EqualTolerance(1, quantity02.CyclesPerHour, CyclesPerHourTolerance);
+            Assert.Equal(FrequencyUnit.CyclePerHour, quantity02.Unit);
 
-            var quantity03 = Frequency.From(1, FrequencyUnit.Gigahertz);
-            AssertEx.EqualTolerance(1, quantity03.Gigahertz, GigahertzTolerance);
-            Assert.Equal(FrequencyUnit.Gigahertz, quantity03.Unit);
+            var quantity03 = Frequency.From(1, FrequencyUnit.CyclePerMinute);
+            AssertEx.EqualTolerance(1, quantity03.CyclesPerMinute, CyclesPerMinuteTolerance);
+            Assert.Equal(FrequencyUnit.CyclePerMinute, quantity03.Unit);
 
-            var quantity04 = Frequency.From(1, FrequencyUnit.Hertz);
-            AssertEx.EqualTolerance(1, quantity04.Hertz, HertzTolerance);
-            Assert.Equal(FrequencyUnit.Hertz, quantity04.Unit);
+            var quantity04 = Frequency.From(1, FrequencyUnit.Gigahertz);
+            AssertEx.EqualTolerance(1, quantity04.Gigahertz, GigahertzTolerance);
+            Assert.Equal(FrequencyUnit.Gigahertz, quantity04.Unit);
 
-            var quantity05 = Frequency.From(1, FrequencyUnit.Kilohertz);
-            AssertEx.EqualTolerance(1, quantity05.Kilohertz, KilohertzTolerance);
-            Assert.Equal(FrequencyUnit.Kilohertz, quantity05.Unit);
+            var quantity05 = Frequency.From(1, FrequencyUnit.Hertz);
+            AssertEx.EqualTolerance(1, quantity05.Hertz, HertzTolerance);
+            Assert.Equal(FrequencyUnit.Hertz, quantity05.Unit);
 
-            var quantity06 = Frequency.From(1, FrequencyUnit.Megahertz);
-            AssertEx.EqualTolerance(1, quantity06.Megahertz, MegahertzTolerance);
-            Assert.Equal(FrequencyUnit.Megahertz, quantity06.Unit);
+            var quantity06 = Frequency.From(1, FrequencyUnit.Kilohertz);
+            AssertEx.EqualTolerance(1, quantity06.Kilohertz, KilohertzTolerance);
+            Assert.Equal(FrequencyUnit.Kilohertz, quantity06.Unit);
 
-            var quantity07 = Frequency.From(1, FrequencyUnit.PerSecond);
-            AssertEx.EqualTolerance(1, quantity07.PerSecond, PerSecondTolerance);
-            Assert.Equal(FrequencyUnit.PerSecond, quantity07.Unit);
+            var quantity07 = Frequency.From(1, FrequencyUnit.Megahertz);
+            AssertEx.EqualTolerance(1, quantity07.Megahertz, MegahertzTolerance);
+            Assert.Equal(FrequencyUnit.Megahertz, quantity07.Unit);
 
-            var quantity08 = Frequency.From(1, FrequencyUnit.RadianPerSecond);
-            AssertEx.EqualTolerance(1, quantity08.RadiansPerSecond, RadiansPerSecondTolerance);
-            Assert.Equal(FrequencyUnit.RadianPerSecond, quantity08.Unit);
+            var quantity08 = Frequency.From(1, FrequencyUnit.PerSecond);
+            AssertEx.EqualTolerance(1, quantity08.PerSecond, PerSecondTolerance);
+            Assert.Equal(FrequencyUnit.PerSecond, quantity08.Unit);
 
-            var quantity09 = Frequency.From(1, FrequencyUnit.Terahertz);
-            AssertEx.EqualTolerance(1, quantity09.Terahertz, TerahertzTolerance);
-            Assert.Equal(FrequencyUnit.Terahertz, quantity09.Unit);
+            var quantity09 = Frequency.From(1, FrequencyUnit.RadianPerSecond);
+            AssertEx.EqualTolerance(1, quantity09.RadiansPerSecond, RadiansPerSecondTolerance);
+            Assert.Equal(FrequencyUnit.RadianPerSecond, quantity09.Unit);
+
+            var quantity10 = Frequency.From(1, FrequencyUnit.Terahertz);
+            AssertEx.EqualTolerance(1, quantity10.Terahertz, TerahertzTolerance);
+            Assert.Equal(FrequencyUnit.Terahertz, quantity10.Unit);
 
         }
 
@@ -208,6 +215,7 @@ namespace UnitsNet.Tests
         {
             var hertz = Frequency.FromHertz(1);
             AssertEx.EqualTolerance(BeatsPerMinuteInOneHertz, hertz.As(FrequencyUnit.BeatPerMinute), BeatsPerMinuteTolerance);
+            AssertEx.EqualTolerance(BUnitsInOneHertz, hertz.As(FrequencyUnit.BUnit), BUnitsTolerance);
             AssertEx.EqualTolerance(CyclesPerHourInOneHertz, hertz.As(FrequencyUnit.CyclePerHour), CyclesPerHourTolerance);
             AssertEx.EqualTolerance(CyclesPerMinuteInOneHertz, hertz.As(FrequencyUnit.CyclePerMinute), CyclesPerMinuteTolerance);
             AssertEx.EqualTolerance(GigahertzInOneHertz, hertz.As(FrequencyUnit.Gigahertz), GigahertzTolerance);
@@ -244,6 +252,10 @@ namespace UnitsNet.Tests
             var beatperminuteQuantity = hertz.ToUnit(FrequencyUnit.BeatPerMinute);
             AssertEx.EqualTolerance(BeatsPerMinuteInOneHertz, (double)beatperminuteQuantity.Value, BeatsPerMinuteTolerance);
             Assert.Equal(FrequencyUnit.BeatPerMinute, beatperminuteQuantity.Unit);
+
+            var bunitQuantity = hertz.ToUnit(FrequencyUnit.BUnit);
+            AssertEx.EqualTolerance(BUnitsInOneHertz, (double)bunitQuantity.Value, BUnitsTolerance);
+            Assert.Equal(FrequencyUnit.BUnit, bunitQuantity.Unit);
 
             var cycleperhourQuantity = hertz.ToUnit(FrequencyUnit.CyclePerHour);
             AssertEx.EqualTolerance(CyclesPerHourInOneHertz, (double)cycleperhourQuantity.Value, CyclesPerHourTolerance);
@@ -294,6 +306,7 @@ namespace UnitsNet.Tests
         {
             Frequency hertz = Frequency.FromHertz(1);
             AssertEx.EqualTolerance(1, Frequency.FromBeatsPerMinute(hertz.BeatsPerMinute).Hertz, BeatsPerMinuteTolerance);
+            AssertEx.EqualTolerance(1, Frequency.FromBUnits(hertz.BUnits).Hertz, BUnitsTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromCyclesPerHour(hertz.CyclesPerHour).Hertz, CyclesPerHourTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromCyclesPerMinute(hertz.CyclesPerMinute).Hertz, CyclesPerMinuteTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromGigahertz(hertz.Gigahertz).Hertz, GigahertzTolerance);
@@ -460,6 +473,7 @@ namespace UnitsNet.Tests
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
             try {
                 Assert.Equal("1 bpm", new Frequency(1, FrequencyUnit.BeatPerMinute).ToString());
+                Assert.Equal("1 B Units", new Frequency(1, FrequencyUnit.BUnit).ToString());
                 Assert.Equal("1 cph", new Frequency(1, FrequencyUnit.CyclePerHour).ToString());
                 Assert.Equal("1 cpm", new Frequency(1, FrequencyUnit.CyclePerMinute).ToString());
                 Assert.Equal("1 GHz", new Frequency(1, FrequencyUnit.Gigahertz).ToString());
@@ -483,6 +497,7 @@ namespace UnitsNet.Tests
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
             Assert.Equal("1 bpm", new Frequency(1, FrequencyUnit.BeatPerMinute).ToString(swedishCulture));
+            Assert.Equal("1 B Units", new Frequency(1, FrequencyUnit.BUnit).ToString(swedishCulture));
             Assert.Equal("1 cph", new Frequency(1, FrequencyUnit.CyclePerHour).ToString(swedishCulture));
             Assert.Equal("1 cpm", new Frequency(1, FrequencyUnit.CyclePerMinute).ToString(swedishCulture));
             Assert.Equal("1 GHz", new Frequency(1, FrequencyUnit.Gigahertz).ToString(swedishCulture));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
@@ -657,6 +657,13 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void Convert_ChangeType_QuantityInfo_EqualsQuantityInfo()
+        {
+            var quantity = StandardVolumeFlow.FromStandardCubicMetersPerSecond(1.0);
+            Assert.Equal(StandardVolumeFlow.Info, Convert.ChangeType(quantity, typeof(QuantityInfo)));
+        }
+
+        [Fact]
         public void Convert_ChangeType_BaseDimensions_EqualsBaseDimensions()
         {
             var quantity = StandardVolumeFlow.FromStandardCubicMetersPerSecond(1.0);
@@ -674,7 +681,7 @@ namespace UnitsNet.Tests
         public void GetHashCode_Equals()
         {
             var quantity = StandardVolumeFlow.FromStandardCubicMetersPerSecond(1.0);
-            Assert.Equal(new {StandardVolumeFlow.QuantityType, quantity.Value, quantity.Unit}.GetHashCode(), quantity.GetHashCode());
+            Assert.Equal(new {StandardVolumeFlow.Info.Name, quantity.Value, quantity.Unit}.GetHashCode(), quantity.GetHashCode());
         }
 
         [Theory]

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.g.cs
@@ -161,6 +161,11 @@ namespace UnitsNet
         public double BeatsPerMinute => As(FrequencyUnit.BeatPerMinute);
 
         /// <summary>
+        ///     Get Frequency in BUnits.
+        /// </summary>
+        public double BUnits => As(FrequencyUnit.BUnit);
+
+        /// <summary>
         ///     Get Frequency in CyclesPerHour.
         /// </summary>
         public double CyclesPerHour => As(FrequencyUnit.CyclePerHour);
@@ -244,6 +249,16 @@ namespace UnitsNet
         {
             double value = (double) beatsperminute;
             return new Frequency(value, FrequencyUnit.BeatPerMinute);
+        }
+        /// <summary>
+        ///     Get Frequency from BUnits.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Frequency FromBUnits(double bunits)
+        {
+            double value = (double) bunits;
+            return new Frequency(value, FrequencyUnit.BUnit);
         }
         /// <summary>
         ///     Get Frequency from CyclesPerHour.
@@ -627,6 +642,7 @@ namespace UnitsNet
             switch(Unit)
             {
                 case FrequencyUnit.BeatPerMinute: return _value/60;
+                case FrequencyUnit.BUnit: return _value * _value * 1e-3;
                 case FrequencyUnit.CyclePerHour: return _value/3600;
                 case FrequencyUnit.CyclePerMinute: return _value/60;
                 case FrequencyUnit.Gigahertz: return (_value) * 1e9d;
@@ -651,6 +667,7 @@ namespace UnitsNet
             switch(unit)
             {
                 case FrequencyUnit.BeatPerMinute: return baseUnitValue*60;
+                case FrequencyUnit.BUnit: return Math.Sqrt(baseUnitValue * 1e3);
                 case FrequencyUnit.CyclePerHour: return baseUnitValue*3600;
                 case FrequencyUnit.CyclePerMinute: return baseUnitValue*60;
                 case FrequencyUnit.Gigahertz: return (baseUnitValue) / 1e9d;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -517,6 +517,7 @@ namespace UnitsNet
                 ("en-US", typeof(ForcePerLengthUnit), (int)ForcePerLengthUnit.TonneForcePerMillimeter, new string[]{"tf/mm"}),
                 ("ru-RU", typeof(ForcePerLengthUnit), (int)ForcePerLengthUnit.TonneForcePerMillimeter, new string[]{"тс/мм"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.BeatPerMinute, new string[]{"bpm"}),
+                ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.BUnit, new string[]{"B Units"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.CyclePerHour, new string[]{"cph"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.CyclePerMinute, new string[]{"cpm"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Gigahertz, new string[]{"GHz"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -27,6 +27,7 @@ namespace UnitsNet.Units
     {
         Undefined = 0,
         BeatPerMinute,
+        BUnit,
         CyclePerHour,
         CyclePerMinute,
         Gigahertz,

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -53,6 +53,7 @@ namespace UnitsNet
             Info = new QuantityInfo<FrequencyUnit>("Frequency",
                 new UnitInfo<FrequencyUnit>[] {
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.BeatPerMinute, BaseUnits.Undefined),
+                    new UnitInfo<FrequencyUnit>(FrequencyUnit.BUnit, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.CyclePerHour, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.CyclePerMinute, BaseUnits.Undefined),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.Gigahertz, BaseUnits.Undefined),
@@ -183,6 +184,11 @@ namespace UnitsNet
         public double BeatsPerMinute => As(FrequencyUnit.BeatPerMinute);
 
         /// <summary>
+        ///     Get Frequency in BUnits.
+        /// </summary>
+        public double BUnits => As(FrequencyUnit.BUnit);
+
+        /// <summary>
         ///     Get Frequency in CyclesPerHour.
         /// </summary>
         public double CyclesPerHour => As(FrequencyUnit.CyclePerHour);
@@ -264,6 +270,15 @@ namespace UnitsNet
         {
             double value = (double) beatsperminute;
             return new Frequency(value, FrequencyUnit.BeatPerMinute);
+        }
+        /// <summary>
+        ///     Get Frequency from BUnits.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Frequency FromBUnits(QuantityValue bunits)
+        {
+            double value = (double) bunits;
+            return new Frequency(value, FrequencyUnit.BUnit);
         }
         /// <summary>
         ///     Get Frequency from CyclesPerHour.
@@ -776,6 +791,7 @@ namespace UnitsNet
             switch(Unit)
             {
                 case FrequencyUnit.BeatPerMinute: return _value/60;
+                case FrequencyUnit.BUnit: return _value * _value * 1e-3;
                 case FrequencyUnit.CyclePerHour: return _value/3600;
                 case FrequencyUnit.CyclePerMinute: return _value/60;
                 case FrequencyUnit.Gigahertz: return (_value) * 1e9d;
@@ -811,6 +827,7 @@ namespace UnitsNet
             switch(unit)
             {
                 case FrequencyUnit.BeatPerMinute: return baseUnitValue*60;
+                case FrequencyUnit.BUnit: return Math.Sqrt(baseUnitValue * 1e3);
                 case FrequencyUnit.CyclePerHour: return baseUnitValue*3600;
                 case FrequencyUnit.CyclePerMinute: return baseUnitValue*60;
                 case FrequencyUnit.Gigahertz: return (baseUnitValue) / 1e9d;

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -109,11 +109,13 @@ namespace UnitsNet
         /// <summary>
         /// Represents the largest possible value of Scalar
         /// </summary>
+        [Obsolete("MaxValue and MinValue will be removed. Choose your own value or use nullability for unbounded lower/upper range checks. See discussion in https://github.com/angularsen/UnitsNet/issues/848.")]
         public static Scalar MaxValue { get; } = new Scalar(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of Scalar
         /// </summary>
+        [Obsolete("MaxValue and MinValue will be removed. Choose your own value or use nullability for unbounded lower/upper range checks. See discussion in https://github.com/angularsen/UnitsNet/issues/848.")]
         public static Scalar MinValue { get; } = new Scalar(double.MinValue, BaseUnit);
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -50,7 +50,7 @@ namespace UnitsNet
         {
             BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
 
-            Info = new QuantityInfo<StandardVolumeFlowUnit>(QuantityType.StandardVolumeFlow,
+            Info = new QuantityInfo<StandardVolumeFlowUnit>("StandardVolumeFlow",
                 new UnitInfo<StandardVolumeFlowUnit>[] {
                     new UnitInfo<StandardVolumeFlowUnit>(StandardVolumeFlowUnit.StandardCubicCentimeterPerMinute, BaseUnits.Undefined),
                     new UnitInfo<StandardVolumeFlowUnit>(StandardVolumeFlowUnit.StandardCubicFootPerHour, BaseUnits.Undefined),
@@ -62,7 +62,7 @@ namespace UnitsNet
                     new UnitInfo<StandardVolumeFlowUnit>(StandardVolumeFlowUnit.StandardCubicMeterPerSecond, BaseUnits.Undefined),
                     new UnitInfo<StandardVolumeFlowUnit>(StandardVolumeFlowUnit.StandardLiterPerMinute, BaseUnits.Undefined),
                 },
-                BaseUnit, Zero, BaseDimensions);
+                BaseUnit, Zero, BaseDimensions, QuantityType.StandardVolumeFlow);
         }
 
         /// <summary>
@@ -117,16 +117,19 @@ namespace UnitsNet
         /// <summary>
         /// Represents the largest possible value of StandardVolumeFlow
         /// </summary>
+        [Obsolete("MaxValue and MinValue will be removed. Choose your own value or use nullability for unbounded lower/upper range checks. See discussion in https://github.com/angularsen/UnitsNet/issues/848.")]
         public static StandardVolumeFlow MaxValue { get; } = new StandardVolumeFlow(double.MaxValue, BaseUnit);
 
         /// <summary>
         /// Represents the smallest possible value of StandardVolumeFlow
         /// </summary>
+        [Obsolete("MaxValue and MinValue will be removed. Choose your own value or use nullability for unbounded lower/upper range checks. See discussion in https://github.com/angularsen/UnitsNet/issues/848.")]
         public static StandardVolumeFlow MinValue { get; } = new StandardVolumeFlow(double.MinValue, BaseUnit);
 
         /// <summary>
         ///     The <see cref="QuantityType" /> of this quantity.
         /// </summary>
+        [Obsolete("QuantityType will be removed in the future. Use Info property instead.")]
         public static QuantityType QuantityType { get; } = QuantityType.StandardVolumeFlow;
 
         /// <summary>
@@ -661,7 +664,7 @@ namespace UnitsNet
         /// <returns>A hash code for the current StandardVolumeFlow.</returns>
         public override int GetHashCode()
         {
-            return new { QuantityType, Value, Unit }.GetHashCode();
+            return new { Info.Name, Value, Unit }.GetHashCode();
         }
 
         #endregion
@@ -962,6 +965,8 @@ namespace UnitsNet
                 return Unit;
             else if(conversionType == typeof(QuantityType))
                 return StandardVolumeFlow.QuantityType;
+            else if(conversionType == typeof(QuantityInfo))
+                return StandardVolumeFlow.Info;
             else if(conversionType == typeof(BaseDimensions))
                 return StandardVolumeFlow.BaseDimensions;
             else

--- a/UnitsNet/GeneratedCode/Quantity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantity.g.cs
@@ -129,6 +129,7 @@ namespace UnitsNet
             { "SpecificVolume", SpecificVolume.Info },
             { "SpecificWeight", SpecificWeight.Info },
             { "Speed", Speed.Info },
+            { "StandardVolumeFlow", StandardVolumeFlow.Info },
             { "Temperature", Temperature.Info },
             { "TemperatureChangeRate", TemperatureChangeRate.Info },
             { "TemperatureDelta", TemperatureDelta.Info },
@@ -240,6 +241,7 @@ namespace UnitsNet
             { "SpecificVolume", QuantityType.SpecificVolume },
             { "SpecificWeight", QuantityType.SpecificWeight },
             { "Speed", QuantityType.Speed },
+            { "StandardVolumeFlow", QuantityType.StandardVolumeFlow },
             { "Temperature", QuantityType.Temperature },
             { "TemperatureChangeRate", QuantityType.TemperatureChangeRate },
             { "TemperatureDelta", QuantityType.TemperatureDelta },
@@ -676,6 +678,8 @@ namespace UnitsNet
                     return SpecificWeight.From(value, SpecificWeight.BaseUnit);
                 case "Speed":
                     return Speed.From(value, Speed.BaseUnit);
+                case "StandardVolumeFlow":
+                    return StandardVolumeFlow.From(value, StandardVolumeFlow.BaseUnit);
                 case "Temperature":
                     return Temperature.From(value, Temperature.BaseUnit);
                 case "TemperatureChangeRate":

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -517,6 +517,7 @@ namespace UnitsNet
                 ("en-US", typeof(ForcePerLengthUnit), (int)ForcePerLengthUnit.TonneForcePerMillimeter, new string[]{"tf/mm"}),
                 ("ru-RU", typeof(ForcePerLengthUnit), (int)ForcePerLengthUnit.TonneForcePerMillimeter, new string[]{"тс/мм"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.BeatPerMinute, new string[]{"bpm"}),
+                ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.BUnit, new string[]{"B Units"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.CyclePerHour, new string[]{"cph"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.CyclePerMinute, new string[]{"cpm"}),
                 ("en-US", typeof(FrequencyUnit), (int)FrequencyUnit.Gigahertz, new string[]{"GHz"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -746,6 +746,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<ForcePerLength>(ForcePerLengthUnit.TonneForcePerMillimeter, ForcePerLength.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.BeatPerMinute, q => q.ToUnit(FrequencyUnit.BeatPerMinute));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.BeatPerMinute, Frequency.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.BUnit, q => q.ToUnit(FrequencyUnit.BUnit));
+            unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.BUnit, Frequency.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.CyclePerHour, q => q.ToUnit(FrequencyUnit.CyclePerHour));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.CyclePerHour, Frequency.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Frequency>(Frequency.BaseUnit, FrequencyUnit.CyclePerMinute, q => q.ToUnit(FrequencyUnit.CyclePerMinute));

--- a/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -27,6 +27,7 @@ namespace UnitsNet.Units
     {
         Undefined = 0,
         BeatPerMinute,
+        BUnit,
         CyclePerHour,
         CyclePerMinute,
         Gigahertz,


### PR DESCRIPTION
"B Unit" is a geotechnical industry term used by a number of companies (Geokon, Geosense, RST Instruments, Sisgeo). B Units = Frequency² / 1000.  Whereas the concept is relatively common in the industry, there isn't a consensus in naming.
- Geokon refers to the unit as "digits" on the B display
- Geosense uses "B" as their unit
- RST Instruments referes to "B-Units"
- Sisgeo calls them digits
We chose "B Units", but we're certainly open to other options.

P.S.  I don't know why changes to "Standard Volume Flow" showed up in the gen.  The only significant changes are "Frequency.json" and "FrequencyTests.cs".