### PR TITLE
Improve update of .NET nanoFramework

### DIFF
--- a/CodeGen/Generators/NanoFrameworkGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGenerator.cs
@@ -119,7 +119,7 @@ namespace CodeGen.Generators
         /// </summary>
         /// <param name="rootDir">The root directory</param>
         /// <param name="quantities">The quantities to update nuspecs</param>
-        public static void UpdateNanoFrameworkDependencies(
+        public static bool UpdateNanoFrameworkDependencies(
             string rootDir,
             Quantity[] quantities)
         {
@@ -127,7 +127,7 @@ namespace CodeGen.Generators
             string path = Path.Combine(rootDir, "UnitsNet.NanoFramework\\GeneratedCode");
 
             Log.Information("");
-            Log.Information("Updating .NET nanoFramework references using nuget CLI");
+            Log.Information("Restoring .NET nanoFramework projects");
 
             // run nuget CLI
             var nugetCLI = new Process
@@ -135,9 +135,61 @@ namespace CodeGen.Generators
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = Path.Combine(rootDir, "Tools/nuget.exe"),
+                    Arguments = $"restore {path}\\UnitsNet.nanoFramework.sln",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardError = true
+                }
+            };
+
+            // start nuget CLI and wait for exit
+            if (!nugetCLI.Start())
+            {
+                Log.Information("");
+                Log.Information("Failed to start nuget CLI to restore .NET nanoFramework projects");
+                Log.Information("");
+            }
+            else
+            {
+                // wait for exit, within 2 minutes
+                if (!nugetCLI.WaitForExit((int)TimeSpan.FromMinutes(2).TotalMilliseconds))
+                {
+                    Log.Information("");
+                    Log.Information("Failed to complete execution of nuget CLI to restore .NET nanoFramework projects");
+                    Log.Information("");
+                }
+                else
+                {
+                    if (nugetCLI.ExitCode == 0)
+                    {
+                        Log.Information("Done!");
+                        Log.Information("");
+                    }
+                    else
+                    {
+                        Log.Information("");
+                        Log.Information($"nuget CLI executed with {nugetCLI.ExitCode} exit code");
+
+                        Log.Information(nugetCLI.StandardError.ReadToEnd());
+
+                        return false;
+                    }
+                }
+            }
+
+            Log.Information("");
+            Log.Information("Updating .NET nanoFramework references using nuget CLI");
+
+            // run nuget CLI to perform update
+            nugetCLI = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = Path.Combine(rootDir, "Tools/nuget.exe"),
                     Arguments = $"update {path}\\UnitsNet.nanoFramework.sln -PreRelease",
                     UseShellExecute = false,
-                    CreateNoWindow = true
+                    CreateNoWindow = true,
+                    RedirectStandardError = true
                 }
             };
 
@@ -199,11 +251,18 @@ namespace CodeGen.Generators
                     {
                         Log.Information("");
                         Log.Information($"nuget CLI executed with {nugetCLI.ExitCode} exit code");
+
+                        Log.Information(nugetCLI.StandardError.ReadToEnd());
+
+                        return false;
                     }
                 }
+
             }
 
             Log.Information("");
+
+            return true;
         }
 
         private static NanoFrameworkVersions ParseCurrentNanoFrameworkVersions(string rootDir)

--- a/CodeGen/Program.cs
+++ b/CodeGen/Program.cs
@@ -74,11 +74,14 @@ namespace CodeGen
                     UnitsNetWrcGenerator.Generate(rootDir, quantities);
                 }
 
-                if(updateNanoFrameworkDependencies)
+                if (updateNanoFrameworkDependencies)
                 {
-                    NanoFrameworkGenerator.UpdateNanoFrameworkDependencies(
+                    if (!NanoFrameworkGenerator.UpdateNanoFrameworkDependencies(
                         rootDir,
-                        quantities);
+                        quantities))
+                    {
+                        return 1;
+                    }
                 }
 
                 if (!skipNanoFramework)

--- a/tools/NuGet.exe
+++ b/tools/NuGet.exe
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:852b71cc8c8c2d40d09ea49d321ff56fd2397b9d6ea9f96e532530307bbbafd3
-size 6784920
+oid sha256:04eb6c4fe4213907e2773e1be1bbbd730e9a655a3c9c58387ce8d4a714a5b9e1
+size 7034784


### PR DESCRIPTION
- Add extra step to UpdateNanoFrameworkDependencies to restore .NET nanoFramework solution before update.
(this is required on usage cases where one hasn't performed the restore previously, like automated updates)
- On run failure of nuget CLI, now outputs the error message.
- UpdateNanoFrameworkDependencies now returns a bool reporting running success.
- Update caller accordingly.
- Update nuget.exe to v6.0.0.