### PR TITLE
Add SquareMeterKelvinsPerWatt in ThermalResistance

### DIFF
--- a/Common/UnitDefinitions/ThermalResistance.json
+++ b/Common/UnitDefinitions/ThermalResistance.json
@@ -21,6 +21,18 @@
       ]
     },
     {
+      "SingularName": "SquareMeterKelvinPerWatt",
+      "PluralName": "SquareMeterKelvinsPerWatt",
+      "FromUnitToBaseFunc": "x*1000",
+      "FromBaseToUnitFunc": "x/1000",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "m²K/W" ]
+        }
+      ]
+    },
+    {
       "SingularName": "SquareMeterDegreeCelsiusPerWatt",
       "PluralName": "SquareMeterDegreesCelsiusPerWatt",
       "FromUnitToBaseFunc": "x*1000.088056074108",

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -102,6 +102,11 @@ namespace UnitsNet
         /// </summary>
         public double SquareMeterKelvinsPerKilowatt => As(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
 
+        /// <summary>
+        ///     Get ThermalResistance in SquareMeterKelvinsPerWatt.
+        /// </summary>
+        public double SquareMeterKelvinsPerWatt => As(ThermalResistanceUnit.SquareMeterKelvinPerWatt);
+
         #endregion
 
         #region Static Factory Methods
@@ -135,6 +140,12 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static ThermalResistance FromSquareMeterKelvinsPerKilowatt(double squaremeterkelvinsperkilowatt) => new ThermalResistance(squaremeterkelvinsperkilowatt, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
+
+        /// <summary>
+        ///     Get ThermalResistance from SquareMeterKelvinsPerWatt.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ThermalResistance FromSquareMeterKelvinsPerWatt(double squaremeterkelvinsperwatt) => new ThermalResistance(squaremeterkelvinsperwatt, ThermalResistanceUnit.SquareMeterKelvinPerWatt);
 
 
         /// <summary>
@@ -184,6 +195,7 @@ namespace UnitsNet
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return _value*0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return _value*1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return _value;
+                case ThermalResistanceUnit.SquareMeterKelvinPerWatt: return _value*1000;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -203,6 +215,7 @@ namespace UnitsNet
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return baseUnitValue/0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return baseUnitValue/1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return baseUnitValue;
+                case ThermalResistanceUnit.SquareMeterKelvinPerWatt: return baseUnitValue/1000;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/ThermalResistanceUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/ThermalResistanceUnit.g.cs
@@ -31,6 +31,7 @@ namespace UnitsNet.Units
         SquareCentimeterKelvinPerWatt,
         SquareMeterDegreeCelsiusPerWatt,
         SquareMeterKelvinPerKilowatt,
+        SquareMeterKelvinPerWatt,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToThermalResistanceExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToThermalResistanceExtensionsTest.g.cs
@@ -44,5 +44,9 @@ namespace UnitsNet.Tests
         public void NumberToSquareMeterKelvinsPerKilowattTest() =>
             Assert.Equal(ThermalResistance.FromSquareMeterKelvinsPerKilowatt(2), 2.SquareMeterKelvinsPerKilowatt());
 
+        [Fact]
+        public void NumberToSquareMeterKelvinsPerWattTest() =>
+            Assert.Equal(ThermalResistance.FromSquareMeterKelvinsPerWatt(2), 2.SquareMeterKelvinsPerWatt());
+
     }
 }

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToThermalResistanceExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToThermalResistanceExtensions.g.cs
@@ -48,5 +48,9 @@ namespace UnitsNet.NumberExtensions.NumberToThermalResistance
         public static ThermalResistance SquareMeterKelvinsPerKilowatt<T>(this T value) =>
             ThermalResistance.FromSquareMeterKelvinsPerKilowatt(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="ThermalResistance.FromSquareMeterKelvinsPerWatt(UnitsNet.QuantityValue)" />
+        public static ThermalResistance SquareMeterKelvinsPerWatt<T>(this T value) =>
+            ThermalResistance.FromSquareMeterKelvinsPerWatt(Convert.ToDouble(value));
+
     }
 }

