### PR TITLE
Add AbbreviatedUnitsConverter for Json.NET

### DIFF
--- a/UnitsNet.Serialization.JsonNet.Tests/AbbreviatedUnitsConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/AbbreviatedUnitsConverterTests.cs
@@ -1,0 +1,361 @@
+﻿using System.Globalization;
+using UnitsNet.Tests.Serialization;
+using UnitsNet.Units;
+using Xunit;
+
+namespace UnitsNet.Serialization.JsonNet.Tests
+{
+    public class AbbreviatedUnitsConverterTests : JsonNetSerializationTestsBase
+    {
+        public AbbreviatedUnitsConverterTests() : base(new AbbreviatedUnitsConverter())
+        {
+        }
+
+        #region Serialization tests
+
+        [Fact]
+        public void DoubleQuantity_SerializedWithDoubleValueAndAbbreviatedUnit()
+        {
+            var quantity = new Mass(1.20, MassUnit.Milligram);
+            var expectedJson = "{\"Value\":1.2,\"Unit\":\"mg\",\"Type\":\"Mass\"}";
+
+            var json = SerializeObject(quantity);
+
+            Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void DecimalQuantity_SerializedWithDecimalValueValueAndAbbreviatedUnit()
+        {
+            var quantity = new Information(1.20m, InformationUnit.Exabyte);
+            var expectedJson = "{\"Value\":1.20,\"Unit\":\"EB\",\"Type\":\"Information\"}";
+
+            var json = SerializeObject(quantity);
+
+            Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void DoubleQuantity_InScientificNotation_SerializedWithExpandedValueAndAbbreviatedUnit()
+        {
+            var quantity = new Mass(1E+9, MassUnit.Milligram);
+            var expectedJson = "{\"Value\":1000000000.0,\"Unit\":\"mg\",\"Type\":\"Mass\"}";
+
+            var json = SerializeObject(quantity);
+
+            Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void DecimalQuantity_InScientificNotation_SerializedWithExpandedValueAndAbbreviatedUnit()
+        {
+            var quantity = new Information(1E+9m, InformationUnit.Exabyte);
+            var expectedJson = "{\"Value\":1000000000,\"Unit\":\"EB\",\"Type\":\"Information\"}";
+
+            var json = SerializeObject(quantity);
+
+            Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void InterfaceObject_IncludesTypeInformation()
+        {
+            var testObject = new TestInterfaceObject { Quantity = new Information(1.20m, InformationUnit.Exabyte) };
+            var expectedJson = "{\"Quantity\":{\"Value\":1.20,\"Unit\":\"EB\",\"Type\":\"Information\"}}";
+
+            var json = SerializeObject(testObject);
+
+            Assert.Equal(expectedJson, json);
+        }
+
+        [Fact]
+        public void InterfaceObject_SerializesWithoutKnownTypeInformation()
+        {
+            var testObject = new TestInterfaceObject { Quantity = new Volume(1.2, VolumeUnit.Microliter) };
+
+            var expectedJson = "{\"Quantity\":{\"Value\":1.2,\"Unit\":\"µl\",\"Type\":\"Volume\"}}";
+
+            var json = SerializeObject(testObject);
+
+            Assert.Equal(expectedJson, json);
+        }
+
+        #endregion
+
+        #region Deserialization tests
+
+        [Fact]
+        public void DoubleIQuantity_DeserializedFromDoubleValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":1.2,\"Unit\":\"mg\",\"Type\":\"Mass\"}";
+
+            var quantity = DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleQuantity_DeserializedFromDoubleValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":1.2,\"Unit\":\"mg\"}";
+
+            var quantity = DeserializeObject<Mass>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+        
+        [Fact]
+        public void DoubleIQuantity_DeserializedFromDoubleValueAndNonAmbiguousAbbreviatedUnit_WithoutQuantityType()
+        {
+            var json = "{\"Value\":1.2,\"Unit\":\"em\"}";
+
+            var quantity = DeserializeObject<Mass>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(MassUnit.EarthMass, quantity.Unit);
+        }
+
+        [Fact]
+        public void AmbiguousUnitParseExceptionUnitsNetExceptionThrown_WhenDeserializing_WithoutQuantityType()
+        {
+            var json = "{\"Value\":1.2,\"Unit\":\"mg\"}";
+
+            Assert.Throws<AmbiguousUnitParseException>(() => DeserializeObject<IQuantity>(json));
+        }
+
+        [Fact]
+        public void DoubleIQuantity_DeserializedFromDoubleValueAndAbbreviatedUnit_CaseInsensitive()
+        {
+            var json = "{\"value\":1.2,\"unit\":\"Mg\",\"type\":\"mass\"}";
+
+            var quantity = DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void UnitsNetExceptionThrown_WhenDeserializing_FromUnknownQuantityType()
+        {
+            var json = "{\"Value\":1.2,\"Unit\":\"mg\",\"Type\":\"invalid\"}";
+
+            Assert.Throws<UnitsNetException>(() => DeserializeObject<Mass>(json));
+        }
+
+        [Fact]
+        public void UnitsNotFoundExceptionThrown_WhenDeserializing_FromUnknownUnit()
+        {
+            var json = "{\"Value\":1.2,\"Unit\":\"invalid\",\"Type\":\"Mass\"}";
+
+            Assert.Throws<UnitNotFoundException>(() => DeserializeObject<Mass>(json));
+        }
+
+        [Fact]
+        public void DoubleIQuantity_DeserializedFromQuotedDoubleValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":\"1.2\",\"Unit\":\"mg\",\"Type\":\"Mass\"}";
+
+            var quantity = DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleQuantity_DeserializedFromQuotedDoubleValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":\"1.2\",\"Unit\":\"mg\"}";
+
+            var quantity = DeserializeObject<Mass>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleZeroIQuantity_DeserializedFromAbbreviatedUnitAndNoValue()
+        {
+            var json = "{\"Unit\":\"mg\",\"Type\":\"Mass\"}";
+
+            var quantity = DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleZeroQuantity_DeserializedFromAbbreviatedUnitAndNoValue()
+        {
+            var json = "{\"Unit\":\"mg\"}";
+
+            var quantity = DeserializeObject<Mass>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleBaseUnitQuantity_DeserializedFromValueAndNoUnit()
+        {
+            var json = "{\"Value\":1.2,\"Type\":\"Mass\"}";
+
+            var quantity = DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(Mass.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleBaseUnitIQuantity_DeserializedFromValueAndNoUnit()
+        {
+            var json = "{\"Value\":1.2}";
+
+            var quantity = DeserializeObject<Mass>(json);
+
+            Assert.Equal(1.2, quantity.Value);
+            Assert.Equal(Mass.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleZeroBaseIQuantity_DeserializedFromQuantityTypeOnly()
+        {
+            var json = "{\"Type\":\"Mass\"}";
+
+            var quantity = DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(Mass.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleZeroBaseQuantity_DeserializedFromEmptyInput()
+        {
+            var json = "{}";
+
+            var quantity = DeserializeObject<Mass>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(Mass.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalIQuantity_DeserializedFromDecimalValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":1.200,\"Unit\":\"EB\",\"Type\":\"Information\"}";
+
+            var quantity = (Information) DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.200m, quantity.Value);
+            Assert.Equal("1.200", quantity.Value.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(InformationUnit.Exabyte, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalQuantity_DeserializedFromDecimalValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":1.200,\"Unit\":\"EB\"}";
+
+            var quantity = DeserializeObject<Information>(json);
+
+            Assert.Equal(1.200m, quantity.Value);
+            Assert.Equal("1.200", quantity.Value.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(InformationUnit.Exabyte, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalIQuantity_DeserializedFromQuotedDecimalValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":\"1.200\",\"Unit\":\"EB\",\"Type\":\"Information\"}";
+
+            var quantity = (Information) DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.200m, quantity.Value);
+            Assert.Equal("1.200", quantity.Value.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(InformationUnit.Exabyte, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalQuantity_DeserializedFromQuotedDecimalValueAndAbbreviatedUnit()
+        {
+            var json = "{\"Value\":\"1.200\",\"Unit\":\"EB\"}";
+
+            var quantity = DeserializeObject<Information>(json);
+
+            Assert.Equal(1.200m, quantity.Value);
+            Assert.Equal("1.200", quantity.Value.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(InformationUnit.Exabyte, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalZeroIQuantity_DeserializedFromAbbreviatedUnitAndNoValue()
+        {
+            var json = "{\"Unit\":\"EB\",\"Type\":\"Information\"}";
+
+            var quantity = (Information)DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(InformationUnit.Exabyte, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalZeroQuantity_DeserializedFromAbbreviatedUnitAndNoValue()
+        {
+            var json = "{\"Unit\":\"EB\"}";
+
+            var quantity = DeserializeObject<Information>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(InformationUnit.Exabyte, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalBaseUnitIQuantity_DeserializedFromDecimalValueAndNoUnit()
+        {
+            var json = "{\"Value\":1.200,\"Type\":\"Information\"}";
+
+            var quantity = (Information)DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(1.200m, quantity.Value);
+            Assert.Equal("1.200", quantity.Value.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(Information.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalBaseUnitQuantity_DeserializedFromDecimalValueAndNoUnit()
+        {
+            var json = "{\"Value\":1.200}";
+
+            var quantity = DeserializeObject<Information>(json);
+
+            Assert.Equal(1.200m, quantity.Value);
+            Assert.Equal("1.200", quantity.Value.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal(Information.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalZeroBaseIQuantity_DeserializedFromQuantityTypeOnly()
+        {
+            var json = "{\"Type\":\"Information\"}";
+
+            var quantity = (Information)DeserializeObject<IQuantity>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(Information.BaseUnit, quantity.Unit);
+        }
+
+        [Fact]
+        public void DecimalZeroBaseQuantity_DeserializedFromEmptyInput()
+        {
+            var json = "{}";
+
+            var quantity = DeserializeObject<Information>(json);
+
+            Assert.Equal(0, quantity.Value);
+            Assert.Equal(Information.BaseUnit, quantity.Unit);
+        }
+
+        #endregion
+    }
+}

--- a/UnitsNet.Serialization.JsonNet.Tests/AbbreviatedUnitsConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/AbbreviatedUnitsConverterTests.cs
@@ -37,28 +37,6 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         [Fact]
-        public void DoubleQuantity_InScientificNotation_SerializedWithExpandedValueAndAbbreviatedUnit()
-        {
-            var quantity = new Mass(1E+9, MassUnit.Milligram);
-            var expectedJson = "{\"Value\":1000000000.0,\"Unit\":\"mg\",\"Type\":\"Mass\"}";
-
-            var json = SerializeObject(quantity);
-
-            Assert.Equal(expectedJson, json);
-        }
-
-        [Fact]
-        public void DecimalQuantity_InScientificNotation_SerializedWithExpandedValueAndAbbreviatedUnit()
-        {
-            var quantity = new Information(1E+9m, InformationUnit.Exabyte);
-            var expectedJson = "{\"Value\":1000000000,\"Unit\":\"EB\",\"Type\":\"Information\"}";
-
-            var json = SerializeObject(quantity);
-
-            Assert.Equal(expectedJson, json);
-        }
-
-        [Fact]
         public void InterfaceObject_IncludesTypeInformation()
         {
             var testObject = new TestInterfaceObject { Quantity = new Information(1.20m, InformationUnit.Exabyte) };
@@ -119,7 +97,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         [Fact]
-        public void AmbiguousUnitParseExceptionUnitsNetExceptionThrown_WhenDeserializing_WithoutQuantityType()
+        public void ThrowsAmbiguousUnitParseException_WhenDeserializingAmbiguousAbbreviation_WithoutQuantityType()
         {
             var json = "{\"Value\":1.2,\"Unit\":\"mg\"}";
 
@@ -135,6 +113,20 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
             Assert.Equal(1.2, quantity.Value);
             Assert.Equal(MassUnit.Milligram, quantity.Unit);
+        }
+
+        [Fact]
+        public void DoubleIQuantity_DeserializedFromDoubleValueAndAbbreviatedUnit_CaseSensitiveUnits()
+        {
+            var json = "{\"value\":1.2,\"unit\":\"Mbar\",\"type\":\"pressure\"}";
+
+            var megabar = DeserializeObject<IQuantity>(json);
+            var millibar = DeserializeObject<IQuantity>(json.ToLower());
+
+            Assert.Equal(1.2, megabar.Value);
+            Assert.Equal(1.2, millibar.Value);
+            Assert.Equal(PressureUnit.Megabar, megabar.Unit);
+            Assert.Equal(PressureUnit.Millibar, millibar.Unit);
         }
 
         [Fact]
@@ -359,7 +351,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 
         #endregion
 
-        #region Compatability
+        #region Compatibility
 
         [JsonObject]
         class PlainOldDoubleQuantity

--- a/UnitsNet.Serialization.JsonNet.Tests/AbbreviatedUnitsConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/AbbreviatedUnitsConverterTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Newtonsoft.Json;
 using UnitsNet.Tests.Serialization;
 using UnitsNet.Units;
 using Xunit;
@@ -25,7 +26,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         [Fact]
-        public void DecimalQuantity_SerializedWithDecimalValueValueAndAbbreviatedUnit()
+        public void DecimalQuantity_SerializedWithDecimalValueAndAbbreviatedUnit()
         {
             var quantity = new Information(1.20m, InformationUnit.Exabyte);
             var expectedJson = "{\"Value\":1.20,\"Unit\":\"EB\",\"Type\":\"Information\"}";
@@ -357,5 +358,48 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         #endregion
+
+        #region Compatability
+
+        [JsonObject]
+        class PlainOldDoubleQuantity
+        {
+            public double Value { get; set; }
+            public string Unit { get; set; }
+        }
+
+        [JsonObject]
+        class PlainOldDecimalQuantity
+        {
+            public decimal Value { get; set; }
+            public string Unit { get; set; }
+        }
+
+        [Fact]
+        public void LargeDecimalQuantity_DeserializedTo_PlainOldDecimalQuantity()
+        {
+            var quantity = new Information(2m * long.MaxValue, InformationUnit.Exabyte);
+
+            var json = SerializeObject(quantity);
+            var plainOldQuantity = JsonConvert.DeserializeObject<PlainOldDecimalQuantity>(json);
+
+            Assert.Equal(2m * long.MaxValue, plainOldQuantity.Value);
+            Assert.Equal("EB", plainOldQuantity.Unit);
+        }
+
+        [Fact]
+        public void LargeDecimalQuantity_DeserializedTo_PlainOldDoubleQuantity()
+        {
+            var quantity = Information.FromExabytes(2m * long.MaxValue);
+
+            var json = SerializeObject(quantity);
+            var plainOldQuantity = JsonConvert.DeserializeObject<PlainOldDoubleQuantity>(json);
+
+            Assert.Equal(2.0 * long.MaxValue, plainOldQuantity.Value);
+            Assert.Equal("EB", plainOldQuantity.Unit);
+        }
+
+        #endregion
+
     }
 }

--- a/UnitsNet.Serialization.JsonNet.Tests/JsonNetSerializationTestsBase.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/JsonNetSerializationTestsBase.cs
@@ -1,0 +1,34 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.Linq;
+using Newtonsoft.Json;
+using UnitsNet.Tests.Serialization;
+
+namespace UnitsNet.Serialization.JsonNet.Tests
+{
+    public abstract class JsonNetSerializationTestsBase : SerializationTestsBase<string>
+    {
+        private readonly JsonSerializerSettings _jsonSerializerSettings;
+
+        protected JsonNetSerializationTestsBase(JsonSerializerSettings jsonSerializerSettings)
+        {
+            _jsonSerializerSettings = jsonSerializerSettings;
+        }
+
+        protected JsonNetSerializationTestsBase(params JsonConverter[] converters)
+            : this(new JsonSerializerSettings { Converters = converters.ToList()})
+        {
+        }
+
+        protected override string SerializeObject(object obj)
+        {
+            return JsonConvert.SerializeObject(obj, _jsonSerializerSettings);
+        }
+
+        protected override T DeserializeObject<T>(string payload)
+        {
+            return JsonConvert.DeserializeObject<T>(payload, _jsonSerializerSettings);
+        }
+    }
+}

--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -30,9 +30,11 @@ namespace UnitsNet.Serialization.JsonNet
             : this(StringComparer.OrdinalIgnoreCase)
         {
         }
+
         /// <summary>
         ///     Construct a converter using the default list of quantities and unit abbreviation provider
         /// </summary>
+        /// <param name="comparer">The comparer used to compare the property/quantity names (e.g. StringComparer.OrdinalIgnoreCase) </param>
         public AbbreviatedUnitsConverter(IEqualityComparer<string> comparer)
             : this(new Dictionary<string, QuantityInfo>(Quantity.ByName, comparer), UnitAbbreviationsCache.Default, comparer)
         {
@@ -178,8 +180,7 @@ namespace UnitsNet.Serialization.JsonNet
         ///     Attempt to find an a unique (non-ambiguous) unit matching the provided abbreviation.
         ///     <remarks>
         ///         An exhaustive search using all quantities is very likely to fail with an
-        ///         <exception cref="AmbiguousUnitParseException" />, so make sure you're using the minimum set of quantities
-        ///         supported quantities.
+        ///         <exception cref="AmbiguousUnitParseException" />, so make sure you're using the minimum set of supported quantities.
         ///     </remarks>
         /// </summary>
         /// <param name="unitAbbreviation">The unit abbreviation </param>

--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -6,12 +6,20 @@ using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.JsonNet
 {
-    /// <inheritdoc />
     /// <summary>
-    ///     JSON.net converter for IQuantity types (e.g. all units in UnitsNet)
-    ///     Use this converter to serialize and deserialize UnitsNet types to and from JSON using the unit abbreviation schema
-    ///     (e.g. 1, "kg", "Mass")
+    ///     JSON.net converter for all <see cref="IQuantity" /> types (e.g. all units in UnitsNet)
+    ///     Use this converter to serialize and deserialize UnitsNet types to and from JSON using the unit abbreviation schema.
     /// </summary>
+    /// <example>
+    /// <code>
+    /// {
+    ///     "Value": 1.20,
+    ///     "Unit": "mg",
+    ///     "Type": "Mass"
+    /// }
+    /// </code>
+    /// </example>
+    /// <inheritdoc />
     public class AbbreviatedUnitsConverter : JsonConverter<IQuantity>
     {
         private const string ValueProperty = "Value";

--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -1,0 +1,319 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Newtonsoft.Json;
+using UnitsNet.Units;
+
+namespace UnitsNet.Serialization.JsonNet
+{
+    /// <inheritdoc />
+    /// <summary>
+    ///     JSON.net converter for IQuantity types (e.g. all units in UnitsNet)
+    ///     Use this converter to serialize and deserialize UnitsNet types to and from JSON using the unit abbreviation schema
+    ///     (e.g. 1, "kg", "Mass")
+    /// </summary>
+    public class AbbreviatedUnitsConverter : JsonConverter<IQuantity>
+    {
+        private const string ValueProperty = "Value";
+        private const string UnitProperty = "Unit";
+        private const string TypeProperty = "Type"; 
+
+        private readonly UnitAbbreviationsCache _abbreviations;
+        private readonly IEqualityComparer<string> _propertyComparer;
+        private readonly IDictionary<string, QuantityInfo> _quantities;
+        private readonly UnitParser _unitParser;
+
+        /// <summary>
+        ///     Construct a converter using the default list of quantities (case insensitive) and unit abbreviation provider
+        /// </summary>
+        public AbbreviatedUnitsConverter()
+            : this(StringComparer.OrdinalIgnoreCase)
+        {
+        }
+        /// <summary>
+        ///     Construct a converter using the default list of quantities and unit abbreviation provider
+        /// </summary>
+        public AbbreviatedUnitsConverter(IEqualityComparer<string> comparer)
+            : this(new Dictionary<string, QuantityInfo>(Quantity.ByName, comparer), UnitAbbreviationsCache.Default, comparer)
+        {
+        }
+
+        /// <summary>
+        ///     Construct a converter using the provided map of {name : quantity}
+        /// </summary>
+        /// <param name="quantities">The dictionary of quantity names</param>
+        /// <param name="abbreviations">The unit abbreviations used for the serialization </param>
+        /// <param name="propertyComparer">The comparer used to compare the property names (e.g. StringComparer.OrdinalIgnoreCase) </param>
+        public AbbreviatedUnitsConverter(IDictionary<string, QuantityInfo> quantities, UnitAbbreviationsCache abbreviations, IEqualityComparer<string> propertyComparer)
+        {
+            _quantities = quantities;
+            _abbreviations = abbreviations;
+            _propertyComparer = propertyComparer;
+            _unitParser = new UnitParser(abbreviations);
+        }
+
+        /// <inheritdoc />
+        public override void WriteJson(JsonWriter writer, IQuantity quantity, JsonSerializer serializer)
+        {
+            if (quantity is null)
+            {
+                writer.WriteNull();
+                return;
+            }
+
+            var unit = GetUnitAbbreviation(quantity.Unit); // by default this should be equal to quantity.ToString("a", CultureInfo.InvariantCulture);
+            var quantityType = GetQuantityType(quantity); // by default this should be equal to quantity.QuantityInfo.Name
+
+            writer.WriteStartObject();
+
+            // write the 'Value' using the actual type
+            writer.WritePropertyName(ValueProperty);
+            if (quantity is IDecimalQuantity decimalQuantity)
+            {
+                // cannot use `writer.WriteValue(decimalQuantity.Value)`: there is a hidden EnsureDecimalPlace(..) method call inside it that converts '123' to '123.0'
+                writer.WriteRawValue(decimalQuantity.Value.ToString(CultureInfo.InvariantCulture));
+            }
+            else
+            {
+                writer.WriteValue(quantity.Value);
+            }
+
+            //  write the 'Unit' abbreviation
+            writer.WritePropertyName(UnitProperty);
+            writer.WriteValue(unit);
+
+            // write the quantity 'Type'
+            writer.WritePropertyName(TypeProperty);
+            writer.WriteValue(quantityType);
+
+            writer.WriteEndObject();
+        }
+
+        /// <summary>
+        ///     Get the string representation associated with the given quantity
+        /// </summary>
+        /// <param name="quantity">The quantity that is being serialized</param>
+        /// <returns>The string representation associated with the given quantity</returns>
+        protected string GetQuantityType(IQuantity quantity)
+        {
+            return _quantities[quantity.QuantityInfo.Name].Name;
+        }
+
+        /// <inheritdoc />
+        public override IQuantity ReadJson(JsonReader reader, Type objectType, IQuantity existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            QuantityInfo quantityInfo;
+            if (reader.TokenType == JsonToken.Null)
+            {
+                // return null;
+                return TryGetQuantity(objectType.Name, out quantityInfo) ? quantityInfo.Zero : default;
+            }
+
+            string valueToken = null;
+            string unitAbbreviation = null, quantityName = null;
+            if (reader.TokenType == JsonToken.StartObject)
+            {
+                while (reader.Read() && reader.TokenType != JsonToken.EndObject)
+                {
+                    if (reader.TokenType == JsonToken.PropertyName)
+                    {
+                        var propertyName = reader.Value as string;
+                        if (_propertyComparer.Equals(propertyName, ValueProperty))
+                        {
+                            valueToken = reader.ReadAsString();
+                        }
+                        else if (_propertyComparer.Equals(propertyName, UnitProperty))
+                        {
+                            unitAbbreviation = reader.ReadAsString();
+                        }
+                        else if (_propertyComparer.Equals(propertyName, TypeProperty))
+                        {
+                            quantityName = reader.ReadAsString();
+                        }
+                        else
+                        {
+                            reader.Skip();
+                        }
+                    }
+                }
+            }
+
+            Enum unit;
+            if (quantityName is null)
+            {
+                if (TryGetQuantity(objectType.Name, out quantityInfo))
+                {
+                    unit = GetUnitOrDefault(unitAbbreviation, quantityInfo);
+                }
+                else // the objectType doesn't match any concrete quantity type (likely it is an IQuantity)
+                {
+                    // failing back to an exhaustive search (it is possible that this converter was created with a short-list of non-ambiguous quantities
+                    unit = FindUnit(unitAbbreviation, out quantityInfo);
+                }
+            }
+            else
+            {
+                quantityInfo = GetQuantityInfo(quantityName);
+                unit = GetUnitOrDefault(unitAbbreviation, quantityInfo);
+            }
+
+            QuantityValue value;
+            if (valueToken is null)
+            {
+                value = default;
+            }
+            else if (quantityInfo.Zero is IDecimalQuantity)
+            {
+                value = decimal.Parse(valueToken, CultureInfo.InvariantCulture);
+            }
+            else
+            {
+                value = double.Parse(valueToken, CultureInfo.InvariantCulture);
+            }
+
+            return Quantity.From(value, unit);
+        }
+        
+        /// <summary>
+        ///     Attempt to find an a unique (non-ambiguous) unit matching the provided abbreviation.
+        ///     <remarks>
+        ///         An exhaustive search using all quantities is very likely to fail with an
+        ///         <exception cref="AmbiguousUnitParseException" />, so make sure you're using the minimum set of quantities
+        ///         supported quantities.
+        ///     </remarks>
+        /// </summary>
+        /// <param name="unitAbbreviation">The unit abbreviation </param>
+        /// <param name="quantityInfo">The quantity type where the resulting unit was found </param>
+        /// <returns>The unit associated with the given <paramref name="unitAbbreviation" /></returns>
+        /// <exception cref="AmbiguousUnitParseException"></exception>
+        /// <exception cref="UnitNotFoundException"></exception>
+        protected virtual Enum FindUnit(string unitAbbreviation, out QuantityInfo quantityInfo)
+        {
+            if (unitAbbreviation is null) // we could assume string.Empty instead
+            {
+                throw new UnitNotFoundException("The unit abbreviation and quantity type cannot both be null");
+            }
+
+            Enum unit = null;
+            quantityInfo = default;
+            foreach (var targetQuantity in _quantities.Values)
+            {
+                if (!TryParse(unitAbbreviation, targetQuantity, out var unitMatched))
+                {
+                    continue;
+                }
+
+                if (unit != null &&
+                    !(targetQuantity == quantityInfo && Equals(unit, unitMatched))) // it is possible to have "synonyms": e.g. "Mass" and "Weight"
+                {
+                    throw new AmbiguousUnitParseException($"Multiple quantities found matching the provided abbreviation: {unit}, {unitMatched}");
+                }
+
+                quantityInfo = targetQuantity;
+                unit = unitMatched;
+            }
+
+            if (unit is null)
+            {
+                throw new UnitNotFoundException($"No quantity found with abbreviation [{unitAbbreviation}].");
+            }
+
+            return unit;
+        }
+
+
+        /// <summary>
+        ///     Get the unit abbreviation associated with the given unit
+        /// </summary>
+        /// <param name="unit">Unit enum value, such as <see cref="MassUnit.Kilogram" />.</param>
+        /// <returns>The default abbreviation as provided by the associated <see cref="UnitAbbreviationsCache" /></returns>
+        protected string GetUnitAbbreviation(Enum unit)
+        {
+            return _abbreviations.GetDefaultAbbreviation(unit.GetType(), Convert.ToInt32(unit), CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        ///     If the unit abbreviation is unspecified: returns the default (BaseUnit) unit for the
+        ///     <paramref name="quantityInfo" />, otherwise attempts to <see cref="Parse" /> the
+        ///     <paramref name="unitAbbreviation" />
+        /// </summary>
+        /// <param name="unitAbbreviation">
+        ///     Unit abbreviation, such as "kg" or "m" for <see cref="MassUnit.Kilogram" /> and
+        ///     <see cref="LengthUnit.Meter" /> respectively.
+        /// </param>
+        /// <param name="quantityInfo">The associated quantity info</param>
+        /// <returns>Unit enum value, such as <see cref="MassUnit.Kilogram" />.</returns>
+        /// <exception cref="UnitNotFoundException">No units match the abbreviation.</exception>
+        /// <exception cref="AmbiguousUnitParseException">More than one unit matches the abbreviation.</exception>
+        protected virtual Enum GetUnitOrDefault(string unitAbbreviation, QuantityInfo quantityInfo)
+        {
+            return unitAbbreviation == null
+                ? quantityInfo.BaseUnitInfo.Value
+                : _unitParser.Parse(unitAbbreviation, quantityInfo.UnitType, CultureInfo.InvariantCulture);
+        }
+
+        /// <param name="unitAbbreviation">
+        ///     Unit abbreviation, such as "kg" or "m" for <see cref="MassUnit.Kilogram" /> and
+        ///     <see cref="LengthUnit.Meter" /> respectively.
+        /// </param>
+        /// <param name="quantityInfo">The associated quantity info</param>
+        /// <returns>Unit enum value, such as <see cref="MassUnit.Kilogram" />.</returns>
+        /// <exception cref="UnitNotFoundException">No units match the abbreviation.</exception>
+        /// <exception cref="AmbiguousUnitParseException">More than one unit matches the abbreviation.</exception>
+        protected Enum Parse(string unitAbbreviation, QuantityInfo quantityInfo)
+        {
+            return _unitParser.Parse(unitAbbreviation, quantityInfo.UnitType, CultureInfo.InvariantCulture);
+        }
+
+        /// <param name="unitAbbreviation">
+        ///     Unit abbreviation, such as "kg" or "m" for <see cref="MassUnit.Kilogram" /> and
+        ///     <see cref="LengthUnit.Meter" /> respectively.
+        /// </param>
+        /// <param name="quantityInfo">The associated quantity info</param>
+        /// <param name="unit">The unit enum value as out result.</param>
+        /// <returns>True if successful.</returns>
+        /// <exception cref="UnitNotFoundException">No units match the abbreviation.</exception>
+        /// <exception cref="AmbiguousUnitParseException">More than one unit matches the abbreviation.</exception>
+        protected bool TryParse(string unitAbbreviation, QuantityInfo quantityInfo, out Enum unit)
+        {
+            return _unitParser.TryParse(unitAbbreviation, quantityInfo.UnitType, CultureInfo.InvariantCulture, out unit);
+        }
+
+        /// <summary>
+        ///     Try to get the quantity info associated with a given quantity name
+        /// </summary>
+        /// <param name="quantityName">The name of the quantity: i.e. <see cref="QuantityInfo.Name" /></param>
+        /// <param name="quantityInfo">The quantity information associated with the given quantity name</param>
+        /// <returns>
+        ///     <value>true</value>
+        ///     if a matching quantity is found or
+        ///     <value>false</value>
+        ///     otherwise
+        /// </returns>
+        protected bool TryGetQuantity(string quantityName, out QuantityInfo quantityInfo)
+        {
+            return _quantities.TryGetValue(quantityName, out quantityInfo);
+        }
+
+        /// <summary>
+        ///     Get the quantity info associated with a given quantity name
+        /// </summary>
+        /// <param name="quantityName">The name of the quantity: i.e. <see cref="QuantityInfo.Name" /></param>
+        /// <returns>
+        ///     <value>true</value>
+        ///     if a matching quantity is found or
+        ///     <value>false</value>
+        ///     otherwise
+        /// </returns>
+        /// <exception cref="UnitsNetException">Quantity not found exception is thrown if no match found</exception>
+        protected QuantityInfo GetQuantityInfo(string quantityName)
+        {
+            if (!TryGetQuantity(quantityName, out var quantityInfo))
+            {
+                throw new UnitsNetException($"Failed to find the quantity type: {quantityName}.") { Data = { ["type"] = quantityName } };
+            }
+
+            return quantityInfo;
+        }
+    }
+}

--- a/UnitsNet.Tests/Serialization/Json/DefaultDataContractJsonSerializerTests.cs
+++ b/UnitsNet.Tests/Serialization/Json/DefaultDataContractJsonSerializerTests.cs
@@ -62,28 +62,6 @@ namespace UnitsNet.Tests.Serialization.Json
 
             Assert.Equal(expectedJson, json);
         }
-
-        [Fact]
-        public void DoubleQuantity_InScientificNotation_SerializedWithExpandedValueAndIntegerUnit()
-        {
-            var quantity = new Mass(1E+9, MassUnit.Milligram);
-            var expectedJson = "{\"Value\":1000000000,\"Unit\":16}";
-
-            var json = SerializeObject(quantity);
-
-            Assert.Equal(expectedJson, json);
-        }
-
-        [Fact]
-        public void DecimalQuantity_InScientificNotation_SerializedWithExpandedValueAndIntegerUnit()
-        {
-            var quantity = new Information(1E+9m, InformationUnit.Exabyte);
-            var expectedJson = "{\"Value\":1000000000,\"Unit\":4}";
-
-            var json = SerializeObject(quantity);
-
-            Assert.Equal(expectedJson, json);
-        }
         
         [Fact]
         public void InterfaceObject_IncludesTypeInformation()

--- a/UnitsNet.Tests/Serialization/Json/DefaultDataContractJsonSerializerTests.cs
+++ b/UnitsNet.Tests/Serialization/Json/DefaultDataContractJsonSerializerTests.cs
@@ -39,6 +39,8 @@ namespace UnitsNet.Tests.Serialization.Json
             return (T)serializer.ReadObject(stream);
         }
 
+        #region Serialization tests
+
         [Fact]
         public void DoubleQuantity_SerializedWithDoubleValueAndIntegerUnit()
         {
@@ -83,6 +85,29 @@ namespace UnitsNet.Tests.Serialization.Json
             Assert.Equal(expectedJson, json);
         }
         
+        [Fact]
+        public void InterfaceObject_IncludesTypeInformation()
+        {
+            var testObject = new TestInterfaceObject { Quantity = new Information(1.20m, InformationUnit.Exabyte) };
+            var expectedJson = "{\"Quantity\":{\"__type\":\"Information:#UnitsNet\",\"Value\":1.20,\"Unit\":4}}";
+
+            var json = SerializeObject(testObject);
+
+            Assert.Equal(expectedJson, json);
+        }
+        
+        [Fact]
+        public void InterfaceObject_WithMissingKnownTypeInformation_ThrowsSerializationException()
+        {
+            var testObject = new TestInterfaceObject { Quantity = new Volume(1.2, VolumeUnit.Microliter) };
+
+            Assert.Throws<SerializationException>(() => SerializeObject(testObject));
+        }
+
+        #endregion
+
+        #region Deserialization tests
+
         [Fact]
         public void DoubleQuantity_DeserializedFromDoubleValueAndIntegerUnit()
         {
@@ -196,23 +221,6 @@ namespace UnitsNet.Tests.Serialization.Json
             Assert.Equal(Information.BaseUnit, quantity.Unit);
         }
 
-        [Fact]
-        public void InterfaceObject_IncludesTypeInformation()
-        {
-            var testObject = new TestInterfaceObject { Quantity = new Information(1.20m, InformationUnit.Exabyte) };
-            var expectedJson = "{\"Quantity\":{\"__type\":\"Information:#UnitsNet\",\"Value\":1.20,\"Unit\":4}}";
-
-            var json = SerializeObject(testObject);
-
-            Assert.Equal(expectedJson, json);
-        }
-
-        [Fact]
-        public void InterfaceObject_WithMissingKnownTypeInformation_ThrowsSerializationException()
-        {
-            var testObject = new TestInterfaceObject { Quantity = new Volume(1.2, VolumeUnit.Microliter) };
-
-            Assert.Throws<SerializationException>(() => SerializeObject(testObject));
-        }
+        #endregion
     }
 }

--- a/UnitsNet.Tests/Serialization/Xml/DataContractSerializerTests.cs
+++ b/UnitsNet.Tests/Serialization/Xml/DataContractSerializerTests.cs
@@ -58,28 +58,6 @@ namespace UnitsNet.Tests.Serialization.Xml
         }
 
         [Fact]
-        public void DoubleQuantity_InScientificNotation_SerializedWithExpandedValueAndMemberName()
-        {
-            var quantity = new Mass(1E+9, MassUnit.Milligram);
-            var expectedXml = $"<Mass {Namespace} {XmlSchema}><Value>1000000000</Value><Unit>Milligram</Unit></Mass>";
-
-            var xml = SerializeObject(quantity);
-
-            Assert.Equal(expectedXml, xml);
-        }
-
-        [Fact]
-        public void DecimalQuantity_InScientificNotation_SerializedWithExpandedValueAndMemberName()
-        {
-            var quantity = new Information(1E+9m, InformationUnit.Exabyte);
-            var expectedXml = $"<Information {Namespace} {XmlSchema}><Value>1000000000</Value><Unit>Exabyte</Unit></Information>";
-
-            var xml = SerializeObject(quantity);
-
-            Assert.Equal(expectedXml, xml);
-        }
-
-        [Fact]
         public void InterfaceObject_IncludesTypeInformation()
         {
             var testObject = new TestInterfaceObject { Quantity = new Information(1.20m, InformationUnit.Exabyte) };


### PR DESCRIPTION
.. with tests based on the SerializationTestsBase

With the default settings matches all properties and values using the StringComparer.OrdinalIgnoreCase comparer (as is the default JsonNet matching strategy). 
It is possible to customize the 'known types' information (defaults to `Quantity.ByName`) - however don't expect to have out of the box handling for `HowMuch` just yet - we're still dependent on the switch in `Quantity.From` (we should maybe consider introducing construction methods into QuantityInfo sub-classes or something).

I managed to get the decimals working with manually operating the reader (not without a few hurtles).

Finally, another break from the original serialization converters (but consistent with the DataContract / protobuf) is handling of the default types (instead of throwing an exception when no value is provided). 

PS I haven't added any handling for EmitDefaultValues = false (I assume there is one such option somewhere in JsonNet) - but I think that's hardly necessary (if we want it- we should discuss the 'default' behavior of the `Type` property)