### PR TITLE
Trim ToString() for units without abbreviation

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
@@ -31,7 +31,7 @@ namespace CodeGen.Generators.UnitsNetGen
         private readonly string _unitEnumName;
 
         /// <summary>
-        /// Example: "m" for Length quantity.
+        /// Example: " m" for Length quantity with leading whitespace or "" for Ratio quantity where base unit does not have an abbreviation.
         /// </summary>
         private readonly string _baseUnitEnglishAbbreviation;
 
@@ -61,8 +61,13 @@ namespace CodeGen.Generators.UnitsNetGen
 
         /// <summary>
         /// Gets the first en-US abbreviation for the unit -or- empty string if none is defined.
+        /// If a unit abbreviation exists, a leading whitespace is added to separate the number and the abbreviation like "1 m".
         /// </summary>
-        private static string GetEnglishAbbreviation(Unit unit) => unit.Localization.First(l => l.Culture == "en-US").Abbreviations.FirstOrDefault() ?? "";
+        private static string GetEnglishAbbreviation(Unit unit)
+        {
+            var unitAbbreviation = unit.Localization.First(l => l.Culture == "en-US").Abbreviations.FirstOrDefault();
+            return string.IsNullOrEmpty(unitAbbreviation) ? "" : $" {unitAbbreviation}";
+        }
 
         public override string Generate()
         {
@@ -464,7 +469,7 @@ namespace UnitsNet.Tests
             foreach (var unit in _quantity.Units)
             {
                 Writer.WL($@"
-                Assert.Equal(""1 {GetEnglishAbbreviation(unit)}"", new {_quantity.Name}(1, {GetUnitFullName(unit)}).ToString());");
+                Assert.Equal(""1{GetEnglishAbbreviation(unit)}"", new {_quantity.Name}(1, {GetUnitFullName(unit)}).ToString());");
             }
             Writer.WL($@"
             }}
@@ -483,7 +488,7 @@ namespace UnitsNet.Tests
             foreach (var unit in _quantity.Units)
             {
                 Writer.WL($@"
-            Assert.Equal(""1 {GetEnglishAbbreviation(unit)}"", new {_quantity.Name}(1, {GetUnitFullName(unit)}).ToString(swedishCulture));");
+            Assert.Equal(""1{GetEnglishAbbreviation(unit)}"", new {_quantity.Name}(1, {GetUnitFullName(unit)}).ToString(swedishCulture));");
             }
             Writer.WL($@"
         }}
@@ -495,10 +500,10 @@ namespace UnitsNet.Tests
             try
             {{
                 CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-                Assert.Equal(""0.1 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s1""));
-                Assert.Equal(""0.12 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s2""));
-                Assert.Equal(""0.123 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s3""));
-                Assert.Equal(""0.1235 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s4""));
+                Assert.Equal(""0.1{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s1""));
+                Assert.Equal(""0.12{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s2""));
+                Assert.Equal(""0.123{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s3""));
+                Assert.Equal(""0.1235{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s4""));
             }}
             finally
             {{
@@ -510,10 +515,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {{
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal(""0.1 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s1"", culture));
-            Assert.Equal(""0.12 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s2"", culture));
-            Assert.Equal(""0.123 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s3"", culture));
-            Assert.Equal(""0.1235 {_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s4"", culture));
+            Assert.Equal(""0.1{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s1"", culture));
+            Assert.Equal(""0.12{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s2"", culture));
+            Assert.Equal(""0.123{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s3"", culture));
+            Assert.Equal(""0.1235{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456{_numberSuffix}, {_baseUnitFullName}).ToString(""s4"", culture));
         }}
 
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
@@ -647,7 +647,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 dag/kg", new MassFraction(1, MassFractionUnit.DecagramPerKilogram).ToString());
                 Assert.Equal("1 dg/g", new MassFraction(1, MassFractionUnit.DecigramPerGram).ToString());
                 Assert.Equal("1 dg/kg", new MassFraction(1, MassFractionUnit.DecigramPerKilogram).ToString());
-                Assert.Equal("1 ", new MassFraction(1, MassFractionUnit.DecimalFraction).ToString());
+                Assert.Equal("1", new MassFraction(1, MassFractionUnit.DecimalFraction).ToString());
                 Assert.Equal("1 g/g", new MassFraction(1, MassFractionUnit.GramPerGram).ToString());
                 Assert.Equal("1 g/kg", new MassFraction(1, MassFractionUnit.GramPerKilogram).ToString());
                 Assert.Equal("1 hg/g", new MassFraction(1, MassFractionUnit.HectogramPerGram).ToString());
