### PR TITLE
Overload * operator for BitRate and Duration

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -36,7 +36,8 @@ namespace CodeGen.Generators.UnitsNetGen
                               baseDimensions.I == 0 &&
                               baseDimensions.Θ == 0 &&
                               baseDimensions.N == 0 &&
-                              baseDimensions.J == 0;
+                              baseDimensions.J == 0 &&
+                              baseDimensions.b == 0;
 
         }
 
@@ -120,7 +121,7 @@ namespace UnitsNet
             BaseDimensions = BaseDimensions.Dimensionless;
 "
                 : $@"
-            BaseDimensions = new BaseDimensions({baseDimensions.L}, {baseDimensions.M}, {baseDimensions.T}, {baseDimensions.I}, {baseDimensions.Θ}, {baseDimensions.N}, {baseDimensions.J});
+            BaseDimensions = new BaseDimensions({baseDimensions.L}, {baseDimensions.M}, {baseDimensions.T}, {baseDimensions.I}, {baseDimensions.Θ}, {baseDimensions.N}, {baseDimensions.J}, {baseDimensions.b});
 ");
 
             Writer.WL($@"

--- a/CodeGen/Generators/UnitsNetWrcGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetWrcGen/QuantityGenerator.cs
@@ -36,7 +36,8 @@ namespace CodeGen.Generators.UnitsNetWrcGen
                               baseDimensions.I == 0 &&
                               baseDimensions.Θ == 0 &&
                               baseDimensions.N == 0 &&
-                              baseDimensions.J == 0;
+                              baseDimensions.J == 0 &&
+                              baseDimensions.b == 0;
 
         }
 
@@ -114,7 +115,7 @@ namespace UnitsNet
                 ? @"
             BaseDimensions = BaseDimensions.Dimensionless;"
                 : $@"
