### PR TITLE
Adding benchmark workflows

### DIFF
--- a/.github/actions/run-benchmarks/action.yaml
+++ b/.github/actions/run-benchmarks/action.yaml
@@ -1,0 +1,43 @@
+name: 'Run benchmark'
+inputs:
+  framework:
+    description: 'The runtime version to use (e.g. net5.0)'
+    required: false
+    default: 'net5.0'
+  runtimes:
+    description: 'The runtime version to use (e.g. netcoreapp31, net5.0)'
+    required: false
+    default: 'net5.0'
+  output-folder:
+    description: 'The output folder for the benchmark (a results folder is created inside)'
+    required: false
+    default: 'Artifacts/Benchmark'
+  exporters:
+    description: 'The exporter(s) used for this run (GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML)'
+    required: false
+    default: fulljson rplot
+  filter:
+    description: 'An optional class filter to apply'
+    required: false
+    default: '*'
+  categories:
+    description: 'An optional categories filter to apply'
+    required: false
+    default: ''
+  execution-options:
+    description: 'Any additional parameters passed to the benchmark'
+    required: false
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - name: Generating benchmark results
+      run: >
+        dotnet run --project UnitsNet.Benchmark -c Release 
+        --framework ${{ inputs.framework }} 
+        --runtimes ${{ inputs.runtimes }} 
+        --artifacts '${{ inputs.output-folder }}' 
+        --exporters ${{ inputs.exporters }} 
+        --filter '${{ inputs.filter }}' 
+        ${{ inputs.categories }} ${{ inputs.execution-options }}
+      shell: bash