--- a/UnitsNet.Tests/CustomCode/ThermalResistanceTests.cs
+++ b/UnitsNet.Tests/CustomCode/ThermalResistanceTests.cs
@@ -33,6 +33,7 @@ namespace UnitsNet.Tests.CustomCode
         protected override double SquareCentimeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt => 10.00035223670306d;
         protected override double SquareMeterDegreesCelsiusPerWattInOneSquareMeterKelvinPerKilowatt => 9.999119516790815e-4;
         protected override double SquareMeterKelvinsPerKilowattInOneSquareMeterKelvinPerKilowatt => 1;
+        protected override double SquareMeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt => 0.001;
 
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
@@ -134,7 +134,7 @@ namespace UnitsNet.Tests
             Assertion(3, TemperatureDeltaUnit.MillidegreeCelsius, Quantity.From(3, TemperatureDeltaUnit.MillidegreeCelsius));
             Assertion(3, TemperatureGradientUnit.KelvinPerMeter, Quantity.From(3, TemperatureGradientUnit.KelvinPerMeter));
             Assertion(3, ThermalConductivityUnit.WattPerMeterKelvin, Quantity.From(3, ThermalConductivityUnit.WattPerMeterKelvin));
-            Assertion(3, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt, Quantity.From(3, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt));
+            Assertion(3, ThermalResistanceUnit.SquareMeterKelvinPerWatt, Quantity.From(3, ThermalResistanceUnit.SquareMeterKelvinPerWatt));
             Assertion(3, TorqueUnit.TonneForceMillimeter, Quantity.From(3, TorqueUnit.TonneForceMillimeter));
             Assertion(3, TorquePerLengthUnit.TonneForceMillimeterPerMeter, Quantity.From(3, TorquePerLengthUnit.TonneForceMillimeterPerMeter));
             Assertion(3, TurbidityUnit.NTU, Quantity.From(3, TurbidityUnit.NTU));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet.Tests
         protected abstract double SquareCentimeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt { get; }
         protected abstract double SquareMeterDegreesCelsiusPerWattInOneSquareMeterKelvinPerKilowatt { get; }
         protected abstract double SquareMeterKelvinsPerKilowattInOneSquareMeterKelvinPerKilowatt { get; }
+        protected abstract double SquareMeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double HourSquareFeetDegreesFahrenheitPerBtuTolerance { get { return 1e-5; } }
@@ -49,6 +50,7 @@ namespace UnitsNet.Tests
         protected virtual double SquareCentimeterKelvinsPerWattTolerance { get { return 1e-5; } }
         protected virtual double SquareMeterDegreesCelsiusPerWattTolerance { get { return 1e-5; } }
         protected virtual double SquareMeterKelvinsPerKilowattTolerance { get { return 1e-5; } }
+        protected virtual double SquareMeterKelvinsPerWattTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         [Fact]
@@ -128,6 +130,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(SquareCentimeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.SquareCentimeterKelvinsPerWatt, SquareCentimeterKelvinsPerWattTolerance);
             AssertEx.EqualTolerance(SquareMeterDegreesCelsiusPerWattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.SquareMeterDegreesCelsiusPerWatt, SquareMeterDegreesCelsiusPerWattTolerance);
             AssertEx.EqualTolerance(SquareMeterKelvinsPerKilowattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.SquareMeterKelvinsPerKilowatt, SquareMeterKelvinsPerKilowattTolerance);
+            AssertEx.EqualTolerance(SquareMeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.SquareMeterKelvinsPerWatt, SquareMeterKelvinsPerWattTolerance);
         }
 
         [Fact]
@@ -153,6 +156,10 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity04.SquareMeterKelvinsPerKilowatt, SquareMeterKelvinsPerKilowattTolerance);
             Assert.Equal(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt, quantity04.Unit);
 
+            var quantity05 = ThermalResistance.From(1, ThermalResistanceUnit.SquareMeterKelvinPerWatt);
+            AssertEx.EqualTolerance(1, quantity05.SquareMeterKelvinsPerWatt, SquareMeterKelvinsPerWattTolerance);
+            Assert.Equal(ThermalResistanceUnit.SquareMeterKelvinPerWatt, quantity05.Unit);
+
         }
 
         [Fact]