@@ -684,7 +684,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 dag/kg", new MassFraction(1, MassFractionUnit.DecagramPerKilogram).ToString(swedishCulture));
             Assert.Equal("1 dg/g", new MassFraction(1, MassFractionUnit.DecigramPerGram).ToString(swedishCulture));
             Assert.Equal("1 dg/kg", new MassFraction(1, MassFractionUnit.DecigramPerKilogram).ToString(swedishCulture));
-            Assert.Equal("1 ", new MassFraction(1, MassFractionUnit.DecimalFraction).ToString(swedishCulture));
+            Assert.Equal("1", new MassFraction(1, MassFractionUnit.DecimalFraction).ToString(swedishCulture));
             Assert.Equal("1 g/g", new MassFraction(1, MassFractionUnit.GramPerGram).ToString(swedishCulture));
             Assert.Equal("1 g/kg", new MassFraction(1, MassFractionUnit.GramPerKilogram).ToString(swedishCulture));
             Assert.Equal("1 hg/g", new MassFraction(1, MassFractionUnit.HectogramPerGram).ToString(swedishCulture));
@@ -711,10 +711,10 @@ namespace UnitsNet.Tests
             try
             {
                 CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-                Assert.Equal("0.1 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s1"));
-                Assert.Equal("0.12 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s2"));
-                Assert.Equal("0.123 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s3"));
-                Assert.Equal("0.1235 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s4"));
+                Assert.Equal("0.1", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s1"));
+                Assert.Equal("0.12", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s2"));
+                Assert.Equal("0.123", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s3"));
+                Assert.Equal("0.1235", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s4"));
             }
             finally
             {
@@ -726,10 +726,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s1", culture));
-            Assert.Equal("0.12 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s2", culture));
-            Assert.Equal("0.123 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s3", culture));
-            Assert.Equal("0.1235 ", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s4", culture));
+            Assert.Equal("0.1", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s1", culture));
+            Assert.Equal("0.12", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s2", culture));
+            Assert.Equal("0.123", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s3", culture));
+            Assert.Equal("0.1235", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s4", culture));
         }
 
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
@@ -407,7 +407,7 @@ namespace UnitsNet.Tests
             var prevCulture = Thread.CurrentThread.CurrentUICulture;
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
             try {
-                Assert.Equal("1 ", new Ratio(1, RatioUnit.DecimalFraction).ToString());
+                Assert.Equal("1", new Ratio(1, RatioUnit.DecimalFraction).ToString());
                 Assert.Equal("1 ppb", new Ratio(1, RatioUnit.PartPerBillion).ToString());
                 Assert.Equal("1 ppm", new Ratio(1, RatioUnit.PartPerMillion).ToString());
                 Assert.Equal("1 ‰", new Ratio(1, RatioUnit.PartPerThousand).ToString());
@@ -426,7 +426,7 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
-            Assert.Equal("1 ", new Ratio(1, RatioUnit.DecimalFraction).ToString(swedishCulture));
+            Assert.Equal("1", new Ratio(1, RatioUnit.DecimalFraction).ToString(swedishCulture));
             Assert.Equal("1 ppb", new Ratio(1, RatioUnit.PartPerBillion).ToString(swedishCulture));
             Assert.Equal("1 ppm", new Ratio(1, RatioUnit.PartPerMillion).ToString(swedishCulture));
             Assert.Equal("1 ‰", new Ratio(1, RatioUnit.PartPerThousand).ToString(swedishCulture));
@@ -441,10 +441,10 @@ namespace UnitsNet.Tests
             try
             {
                 CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-                Assert.Equal("0.1 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s1"));
-                Assert.Equal("0.12 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s2"));
-                Assert.Equal("0.123 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s3"));
-                Assert.Equal("0.1235 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s4"));
+                Assert.Equal("0.1", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s1"));
+                Assert.Equal("0.12", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s2"));
+                Assert.Equal("0.123", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s3"));
+                Assert.Equal("0.1235", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s4"));
             }
             finally
             {
@@ -456,10 +456,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s1", culture));
-            Assert.Equal("0.12 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s2", culture));
-            Assert.Equal("0.123 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s3", culture));
-            Assert.Equal("0.1235 ", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s4", culture));
+            Assert.Equal("0.1", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s1", culture));
+            Assert.Equal("0.12", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s2", culture));
+            Assert.Equal("0.123", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s3", culture));
+            Assert.Equal("0.1235", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s4", culture));
         }
 
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
@@ -342,7 +342,7 @@ namespace UnitsNet.Tests
             var prevCulture = Thread.CurrentThread.CurrentUICulture;
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
             try {
-                Assert.Equal("1 ", new Scalar(1, ScalarUnit.Amount).ToString());
+                Assert.Equal("1", new Scalar(1, ScalarUnit.Amount).ToString());
             }
             finally
             {
@@ -356,7 +356,7 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
-            Assert.Equal("1 ", new Scalar(1, ScalarUnit.Amount).ToString(swedishCulture));
+            Assert.Equal("1", new Scalar(1, ScalarUnit.Amount).ToString(swedishCulture));
         }
 
         [Fact]
@@ -366,10 +366,10 @@ namespace UnitsNet.Tests
             try
             {
                 CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-                Assert.Equal("0.1 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s1"));
-                Assert.Equal("0.12 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s2"));
-                Assert.Equal("0.123 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s3"));
-                Assert.Equal("0.1235 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s4"));
+                Assert.Equal("0.1", new Scalar(0.123456, ScalarUnit.Amount).ToString("s1"));
+                Assert.Equal("0.12", new Scalar(0.123456, ScalarUnit.Amount).ToString("s2"));
+                Assert.Equal("0.123", new Scalar(0.123456, ScalarUnit.Amount).ToString("s3"));
+                Assert.Equal("0.1235", new Scalar(0.123456, ScalarUnit.Amount).ToString("s4"));
             }
             finally
             {
@@ -381,10 +381,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s1", culture));
-            Assert.Equal("0.12 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s2", culture));
-            Assert.Equal("0.123 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s3", culture));
-            Assert.Equal("0.1235 ", new Scalar(0.123456, ScalarUnit.Amount).ToString("s4", culture));
+            Assert.Equal("0.1", new Scalar(0.123456, ScalarUnit.Amount).ToString("s1", culture));
+            Assert.Equal("0.12", new Scalar(0.123456, ScalarUnit.Amount).ToString("s2", culture));
+            Assert.Equal("0.123", new Scalar(0.123456, ScalarUnit.Amount).ToString("s3", culture));
+            Assert.Equal("0.1235", new Scalar(0.123456, ScalarUnit.Amount).ToString("s4", culture));
         }
 
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
@@ -593,7 +593,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 cL/mL", new VolumeConcentration(1, VolumeConcentrationUnit.CentilitersPerMililiter).ToString());
                 Assert.Equal("1 dL/L", new VolumeConcentration(1, VolumeConcentrationUnit.DecilitersPerLiter).ToString());
                 Assert.Equal("1 dL/mL", new VolumeConcentration(1, VolumeConcentrationUnit.DecilitersPerMililiter).ToString());
-                Assert.Equal("1 ", new VolumeConcentration(1, VolumeConcentrationUnit.DecimalFraction).ToString());
+                Assert.Equal("1", new VolumeConcentration(1, VolumeConcentrationUnit.DecimalFraction).ToString());
                 Assert.Equal("1 L/L", new VolumeConcentration(1, VolumeConcentrationUnit.LitersPerLiter).ToString());
                 Assert.Equal("1 L/mL", new VolumeConcentration(1, VolumeConcentrationUnit.LitersPerMililiter).ToString());
                 Assert.Equal("1 µL/L", new VolumeConcentration(1, VolumeConcentrationUnit.MicrolitersPerLiter).ToString());
@@ -626,7 +626,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 cL/mL", new VolumeConcentration(1, VolumeConcentrationUnit.CentilitersPerMililiter).ToString(swedishCulture));
             Assert.Equal("1 dL/L", new VolumeConcentration(1, VolumeConcentrationUnit.DecilitersPerLiter).ToString(swedishCulture));
             Assert.Equal("1 dL/mL", new VolumeConcentration(1, VolumeConcentrationUnit.DecilitersPerMililiter).ToString(swedishCulture));
-            Assert.Equal("1 ", new VolumeConcentration(1, VolumeConcentrationUnit.DecimalFraction).ToString(swedishCulture));
+            Assert.Equal("1", new VolumeConcentration(1, VolumeConcentrationUnit.DecimalFraction).ToString(swedishCulture));
             Assert.Equal("1 L/L", new VolumeConcentration(1, VolumeConcentrationUnit.LitersPerLiter).ToString(swedishCulture));
             Assert.Equal("1 L/mL", new VolumeConcentration(1, VolumeConcentrationUnit.LitersPerMililiter).ToString(swedishCulture));
             Assert.Equal("1 µL/L", new VolumeConcentration(1, VolumeConcentrationUnit.MicrolitersPerLiter).ToString(swedishCulture));
@@ -651,10 +651,10 @@ namespace UnitsNet.Tests
             try
             {
                 CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
-                Assert.Equal("0.1 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s1"));
-                Assert.Equal("0.12 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s2"));
-                Assert.Equal("0.123 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s3"));
-                Assert.Equal("0.1235 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s4"));
+                Assert.Equal("0.1", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s1"));
+                Assert.Equal("0.12", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s2"));
+                Assert.Equal("0.123", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s3"));
+                Assert.Equal("0.1235", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s4"));
             }
             finally
             {
@@ -666,10 +666,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s1", culture));
-            Assert.Equal("0.12 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s2", culture));
-            Assert.Equal("0.123 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s3", culture));
-            Assert.Equal("0.1235 ", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s4", culture));
+            Assert.Equal("0.1", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s1", culture));
+            Assert.Equal("0.12", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s2", culture));
+            Assert.Equal("0.123", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s3", culture));
+            Assert.Equal("0.1235", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s4", culture));
         }
 
 

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
@@ -993,7 +993,7 @@ namespace UnitsNet.Tests
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
             try {
                 Assert.Equal("1 ac-ft", new Volume(1, VolumeUnit.AcreFoot).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.AuTablespoon).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.AuTablespoon).ToString());
                 Assert.Equal("1 bf", new Volume(1, VolumeUnit.BoardFoot).ToString());
                 Assert.Equal("1 cl", new Volume(1, VolumeUnit.Centiliter).ToString());
                 Assert.Equal("1 cm³", new Volume(1, VolumeUnit.CubicCentimeter).ToString());
@@ -1028,21 +1028,21 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 Mgal (imp.)", new Volume(1, VolumeUnit.MegaimperialGallon).ToString());
                 Assert.Equal("1 Ml", new Volume(1, VolumeUnit.Megaliter).ToString());
                 Assert.Equal("1 Mgal (U.S.)", new Volume(1, VolumeUnit.MegausGallon).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.MetricCup).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.MetricCup).ToString());
                 Assert.Equal("1 tsp", new Volume(1, VolumeUnit.MetricTeaspoon).ToString());
                 Assert.Equal("1 µl", new Volume(1, VolumeUnit.Microliter).ToString());
                 Assert.Equal("1 ml", new Volume(1, VolumeUnit.Milliliter).ToString());
                 Assert.Equal("1 bbl", new Volume(1, VolumeUnit.OilBarrel).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.UkTablespoon).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.UkTablespoon).ToString());
                 Assert.Equal("1 bl (U.S.)", new Volume(1, VolumeUnit.UsBeerBarrel).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.UsCustomaryCup).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.UsCustomaryCup).ToString());
                 Assert.Equal("1 gal (U.S.)", new Volume(1, VolumeUnit.UsGallon).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.UsLegalCup).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.UsLegalCup).ToString());
                 Assert.Equal("1 oz (U.S.)", new Volume(1, VolumeUnit.UsOunce).ToString());
                 Assert.Equal("1 pt (U.S.)", new Volume(1, VolumeUnit.UsPint).ToString());
                 Assert.Equal("1 qt (U.S.)", new Volume(1, VolumeUnit.UsQuart).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.UsTablespoon).ToString());