--- a/.github/workflows/continious-benchmarking.yml
+++ b/.github/workflows/continious-benchmarking.yml
@@ -1,0 +1,101 @@
+name: UnitsNet Benchmarks (auto)
+on:
+  push:
+    branches: [master]    
+    paths:
+      - "UnitsNet/*"
+      - "UnitsNet.Benchmark/*"
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      
+env:
+  FRAMEWORK: net5.0 
+  EXECUTION_OPTIONS: --iterationTime 500 --disableLogFile # see https://benchmarkdotnet.org/articles/guides/console-args.html
+  BENCHMARK_PAGES_BRANCH: gh-pages
+  BENCHMARK_DATA_FOLDER: benchmarks
+  
+jobs:
+  benchmark:
+    runs-on: windows-latest # required by the older frameworks
+    strategy:
+      # max-parallel: 1 # is it better to avoid running in parallel?
+      matrix: 
+        runtime: ["netcoreapp50", "netcoreapp21", "net472"]        
+    steps:
+      - run: echo Starting benchmarks for ${{ matrix.runtime }} 
+      
+      # checkout the current branch
+      - uses: actions/checkout@v2 
+      
+      # we need all frameworks (even if only running one target at a time)
+      - uses: actions/setup-dotnet@v1
+        with: 
+          dotnet-version: '2.1.x'
+            
+      - uses: actions/setup-dotnet@v1
+        with: 
+          dotnet-version: '3.1.x'
+            
+      - uses: actions/setup-dotnet@v1
+        with: 
+          dotnet-version: '5.0.x'
+            
+      # executing the benchmark for the current framework, placing the result in a corresponding sub-folder              
+      - uses: ./.github/actions/run-benchmarks
+        with:
+          framework: ${{ env.FRAMEWORK }}
+          runtimes: ${{ matrix.runtime }}
+          output-folder: Artifacts/Benchmark/${{ matrix.runtime }}
+          execution-options: ${{ env.EXECUTION_OPTIONS }}
+            
+      # saving the current artifact (downloadable until the expiration date of this action)        
+      - name: Store benchmark artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: UnitsNet Benchmarks (${{ matrix.runtime }})
+          path: Artifacts/Benchmark/${{ matrix.runtime }}/results/
+          
+  publish-results:
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1 # cannot commit on the same branch in parallel
+      matrix: 
+        runtime: ["netcoreapp50", "netcoreapp21", "net472"]
+    steps:        
+      - name: Initializing git folder ️
+        uses: actions/checkout@v2.3.1
+
+      - name: Download Artifacts # The benchmark results are downloaded into a 'runtime' folder.
+        uses: actions/download-artifact@v1
+        with:
+          name: UnitsNet Benchmarks (${{ matrix.runtime }})
+          path: ${{ matrix.runtime }}        
+        
+      # publishing the current results to the benchmark-pages branch (overriding the previous result)
+      - name: Saving benchmark results to ${{ env.BENCHMARK_PAGES_BRANCH }}/${{ env.BENCHMARK_DATA_FOLDER }}/${{ matrix.runtime }}/results
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          folder: ${{ matrix.runtime }}
+          branch: ${{ env.BENCHMARK_PAGES_BRANCH }}
+          target-folder: ${{ env.BENCHMARK_DATA_FOLDER }}/${{ matrix.runtime }}/results
+          commit-message: Automatic benchmark generation for ${{ github.sha }}
+      
+      # appending to the running benchmark data on the benchmark-pages branch
+      - name: Updating benchmark charts
+        uses: starburst997/github-action-benchmark@v1.8.7
+        with:
+          name: UnitsNet Benchmarks (${{ matrix.runtime }})
+          tool: 'benchmarkdotnet'
+          output-file-path: ${{ matrix.runtime }}/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json
+          gh-pages-branch: ${{ env.BENCHMARK_PAGES_BRANCH }}
+          benchmark-data-dir-path: ${{ env.BENCHMARK_DATA_FOLDER }}/${{ matrix.runtime }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-always: true
+          comment-on-alert: true
+          fail-on-alert: false
+          alert-comment-cc-users: '@lipchev'
+     

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -1,0 +1,142 @@
+name: Run UnitsNet Benchmarks
+on:
+  workflow_dispatch:
+    inputs:
+      benchmark-name:
+        description: 'A name given for this benchmark'
+        required: false
+        default: 'UnitsNet Benchmarks'
+      runtimes:
+        description: 'The runtime version to use (e.g. net472 net48 netcoreapp21 netcoreapp31 netcoreapp50)'
+        default: net472 netcoreapp21 netcoreapp50
+        required: true
+      exporters:
+        description: 'The exporter(s) used for this run (GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML)'
+        required: false
+        default: fulljson rplot
+      filter:
+        description: 'An optional class filter to apply'
+        required: false
+        default: '*'
+      categories:
+        description: 'An optional categories filter to apply'
+        required: false
+        default: ''
+      execution-options:
+        description: 'Any additional parameters passed to the benchmark'
+        required: false
+        default: --disableLogFile     
+      comparison-baseline:
+        description: 'Compare against a previous result (expecting a link to *-report-full.json'
+        required: true
+        default: 'https://angularsen.github.io/UnitsNet-Benchmarks/benchmarks/netcoreapp50/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json'              
+      comparison-threshold:
+        description: 'The (comparison) threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s'
+        required: false
+        default: '1%'      
+      comparison-top:
+        description: 'Filter the comparison to the top/bottom N results'
+        required: false
+        default: 10               
+      framework:
+        description: 'The dotnet-version version to use (e.g. net5.0)'
+        default: 'net5.0'
+        required: true     
+jobs:
+  benchmark:
+    env:
+      OUTPUT_FOLDER: Artifacts/Benchmarks/${{ github.event.inputs.benchmark-name }}
+    runs-on: windows-latest
+    steps:      
+      # checkout the current branch
+      - uses: actions/checkout@v2 
+      
+      # we need all frameworks (even if only running one target at a time)
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '2.1.x'
+            
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+            
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '5.0.x'
+            
+      # executing the benchmark for the current framework(s), placing the result in the output-folder
+      - uses: ./.github/actions/run-benchmarks
+        with:
+          framework: ${{ github.event.inputs.framework }}
+          runtimes: ${{ github.event.inputs.runtimes }}
+          output-folder: ${{ env.OUTPUT_FOLDER }}
+          filter: ${{ github.event.inputs.filter }}
+          categories: ${{ github.event.inputs.categories }}
+          execution-options: ${{ github.event.inputs.execution-options }}
+            
+      # saving the current artifact (downloadable until the expiration date of this action)        
+      - name: Store benchmark result
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ github.event.inputs.benchmark-name }} (${{ github.event.inputs.runtimes }})
+          path: ${{ env.OUTPUT_FOLDER }}/results
+          if-no-files-found: error 
+          
+  compare-results:
+    if: ${{ endsWith(github.event.inputs.comparison-baseline, '-report-full.json') }}
+    env:
+      OUPUT_NAME: Baseline vs ${{ github.event.inputs.benchmark-name }} (${{ github.event.inputs.runtimes }})
+    needs: [benchmark]
+    runs-on: ubuntu-latest
+    steps:                    
+      # The baseline results are downloaded into a 'baseline' folder.  
+      - name: Download Baseline
+        uses: carlosperate/download-file-action@v1.0.3
+        with:
+          file-url: ${{ github.event.inputs.comparison-baseline }}
+          location: baseline
+      
+      # The benchmark results are downloaded into a 'runtime' folder.  
+      - name: Download Artifacts 
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{ github.event.inputs.benchmark-name }} (${{ github.event.inputs.runtimes }})
+          path: results    
+          
+      # The benchmark comparer is currently taken from dotnet/performance/src/tools/ResultsComparer (hoping that a 'tool' would eventually be made available)
+      - name: Download ResultsComparer
+        uses: actions/checkout@v2
+        with:
+          repository: dotnet/performance
+          path: comparer
+                  
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '3.1.x'
+              
+      - run: mkdir -p artifacts
+      
+      # Executing the comparer, placing the result in a 'comparison' folder (as well as creating a summary from the output)
+      - name: Running the ResultsComparer
+        env:
+          PERFLAB_TARGET_FRAMEWORKS: netcoreapp3.1
+        run: > 
+          dotnet run --project 'comparer/src/tools/ResultsComparer' -c Release
+          --framework netcoreapp31
+          --base baseline --diff results 
+          --csv "artifacts/${{ env.OUPUT_NAME }}.csv"
+          --xml "artifacts/${{ env.OUPUT_NAME }}.xml"
+          --threshold ${{ github.event.inputs.comparison-threshold }} 
+          --top ${{ github.event.inputs.comparison-top }} 
+          > "artifacts/${{ env.OUPUT_NAME }}.md"
+      
+      - name: Summary
+        run: cat "artifacts/${{ env.OUPUT_NAME }}.md"
+      
+      # saving the current artifacts (downloadable until the expiration date of this action)        
+      - name: Store comparison result
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.OUPUT_NAME }}
+          path: artifacts
+          

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -27,9 +27,9 @@ on:
         required: false
         default: --disableLogFile     
       comparison-baseline:
