### PR TITLE
Add Tilt to Angle

### DIFF
--- a/Common/UnitDefinitions/Angle.json
+++ b/Common/UnitDefinitions/Angle.json
@@ -92,6 +92,18 @@
           "Abbreviations": [ "r" ]
         }
       ]
+    },
+    {
+      "SingularName": "Tilt",
+      "PluralName": "Tilt",
+      "FromUnitToBaseFunc": "Math.Asin(x)*180/Math.PI",
+      "FromBaseToUnitFunc": "Math.Sin(x/180*Math.PI)",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "sin(θ)" ]
+        }
+      ]
     }
   ]
 }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToAngleExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToAngleExtensionsTest.g.cs
@@ -80,5 +80,9 @@ namespace UnitsNet.Tests
         public void NumberToRevolutionsTest() =>
             Assert.Equal(Angle.FromRevolutions(2), 2.Revolutions());
 
+        [Fact]
+        public void NumberToTiltTest() =>
+            Assert.Equal(Angle.FromTilt(2), 2.Tilt());
+
     }
 }

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToAngleExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToAngleExtensions.g.cs
@@ -84,5 +84,9 @@ namespace UnitsNet.NumberExtensions.NumberToAngle
         public static Angle Revolutions<T>(this T value) =>
             Angle.FromRevolutions(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Angle.FromTilt(UnitsNet.QuantityValue)" />
+        public static Angle Tilt<T>(this T value) =>
+            Angle.FromTilt(Convert.ToDouble(value));
+
     }
 }

--- a/UnitsNet.Tests/CustomCode/AngleTests.cs
+++ b/UnitsNet.Tests/CustomCode/AngleTests.cs
@@ -38,6 +38,8 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double RevolutionsInOneDegree => 2.777777777777777e-3;
 
+        protected override double TiltInOneDegree => 0.01745240643728351281941897851632;
+
         [Fact]
         public void AngleDividedByDurationEqualsRotationalSpeed()
         {

--- a/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
@@ -37,7 +37,7 @@ namespace UnitsNet.Tests
             Assertion(3, AccelerationUnit.StandardGravity, Quantity.From(3, AccelerationUnit.StandardGravity));
             Assertion(3, AmountOfSubstanceUnit.PoundMole, Quantity.From(3, AmountOfSubstanceUnit.PoundMole));
             Assertion(3, AmplitudeRatioUnit.DecibelVolt, Quantity.From(3, AmplitudeRatioUnit.DecibelVolt));
-            Assertion(3, AngleUnit.Revolution, Quantity.From(3, AngleUnit.Revolution));
+            Assertion(3, AngleUnit.Tilt, Quantity.From(3, AngleUnit.Tilt));
             Assertion(3, ApparentEnergyUnit.VoltampereHour, Quantity.From(3, ApparentEnergyUnit.VoltampereHour));
             Assertion(3, ApparentPowerUnit.Voltampere, Quantity.From(3, ApparentPowerUnit.Voltampere));
             Assertion(3, AreaUnit.UsSurveySquareFoot, Quantity.From(3, AreaUnit.UsSurveySquareFoot));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
@@ -51,6 +51,7 @@ namespace UnitsNet.Tests
         protected abstract double NanoradiansInOneDegree { get; }
         protected abstract double RadiansInOneDegree { get; }
         protected abstract double RevolutionsInOneDegree { get; }
+        protected abstract double TiltInOneDegree { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double ArcminutesTolerance { get { return 1e-5; } }
@@ -67,6 +68,7 @@ namespace UnitsNet.Tests
         protected virtual double NanoradiansTolerance { get { return 1e-5; } }
         protected virtual double RadiansTolerance { get { return 1e-5; } }
         protected virtual double RevolutionsTolerance { get { return 1e-5; } }
+        protected virtual double TiltTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
@@ -155,6 +157,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(NanoradiansInOneDegree, degree.Nanoradians, NanoradiansTolerance);
             AssertEx.EqualTolerance(RadiansInOneDegree, degree.Radians, RadiansTolerance);
             AssertEx.EqualTolerance(RevolutionsInOneDegree, degree.Revolutions, RevolutionsTolerance);
+            AssertEx.EqualTolerance(TiltInOneDegree, degree.Tilt, TiltTolerance);
         }
 
         [Fact]
@@ -216,6 +219,10 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity13.Revolutions, RevolutionsTolerance);
             Assert.Equal(AngleUnit.Revolution, quantity13.Unit);
 
+            var quantity14 = Angle.From(1, AngleUnit.Tilt);
+            AssertEx.EqualTolerance(1, quantity14.Tilt, TiltTolerance);
+            Assert.Equal(AngleUnit.Tilt, quantity14.Unit);
+
         }
 
         [Fact]
@@ -249,6 +256,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(NanoradiansInOneDegree, degree.As(AngleUnit.Nanoradian), NanoradiansTolerance);
             AssertEx.EqualTolerance(RadiansInOneDegree, degree.As(AngleUnit.Radian), RadiansTolerance);
             AssertEx.EqualTolerance(RevolutionsInOneDegree, degree.As(AngleUnit.Revolution), RevolutionsTolerance);