@@ -177,6 +184,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(SquareCentimeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.As(ThermalResistanceUnit.SquareCentimeterKelvinPerWatt), SquareCentimeterKelvinsPerWattTolerance);
             AssertEx.EqualTolerance(SquareMeterDegreesCelsiusPerWattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.As(ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt), SquareMeterDegreesCelsiusPerWattTolerance);
             AssertEx.EqualTolerance(SquareMeterKelvinsPerKilowattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.As(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt), SquareMeterKelvinsPerKilowattTolerance);
+            AssertEx.EqualTolerance(SquareMeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowatt.As(ThermalResistanceUnit.SquareMeterKelvinPerWatt), SquareMeterKelvinsPerWattTolerance);
         }
 
         [Fact]
@@ -220,6 +228,10 @@ namespace UnitsNet.Tests
             var squaremeterkelvinperkilowattQuantity = squaremeterkelvinperkilowatt.ToUnit(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
             AssertEx.EqualTolerance(SquareMeterKelvinsPerKilowattInOneSquareMeterKelvinPerKilowatt, (double)squaremeterkelvinperkilowattQuantity.Value, SquareMeterKelvinsPerKilowattTolerance);
             Assert.Equal(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt, squaremeterkelvinperkilowattQuantity.Unit);
+
+            var squaremeterkelvinperwattQuantity = squaremeterkelvinperkilowatt.ToUnit(ThermalResistanceUnit.SquareMeterKelvinPerWatt);
+            AssertEx.EqualTolerance(SquareMeterKelvinsPerWattInOneSquareMeterKelvinPerKilowatt, (double)squaremeterkelvinperwattQuantity.Value, SquareMeterKelvinsPerWattTolerance);
+            Assert.Equal(ThermalResistanceUnit.SquareMeterKelvinPerWatt, squaremeterkelvinperwattQuantity.Unit);
         }
 
         [Fact]
@@ -238,6 +250,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, ThermalResistance.FromSquareCentimeterKelvinsPerWatt(squaremeterkelvinperkilowatt.SquareCentimeterKelvinsPerWatt).SquareMeterKelvinsPerKilowatt, SquareCentimeterKelvinsPerWattTolerance);
             AssertEx.EqualTolerance(1, ThermalResistance.FromSquareMeterDegreesCelsiusPerWatt(squaremeterkelvinperkilowatt.SquareMeterDegreesCelsiusPerWatt).SquareMeterKelvinsPerKilowatt, SquareMeterDegreesCelsiusPerWattTolerance);
             AssertEx.EqualTolerance(1, ThermalResistance.FromSquareMeterKelvinsPerKilowatt(squaremeterkelvinperkilowatt.SquareMeterKelvinsPerKilowatt).SquareMeterKelvinsPerKilowatt, SquareMeterKelvinsPerKilowattTolerance);
+            AssertEx.EqualTolerance(1, ThermalResistance.FromSquareMeterKelvinsPerWatt(squaremeterkelvinperkilowatt.SquareMeterKelvinsPerWatt).SquareMeterKelvinsPerKilowatt, SquareMeterKelvinsPerWattTolerance);
         }
 
         [Fact]
@@ -401,6 +414,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 cm²K/W", new ThermalResistance(1, ThermalResistanceUnit.SquareCentimeterKelvinPerWatt).ToString());
                 Assert.Equal("1 m²°C/W", new ThermalResistance(1, ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt).ToString());
                 Assert.Equal("1 m²K/kW", new ThermalResistance(1, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt).ToString());