-                Assert.Equal("1 ", new Volume(1, VolumeUnit.UsTeaspoon).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.UsTablespoon).ToString());
+                Assert.Equal("1", new Volume(1, VolumeUnit.UsTeaspoon).ToString());
             }
             finally
             {
@@ -1057,7 +1057,7 @@ namespace UnitsNet.Tests
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
             Assert.Equal("1 ac-ft", new Volume(1, VolumeUnit.AcreFoot).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.AuTablespoon).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.AuTablespoon).ToString(swedishCulture));
             Assert.Equal("1 bf", new Volume(1, VolumeUnit.BoardFoot).ToString(swedishCulture));
             Assert.Equal("1 cl", new Volume(1, VolumeUnit.Centiliter).ToString(swedishCulture));
             Assert.Equal("1 cm³", new Volume(1, VolumeUnit.CubicCentimeter).ToString(swedishCulture));
@@ -1092,21 +1092,21 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Mgal (imp.)", new Volume(1, VolumeUnit.MegaimperialGallon).ToString(swedishCulture));
             Assert.Equal("1 Ml", new Volume(1, VolumeUnit.Megaliter).ToString(swedishCulture));
             Assert.Equal("1 Mgal (U.S.)", new Volume(1, VolumeUnit.MegausGallon).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.MetricCup).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.MetricCup).ToString(swedishCulture));
             Assert.Equal("1 tsp", new Volume(1, VolumeUnit.MetricTeaspoon).ToString(swedishCulture));
             Assert.Equal("1 µl", new Volume(1, VolumeUnit.Microliter).ToString(swedishCulture));
             Assert.Equal("1 ml", new Volume(1, VolumeUnit.Milliliter).ToString(swedishCulture));
             Assert.Equal("1 bbl", new Volume(1, VolumeUnit.OilBarrel).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.UkTablespoon).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.UkTablespoon).ToString(swedishCulture));
             Assert.Equal("1 bl (U.S.)", new Volume(1, VolumeUnit.UsBeerBarrel).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.UsCustomaryCup).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.UsCustomaryCup).ToString(swedishCulture));
             Assert.Equal("1 gal (U.S.)", new Volume(1, VolumeUnit.UsGallon).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.UsLegalCup).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.UsLegalCup).ToString(swedishCulture));
             Assert.Equal("1 oz (U.S.)", new Volume(1, VolumeUnit.UsOunce).ToString(swedishCulture));
             Assert.Equal("1 pt (U.S.)", new Volume(1, VolumeUnit.UsPint).ToString(swedishCulture));
             Assert.Equal("1 qt (U.S.)", new Volume(1, VolumeUnit.UsQuart).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.UsTablespoon).ToString(swedishCulture));