-            BaseDimensions = new BaseDimensions({baseDimensions.L}, {baseDimensions.M}, {baseDimensions.T}, {baseDimensions.I}, {baseDimensions.Θ}, {baseDimensions.N}, {baseDimensions.J});");
+            BaseDimensions = new BaseDimensions({baseDimensions.L}, {baseDimensions.M}, {baseDimensions.T}, {baseDimensions.I}, {baseDimensions.Θ}, {baseDimensions.N}, {baseDimensions.J}, {baseDimensions.b});");
 
             Writer.WL($@"
             Info = new QuantityInfo(QuantityType.{_quantity.Name}, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);

--- a/CodeGen/JsonTypes/BaseDimensions.cs
+++ b/CodeGen/JsonTypes/BaseDimensions.cs
@@ -22,6 +22,8 @@ namespace CodeGen.JsonTypes
         public int Θ = 0;
         /// <summary>Time.</summary>
         public int T = 0;
+        /// <summary>Information.</summary>
+        public int b = 0;
 
         // 0649 Field is never assigned to
 #pragma warning restore 0649

--- a/Common/UnitDefinitions/BitRate.json
+++ b/Common/UnitDefinitions/BitRate.json
@@ -3,6 +3,10 @@
   "BaseUnit": "BitPerSecond",
   "BaseType": "decimal",
   "XmlDoc": "In telecommunications and computing, bit rate is the number of bits that are conveyed or processed per unit of time.",
+  "BaseDimensions": {
+    "b": 1,
+    "T": -1
+  },
   "XmlDocRemarks": "https://en.wikipedia.org/wiki/Bit_rate",
   "Units": [
     {

--- a/Common/UnitDefinitions/Information.json
+++ b/Common/UnitDefinitions/Information.json
@@ -3,6 +3,9 @@
   "BaseUnit": "Bit",
   "BaseType": "decimal",
   "XmlDoc": "In computing and telecommunications, a unit of information is the capacity of some standard data storage system or communication channel, used to measure the capacities of other systems and channels. In information theory, units of information are also used to measure the information contents or entropy of random variables.",
+  "BaseDimensions": {
+    "b": 1
+  },
   "Units": [
     {
       "SingularName": "Byte",

--- a/UnitsNet.Tests/BaseDimensionsTests.cs
+++ b/UnitsNet.Tests/BaseDimensionsTests.cs
@@ -9,7 +9,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void ConstructorImplementedCorrectly()
         {
-            var baseDimensions = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
+            var baseDimensions = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
 
             Assert.True(baseDimensions.Length == 1);
             Assert.True(baseDimensions.Mass == 2);
@@ -18,37 +18,40 @@ namespace UnitsNet.Tests
             Assert.True(baseDimensions.Temperature == 5);
             Assert.True(baseDimensions.Amount == 6);
             Assert.True(baseDimensions.LuminousIntensity == 7);
+            Assert.True(baseDimensions.Information == 8);
         }
 
         [Theory]
-        [InlineData(1, 0, 0, 0, 0, 0, 0)]
-        [InlineData(0, 1, 0, 0, 0, 0, 0)]
-        [InlineData(0, 0, 1, 0, 0, 0, 0)]
-        [InlineData(0, 0, 0, 1, 0, 0, 0)]
-        [InlineData(0, 0, 0, 0, 1, 0, 0)]
-        [InlineData(0, 0, 0, 0, 0, 1, 0)]
-        [InlineData(0, 0, 0, 0, 0, 0, 1)]
-        public void IsBaseQuantityImplementedProperly(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
+        [InlineData(1, 0, 0, 0, 0, 0, 0, 0)]
+        [InlineData(0, 1, 0, 0, 0, 0, 0, 0)]
+        [InlineData(0, 0, 1, 0, 0, 0, 0, 0)]
+        [InlineData(0, 0, 0, 1, 0, 0, 0, 0)]
+        [InlineData(0, 0, 0, 0, 1, 0, 0, 0)]
+        [InlineData(0, 0, 0, 0, 0, 1, 0, 0)]
+        [InlineData(0, 0, 0, 0, 0, 0, 1, 0)]
+        [InlineData(0, 0, 0, 0, 0, 0, 0, 1)]
+        public void IsBaseQuantityImplementedProperly(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity, int information)
         {
-            var baseDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity);
-            var derivedDimensions = new BaseDimensions(length * 2, mass * 2, time * 2, current * 2, temperature * 2, amount * 2, luminousIntensity * 2);
+            var baseDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity, information);
+            var derivedDimensions = new BaseDimensions(length * 2, mass * 2, time * 2, current * 2, temperature * 2, amount * 2, luminousIntensity * 2, information * 2);
 
             Assert.True(baseDimensions.IsBaseQuantity());
             Assert.False(derivedDimensions.IsBaseQuantity());
         }
 
         [Theory]
-        [InlineData(2, 0, 0, 0, 0, 0, 0)]
-        [InlineData(0, 2, 0, 0, 0, 0, 0)]
-        [InlineData(0, 0, 2, 0, 0, 0, 0)]
-        [InlineData(0, 0, 0, 2, 0, 0, 0)]
-        [InlineData(0, 0, 0, 0, 2, 0, 0)]
-        [InlineData(0, 0, 0, 0, 0, 2, 0)]
-        [InlineData(0, 0, 0, 0, 0, 0, 2)]
-        public void IsDerivedQuantityImplementedProperly(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
+        [InlineData(2, 0, 0, 0, 0, 0, 0, 0)]
+        [InlineData(0, 2, 0, 0, 0, 0, 0, 0)]
+        [InlineData(0, 0, 2, 0, 0, 0, 0, 0)]
+        [InlineData(0, 0, 0, 2, 0, 0, 0, 0)]
+        [InlineData(0, 0, 0, 0, 2, 0, 0, 0)]
+        [InlineData(0, 0, 0, 0, 0, 2, 0, 0)]
+        [InlineData(0, 0, 0, 0, 0, 0, 2, 0)]
+        [InlineData(0, 0, 0, 0, 0, 0, 0, 2)]
+        public void IsDerivedQuantityImplementedProperly(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity, int information)
         {
-            var baseDimensions = new BaseDimensions(length / 2, mass / 2, time / 2, current / 2, temperature / 2, amount / 2, luminousIntensity / 2);
-            var derivedDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity);
+            var baseDimensions = new BaseDimensions(length / 2, mass / 2, time / 2, current / 2, temperature / 2, amount / 2, luminousIntensity / 2, information / 2);
+            var derivedDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity, information);
 
             Assert.False(baseDimensions.IsDerivedQuantity());
             Assert.True(derivedDimensions.IsDerivedQuantity());
@@ -57,8 +60,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void EqualsWorksAsExpected()
         {
-            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
-            var baseDimensions2 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
+            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
+            var baseDimensions2 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
 
             Assert.True(baseDimensions1.Equals(baseDimensions2));
             Assert.True(baseDimensions2.Equals(baseDimensions1));
@@ -69,8 +72,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void EqualityOperatorsWorkAsExpected()
         {
-            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
-            var baseDimensions2 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
+            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
+            var baseDimensions2 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
 
             Assert.True(baseDimensions1 == baseDimensions2);
             Assert.True(baseDimensions2 == baseDimensions1);
@@ -90,8 +93,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void InequalityOperatorsWorkAsExpected()
         {
-            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
-            var baseDimensions2 = new BaseDimensions(7, 6, 5, 4, 3, 2, 1);
+            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
+            var baseDimensions2 = new BaseDimensions(8, 7, 6, 5, 4, 3, 2, 1);
 
             Assert.True(baseDimensions1 != baseDimensions2);
             Assert.True(baseDimensions2 != baseDimensions1);
@@ -111,21 +114,21 @@ namespace UnitsNet.Tests
         [Fact]
         public void MultiplyThrowsExceptionIfPassedNull()
         {
-            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
             Assert.Throws<ArgumentNullException>(() => baseDimensions1.Multiply(null));
         }
 
         [Fact]
         public void DivideThrowsExceptionIfPassedNull()
         {
-            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
             Assert.Throws<ArgumentNullException>(() => baseDimensions1.Divide(null));
         }
 
         [Fact]
         public void MultiplyOperatorThrowsExceptionWithNull()
         {
-            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
             Assert.Throws<ArgumentNullException>(() => baseDimensions1 / null);
             Assert.Throws<ArgumentNullException>(() => null / baseDimensions1);
         }
@@ -133,7 +136,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void DivideOperatorThrowsExceptionWithNull()
         {
-            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
             Assert.Throws<ArgumentNullException>(() => baseDimensions1 * null);
             Assert.Throws<ArgumentNullException>(() => null * baseDimensions1);
         }
@@ -141,8 +144,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void LengthDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(2, 0, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -153,13 +156,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void MassDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 2, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 3, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 2, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 3, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -170,13 +174,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TimeDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 3, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 4, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 3, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 4, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -187,13 +192,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void CurrentDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -204,13 +210,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TemperatureDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 5, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 6, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 5, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 6, 0, 0, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -221,13 +228,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 11);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void AmountDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 6, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 7, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 6, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 7, 0, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -238,13 +246,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 13);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void LuminousIntensityDimensionsMultiplyCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 7);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 8);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 7, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 8, 0);
 
             var result = baseDimensions1.Multiply(baseDimensions2);
 
@@ -255,13 +264,32 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 15);
+            Assert.True(result.Information == 0);
+        }
+
+        [Fact]
+        public void InformationDimensionsMultiplyCorrectly()
+        {
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 7);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 8);
+
+            var result = baseDimensions1.Multiply(baseDimensions2);
+
+            Assert.True(result.Length == 0);
+            Assert.True(result.Mass == 0);
+            Assert.True(result.Time == 0);
+            Assert.True(result.Current == 0);
+            Assert.True(result.Temperature == 0);
+            Assert.True(result.Amount == 0);
+            Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 15);
         }
 
         [Fact]
         public void LengthDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(8, 0, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(7, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(8, 0, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(7, 0, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -272,13 +300,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void MassDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 7, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 6, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 7, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 6, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -289,13 +318,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TimeDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 6, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 5, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 6, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 5, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -306,13 +336,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void CurrentDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -323,13 +354,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TemperatureDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 4, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 3, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 4, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 3, 0, 0, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -340,13 +372,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 1);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void AmountDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 3, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 2, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 3, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 2, 0, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -357,13 +390,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 1);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void LuminousIntensityDimensionsDivideCorrectly()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 2);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 2, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 1, 0);
 
             var result = baseDimensions1.Divide(baseDimensions2);
 