-        description: 'Compare against a previous result (expecting a link to *-report-full.json'
+        description: 'Compare against a previous result (expecting a link to *-report-full.json)'
         required: true
-        default: 'https://angularsen.github.io/UnitsNet-Benchmarks/benchmarks/netcoreapp50/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json'              
+        default: 'https://angularsen.github.io/UnitsNet/benchmarks/netcoreapp50/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json'              
       comparison-threshold:
         description: 'The (comparison) threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s'
         required: false

--- a/UnitsNet.Benchmark/Program.cs
+++ b/UnitsNet.Benchmark/Program.cs
@@ -11,62 +11,77 @@ namespace UnitsNet.Benchmark
         private IQuantity lengthIQuantity = Length.FromMeters(3.0);
 
         [Benchmark]
+        [BenchmarkCategory("Construction")]
         public Length Constructor() => new Length(3.0, LengthUnit.Meter);
 
         [Benchmark]
+        [BenchmarkCategory("Construction")]
         public Length Constructor_SI() => new Length(3.0, UnitSystem.SI);
 
         [Benchmark]
+        [BenchmarkCategory("Construction")]
         public Length FromMethod() => Length.FromMeters(3.0);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation")]
         public double ToProperty() => length.Centimeters;
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Value")]
         public double As() => length.As(LengthUnit.Centimeter);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Value")]
         public double As_SI() => length.As(UnitSystem.SI);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Quantity")]
         public Length ToUnit() => length.ToUnit(LengthUnit.Centimeter);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Quantity")]
         public Length ToUnit_SI() => length.ToUnit(UnitSystem.SI);
 
         [Benchmark]
+        [BenchmarkCategory("ToString")]
         public string ToStringTest() => length.ToString();
 
         [Benchmark]
+        [BenchmarkCategory("Parsing")]
         public Length Parse() => Length.Parse("3.0 m");
 
         [Benchmark]
+        [BenchmarkCategory("Parsing")]
         public bool TryParseValid() => Length.TryParse("3.0 m", out var l);
 
         [Benchmark]
+        [BenchmarkCategory("Parsing")]
         public bool TryParseInvalid() => Length.TryParse("3.0 zoom", out var l);
 
         [Benchmark]