+                Assert.Equal("1 m²K/W", new ThermalResistance(1, ThermalResistanceUnit.SquareMeterKelvinPerWatt).ToString());
             }
             finally
             {
@@ -419,6 +433,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 cm²K/W", new ThermalResistance(1, ThermalResistanceUnit.SquareCentimeterKelvinPerWatt).ToString(swedishCulture));
             Assert.Equal("1 m²°C/W", new ThermalResistance(1, ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt).ToString(swedishCulture));
             Assert.Equal("1 m²K/kW", new ThermalResistance(1, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt).ToString(swedishCulture));
+            Assert.Equal("1 m²K/W", new ThermalResistance(1, ThermalResistanceUnit.SquareMeterKelvinPerWatt).ToString(swedishCulture));
         }
 
         [Fact]

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -180,6 +180,11 @@ namespace UnitsNet
         /// </summary>
         public double SquareMeterKelvinsPerKilowatt => As(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
 
+        /// <summary>
+        ///     Get ThermalResistance in SquareMeterKelvinsPerWatt.
+        /// </summary>
+        public double SquareMeterKelvinsPerWatt => As(ThermalResistanceUnit.SquareMeterKelvinPerWatt);
+
         #endregion
 
         #region Static Methods
@@ -259,6 +264,16 @@ namespace UnitsNet
         {
             double value = (double) squaremeterkelvinsperkilowatt;
             return new ThermalResistance(value, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
+        }
+        /// <summary>
+        ///     Get ThermalResistance from SquareMeterKelvinsPerWatt.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static ThermalResistance FromSquareMeterKelvinsPerWatt(double squaremeterkelvinsperwatt)
+        {
+            double value = (double) squaremeterkelvinsperwatt;
+            return new ThermalResistance(value, ThermalResistanceUnit.SquareMeterKelvinPerWatt);
         }
 
         /// <summary>
@@ -556,6 +571,7 @@ namespace UnitsNet
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return _value*0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return _value*1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return _value;
+                case ThermalResistanceUnit.SquareMeterKelvinPerWatt: return _value*1000;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -575,6 +591,7 @@ namespace UnitsNet
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return baseUnitValue/0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return baseUnitValue/1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return baseUnitValue;
+                case ThermalResistanceUnit.SquareMeterKelvinPerWatt: return baseUnitValue/1000;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -1456,6 +1456,7 @@ namespace UnitsNet
                 ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareCentimeterKelvinPerWatt, new string[]{"cm²K/W"}),
                 ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt, new string[]{"m²°C/W"}),
                 ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareMeterKelvinPerKilowatt, new string[]{"m²K/kW"}),
+                ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareMeterKelvinPerWatt, new string[]{"m²K/W"}),
                 ("en-US", typeof(TorqueUnit), (int)TorqueUnit.KilogramForceCentimeter, new string[]{"kgf·cm"}),
                 ("en-US", typeof(TorqueUnit), (int)TorqueUnit.KilogramForceMeter, new string[]{"kgf·m"}),
                 ("en-US", typeof(TorqueUnit), (int)TorqueUnit.KilogramForceMillimeter, new string[]{"kgf·mm"}),

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/ThermalResistanceUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/ThermalResistanceUnit.g.cs
@@ -31,6 +31,7 @@ namespace UnitsNet.Units
         SquareCentimeterKelvinPerWatt,
         SquareMeterDegreeCelsiusPerWatt,
         SquareMeterKelvinPerKilowatt,
+        SquareMeterKelvinPerWatt,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -61,6 +61,7 @@ namespace UnitsNet
                     new UnitInfo<ThermalResistanceUnit>(ThermalResistanceUnit.SquareCentimeterKelvinPerWatt, "SquareCentimeterKelvinsPerWatt", BaseUnits.Undefined),
                     new UnitInfo<ThermalResistanceUnit>(ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt, "SquareMeterDegreesCelsiusPerWatt", BaseUnits.Undefined),
                     new UnitInfo<ThermalResistanceUnit>(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt, "SquareMeterKelvinsPerKilowatt", BaseUnits.Undefined),
+                    new UnitInfo<ThermalResistanceUnit>(ThermalResistanceUnit.SquareMeterKelvinPerWatt, "SquareMeterKelvinsPerWatt", BaseUnits.Undefined),
                 },
                 BaseUnit, Zero, BaseDimensions, QuantityType.ThermalResistance);
         }
@@ -201,6 +202,11 @@ namespace UnitsNet
         /// </summary>
         public double SquareMeterKelvinsPerKilowatt => As(ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
 
+        /// <summary>
+        ///     Get ThermalResistance in SquareMeterKelvinsPerWatt.
+        /// </summary>
+        public double SquareMeterKelvinsPerWatt => As(ThermalResistanceUnit.SquareMeterKelvinPerWatt);
+
         #endregion
 
         #region Static Methods
@@ -274,6 +280,15 @@ namespace UnitsNet
         {
             double value = (double) squaremeterkelvinsperkilowatt;
             return new ThermalResistance(value, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt);
+        }
+        /// <summary>
+        ///     Get ThermalResistance from SquareMeterKelvinsPerWatt.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ThermalResistance FromSquareMeterKelvinsPerWatt(QuantityValue squaremeterkelvinsperwatt)
+        {
+            double value = (double) squaremeterkelvinsperwatt;
+            return new ThermalResistance(value, ThermalResistanceUnit.SquareMeterKelvinPerWatt);
         }
 
         /// <summary>
@@ -709,6 +724,7 @@ namespace UnitsNet
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return _value*0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return _value*1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return _value;
+                case ThermalResistanceUnit.SquareMeterKelvinPerWatt: return _value*1000;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to base units.");
             }
