### PR TITLE
Improve generation on nuspecs for .NET nanoFramework

### DIFF
--- a/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Text;
 using CodeGen.JsonTypes;
@@ -8,11 +8,16 @@ namespace CodeGen.Generators.NanoFrameworkGen
     class NuspecGenerator : GeneratorBase
     {
         private readonly Quantity _quantity;
+        private readonly string _mscorlibNuGetVersion;
         private readonly string _mathNuGetVersion;
 
-        public NuspecGenerator(Quantity quantity, string mathNuGetVersion)
+        public NuspecGenerator(
+            Quantity quantity,
+            string mscorlibNuGetVersion,
+            string mathNuGetVersion)
         {
             _quantity = quantity ?? throw new ArgumentNullException(nameof(quantity));
+            _mscorlibNuGetVersion = mscorlibNuGetVersion;
             _mathNuGetVersion = mathNuGetVersion;
         }
 
@@ -37,7 +42,7 @@ namespace CodeGen.Generators.NanoFrameworkGen
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component {_quantity.Name.ToLower()}</tags>
     <dependencies>
-      <dependency id=""nanoFramework.CoreLibrary"" version=""1.10.5-preview.13"" />");
+      <dependency id=""nanoFramework.CoreLibrary"" version=""{_mscorlibNuGetVersion}"" />");
 
     if(NanoFrameworkGenerator.ProjectsRequiringMath.Contains(_quantity.Name))
     {

--- a/CodeGen/Generators/NanoFrameworkGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGenerator.cs
@@ -115,7 +115,13 @@ namespace CodeGen.Generators
                 var sb = new StringBuilder($"{quantity.Name}:".PadRight(AlignPad));
 
                 GeneratePackageConfig(projectPath, quantity.Name);
-                GenerateNuspec(projectPath, quantity, MathNuGetVersion);
+
+                GenerateNuspec(
+                    projectPath,
+                    quantity,
+                    MscorlibNuGetVersion,
+                    MathNuGetVersion);
+
                 GenerateUnitType(sb, quantity, Path.Combine(outputUnits, $"{quantity.Name}Unit.g.cs"));
                 GenerateQuantity(sb, quantity, Path.Combine(outputQuantitites, $"{quantity.Name}.g.cs"));
                 GenerateProject(sb, quantity, projectPath);
@@ -151,11 +157,19 @@ namespace CodeGen.Generators
             var content = GeneratePackageConfigFile(quantityName);
             File.WriteAllText(filePath, content, Encoding.UTF8);
         }
-        private static void GenerateNuspec(string projectPath, Quantity quantity, string mathNuGetVersion)
+        private static void GenerateNuspec(
+            string projectPath,
+            Quantity quantity,
+            string mscorlibNuGetVersion,
+            string mathNuGetVersion)
         {
             string filePath = Path.Combine(projectPath, $"UnitsNet.NanoFramework.{quantity.Name}.nuspec");
 
-            var content = new NuspecGenerator(quantity, mathNuGetVersion).Generate();
+            var content = new NuspecGenerator(
+                quantity,
+                mscorlibNuGetVersion,
+                mathNuGetVersion).Generate();
+
             File.WriteAllText(filePath, content, Encoding.UTF8);
         }
 


### PR DESCRIPTION
- Mscorlib version is now set to the latest available version.

(Math version was already being properly handled, for some reason mscorlib was wrongly left with a fixed version)