### PR TITLE
Fix deserializing decimal quantities regardless of local culture

### DIFF
--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetBaseJsonConverterTest.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetBaseJsonConverterTest.cs
@@ -239,7 +239,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
                 var result = ConvertIQuantity(value);
                 if (result is ExtendedValueUnit {ValueType: "decimal"} decimalResult)
                 {
-                    return (result.Unit, decimal.Parse(decimalResult.ValueString));
+                    return (result.Unit, decimal.Parse(decimalResult.ValueString, CultureInfo.InvariantCulture));
                 }
 
                 throw new ArgumentException("The quantity does not have a decimal value", nameof(value));
@@ -274,7 +274,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
                 if (result is ExtendedValueUnit {ValueType: "decimal"} decimalResult)
                 {
-                    return (result.Unit, decimal.Parse(decimalResult.ValueString));
+                    return (result.Unit, decimal.Parse(decimalResult.ValueString, CultureInfo.InvariantCulture));
                 }
 
                 return null;

--- a/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
@@ -82,7 +82,7 @@ namespace UnitsNet.Serialization.JsonNet
 
             return valueUnit switch
             {
-                ExtendedValueUnit {ValueType: "decimal"} extendedValueUnit => Quantity.From(decimal.Parse(extendedValueUnit.ValueString), unit),
+                ExtendedValueUnit {ValueType: "decimal"} extendedValueUnit => Quantity.From(decimal.Parse(extendedValueUnit.ValueString, CultureInfo.InvariantCulture), unit),
                 _ => Quantity.From(valueUnit.Value, unit)
             };
         }


### PR DESCRIPTION
Fixes parsing JSON for decimal quantities like Power on machines with cultures like Norwegian, where a comma is decimal separator is used. Several tests were red on my machine, but green on build agent.

Related to #847, #868