### PR TITLE
Update nanoFramework dependencies

### DIFF
--- a/CodeGen/Generators/NanoFrameworkGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGenerator.cs
@@ -134,7 +134,7 @@ namespace CodeGen.Generators
             {
                 StartInfo = new ProcessStartInfo
                 {
-                    FileName = "Tools/nuget.exe",
+                    FileName = Path.Combine(rootDir, "Tools/nuget.exe"),
                     Arguments = $"update {path}\\UnitsNet.nanoFramework.sln -PreRelease",
                     UseShellExecute = false,
                     CreateNoWindow = true

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/Acceleration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/Acceleration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/UnitsNet.NanoFramework.Acceleration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/UnitsNet.NanoFramework.Acceleration.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component acceleration</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/AmountOfSubstance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/AmountOfSubstance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/UnitsNet.NanoFramework.AmountOfSubstance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/UnitsNet.NanoFramework.AmountOfSubstance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component amountofsubstance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/AmplitudeRatio.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/AmplitudeRatio.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/UnitsNet.NanoFramework.AmplitudeRatio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/UnitsNet.NanoFramework.AmplitudeRatio.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component amplituderatio</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/Angle.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/Angle.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.3.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.4.3\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/UnitsNet.NanoFramework.Angle.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/UnitsNet.NanoFramework.Angle.nuspec
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component angle</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
-      <dependency id="nanoFramework.System.Math" version="1.4.1" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
+      <dependency id="nanoFramework.System.Math" version="1.4.3" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.3" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/ApparentEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/ApparentEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/UnitsNet.NanoFramework.ApparentEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/UnitsNet.NanoFramework.ApparentEnergy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component apparentenergy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/ApparentPower.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/ApparentPower.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/UnitsNet.NanoFramework.ApparentPower.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/UnitsNet.NanoFramework.ApparentPower.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component apparentpower</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/Area.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/Area.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/UnitsNet.NanoFramework.Area.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/UnitsNet.NanoFramework.Area.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component area</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/AreaDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/AreaDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/UnitsNet.NanoFramework.AreaDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/UnitsNet.NanoFramework.AreaDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component areadensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/AreaMomentOfInertia.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/AreaMomentOfInertia.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/UnitsNet.NanoFramework.AreaMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/UnitsNet.NanoFramework.AreaMomentOfInertia.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component areamomentofinertia</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/BitRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/BitRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/UnitsNet.NanoFramework.BitRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/UnitsNet.NanoFramework.BitRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component bitrate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumption.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumption.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/UnitsNet.NanoFramework.BrakeSpecificFuelConsumption.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/UnitsNet.NanoFramework.BrakeSpecificFuelConsumption.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component brakespecificfuelconsumption</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/Capacitance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/Capacitance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/UnitsNet.NanoFramework.Capacitance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/UnitsNet.NanoFramework.Capacitance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component capacitance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/CoefficientOfThermalExpansion.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/CoefficientOfThermalExpansion.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/UnitsNet.NanoFramework.CoefficientOfThermalExpansion.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/UnitsNet.NanoFramework.CoefficientOfThermalExpansion.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component coefficientofthermalexpansion</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/Density.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/Density.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/UnitsNet.NanoFramework.Density.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/UnitsNet.NanoFramework.Density.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component density</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/Duration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/Duration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/UnitsNet.NanoFramework.Duration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/UnitsNet.NanoFramework.Duration.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component duration</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/DynamicViscosity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/DynamicViscosity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/UnitsNet.NanoFramework.DynamicViscosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/UnitsNet.NanoFramework.DynamicViscosity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component dynamicviscosity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/ElectricAdmittance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/ElectricAdmittance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/UnitsNet.NanoFramework.ElectricAdmittance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/UnitsNet.NanoFramework.ElectricAdmittance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricadmittance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/ElectricCharge.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/ElectricCharge.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/UnitsNet.NanoFramework.ElectricCharge.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/UnitsNet.NanoFramework.ElectricCharge.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electriccharge</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/ElectricChargeDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/ElectricChargeDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/UnitsNet.NanoFramework.ElectricChargeDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/UnitsNet.NanoFramework.ElectricChargeDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricchargedensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/ElectricConductance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/ElectricConductance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/UnitsNet.NanoFramework.ElectricConductance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/UnitsNet.NanoFramework.ElectricConductance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricconductance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/ElectricConductivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/ElectricConductivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/UnitsNet.NanoFramework.ElectricConductivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/UnitsNet.NanoFramework.ElectricConductivity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricconductivity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/ElectricCurrent.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/ElectricCurrent.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/UnitsNet.NanoFramework.ElectricCurrent.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/UnitsNet.NanoFramework.ElectricCurrent.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electriccurrent</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/ElectricCurrentDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/ElectricCurrentDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/UnitsNet.NanoFramework.ElectricCurrentDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/UnitsNet.NanoFramework.ElectricCurrentDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electriccurrentdensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/ElectricCurrentGradient.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/ElectricCurrentGradient.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/UnitsNet.NanoFramework.ElectricCurrentGradient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/UnitsNet.NanoFramework.ElectricCurrentGradient.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electriccurrentgradient</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/ElectricField.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/ElectricField.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/UnitsNet.NanoFramework.ElectricField.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/UnitsNet.NanoFramework.ElectricField.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricfield</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/ElectricInductance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/ElectricInductance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/UnitsNet.NanoFramework.ElectricInductance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/UnitsNet.NanoFramework.ElectricInductance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricinductance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/ElectricPotential.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/ElectricPotential.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/UnitsNet.NanoFramework.ElectricPotential.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/UnitsNet.NanoFramework.ElectricPotential.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricpotential</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/ElectricPotentialAc.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/ElectricPotentialAc.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/UnitsNet.NanoFramework.ElectricPotentialAc.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/UnitsNet.NanoFramework.ElectricPotentialAc.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricpotentialac</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/ElectricPotentialChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/ElectricPotentialChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/UnitsNet.NanoFramework.ElectricPotentialChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/UnitsNet.NanoFramework.ElectricPotentialChangeRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricpotentialchangerate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/ElectricPotentialDc.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/ElectricPotentialDc.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/UnitsNet.NanoFramework.ElectricPotentialDc.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/UnitsNet.NanoFramework.ElectricPotentialDc.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricpotentialdc</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/ElectricResistance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/ElectricResistance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/UnitsNet.NanoFramework.ElectricResistance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/UnitsNet.NanoFramework.ElectricResistance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricresistance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/ElectricResistivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/ElectricResistivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/UnitsNet.NanoFramework.ElectricResistivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/UnitsNet.NanoFramework.ElectricResistivity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricresistivity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/UnitsNet.NanoFramework.ElectricSurfaceChargeDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/UnitsNet.NanoFramework.ElectricSurfaceChargeDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component electricsurfacechargedensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/Energy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/Energy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/UnitsNet.NanoFramework.Energy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/UnitsNet.NanoFramework.Energy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component energy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/Entropy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/Entropy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/UnitsNet.NanoFramework.Entropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/UnitsNet.NanoFramework.Entropy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component entropy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/Force.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/Force.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/UnitsNet.NanoFramework.Force.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/UnitsNet.NanoFramework.Force.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component force</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/ForceChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/ForceChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/UnitsNet.NanoFramework.ForceChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/UnitsNet.NanoFramework.ForceChangeRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component forcechangerate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/ForcePerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/ForcePerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/UnitsNet.NanoFramework.ForcePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/UnitsNet.NanoFramework.ForcePerLength.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component forceperlength</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/Frequency.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/Frequency.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.3.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.4.3\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/UnitsNet.NanoFramework.Frequency.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/UnitsNet.NanoFramework.Frequency.nuspec
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component frequency</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
-      <dependency id="nanoFramework.System.Math" version="1.4.1" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
+      <dependency id="nanoFramework.System.Math" version="1.4.3" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.3" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/FuelEfficiency.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/FuelEfficiency.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/UnitsNet.NanoFramework.FuelEfficiency.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/UnitsNet.NanoFramework.FuelEfficiency.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component fuelefficiency</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/HeatFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/HeatFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/UnitsNet.NanoFramework.HeatFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/UnitsNet.NanoFramework.HeatFlux.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component heatflux</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/HeatTransferCoefficient.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/HeatTransferCoefficient.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/UnitsNet.NanoFramework.HeatTransferCoefficient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/UnitsNet.NanoFramework.HeatTransferCoefficient.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component heattransfercoefficient</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/Illuminance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/Illuminance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/UnitsNet.NanoFramework.Illuminance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/UnitsNet.NanoFramework.Illuminance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component illuminance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/Information.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/Information.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/UnitsNet.NanoFramework.Information.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/UnitsNet.NanoFramework.Information.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component information</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/Irradiance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/Irradiance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/UnitsNet.NanoFramework.Irradiance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/UnitsNet.NanoFramework.Irradiance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component irradiance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/Irradiation.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/Irradiation.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/UnitsNet.NanoFramework.Irradiation.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/UnitsNet.NanoFramework.Irradiation.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component irradiation</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/KinematicViscosity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/KinematicViscosity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/UnitsNet.NanoFramework.KinematicViscosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/UnitsNet.NanoFramework.KinematicViscosity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component kinematicviscosity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/LapseRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/LapseRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/UnitsNet.NanoFramework.LapseRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/UnitsNet.NanoFramework.LapseRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component lapserate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/Length.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/Length.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/UnitsNet.NanoFramework.Length.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/UnitsNet.NanoFramework.Length.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component length</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/Level.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/Level.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/UnitsNet.NanoFramework.Level.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/UnitsNet.NanoFramework.Level.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component level</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/LinearDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/LinearDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/UnitsNet.NanoFramework.LinearDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/UnitsNet.NanoFramework.LinearDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component lineardensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/LinearPowerDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/LinearPowerDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/UnitsNet.NanoFramework.LinearPowerDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/UnitsNet.NanoFramework.LinearPowerDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component linearpowerdensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/Luminosity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/Luminosity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/UnitsNet.NanoFramework.Luminosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/UnitsNet.NanoFramework.Luminosity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component luminosity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/LuminousFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/LuminousFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/UnitsNet.NanoFramework.LuminousFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/UnitsNet.NanoFramework.LuminousFlux.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component luminousflux</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/LuminousIntensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/LuminousIntensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/UnitsNet.NanoFramework.LuminousIntensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/UnitsNet.NanoFramework.LuminousIntensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component luminousintensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/MagneticField.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/MagneticField.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/UnitsNet.NanoFramework.MagneticField.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/UnitsNet.NanoFramework.MagneticField.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component magneticfield</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/MagneticFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/MagneticFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/UnitsNet.NanoFramework.MagneticFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/UnitsNet.NanoFramework.MagneticFlux.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component magneticflux</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/Magnetization.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/Magnetization.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/UnitsNet.NanoFramework.Magnetization.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/UnitsNet.NanoFramework.Magnetization.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component magnetization</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/Mass.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/Mass.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/UnitsNet.NanoFramework.Mass.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/UnitsNet.NanoFramework.Mass.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component mass</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/MassConcentration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/MassConcentration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/UnitsNet.NanoFramework.MassConcentration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/UnitsNet.NanoFramework.MassConcentration.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component massconcentration</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/MassFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/MassFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/UnitsNet.NanoFramework.MassFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/UnitsNet.NanoFramework.MassFlow.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component massflow</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/MassFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/MassFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/UnitsNet.NanoFramework.MassFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/UnitsNet.NanoFramework.MassFlux.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component massflux</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/MassFraction.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/MassFraction.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/UnitsNet.NanoFramework.MassFraction.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/UnitsNet.NanoFramework.MassFraction.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component massfraction</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/MassMomentOfInertia.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/MassMomentOfInertia.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/UnitsNet.NanoFramework.MassMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/UnitsNet.NanoFramework.MassMomentOfInertia.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component massmomentofinertia</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/MolarEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/MolarEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/UnitsNet.NanoFramework.MolarEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/UnitsNet.NanoFramework.MolarEnergy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component molarenergy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/MolarEntropy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/MolarEntropy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/UnitsNet.NanoFramework.MolarEntropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/UnitsNet.NanoFramework.MolarEntropy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component molarentropy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/MolarMass.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/MolarMass.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/UnitsNet.NanoFramework.MolarMass.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/UnitsNet.NanoFramework.MolarMass.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component molarmass</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/Molarity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/Molarity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/UnitsNet.NanoFramework.Molarity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/UnitsNet.NanoFramework.Molarity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component molarity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/Permeability.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/Permeability.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/UnitsNet.NanoFramework.Permeability.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/UnitsNet.NanoFramework.Permeability.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component permeability</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/Permittivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/Permittivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/UnitsNet.NanoFramework.Permittivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/UnitsNet.NanoFramework.Permittivity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component permittivity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/Power.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/Power.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/UnitsNet.NanoFramework.Power.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/UnitsNet.NanoFramework.Power.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component power</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/PowerDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/PowerDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/UnitsNet.NanoFramework.PowerDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/UnitsNet.NanoFramework.PowerDensity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component powerdensity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/PowerRatio.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/PowerRatio.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/UnitsNet.NanoFramework.PowerRatio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/UnitsNet.NanoFramework.PowerRatio.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component powerratio</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/Pressure.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/Pressure.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.3.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.4.3\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/UnitsNet.NanoFramework.Pressure.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/UnitsNet.NanoFramework.Pressure.nuspec
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component pressure</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
-      <dependency id="nanoFramework.System.Math" version="1.4.1" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
+      <dependency id="nanoFramework.System.Math" version="1.4.3" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.3" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/PressureChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/PressureChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/UnitsNet.NanoFramework.PressureChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/UnitsNet.NanoFramework.PressureChangeRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component pressurechangerate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/Ratio.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/Ratio.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/UnitsNet.NanoFramework.Ratio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/UnitsNet.NanoFramework.Ratio.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component ratio</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/RatioChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/RatioChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/UnitsNet.NanoFramework.RatioChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/UnitsNet.NanoFramework.RatioChangeRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component ratiochangerate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/ReactiveEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/ReactiveEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/UnitsNet.NanoFramework.ReactiveEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/UnitsNet.NanoFramework.ReactiveEnergy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component reactiveenergy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/ReactivePower.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/ReactivePower.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/UnitsNet.NanoFramework.ReactivePower.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/UnitsNet.NanoFramework.ReactivePower.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component reactivepower</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/ReciprocalArea.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/ReciprocalArea.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/UnitsNet.NanoFramework.ReciprocalArea.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/UnitsNet.NanoFramework.ReciprocalArea.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component reciprocalarea</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/ReciprocalLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/ReciprocalLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/UnitsNet.NanoFramework.ReciprocalLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/UnitsNet.NanoFramework.ReciprocalLength.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component reciprocallength</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/RelativeHumidity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/RelativeHumidity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/UnitsNet.NanoFramework.RelativeHumidity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/UnitsNet.NanoFramework.RelativeHumidity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component relativehumidity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/RotationalAcceleration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/RotationalAcceleration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/UnitsNet.NanoFramework.RotationalAcceleration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/UnitsNet.NanoFramework.RotationalAcceleration.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component rotationalacceleration</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/RotationalSpeed.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/RotationalSpeed.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/UnitsNet.NanoFramework.RotationalSpeed.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/UnitsNet.NanoFramework.RotationalSpeed.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component rotationalspeed</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/RotationalStiffness.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/RotationalStiffness.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/UnitsNet.NanoFramework.RotationalStiffness.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/UnitsNet.NanoFramework.RotationalStiffness.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component rotationalstiffness</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/RotationalStiffnessPerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/RotationalStiffnessPerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/UnitsNet.NanoFramework.RotationalStiffnessPerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/UnitsNet.NanoFramework.RotationalStiffnessPerLength.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component rotationalstiffnessperlength</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/Scalar.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/Scalar.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/UnitsNet.NanoFramework.Scalar.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/UnitsNet.NanoFramework.Scalar.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component scalar</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/SolidAngle.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/SolidAngle.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/UnitsNet.NanoFramework.SolidAngle.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/UnitsNet.NanoFramework.SolidAngle.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component solidangle</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/SpecificEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/SpecificEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/UnitsNet.NanoFramework.SpecificEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/UnitsNet.NanoFramework.SpecificEnergy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component specificenergy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/SpecificEntropy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/SpecificEntropy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/UnitsNet.NanoFramework.SpecificEntropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/UnitsNet.NanoFramework.SpecificEntropy.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component specificentropy</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/SpecificFuelConsumption.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/SpecificFuelConsumption.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/UnitsNet.NanoFramework.SpecificFuelConsumption.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/UnitsNet.NanoFramework.SpecificFuelConsumption.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component specificfuelconsumption</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/SpecificVolume.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/SpecificVolume.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/UnitsNet.NanoFramework.SpecificVolume.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/UnitsNet.NanoFramework.SpecificVolume.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component specificvolume</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/SpecificWeight.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/SpecificWeight.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/UnitsNet.NanoFramework.SpecificWeight.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/UnitsNet.NanoFramework.SpecificWeight.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component specificweight</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/Speed.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/Speed.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/UnitsNet.NanoFramework.Speed.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/UnitsNet.NanoFramework.Speed.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component speed</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/StandardVolumeFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/StandardVolumeFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/UnitsNet.NanoFramework.StandardVolumeFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/UnitsNet.NanoFramework.StandardVolumeFlow.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component standardvolumeflow</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/Temperature.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/Temperature.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/UnitsNet.NanoFramework.Temperature.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/UnitsNet.NanoFramework.Temperature.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component temperature</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/TemperatureChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/TemperatureChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/UnitsNet.NanoFramework.TemperatureChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/UnitsNet.NanoFramework.TemperatureChangeRate.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component temperaturechangerate</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/TemperatureDelta.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/TemperatureDelta.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/UnitsNet.NanoFramework.TemperatureDelta.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/UnitsNet.NanoFramework.TemperatureDelta.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component temperaturedelta</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/TemperatureGradient.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/TemperatureGradient.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/UnitsNet.NanoFramework.TemperatureGradient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/UnitsNet.NanoFramework.TemperatureGradient.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component temperaturegradient</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/ThermalConductivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/ThermalConductivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/UnitsNet.NanoFramework.ThermalConductivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/UnitsNet.NanoFramework.ThermalConductivity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component thermalconductivity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/ThermalResistance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/ThermalResistance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/UnitsNet.NanoFramework.ThermalResistance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/UnitsNet.NanoFramework.ThermalResistance.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component thermalresistance</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/Torque.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/Torque.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/UnitsNet.NanoFramework.Torque.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/UnitsNet.NanoFramework.Torque.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component torque</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/TorquePerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/TorquePerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/UnitsNet.NanoFramework.TorquePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/UnitsNet.NanoFramework.TorquePerLength.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component torqueperlength</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/Turbidity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/Turbidity.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.3.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.4.3\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/UnitsNet.NanoFramework.Turbidity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/UnitsNet.NanoFramework.Turbidity.nuspec
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component turbidity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
-      <dependency id="nanoFramework.System.Math" version="1.4.1" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
+      <dependency id="nanoFramework.System.Math" version="1.4.3" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.3" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/UnitsNet.NanoFramework.VitaminA.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/UnitsNet.NanoFramework.VitaminA.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component vitamina</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/VitaminA.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/VitaminA.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/UnitsNet.NanoFramework.Volume.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/UnitsNet.NanoFramework.Volume.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component volume</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/Volume.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/Volume.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/UnitsNet.NanoFramework.VolumeConcentration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/UnitsNet.NanoFramework.VolumeConcentration.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component volumeconcentration</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/VolumeConcentration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/VolumeConcentration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/UnitsNet.NanoFramework.VolumeFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/UnitsNet.NanoFramework.VolumeFlow.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component volumeflow</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/VolumeFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/VolumeFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/UnitsNet.NanoFramework.VolumePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/UnitsNet.NanoFramework.VolumePerLength.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component volumeperlength</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/VolumePerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/VolumePerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/UnitsNet.NanoFramework.VolumetricHeatCapacity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/UnitsNet.NanoFramework.VolumetricHeatCapacity.nuspec
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component volumetricheatcapacity</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/VolumetricHeatCapacity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/VolumetricHeatCapacity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/UnitsNet.NanoFramework.WarpingMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/UnitsNet.NanoFramework.WarpingMomentOfInertia.nuspec
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework unit units measurement si metric imperial abbreviation abbreviations convert conversion parse c# .net immutable uwp uap winrt win10 windows runtime component warpingmomentofinertia</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.10.5" />
-      <dependency id="nanoFramework.System.Math" version="1.4.1" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.11.7" />
+      <dependency id="nanoFramework.System.Math" version="1.4.3" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/WarpingMomentOfInertia.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/WarpingMomentOfInertia.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.10.5.4, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.11.7.2, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.11.7\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.4.1.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.4.1\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.4.3.3, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.4.3\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.10.5" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.4.1" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.11.7" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.4.3" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
- Fix bug in path when calling nuget CLI.
- Automatic update of all libraries with latest stable versions:
  + nanoFramework.CoreLibrary.1.11.7
  + nanoFramework.System.Math.1.4.3