-            Assert.Equal("1 ", new Volume(1, VolumeUnit.UsTeaspoon).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.UsTablespoon).ToString(swedishCulture));
+            Assert.Equal("1", new Volume(1, VolumeUnit.UsTeaspoon).ToString(swedishCulture));
         }
 
         [Fact]

--- a/UnitsNet/QuantityFormatter.cs
+++ b/UnitsNet/QuantityFormatter.cs
@@ -125,6 +125,12 @@ namespace UnitsNet
         public static string Format<TUnitType>(IQuantity<TUnitType> quantity, string format, IFormatProvider? formatProvider)
             where TUnitType : Enum
         {
+            return FormatUntrimmed(quantity, format, formatProvider).Trim();
+        }
+
+        private static string FormatUntrimmed<TUnitType>(IQuantity<TUnitType> quantity, string format, IFormatProvider? formatProvider)
+            where TUnitType : Enum
+        {
             formatProvider ??= CultureInfo.CurrentUICulture;
 
             if(string.IsNullOrWhiteSpace(format))

--- a/UnitsNet/QuantityFormatter.cs
+++ b/UnitsNet/QuantityFormatter.cs
@@ -125,7 +125,7 @@ namespace UnitsNet
         public static string Format<TUnitType>(IQuantity<TUnitType> quantity, string format, IFormatProvider? formatProvider)
             where TUnitType : Enum
         {
-            return FormatUntrimmed(quantity, format, formatProvider).Trim();
+            return FormatUntrimmed(quantity, format, formatProvider).TrimEnd();
         }
 
         private static string FormatUntrimmed<TUnitType>(IQuantity<TUnitType> quantity, string format, IFormatProvider? formatProvider)


### PR DESCRIPTION
Scalar, Ratio and other quantities with units that don't have an abbreviation,
would result in a trailing whitespace.

Example: `Scalar.FromAmount(1).ToString() == "1 "`