### PR TITLE
Fix referencing stable/preview NuGets for .NET nanoFramework

### DIFF
--- a/CodeGen/Generators/NanoFrameworkGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGenerator.cs
@@ -141,47 +141,23 @@ namespace CodeGen.Generators
                     cancellationToken).Result;
 
                 // get NuGet package Version for mscorlib
-                var latestStableVersion = packageVersions.OrderByDescending(v => v).First();
-                var latestPreviewVersion = packageVersions.Where(v => v.IsPrerelease).OrderByDescending(v => v).First();
-                NuGetVersion mscorlibVersion;
+                // grab latest available (doesn't matter if it's preview or stable)
+                NuGetVersion mscorlibVersion = packageVersions.OrderByDescending(v => v).First();
+                MscorlibVersion = mscorlibVersion.Version.ToString();
+                MscorlibNuGetVersion = mscorlibVersion.ToNormalizedString();
 
-                // check which version is greatest
-                if (latestStableVersion > latestPreviewVersion)
-                {
-                    // newest is stable
-                    MscorlibVersion = latestStableVersion.Version.ToString();
-                    MscorlibNuGetVersion = latestStableVersion.ToNormalizedString();
-                    mscorlibVersion = latestStableVersion;
-                }
-                else
-                {
-                    // newest is preview
-                    MscorlibVersion = latestPreviewVersion.Version.ToString();
-                    MscorlibNuGetVersion = latestPreviewVersion.ToNormalizedString();
-                    mscorlibVersion = latestPreviewVersion;
-                }
-
-                // Math
+                // System.Math
                 packageVersions = resource.GetAllVersionsAsync(
                     "nanoFramework.System.Math",
                     cache,
                     logger,
                     cancellationToken).Result;
 
-                if(mscorlibVersion.IsPrerelease)
-                {
-                    // we are working with a preview version
-                    var mathPackage = packageVersions.Where(v => v.IsPrerelease).OrderByDescending(v => v).First();
-                    MathVersion = mathPackage.Version.ToString();
-                    MathNuGetVersion = mathPackage.ToNormalizedString();
-                }
-                else
-                {
-                    // we are working with a stable version
-                    var mathPackage = packageVersions.OrderByDescending(v => v).First();
-                    MathVersion = mathPackage.Version.ToString();
-                    MathNuGetVersion = mathPackage.ToNormalizedString();
-                }
+                // grab latest available (doesn't matter if it's preview or stable)
+                // making an assumption here that the available version is referencing the correct mscolib
+                var mathVersion = packageVersions.OrderByDescending(v => v).First();
+                MathVersion = mathVersion.Version.ToString();
+                MathNuGetVersion = mathVersion.ToNormalizedString();
 
                 logger.LogInformation($"Referencing nanoFramework.CoreLibrary {MscorlibNuGetVersion}");
                 logger.LogInformation($"Referencing nanoFramework.System.Math {MathNuGetVersion}");

--- a/CodeGen/Generators/NanoFrameworkGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGenerator.cs
@@ -140,14 +140,26 @@ namespace CodeGen.Generators
                     logger,
                     cancellationToken).Result;
 
-                // NuGet package Version
-                // including preview
-                var mscorlibPackage = packageVersions.Where(v => v.IsPrerelease).OrderByDescending(v => v).First();
-                // stable only
-                //var mscorlibPackage = packageVersions.OrderByDescending(v => v).First();
+                // get NuGet package Version for mscorlib
+                var latestStableVersion = packageVersions.OrderByDescending(v => v).First();
+                var latestPreviewVersion = packageVersions.Where(v => v.IsPrerelease).OrderByDescending(v => v).First();
+                NuGetVersion mscorlibVersion;
 
-                MscorlibVersion = mscorlibPackage.Version.ToString();
-                MscorlibNuGetVersion = mscorlibPackage.ToNormalizedString();
+                // check which version is greatest
+                if (latestStableVersion > latestPreviewVersion)
+                {
+                    // newest is stable
+                    MscorlibVersion = latestStableVersion.Version.ToString();
+                    MscorlibNuGetVersion = latestStableVersion.ToNormalizedString();
+                    mscorlibVersion = latestStableVersion;
+                }
+                else
+                {
+                    // newest is preview
+                    MscorlibVersion = latestPreviewVersion.Version.ToString();
+                    MscorlibNuGetVersion = latestPreviewVersion.ToNormalizedString();
+                    mscorlibVersion = latestPreviewVersion;
+                }
 
                 // Math
                 packageVersions = resource.GetAllVersionsAsync(
@@ -156,14 +168,23 @@ namespace CodeGen.Generators
                     logger,
                     cancellationToken).Result;
 
-                // NuGet package Version
-                // including preview
-                var mathPackage = packageVersions.Where(v => v.IsPrerelease).OrderByDescending(v => v).First();
-                // stable only
-                //var mathPackage = MathNuGetVersion = packageVersions.OrderByDescending(v => v).First();
+                if(mscorlibVersion.IsPrerelease)
+                {
+                    // we are working with a preview version
+                    var mathPackage = packageVersions.Where(v => v.IsPrerelease).OrderByDescending(v => v).First();
+                    MathVersion = mathPackage.Version.ToString();
+                    MathNuGetVersion = mathPackage.ToNormalizedString();
+                }
+                else
+                {
+                    // we are working with a stable version
+                    var mathPackage = packageVersions.OrderByDescending(v => v).First();
+                    MathVersion = mathPackage.Version.ToString();
+                    MathNuGetVersion = mathPackage.ToNormalizedString();
+                }
 
-                MathVersion = mathPackage.Version.ToString();
-                MathNuGetVersion = mathPackage.ToNormalizedString();
+                logger.LogInformation($"Referencing nanoFramework.CoreLibrary {MscorlibNuGetVersion}");
+                logger.LogInformation($"Referencing nanoFramework.System.Math {MathNuGetVersion}");
             }
             else
             {


### PR DESCRIPTION
- Implement code to figure out if the the latest mscorlib version is preview or stable and use the appropriate version.
(previously it was referencing only preview versions)
- Resolves nanoframework/Home#796.