@@ -374,6 +408,25 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 1);
+            Assert.True(result.Information == 0);
+        }
+
+        [Fact]
+        public void InformationDimensionsDivideCorrectly()
+        {
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 2);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 1);
+
+            var result = baseDimensions1.Divide(baseDimensions2);
+
+            Assert.True(result.Length == 0);
+            Assert.True(result.Mass == 0);
+            Assert.True(result.Time == 0);
+            Assert.True(result.Current == 0);
+            Assert.True(result.Temperature == 0);
+            Assert.True(result.Amount == 0);
+            Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 1);
         }
 
         [Fact]
@@ -413,8 +466,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void EqualityWorksAsExpectedWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
-            var baseDimensions2 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
+            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
+            var baseDimensions2 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
 
             Assert.True(baseDimensions1 == baseDimensions2);
             Assert.True(baseDimensions2 == baseDimensions1);
@@ -423,8 +476,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void LengthDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(2, 0, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -435,13 +488,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void MassDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 2, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 3, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 2, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 3, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -452,13 +506,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TimeDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 3, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 4, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 3, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 4, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -469,13 +524,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void CurrentDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -486,13 +542,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TemperatureDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 5, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 6, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 5, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 6, 0, 0, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -503,13 +560,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 11);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void AmountDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 6, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 7, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 6, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 7, 0, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -520,13 +578,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 13);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void LuminousIntensityDimensionsMultiplyCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 7);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 8);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 7, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 8, 0);
 
             var result = baseDimensions1 * baseDimensions2;
 
@@ -537,13 +596,32 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 15);
+            Assert.True(result.Information == 0);
+        }
+
+        [Fact]
+        public void InformationDimensionsMultiplyCorrectlyWithOperatorOverloads()
+        {
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 8);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 9);
+
+            var result = baseDimensions1 * baseDimensions2;
+
+            Assert.True(result.Length == 0);
+            Assert.True(result.Mass == 0);
+            Assert.True(result.Time == 0);
+            Assert.True(result.Current == 0);
+            Assert.True(result.Temperature == 0);
+            Assert.True(result.Amount == 0);
+            Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 17);
         }
 
         [Fact]
         public void LengthDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(8, 0, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(7, 0, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(8, 0, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(7, 0, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -554,13 +632,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void MassDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 7, 0, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 6, 0, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 7, 0, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 6, 0, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -571,13 +650,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TimeDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 6, 0, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 5, 0, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 6, 0, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 5, 0, 0, 0, 0, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -588,13 +668,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void CurrentDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 5, 0, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 4, 0, 0, 0, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -605,13 +686,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void TemperatureDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 4, 0, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 3, 0, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 4, 0, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 3, 0, 0, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -622,13 +704,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 1);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void AmountDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 3, 0);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 2, 0);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 3, 0, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 2, 0, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -639,13 +722,14 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 1);
             Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 0);
         }
 
         [Fact]
         public void LuminousIntensityDimensionsDivideCorrectlyWithOperatorOverloads()
         {
-            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 2);
-            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 2, 0);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 1, 0);
 
             var result = baseDimensions1 / baseDimensions2;
 
@@ -656,6 +740,25 @@ namespace UnitsNet.Tests
             Assert.True(result.Temperature == 0);
             Assert.True(result.Amount == 0);
             Assert.True(result.LuminousIntensity == 1);
+            Assert.True(result.Information == 0);
+        }
+
+        [Fact]
+        public void InformationDimensionsDivideCorrectlyWithOperatorOverloads()
+        {
+            var baseDimensions1 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 2);
+            var baseDimensions2 = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 1);
+
+            var result = baseDimensions1 / baseDimensions2;
+
+            Assert.True(result.Length == 0);
+            Assert.True(result.Mass == 0);
+            Assert.True(result.Time == 0);
+            Assert.True(result.Current == 0);
+            Assert.True(result.Temperature == 0);
+            Assert.True(result.Amount == 0);
+            Assert.True(result.LuminousIntensity == 0);
+            Assert.True(result.Information == 1);
         }
 
         [Fact]
