### PR TITLE
Add ForceChangeRate arithmetic operators

### DIFF
--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -199,5 +199,12 @@ namespace UnitsNet.Tests.CustomCode
             Speed speed = Duration.FromSeconds(10) * Acceleration.FromMetersPerSecondSquared(10);
             Assert.Equal(Speed.FromMetersPerSecond(100), speed);
         }
+
+        [Fact]
+        public void DurationTimesForceChangeRate()
+        {
+            Force force = Duration.FromSeconds(10) * ForceChangeRate.FromNewtonsPerSecond(100);
+            Assert.Equal(Force.FromNewtons(1000), force);
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/ForceChangeRateTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceChangeRateTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using Xunit;
+
 namespace UnitsNet.Tests.CustomCode
 {
     public class ForceChangeRateTests : ForceChangeRateTestsBase
@@ -21,5 +23,12 @@ namespace UnitsNet.Tests.CustomCode
         protected override double MillinewtonsPerSecondInOneNewtonPerSecond => 1E3;
         protected override double MicronewtonsPerSecondInOneNewtonPerSecond => 1E6;
         protected override double NanonewtonsPerSecondInOneNewtonPerSecond => 1E9;
+
+        [Fact]
+        public void DurationTimesForceChangeRate()
+        {
+            Force force = ForceChangeRate.FromNewtonsPerSecond(100) * Duration.FromSeconds(10);
+            Assert.Equal(Force.FromNewtons(1000), force);
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/ForceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ForceTests.cs
@@ -97,5 +97,12 @@ namespace UnitsNet.Tests.CustomCode
             Pressure pressure = Force.FromNewtons(2) * ReciprocalArea.FromInverseSquareMeters(25);
             Assert.Equal(pressure, Pressure.FromNewtonsPerSquareMeter(50));
         }
+
+        [Fact]
+        public void ForceDividedByForceChangeRateEqualsDuration()
+        {
+            Duration duration = Force.FromNewtons(200) / ForceChangeRate.FromNewtonsPerSecond(50);
+            Assert.Equal(duration, Duration.FromSeconds(4));
+        }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Duration.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Duration.extra.cs
@@ -2,6 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using UnitsNet.Units;
 
 namespace UnitsNet
 {
@@ -92,24 +93,28 @@ namespace UnitsNet
             return timeSpan.TotalSeconds >= duration.Seconds;
         }
 
-        /// <summary>Get <see cref="Volume"/> from <see cref="Duration"/> times <see cref="VolumeFlow"/>.</summary>
+        /// <summary>Get <see cref="Volume"/> from <see cref="Duration"/> multiplied by <see cref="VolumeFlow"/>.</summary>
         public static Volume operator *(Duration duration, VolumeFlow volumeFlow)
         {
             return Volume.FromCubicMeters(volumeFlow.CubicMetersPerSecond * duration.Seconds);
         }
 
-        /// <summary>Calculate <see cref="ElectricCharge"/> from <see cref="Duration"/> multiplied by <see cref="ElectricCurrent"/>.</summary>
+        /// <summary>Get <see cref="ElectricCharge"/> from <see cref="Duration"/> multiplied by <see cref="ElectricCurrent"/>.</summary>
         public static ElectricCharge operator *(Duration time, ElectricCurrent current)
         {
             return ElectricCharge.FromAmpereHours(current.Amperes * time.Hours);
         }
 
-        /// <summary>
-        /// Multiply <see cref="Duration"/> and <see cref="Acceleration"/> to get <see cref="Speed"/>.
-        /// </summary>
+        /// <summary>Get <see cref="Speed"/> from <see cref="Duration"/> multiplied by <see cref="Acceleration"/>.</summary>
         public static Speed operator *(Duration duration, Acceleration acceleration)
         {
-            return new Speed(acceleration.MetersPerSecondSquared * duration.Seconds, UnitsNet.Units.SpeedUnit.MeterPerSecond);
+            return new Speed(acceleration.MetersPerSecondSquared * duration.Seconds, SpeedUnit.MeterPerSecond);
+        }
+
+        /// <summary>Get <see cref="Force"/> from <see cref="Duration"/> multiplied by <see cref="ForceChangeRate"/>.</summary>
+        public static Force operator *(Duration duration, ForceChangeRate forceChangeRate)
+        {
+            return new Force(forceChangeRate.NewtonsPerSecond * duration.Seconds, ForceUnit.Newton);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Force.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Force.extra.cs
@@ -67,5 +67,11 @@ namespace UnitsNet
         {
             return ForcePerLength.FromNewtonsPerMeter(force.Newtons / length.Meters);
         }
+
+        /// <summary>Get <see cref="Duration"/> from <see cref="Force"/> divided by <see cref="ForceChangeRate"/>.</summary>
+        public static Duration operator /(Force force, ForceChangeRate forceChangeRate)
+        {
+            return new Duration(force.Newtons / forceChangeRate.NewtonsPerSecond, DurationUnit.Second);
+        }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/ForceChangeRate.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/ForceChangeRate.extra.cs
@@ -1,0 +1,16 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using UnitsNet.Units;
+
+namespace UnitsNet
+{
+    public partial struct ForceChangeRate
+    {
+        /// <summary>Get <see cref="Force"/> from <see cref="ForcePerLength"/> multiplied by <see cref="Length"/>.</summary>
+        public static Force operator *(ForceChangeRate forceChangeRate, Duration duration)
+        {
+            return new Force(forceChangeRate.NewtonsPerSecond * duration.Seconds, ForceUnit.Newton);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #989

I added the additional calculation operators for `ForceChangeRate`, as agreed in #989.
Additionally, I added the appropriate unit tests.

I noticed some differences between creating the new unit in various other operators, where some use the `FromXxx(value)` static factory methods and others use the constructors directly.
I used the constructors directly to reduce method calls, but I am wondering what is preferred.