+        [BenchmarkCategory("Construction")]
         public IQuantity QuantityFrom() => Quantity.From(3.0, LengthUnit.Meter);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Value")]
         public double IQuantity_As() => lengthIQuantity.As(LengthUnit.Centimeter);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Value")]
         public double IQuantity_As_SI() => lengthIQuantity.As(UnitSystem.SI);
 
         [Benchmark]
+        [BenchmarkCategory("Transformation, Quantity")]
         public IQuantity IQuantity_ToUnit() => lengthIQuantity.ToUnit(LengthUnit.Centimeter);
 
         [Benchmark]
+        [BenchmarkCategory("ToString")]
         public string IQuantity_ToStringTest() => lengthIQuantity.ToString();
     }
 
     class Program
     {
         static void Main(string[] args)
-        {
-            var summary = BenchmarkRunner.Run<UnitsNetBenchmarks>();
-        }
+            => BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
     }
 }

--- a/UnitsNet.Benchmark/Scripts/json-export-all-runtimes.bat
+++ b/UnitsNet.Benchmark/Scripts/json-export-all-runtimes.bat
@@ -1,0 +1,17 @@
+@echo off
+SET scriptdir=%~dp0
+SET projectdir="%scriptdir%..\.."
+SET exportdir="%projectdir%\Artifacts\Benchmark"
+:: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
+dotnet run --project "%projectdir%/UnitsNet.Benchmark" -c Release ^
+--framework net5.0 ^
+--runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 netcoreapp50 ^
+--artifacts=%exportdir% ^
+--exporters json ^
+--filter * ^
+--iterationTime 250 ^
+--statisticalTest 0.001ms ^
+--join %1 %2 %3
+
+:: this runs fine, however there is currently no way of displaying multiple-lines-per-chart: see https://github.com/rhysd/github-action-benchmark/issues/18
+:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json

--- a/UnitsNet.Benchmark/Scripts/json-export-net5.bat
+++ b/UnitsNet.Benchmark/Scripts/json-export-net5.bat
@@ -1,0 +1,17 @@
+@echo off
+SET scriptdir=%~dp0
+SET projectdir="%scriptdir%..\.."
+SET exportdir="%projectdir%\Artifacts\Benchmark"
+:: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
+dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
+--framework net5.0 ^
+--runtimes netcoreapp50 ^
+--artifacts=%exportdir% ^
+--exporters json ^
+--filter * ^
+--iterationTime 250 ^
+--statisticalTest 0.001ms ^
+--join %1 %2 %3
+
+:: this runs fine, however there is currently no way of displaying multiple-lines-per-chart: see https://github.com/rhysd/github-action-benchmark/issues/18
+:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json

--- a/UnitsNet.Benchmark/Scripts/r-plot-all-runtimes.bat
+++ b/UnitsNet.Benchmark/Scripts/r-plot-all-runtimes.bat
@@ -1,0 +1,17 @@
+@echo off
+SET scriptdir=%~dp0
+SET projectdir="%scriptdir%..\.."
+SET exportdir="%projectdir%\Artifacts\Benchmark"
+:: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
+dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
+--framework net5.0 ^
+--runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 netcoreapp50 ^
+--artifacts=%exportdir% ^
+--exporters rplot ^
+--filter * ^
+--iterationTime 1500 ^
+--statisticalTest 10us ^
+--join %1 %2 %3
+
+:: this creates an R script producing that uses the Job_Runtime instead of Job_Id (for readibility)
+powershell "(Get-Content %exportdir%\results\BuildPlots.R) -replace 'Job_Id', 'Job_Runtime' | Out-File -encoding ASCII %exportdir%\results\BuildPlots_Runtime.R"

--- a/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
+++ b/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
@@ -1,21 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <!-- Assembly and msbuild properties -->
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48;net472</TargetFrameworks>
     <Version>4.0.0.0</Version>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion> <!-- Should reflect major part of Version -->
+    <AssemblyVersion>4.0.0.0</AssemblyVersion> 
     <AssemblyTitle>UnitsNet.Benchmark</AssemblyTitle>
     <Product>UnitsNet.Benchmark</Product>
-    <LangVersion>latest</LangVersion>
     <RootNamespace>UnitsNet</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