@@ -701,9 +804,9 @@ namespace UnitsNet.Tests
         [Fact]
         public void GetHashCodeWorksProperly()
         {
-            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
-            var baseDimensions2 = new BaseDimensions(7, 6, 5, 4, 3, 2, 1);
-            var baseDimensions3 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7);
+            var baseDimensions1 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
+            var baseDimensions2 = new BaseDimensions(8, 7, 6, 5, 4, 3, 2, 1);
+            var baseDimensions3 = new BaseDimensions(1, 2, 3, 4, 5, 6, 7, 8);
 
             var hashSet = new HashSet<BaseDimensions>();
 
@@ -723,14 +826,14 @@ namespace UnitsNet.Tests
         [Fact]
         public void DimensionlessPropertyIsCorrect()
         {
-            Assert.True(BaseDimensions.Dimensionless == new BaseDimensions(0, 0, 0, 0, 0, 0, 0));
+            Assert.True(BaseDimensions.Dimensionless == new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 0));
         }
 
         [Fact]
         public void IsDimensionlessMethodImplementedCorrectly()
         {
             Assert.True(BaseDimensions.Dimensionless.IsDimensionless());
-            Assert.True(new BaseDimensions(0, 0, 0, 0, 0, 0, 0).IsDimensionless());
+            Assert.True(new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 0).IsDimensionless());
 
             Assert.False(BaseDimensions.Dimensionless.IsBaseQuantity());
             Assert.False(BaseDimensions.Dimensionless.IsDerivedQuantity());

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Acceleration.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Acceleration()
         {
-            BaseDimensions = new BaseDimensions(1, 0, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 0, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Acceleration, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static AmountOfSubstance()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 1, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 1, 0, 0);
             Info = new QuantityInfo(QuantityType.AmountOfSubstance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ApparentEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ApparentEnergy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ApparentPower()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ApparentPower, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Area.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Area()
         {
-            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Area, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static AreaDensity()
         {
-            BaseDimensions = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.AreaDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static AreaMomentOfInertia()
         {
-            BaseDimensions = new BaseDimensions(4, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(4, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.AreaMomentOfInertia, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BitRate.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static BitRate()
         {
-            BaseDimensions = BaseDimensions.Dimensionless;
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0, 1);
             Info = new QuantityInfo(QuantityType.BitRate, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static BrakeSpecificFuelConsumption()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.BrakeSpecificFuelConsumption, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Capacitance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Capacitance()
         {
-            BaseDimensions = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Capacitance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static CoefficientOfThermalExpansion()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, -1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.CoefficientOfThermalExpansion, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Density.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Density()
         {
-            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Density, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Duration.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Duration()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Duration, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static DynamicViscosity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.DynamicViscosity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricAdmittance()
         {
-            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricAdmittance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricCharge()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 1, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricCharge, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricChargeDensity()
         {
-            BaseDimensions = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricChargeDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricConductance()
         {
-            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricConductance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricConductivity()
         {
-            BaseDimensions = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricConductivity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricCurrent()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricCurrent, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricCurrentDensity()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricCurrentDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricCurrentGradient()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricCurrentGradient, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricField.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricField()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, -1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricField, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricInductance()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, -2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricInductance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricPotential()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, -1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricPotential, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricPotentialChangeRate()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -4, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -4, -1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricPotentialChangeRate, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricResistance()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, -2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricResistance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricResistivity()
         {
-            BaseDimensions = new BaseDimensions(3, 1, -3, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, 1, -3, -2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricResistivity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricSurfaceChargeDensity()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 1, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ElectricSurfaceChargeDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Energy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Energy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Energy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Entropy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Entropy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Entropy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Force.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Force()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Force, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ForceChangeRate()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ForceChangeRate, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ForcePerLength()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ForcePerLength, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Frequency.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Frequency()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Frequency, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static HeatFlux()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.HeatFlux, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static HeatTransferCoefficient()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -3, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -3, 0, -1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.HeatTransferCoefficient, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Illuminance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Illuminance()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
+            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1, 0);
             Info = new QuantityInfo(QuantityType.Illuminance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Information.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Information()
         {
-            BaseDimensions = BaseDimensions.Dimensionless;
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 1);
             Info = new QuantityInfo(QuantityType.Information, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Irradiance()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Irradiance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Irradiation.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Irradiation()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Irradiation, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static KinematicViscosity()
         {
-            BaseDimensions = new BaseDimensions(2, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.KinematicViscosity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LapseRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static LapseRate()
         {
-            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.LapseRate, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Length.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Length()
         {
-            BaseDimensions = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Length, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LinearDensity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.LinearDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LinearPowerDensity()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.LinearPowerDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Luminosity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Luminosity()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Luminosity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LuminousFlux()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1, 0);
             Info = new QuantityInfo(QuantityType.LuminousFlux, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LuminousIntensity()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1, 0);
             Info = new QuantityInfo(QuantityType.LuminousIntensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticField.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static MagneticField()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -2, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -2, -1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.MagneticField, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static MagneticFlux()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, -1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.MagneticFlux, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Magnetization.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Magnetization()
         {
-            BaseDimensions = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Magnetization, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Mass.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Mass()
         {
-            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Mass, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static MassConcentration()
         {
-            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.MassConcentration, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlow.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MassFlow()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.MassFlow, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassFlux.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MassFlux()
         {
-            BaseDimensions = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.MassFlux, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MassMomentOfInertia()
         {
-            BaseDimensions = new BaseDimensions(2, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.MassMomentOfInertia, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MolarEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, -1, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, -1, 0, 0);
             Info = new QuantityInfo(QuantityType.MolarEnergy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MolarEntropy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, -1, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, -1, 0, 0);
             Info = new QuantityInfo(QuantityType.MolarEntropy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/MolarMass.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MolarMass()
         {
-            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, -1, 0);
+            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, -1, 0, 0);
             Info = new QuantityInfo(QuantityType.MolarMass, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Molarity()
         {
-            BaseDimensions = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0);
+            BaseDimensions = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0, 0);
             Info = new QuantityInfo(QuantityType.Molarity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permeability.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Permeability()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, -2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Permeability, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Permittivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Permittivity()
         {
-            BaseDimensions = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Permittivity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Power.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Power()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Power, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static PowerDensity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.PowerDensity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Pressure.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Pressure()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Pressure, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static PressureChangeRate()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.PressureChangeRate, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ReactiveEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ReactiveEnergy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ReactivePower()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ReactivePower, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ReciprocalArea()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ReciprocalArea, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ReciprocalLength()
         {
-            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ReciprocalLength, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalAcceleration()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.RotationalAcceleration, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalSpeed()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.RotationalSpeed, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalStiffness()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.RotationalStiffness, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalStiffnessPerLength()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.RotationalStiffnessPerLength, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static SpecificEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.SpecificEnergy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static SpecificEntropy()
         {
-            BaseDimensions = new BaseDimensions(2, 0, -2, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, -2, 0, -1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.SpecificEntropy, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static SpecificVolume()
         {
-            BaseDimensions = new BaseDimensions(3, -1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, -1, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.SpecificVolume, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static SpecificWeight()
         {
-            BaseDimensions = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.SpecificWeight, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Speed.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Speed()
         {
-            BaseDimensions = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 0, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Speed, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static StandardVolumeFlow()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.StandardVolumeFlow, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Temperature.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Temperature()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Temperature, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static TemperatureChangeRate()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.TemperatureChangeRate, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static TemperatureDelta()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.TemperatureDelta, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ThermalConductivity()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, 0, -1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ThermalConductivity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ThermalResistance()
         {
-            BaseDimensions = new BaseDimensions(0, -1, 3, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, -1, 3, 0, 1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.ThermalResistance, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Torque.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Torque()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Torque, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TorquePerLength.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/TorquePerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static TorquePerLength()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.TorquePerLength, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Volume.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Volume()
         {
-            BaseDimensions = new BaseDimensions(3, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.Volume, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static VolumeFlow()
         {
-            BaseDimensions = new BaseDimensions(3, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, 0, -1, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.VolumeFlow, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static VolumePerLength()
         {
-            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.VolumePerLength, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static VolumetricHeatCapacity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, -1, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.VolumetricHeatCapacity, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static WarpingMomentOfInertia()
         {
-            BaseDimensions = new BaseDimensions(6, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(6, 0, 0, 0, 0, 0, 0, 0);
             Info = new QuantityInfo(QuantityType.WarpingMomentOfInertia, Units.Cast<Enum>().ToArray(), BaseUnit, Zero, BaseDimensions);
         }
 

--- a/UnitsNet/BaseDimensions.cs
+++ b/UnitsNet/BaseDimensions.cs
@@ -13,7 +13,7 @@ namespace UnitsNet
     public sealed class BaseDimensions
     {
         /// <inheritdoc />
-        public BaseDimensions(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
+        public BaseDimensions(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity, int information)
         {
             Length = length;
             Mass = mass;
@@ -22,6 +22,7 @@ namespace UnitsNet
             Temperature = temperature;
             Amount = amount;
             LuminousIntensity = luminousIntensity;
+            Information = information;
         }
 
         /// <summary>
@@ -30,7 +31,7 @@ namespace UnitsNet
         /// <returns>True if the dimensions represent a base quantity, otherwise false.</returns>
         public bool IsBaseQuantity()
         {
-            var dimensionsArray = new int[]{Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity};
+            var dimensionsArray = new int[]{Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity, Information};
             bool onlyOneEqualsOne = dimensionsArray.Where(dimension => dimension == 1).Take(2).Count() == 1;
             return onlyOneEqualsOne;
         }
@@ -67,7 +68,8 @@ namespace UnitsNet
                 Current == other.Current &&
                 Temperature == other.Temperature &&
                 Amount == other.Amount &&
-                LuminousIntensity == other.LuminousIntensity;
+                LuminousIntensity == other.LuminousIntensity &&
+                Information == other.Information;
         }
 
         /// <inheritdoc />
@@ -93,7 +95,8 @@ namespace UnitsNet
                 Current + right.Current,
                 Temperature + right.Temperature,
                 Amount + right.Amount,
-                LuminousIntensity + right.LuminousIntensity);
+                LuminousIntensity + right.LuminousIntensity,
+                Information + right.Information);
         }
 
         /// <summary>
@@ -113,7 +116,8 @@ namespace UnitsNet
                 Current - right.Current,
                 Temperature - right.Temperature,
                 Amount - right.Amount,
-                LuminousIntensity - right.LuminousIntensity);
+                LuminousIntensity - right.LuminousIntensity,
+                Information - right.Information);
         }
 
         /// <summary>
@@ -182,6 +186,7 @@ namespace UnitsNet
             AppendDimensionString(sb, "Temperature", Temperature);
             AppendDimensionString(sb, "Amount", Amount);
             AppendDimensionString(sb, "LuminousIntensity", LuminousIntensity);
+            AppendDimensionString(sb, "Information", Information);
 
             return sb.ToString();
         }
@@ -235,8 +240,13 @@ namespace UnitsNet
         public int LuminousIntensity{ get; }
 
         /// <summary>
+        /// Gets the information dimensions (b).
+        /// </summary>
+        public int Information { get; }
+
+        /// <summary>
         /// Represents a dimensionless (unitless) quantity.
         /// </summary>
-        public static BaseDimensions Dimensionless { get; } = new BaseDimensions(0, 0, 0, 0, 0, 0, 0);
+        public static BaseDimensions Dimensionless { get; } = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 0);
     }
 }

--- a/UnitsNet/CustomCode/Quantities/BitRate.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/BitRate.extra.cs
@@ -1,0 +1,19 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+
+namespace UnitsNet
+{
+    public partial struct BitRate
+    {
+        /// <summary>Get <see cref="Information"/> from <see cref="BitRate"/> times <see cref="Duration"/>.</summary>
+        public static Information operator *(BitRate bitRate, Duration duration)
+        {
+            return Information.FromBits(bitRate.BitsPerSecond * duration.Seconds);
+        }
+
+        /// <summary>Get <see cref="Information"/> from <see cref="Duration"/> times <see cref="BitRate"/>.</summary>
+        public static Information operator *(Duration duration, BitRate bitRate)
+        {
+            return Information.FromBits(bitRate.BitsPerSecond * duration.Seconds);
+        }
+    }
+}

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Acceleration()
         {
-            BaseDimensions = new BaseDimensions(1, 0, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 0, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<AccelerationUnit>("Acceleration",
                 new UnitInfo<AccelerationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static AmountOfSubstance()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 1, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 1, 0, 0);
 
             Info = new QuantityInfo<AmountOfSubstanceUnit>("AmountOfSubstance",
                 new UnitInfo<AmountOfSubstanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ApparentEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ApparentEnergyUnit>("ApparentEnergy",
                 new UnitInfo<ApparentEnergyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ApparentPower()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ApparentPowerUnit>("ApparentPower",
                 new UnitInfo<ApparentPowerUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Area()
         {
-            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<AreaUnit>("Area",
                 new UnitInfo<AreaUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static AreaDensity()
         {
-            BaseDimensions = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<AreaDensityUnit>("AreaDensity",
                 new UnitInfo<AreaDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static AreaMomentOfInertia()
         {
-            BaseDimensions = new BaseDimensions(4, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(4, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<AreaMomentOfInertiaUnit>("AreaMomentOfInertia",
                 new UnitInfo<AreaMomentOfInertiaUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static BitRate()
         {
-            BaseDimensions = BaseDimensions.Dimensionless;
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0, 1);
 
             Info = new QuantityInfo<BitRateUnit>("BitRate",
                 new UnitInfo<BitRateUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static BrakeSpecificFuelConsumption()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<BrakeSpecificFuelConsumptionUnit>("BrakeSpecificFuelConsumption",
                 new UnitInfo<BrakeSpecificFuelConsumptionUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Capacitance()
         {
-            BaseDimensions = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<CapacitanceUnit>("Capacitance",
                 new UnitInfo<CapacitanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static CoefficientOfThermalExpansion()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, -1, 0, 0, 0);
 
             Info = new QuantityInfo<CoefficientOfThermalExpansionUnit>("CoefficientOfThermalExpansion",
                 new UnitInfo<CoefficientOfThermalExpansionUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Density()
         {
-            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<DensityUnit>("Density",
                 new UnitInfo<DensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Duration()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<DurationUnit>("Duration",
                 new UnitInfo<DurationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static DynamicViscosity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<DynamicViscosityUnit>("DynamicViscosity",
                 new UnitInfo<DynamicViscosityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricAdmittance()
         {
-            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricAdmittanceUnit>("ElectricAdmittance",
                 new UnitInfo<ElectricAdmittanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricCharge()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 1, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricChargeUnit>("ElectricCharge",
                 new UnitInfo<ElectricChargeUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricChargeDensity()
         {
-            BaseDimensions = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricChargeDensityUnit>("ElectricChargeDensity",
                 new UnitInfo<ElectricChargeDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricConductance()
         {
-            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricConductanceUnit>("ElectricConductance",
                 new UnitInfo<ElectricConductanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricConductivity()
         {
-            BaseDimensions = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricConductivityUnit>("ElectricConductivity",
                 new UnitInfo<ElectricConductivityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricCurrent()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricCurrentUnit>("ElectricCurrent",
                 new UnitInfo<ElectricCurrentUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricCurrentDensity()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricCurrentDensityUnit>("ElectricCurrentDensity",
                 new UnitInfo<ElectricCurrentDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricCurrentGradient()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricCurrentGradientUnit>("ElectricCurrentGradient",
                 new UnitInfo<ElectricCurrentGradientUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricField()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, -1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricFieldUnit>("ElectricField",
                 new UnitInfo<ElectricFieldUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricInductance()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, -2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricInductanceUnit>("ElectricInductance",
                 new UnitInfo<ElectricInductanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricPotential()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, -1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricPotentialUnit>("ElectricPotential",
                 new UnitInfo<ElectricPotentialUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricPotentialChangeRate()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -4, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -4, -1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricPotentialChangeRateUnit>("ElectricPotentialChangeRate",
                 new UnitInfo<ElectricPotentialChangeRateUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ElectricResistance()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, -2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricResistanceUnit>("ElectricResistance",
                 new UnitInfo<ElectricResistanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricResistivity()
         {
-            BaseDimensions = new BaseDimensions(3, 1, -3, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, 1, -3, -2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricResistivityUnit>("ElectricResistivity",
                 new UnitInfo<ElectricResistivityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ElectricSurfaceChargeDensity()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 1, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 1, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ElectricSurfaceChargeDensityUnit>("ElectricSurfaceChargeDensity",
                 new UnitInfo<ElectricSurfaceChargeDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Energy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<EnergyUnit>("Energy",
                 new UnitInfo<EnergyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Entropy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, 0, 0, 0);
 
             Info = new QuantityInfo<EntropyUnit>("Entropy",
                 new UnitInfo<EntropyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Force()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ForceUnit>("Force",
                 new UnitInfo<ForceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ForceChangeRate()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ForceChangeRateUnit>("ForceChangeRate",
                 new UnitInfo<ForceChangeRateUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ForcePerLength()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ForcePerLengthUnit>("ForcePerLength",
                 new UnitInfo<ForcePerLengthUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Frequency()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<FrequencyUnit>("Frequency",
                 new UnitInfo<FrequencyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static HeatFlux()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<HeatFluxUnit>("HeatFlux",
                 new UnitInfo<HeatFluxUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static HeatTransferCoefficient()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -3, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -3, 0, -1, 0, 0, 0);
 
             Info = new QuantityInfo<HeatTransferCoefficientUnit>("HeatTransferCoefficient",
                 new UnitInfo<HeatTransferCoefficientUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Illuminance()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
+            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1, 0);
 
             Info = new QuantityInfo<IlluminanceUnit>("Illuminance",
                 new UnitInfo<IlluminanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Information()
         {
-            BaseDimensions = BaseDimensions.Dimensionless;
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 0, 1);
 
             Info = new QuantityInfo<InformationUnit>("Information",
                 new UnitInfo<InformationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Irradiance()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<IrradianceUnit>("Irradiance",
                 new UnitInfo<IrradianceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Irradiation()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<IrradiationUnit>("Irradiation",
                 new UnitInfo<IrradiationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static KinematicViscosity()
         {
-            BaseDimensions = new BaseDimensions(2, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<KinematicViscosityUnit>("KinematicViscosity",
                 new UnitInfo<KinematicViscosityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static LapseRate()
         {
-            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0, 0);
 
             Info = new QuantityInfo<LapseRateUnit>("LapseRate",
                 new UnitInfo<LapseRateUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Length()
         {
-            BaseDimensions = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<LengthUnit>("Length",
                 new UnitInfo<LengthUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LinearDensity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<LinearDensityUnit>("LinearDensity",
                 new UnitInfo<LinearDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LinearPowerDensity()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<LinearPowerDensityUnit>("LinearPowerDensity",
                 new UnitInfo<LinearPowerDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Luminosity()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<LuminosityUnit>("Luminosity",
                 new UnitInfo<LuminosityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LuminousFlux()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1, 0);
 
             Info = new QuantityInfo<LuminousFluxUnit>("LuminousFlux",
                 new UnitInfo<LuminousFluxUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static LuminousIntensity()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 0, 0, 1, 0);
 
             Info = new QuantityInfo<LuminousIntensityUnit>("LuminousIntensity",
                 new UnitInfo<LuminousIntensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static MagneticField()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -2, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -2, -1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MagneticFieldUnit>("MagneticField",
                 new UnitInfo<MagneticFieldUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static MagneticFlux()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, -1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, -1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MagneticFluxUnit>("MagneticFlux",
                 new UnitInfo<MagneticFluxUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Magnetization()
         {
-            BaseDimensions = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MagnetizationUnit>("Magnetization",
                 new UnitInfo<MagnetizationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Mass()
         {
-            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MassUnit>("Mass",
                 new UnitInfo<MassUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static MassConcentration()
         {
-            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MassConcentrationUnit>("MassConcentration",
                 new UnitInfo<MassConcentrationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MassFlow()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MassFlowUnit>("MassFlow",
                 new UnitInfo<MassFlowUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MassFlux()
         {
-            BaseDimensions = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MassFluxUnit>("MassFlux",
                 new UnitInfo<MassFluxUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MassMomentOfInertia()
         {
-            BaseDimensions = new BaseDimensions(2, 1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<MassMomentOfInertiaUnit>("MassMomentOfInertia",
                 new UnitInfo<MassMomentOfInertiaUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MolarEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, -1, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, -1, 0, 0);
 
             Info = new QuantityInfo<MolarEnergyUnit>("MolarEnergy",
                 new UnitInfo<MolarEnergyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MolarEntropy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, -1, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, -1, -1, 0, 0);
 
             Info = new QuantityInfo<MolarEntropyUnit>("MolarEntropy",
                 new UnitInfo<MolarEntropyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static MolarMass()
         {
-            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, -1, 0);
+            BaseDimensions = new BaseDimensions(0, 1, 0, 0, 0, -1, 0, 0);
 
             Info = new QuantityInfo<MolarMassUnit>("MolarMass",
                 new UnitInfo<MolarMassUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Molarity()
         {
-            BaseDimensions = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0);
+            BaseDimensions = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0, 0);
 
             Info = new QuantityInfo<MolarityUnit>("Molarity",
                 new UnitInfo<MolarityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Permeability()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, -2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, -2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<PermeabilityUnit>("Permeability",
                 new UnitInfo<PermeabilityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static Permittivity()
         {
-            BaseDimensions = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0, 0);
 
             Info = new QuantityInfo<PermittivityUnit>("Permittivity",
                 new UnitInfo<PermittivityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Power()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<PowerUnit>("Power",
                 new UnitInfo<PowerUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static PowerDensity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<PowerDensityUnit>("PowerDensity",
                 new UnitInfo<PowerDensityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Pressure()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<PressureUnit>("Pressure",
                 new UnitInfo<PressureUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static PressureChangeRate()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<PressureChangeRateUnit>("PressureChangeRate",
                 new UnitInfo<PressureChangeRateUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ReactiveEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ReactiveEnergyUnit>("ReactiveEnergy",
                 new UnitInfo<ReactiveEnergyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ReactivePower()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -3, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ReactivePowerUnit>("ReactivePower",
                 new UnitInfo<ReactivePowerUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ReciprocalArea()
         {
-            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ReciprocalAreaUnit>("ReciprocalArea",
                 new UnitInfo<ReciprocalAreaUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ReciprocalLength()
         {
-            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<ReciprocalLengthUnit>("ReciprocalLength",
                 new UnitInfo<ReciprocalLengthUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalAcceleration()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<RotationalAccelerationUnit>("RotationalAcceleration",
                 new UnitInfo<RotationalAccelerationUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalSpeed()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<RotationalSpeedUnit>("RotationalSpeed",
                 new UnitInfo<RotationalSpeedUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalStiffness()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<RotationalStiffnessUnit>("RotationalStiffness",
                 new UnitInfo<RotationalStiffnessUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static RotationalStiffnessPerLength()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<RotationalStiffnessPerLengthUnit>("RotationalStiffnessPerLength",
                 new UnitInfo<RotationalStiffnessPerLengthUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static SpecificEnergy()
         {
-            BaseDimensions = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<SpecificEnergyUnit>("SpecificEnergy",
                 new UnitInfo<SpecificEnergyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static SpecificEntropy()
         {
-            BaseDimensions = new BaseDimensions(2, 0, -2, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, -2, 0, -1, 0, 0, 0);
 
             Info = new QuantityInfo<SpecificEntropyUnit>("SpecificEntropy",
                 new UnitInfo<SpecificEntropyUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static SpecificVolume()
         {
-            BaseDimensions = new BaseDimensions(3, -1, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, -1, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<SpecificVolumeUnit>("SpecificVolume",
                 new UnitInfo<SpecificVolumeUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static SpecificWeight()
         {
-            BaseDimensions = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<SpecificWeightUnit>("SpecificWeight",
                 new UnitInfo<SpecificWeightUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Speed()
         {
-            BaseDimensions = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 0, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<SpeedUnit>("Speed",
                 new UnitInfo<SpeedUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static StandardVolumeFlow()
         {
-            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 1, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<StandardVolumeFlowUnit>("StandardVolumeFlow",
                 new UnitInfo<StandardVolumeFlowUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Temperature()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0, 0);
 
             Info = new QuantityInfo<TemperatureUnit>("Temperature",
                 new UnitInfo<TemperatureUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static TemperatureChangeRate()
         {
-            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, -1, 0, 1, 0, 0, 0);
 
             Info = new QuantityInfo<TemperatureChangeRateUnit>("TemperatureChangeRate",
                 new UnitInfo<TemperatureChangeRateUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static TemperatureDelta()
         {
-            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, 0, 0, 0, 1, 0, 0, 0);
 
             Info = new QuantityInfo<TemperatureDeltaUnit>("TemperatureDelta",
                 new UnitInfo<TemperatureDeltaUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static ThermalConductivity()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -3, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -3, 0, -1, 0, 0, 0);
 
             Info = new QuantityInfo<ThermalConductivityUnit>("ThermalConductivity",
                 new UnitInfo<ThermalConductivityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static ThermalResistance()
         {
-            BaseDimensions = new BaseDimensions(0, -1, 3, 0, 1, 0, 0);
+            BaseDimensions = new BaseDimensions(0, -1, 3, 0, 1, 0, 0, 0);
 
             Info = new QuantityInfo<ThermalResistanceUnit>("ThermalResistance",
                 new UnitInfo<ThermalResistanceUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Torque()
         {
-            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<TorqueUnit>("Torque",
                 new UnitInfo<TorqueUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static TorquePerLength()
         {
-            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(1, 1, -2, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<TorquePerLengthUnit>("TorquePerLength",
                 new UnitInfo<TorquePerLengthUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static Volume()
         {
-            BaseDimensions = new BaseDimensions(3, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<VolumeUnit>("Volume",
                 new UnitInfo<VolumeUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static VolumeFlow()
         {
-            BaseDimensions = new BaseDimensions(3, 0, -1, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(3, 0, -1, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<VolumeFlowUnit>("VolumeFlow",
                 new UnitInfo<VolumeFlowUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static VolumePerLength()
         {
-            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(2, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<VolumePerLengthUnit>("VolumePerLength",
                 new UnitInfo<VolumePerLengthUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -51,7 +51,7 @@ namespace UnitsNet
 
         static VolumetricHeatCapacity()
         {
-            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, -1, 0, 0);
+            BaseDimensions = new BaseDimensions(-1, 1, -2, 0, -1, 0, 0, 0);
 
             Info = new QuantityInfo<VolumetricHeatCapacityUnit>("VolumetricHeatCapacity",
                 new UnitInfo<VolumetricHeatCapacityUnit>[] {

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -48,7 +48,7 @@ namespace UnitsNet
 
         static WarpingMomentOfInertia()
         {
-            BaseDimensions = new BaseDimensions(6, 0, 0, 0, 0, 0, 0);
+            BaseDimensions = new BaseDimensions(6, 0, 0, 0, 0, 0, 0, 0);
 
             Info = new QuantityInfo<WarpingMomentOfInertiaUnit>("WarpingMomentOfInertia",
                 new UnitInfo<WarpingMomentOfInertiaUnit>[] {


### PR DESCRIPTION
The change to overload the * operator for BitRate and Duration is simple, but doing so broke unit tests. To fix them, I needed to make Information a BaseDimension, which is the bulk of the diff. I believe I've done that successfully, but I confess I don't understand why "BaseDimensions" exists. (Does it enable a feature? Does it offer redundancy for testing?)