+            AssertEx.EqualTolerance(TiltInOneDegree, degree.As(AngleUnit.Tilt), TiltTolerance);
         }
 
         [Fact]
@@ -328,6 +336,10 @@ namespace UnitsNet.Tests
             var revolutionQuantity = degree.ToUnit(AngleUnit.Revolution);
             AssertEx.EqualTolerance(RevolutionsInOneDegree, (double)revolutionQuantity.Value, RevolutionsTolerance);
             Assert.Equal(AngleUnit.Revolution, revolutionQuantity.Unit);
+
+            var tiltQuantity = degree.ToUnit(AngleUnit.Tilt);
+            AssertEx.EqualTolerance(TiltInOneDegree, (double)tiltQuantity.Value, TiltTolerance);
+            Assert.Equal(AngleUnit.Tilt, tiltQuantity.Unit);
         }
 
         [Fact]
@@ -355,6 +367,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Angle.FromNanoradians(degree.Nanoradians).Degrees, NanoradiansTolerance);
             AssertEx.EqualTolerance(1, Angle.FromRadians(degree.Radians).Degrees, RadiansTolerance);
             AssertEx.EqualTolerance(1, Angle.FromRevolutions(degree.Revolutions).Degrees, RevolutionsTolerance);
+            AssertEx.EqualTolerance(1, Angle.FromTilt(degree.Tilt).Degrees, TiltTolerance);
         }
 
         [Fact]
@@ -525,6 +538,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 nrad", new Angle(1, AngleUnit.Nanoradian).ToString());
                 Assert.Equal("1 rad", new Angle(1, AngleUnit.Radian).ToString());
                 Assert.Equal("1 r", new Angle(1, AngleUnit.Revolution).ToString());
+                Assert.Equal("1 sin(θ)", new Angle(1, AngleUnit.Tilt).ToString());
             }
             finally
             {
@@ -552,6 +566,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 nrad", new Angle(1, AngleUnit.Nanoradian).ToString(swedishCulture));
             Assert.Equal("1 rad", new Angle(1, AngleUnit.Radian).ToString(swedishCulture));
             Assert.Equal("1 r", new Angle(1, AngleUnit.Revolution).ToString(swedishCulture));
+            Assert.Equal("1 sin(θ)", new Angle(1, AngleUnit.Tilt).ToString(swedishCulture));
         }
 
         [Fact]

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Angle.g.cs
@@ -225,6 +225,11 @@ namespace UnitsNet
         /// </summary>
         public double Revolutions => As(AngleUnit.Revolution);
 
+        /// <summary>
+        ///     Get Angle in Tilt.
+        /// </summary>
+        public double Tilt => As(AngleUnit.Tilt);
+
         #endregion
 
         #region Static Methods
@@ -394,6 +399,16 @@ namespace UnitsNet
         {
             double value = (double) revolutions;
             return new Angle(value, AngleUnit.Revolution);
+        }
+        /// <summary>
+        ///     Get Angle from Tilt.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Angle FromTilt(double tilt)
+        {
+            double value = (double) tilt;
+            return new Angle(value, AngleUnit.Tilt);
         }
 
         /// <summary>
@@ -700,6 +715,7 @@ namespace UnitsNet
                 case AngleUnit.Nanoradian: return (_value*180/Math.PI) * 1e-9d;
                 case AngleUnit.Radian: return _value*180/Math.PI;
                 case AngleUnit.Revolution: return _value*360;
+                case AngleUnit.Tilt: return Math.Asin(_value)*180/Math.PI;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -728,6 +744,7 @@ namespace UnitsNet
                 case AngleUnit.Nanoradian: return (baseUnitValue/180*Math.PI) / 1e-9d;
                 case AngleUnit.Radian: return baseUnitValue/180*Math.PI;
                 case AngleUnit.Revolution: return baseUnitValue/360;
+                case AngleUnit.Tilt: return Math.Sin(baseUnitValue/180*Math.PI);
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -102,6 +102,7 @@ namespace UnitsNet
                 ("ru-RU", typeof(AngleUnit), (int)AngleUnit.Radian, new string[]{"рад"}),
                 ("en-US", typeof(AngleUnit), (int)AngleUnit.Revolution, new string[]{"r"}),
                 ("ru-RU", typeof(AngleUnit), (int)AngleUnit.Revolution, new string[]{"r"}),