-    <PackageReference Include="CommandLineParser" Version="2.7.82" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="2.9.8">
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
- updated the UnitsNet.Benchmark project (updated nugets & added frameworks)
- added BenchmarkCategories to the existing benchmarks
- added a few scripts for local testing (individual, multi-platform + rplots)
- added an automatic benchmark workflow on pushing to [master] (some folders), running for ["netcoreapp50", "netcoreapp21", "net472"]
- added workflows triggered on workflow_dispatch for running a benchmark (with options for comparing against a baseline)

Closes #920 

First a few ground rules

1. As of this writing, manually triggered workflows (a.k.a. `workflow_dispatch`), [only work on the master branch](https://github.community/t/how-to-trigger-repository-dispatch-event-for-non-default-branch/14470). 
2. Composite actions have some nasty [limitations](https://github.com/actions/runner/issues/862)
3. The Continuous Benchmark [needs to be in a context](https://github.com/rhysd/github-action-benchmark/issues/24) with a commit in order to work 
4.  It publishes [commits](https://github.com/lipchev/UnitsNet-Benchmarks/commits/gh-pages/benchmarks/netcoreapp50) (with optional comments and alerts) targeting a given folder on a separate branch (typically gh-pages/benchmark/)- [here](https://lipchev.github.io/UnitsNet-Benchmarks/benchmarks/netcoreapp50/) is an example (all but the last benchmarks were run using a very-low iteration count- a sort of DryRun, so the wild fluctuations are expected). Here is [another](https://lipchev.github.io/UnitsNet-Benchmarks/benchmarks/net472/) (that's consistently slower).
5. It [does not support](https://github.com/rhysd/github-action-benchmark/issues/18) multi-line charts (out-of-the-box)
6. I read somewhere that the average performance of the virtual machines vary within about 10-15%
7. We can run the benchmarks for [any framework](https://benchmarkdotnet.org/articles/configs/toolchains.html#multiple-frameworks-support) from 472 onward (windows required)
8. We can easily configure all aspects of a benchmark using the [command line arguments](https://benchmarkdotnet.org/articles/guides/console-args.html) (there is also a `dotnet benchmark tool` but that seems to be doing the exact same things- although I suspect it's also going to get some 'compare results' functionality at some point which would likely remove the need for the next step)
9. There are a few result-comparing extensions out there- but I most liked the one from [dotnet/performance](https://github.com/dotnet/performance/tree/main/src/tools/ResultsComparer)
10. Just a few days ago, I knew almost none of that.

The workflows are well documented, I think you would easily figure out what's going on. Here are the highlights:

1. The automatic workflow runs the benchmarks (multiple frameworks), for each one exporting the result to the [gh-pages/benchmarks](https://github.com/lipchev/UnitsNet-Benchmarks/tree/gh-pages/benchmarks)- one framework one sub-folder
2. It is only supposed to run on the master branch & only on certain occasions (see [here](https://github.com/lipchev/UnitsNet/blob/dd071c6255424049401ad1d2ea6c7c85383eb38c/.github/workflows/continious-benchmarking.yml#L2))
2. For [each folder](https://github.com/lipchev/UnitsNet-Benchmarks/tree/gh-pages/benchmarks/net472) (framework) we have the chart data: `data.js & index.html` (here we append results) and the [results](https://github.com/lipchev/UnitsNet-Benchmarks/tree/gh-pages/benchmarks/net472/results) folder containing the latest benchmark results, as exported by BenchmarkDotNet (we override these each time the script is executed)
3. We can then reference / compare results across branches & repositories (a fork doesn't have to have gh-pages in order to compare against upstream/gh-pages/benchmark/xxx/)
4. This can be done using the second action: which can be used to generate a report (the typical results folder) which can then be compared against a baseline (this step only runs if the [baseline parameter](https://github.com/lipchev/UnitsNet/blob/dd071c6255424049401ad1d2ea6c7c85383eb38c/.github/workflows/run-benchmarks.yml#L29) points to a valid "*-report-full.json")

PS Some of the links point to lipchev/UnitsNet-Benchmarks which is the repository I used for testing. Unfortunately something got messed up during the rebase so I made the PR in a new branch (of my main fork) - this (as expected) did not trigger a benchmark-run as I pushed on a non master branch. As to why the manual flow isn't showing up in the actions menu- see 1). 

PS2 You should still have access to the test repository (lipchev/UnitsNet-Benchmarks) if you want to test out the [workflows](https://github.com/lipchev/UnitsNet-Benchmarks/actions)- feel free to commit on it if you want, I plan to delete it after this is merged.