@@ -739,6 +755,7 @@ namespace UnitsNet
                 case ThermalResistanceUnit.SquareCentimeterKelvinPerWatt: return baseUnitValue/0.0999964777570357;
                 case ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt: return baseUnitValue/1000.088056074108;
                 case ThermalResistanceUnit.SquareMeterKelvinPerKilowatt: return baseUnitValue;
+                case ThermalResistanceUnit.SquareMeterKelvinPerWatt: return baseUnitValue/1000;
                 default:
                     throw new NotImplementedException($"Can not convert {Unit} to {unit}.");
             }

--- a/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
+++ b/UnitsNet/GeneratedCode/UnitAbbreviationsCache.g.cs
@@ -1456,6 +1456,7 @@ namespace UnitsNet
                 ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareCentimeterKelvinPerWatt, new string[]{"cm²K/W"}),
                 ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt, new string[]{"m²°C/W"}),
                 ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareMeterKelvinPerKilowatt, new string[]{"m²K/kW"}),
+                ("en-US", typeof(ThermalResistanceUnit), (int)ThermalResistanceUnit.SquareMeterKelvinPerWatt, new string[]{"m²K/W"}),
                 ("en-US", typeof(TorqueUnit), (int)TorqueUnit.KilogramForceCentimeter, new string[]{"kgf·cm"}),
                 ("en-US", typeof(TorqueUnit), (int)TorqueUnit.KilogramForceMeter, new string[]{"kgf·m"}),
                 ("en-US", typeof(TorqueUnit), (int)TorqueUnit.KilogramForceMillimeter, new string[]{"kgf·mm"}),

--- a/UnitsNet/GeneratedCode/UnitConverter.g.cs
+++ b/UnitsNet/GeneratedCode/UnitConverter.g.cs
@@ -2207,6 +2207,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<ThermalResistance>(ThermalResistance.BaseUnit, ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt, q => q.ToUnit(ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt));
             unitConverter.SetConversionFunction<ThermalResistance>(ThermalResistanceUnit.SquareMeterDegreeCelsiusPerWatt, ThermalResistance.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<ThermalResistance>(ThermalResistance.BaseUnit, ThermalResistance.BaseUnit, q => q);
+            unitConverter.SetConversionFunction<ThermalResistance>(ThermalResistance.BaseUnit, ThermalResistanceUnit.SquareMeterKelvinPerWatt, q => q.ToUnit(ThermalResistanceUnit.SquareMeterKelvinPerWatt));
+            unitConverter.SetConversionFunction<ThermalResistance>(ThermalResistanceUnit.SquareMeterKelvinPerWatt, ThermalResistance.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Torque>(Torque.BaseUnit, TorqueUnit.KilogramForceCentimeter, q => q.ToUnit(TorqueUnit.KilogramForceCentimeter));
             unitConverter.SetConversionFunction<Torque>(TorqueUnit.KilogramForceCentimeter, Torque.BaseUnit, q => q.ToBaseUnit());
             unitConverter.SetConversionFunction<Torque>(Torque.BaseUnit, TorqueUnit.KilogramForceMeter, q => q.ToUnit(TorqueUnit.KilogramForceMeter));

--- a/UnitsNet/GeneratedCode/Units/ThermalResistanceUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ThermalResistanceUnit.g.cs
@@ -31,6 +31,7 @@ namespace UnitsNet.Units
         SquareCentimeterKelvinPerWatt,
         SquareMeterDegreeCelsiusPerWatt,
         SquareMeterKelvinPerKilowatt,
+        SquareMeterKelvinPerWatt,
     }
 
     #pragma warning restore 1591


### PR DESCRIPTION
SquareMeterKelvinsPerWatt is the standard unit used in the building industry.