+                ("en-US", typeof(AngleUnit), (int)AngleUnit.Tilt, new string[]{"sin(θ)"}),
                 ("en-US", typeof(ApparentEnergyUnit), (int)ApparentEnergyUnit.KilovoltampereHour, new string[]{"kVAh"}),
                 ("en-US", typeof(ApparentEnergyUnit), (int)ApparentEnergyUnit.MegavoltampereHour, new string[]{"MVAh"}),
                 ("en-US", typeof(ApparentEnergyUnit), (int)ApparentEnergyUnit.VoltampereHour, new string[]{"VAh"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/AngleUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/AngleUnit.g.cs
@@ -40,6 +40,7 @@ namespace UnitsNet.Units
         Nanoradian,
         Radian,
         Revolution,
+        Tilt,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -66,6 +66,7 @@ namespace UnitsNet
                     new UnitInfo<AngleUnit>(AngleUnit.Nanoradian, BaseUnits.Undefined),
                     new UnitInfo<AngleUnit>(AngleUnit.Radian, BaseUnits.Undefined),
                     new UnitInfo<AngleUnit>(AngleUnit.Revolution, BaseUnits.Undefined),
+                    new UnitInfo<AngleUnit>(AngleUnit.Tilt, BaseUnits.Undefined),
                 },
                 BaseUnit, Zero, BaseDimensions, QuantityType.Angle);
         }
@@ -251,6 +252,11 @@ namespace UnitsNet
         /// </summary>
         public double Revolutions => As(AngleUnit.Revolution);
 
+        /// <summary>
+        ///     Get Angle in Tilt.
+        /// </summary>
+        public double Tilt => As(AngleUnit.Tilt);
+
         #endregion
 
         #region Static Methods
@@ -405,6 +411,15 @@ namespace UnitsNet
         {
             double value = (double) revolutions;
             return new Angle(value, AngleUnit.Revolution);
+        }
+        /// <summary>
+        ///     Get Angle from Tilt.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Angle FromTilt(QuantityValue tilt)
+        {
+            double value = (double) tilt;
+            return new Angle(value, AngleUnit.Tilt);
         }
 
         /// <summary>
@@ -849,6 +864,7 @@ namespace UnitsNet
                 case AngleUnit.Nanoradian: return (_value*180/Math.PI) * 1e-9d;
                 case AngleUnit.Radian: return _value*180/Math.PI;
                 case AngleUnit.Revolution: return _value*360;
+                case AngleUnit.Tilt: return Math.Asin(_value)*180/Math.PI;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -888,6 +904,7 @@ namespace UnitsNet
                 case AngleUnit.Nanoradian: return (baseUnitValue/180*Math.PI) / 1e-9d;
                 case AngleUnit.Radian: return baseUnitValue/180*Math.PI;
                 case AngleUnit.Revolution: return baseUnitValue/360;
+                case AngleUnit.Tilt: return Math.Sin(baseUnitValue/180*Math.PI);
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -102,6 +102,7 @@ namespace UnitsNet
                 ("ru-RU", typeof(AngleUnit), (int)AngleUnit.Radian, new string[]{"рад"}),
                 ("en-US", typeof(AngleUnit), (int)AngleUnit.Revolution, new string[]{"r"}),
                 ("ru-RU", typeof(AngleUnit), (int)AngleUnit.Revolution, new string[]{"r"}),
+                ("en-US", typeof(AngleUnit), (int)AngleUnit.Tilt, new string[]{"sin(θ)"}),
                 ("en-US", typeof(ApparentEnergyUnit), (int)ApparentEnergyUnit.KilovoltampereHour, new string[]{"kVAh"}),
                 ("en-US", typeof(ApparentEnergyUnit), (int)ApparentEnergyUnit.MegavoltampereHour, new string[]{"MVAh"}),
                 ("en-US", typeof(ApparentEnergyUnit), (int)ApparentEnergyUnit.VoltampereHour, new string[]{"VAh"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -122,6 +122,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Angle>(AngleUnit.Radian, Angle.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Angle>(Angle.BaseUnit, AngleUnit.Revolution, q => q.ToUnit(AngleUnit.Revolution));
             unitConverter.SetConversionFunction<Angle>(AngleUnit.Revolution, Angle.BaseUnit, q => q.ToBaseUnit());
+            unitConverter.SetConversionFunction<Angle>(Angle.BaseUnit, AngleUnit.Tilt, q => q.ToUnit(AngleUnit.Tilt));
+            unitConverter.SetConversionFunction<Angle>(AngleUnit.Tilt, Angle.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<ApparentEnergy>(ApparentEnergy.BaseUnit, ApparentEnergyUnit.KilovoltampereHour, q => q.ToUnit(ApparentEnergyUnit.KilovoltampereHour));
             unitConverter.SetConversionFunction<ApparentEnergy>(ApparentEnergyUnit.KilovoltampereHour, ApparentEnergy.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<ApparentEnergy>(ApparentEnergy.BaseUnit, ApparentEnergyUnit.MegavoltampereHour, q => q.ToUnit(ApparentEnergyUnit.MegavoltampereHour));

--- a/UnitsNet/GeneratedCode/Units/AngleUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/AngleUnit.g.cs
@@ -40,6 +40,7 @@ namespace UnitsNet.Units
         Nanoradian,
         Radian,
         Revolution,
+        Tilt,
     }
 
     #pragma warning restore 1591


### PR DESCRIPTION
"Tilt" is commonly used in Tilt Meters, and it is simply the Sin of the angle.