### PR TITLE
Add implicit cast to double for Scalar.

### DIFF
--- a/UnitsNet.Tests/CustomCode/ScalarTests.cs
+++ b/UnitsNet.Tests/CustomCode/ScalarTests.cs
@@ -27,6 +27,17 @@ namespace UnitsNet.Tests.CustomCode
         // Override properties in base class here
         protected override double AmountInOneAmount => 1;
         protected override bool SupportsSIUnitSystem => false;
-       
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1.0)]
+        [InlineData(-Math.PI)]
+        public void ImplicitCast_ToDouble_IsAmount(double amount)
+        {
+            var scalar = Scalar.FromAmount(amount);
+            double asDouble = scalar;
+
+            Assert.Equal(asDouble, scalar.Amount);
+        }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Scalar.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Scalar.extra.cs
@@ -1,0 +1,14 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+namespace UnitsNet
+{
+    public partial struct Scalar
+    {
+        /// <summary>Defines an implicit conversion of a <see cref="Scalar"/> to a <see cref="double"/>.</summary>
+        public static implicit operator double(Scalar scalar)
+        {
+            return scalar.Amount;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #897 
Allows Scalar to be used in arithmetic operations with other quantities #897 .