### PR TITLE
Add Molarity.FemtomolePerLiter

### DIFF
--- a/Common/UnitDefinitions/Molarity.json
+++ b/Common/UnitDefinitions/Molarity.json
@@ -74,7 +74,7 @@
       },
       "FromUnitToBaseFunc": "{x} / 1e-3",
       "FromBaseToUnitFunc": "{x} * 1e-3",
-      "Prefixes": [ "Pico", "Nano", "Micro", "Milli", "Centi", "Deci" ],
+      "Prefixes": [ "Femto", "Pico", "Nano", "Micro", "Milli", "Centi", "Deci" ],
       "Localization": [
         {
           "Culture": "en-US",

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/Molarity.g.cs
@@ -93,6 +93,11 @@ namespace UnitsNet
         public double DecimolesPerLiter => As(MolarityUnit.DecimolePerLiter);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MolarityUnit.FemtomolePerLiter"/>
+        /// </summary>
+        public double FemtomolesPerLiter => As(MolarityUnit.FemtomolePerLiter);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MolarityUnit.MicromolePerLiter"/>
         /// </summary>
         public double MicromolesPerLiter => As(MolarityUnit.MicromolePerLiter);
@@ -137,6 +142,12 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static Molarity FromDecimolesPerLiter(double decimolesperliter) => new Molarity(decimolesperliter, MolarityUnit.DecimolePerLiter);
+
+        /// <summary>
+        ///     Creates a <see cref="Molarity"/> from <see cref="MolarityUnit.FemtomolePerLiter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Molarity FromFemtomolesPerLiter(double femtomolesperliter) => new Molarity(femtomolesperliter, MolarityUnit.FemtomolePerLiter);
 
         /// <summary>
         ///     Creates a <see cref="Molarity"/> from <see cref="MolarityUnit.MicromolePerLiter"/>.
@@ -218,6 +229,7 @@ namespace UnitsNet
                 MolarityUnit.CentimolesPerLiter => (_value / 1e-3) * 1e-2d,
                 MolarityUnit.DecimolePerLiter => (_value / 1e-3) * 1e-1d,
                 MolarityUnit.DecimolesPerLiter => (_value / 1e-3) * 1e-1d,
+                MolarityUnit.FemtomolePerLiter => (_value / 1e-3) * 1e-15d,
                 MolarityUnit.MicromolePerLiter => (_value / 1e-3) * 1e-6d,
                 MolarityUnit.MicromolesPerLiter => (_value / 1e-3) * 1e-6d,
                 MolarityUnit.MillimolePerLiter => (_value / 1e-3) * 1e-3d,
@@ -247,6 +259,7 @@ namespace UnitsNet
                 MolarityUnit.CentimolesPerLiter => (baseUnitValue * 1e-3) / 1e-2d,
                 MolarityUnit.DecimolePerLiter => (baseUnitValue * 1e-3) / 1e-1d,
                 MolarityUnit.DecimolesPerLiter => (baseUnitValue * 1e-3) / 1e-1d,
+                MolarityUnit.FemtomolePerLiter => (baseUnitValue * 1e-3) / 1e-15d,
                 MolarityUnit.MicromolePerLiter => (baseUnitValue * 1e-3) / 1e-6d,
                 MolarityUnit.MicromolesPerLiter => (baseUnitValue * 1e-3) / 1e-6d,
                 MolarityUnit.MillimolePerLiter => (baseUnitValue * 1e-3) / 1e-3d,

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/MolarityUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/MolarityUnit.g.cs
@@ -32,6 +32,7 @@ namespace UnitsNet.Units
         DecimolePerLiter,
         [System.Obsolete("Use the singular unit instead.")]
         DecimolesPerLiter,
+        FemtomolePerLiter,
         MicromolePerLiter,
         [System.Obsolete("Use the singular unit instead.")]
         MicromolesPerLiter,

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToMolarityExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToMolarityExtensionsTest.g.cs
@@ -33,6 +33,10 @@ namespace UnitsNet.Tests
             Assert.Equal(Molarity.FromDecimolesPerLiter(2), 2.DecimolesPerLiter());
 
         [Fact]
+        public void NumberToFemtomolesPerLiterTest() =>
+            Assert.Equal(Molarity.FromFemtomolesPerLiter(2), 2.FemtomolesPerLiter());
+
+        [Fact]
         public void NumberToMicromolesPerLiterTest() =>
             Assert.Equal(Molarity.FromMicromolesPerLiter(2), 2.MicromolesPerLiter());
 

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToMolarityExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToMolarityExtensions.g.cs
@@ -36,6 +36,10 @@ namespace UnitsNet.NumberExtensions.NumberToMolarity
         public static Molarity DecimolesPerLiter<T>(this T value) =>
             Molarity.FromDecimolesPerLiter(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Molarity.FromFemtomolesPerLiter(UnitsNet.QuantityValue)" />
+        public static Molarity FemtomolesPerLiter<T>(this T value) =>
+            Molarity.FromFemtomolesPerLiter(Convert.ToDouble(value));
+
         /// <inheritdoc cref="Molarity.FromMicromolesPerLiter(UnitsNet.QuantityValue)" />
         public static Molarity MicromolesPerLiter<T>(this T value) =>
             Molarity.FromMicromolesPerLiter(Convert.ToDouble(value));

--- a/UnitsNet.Tests/CustomCode/MolarityTests.cs
+++ b/UnitsNet.Tests/CustomCode/MolarityTests.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double CentimolesPerLiterInOneMolesPerCubicMeter => 1e-1;
         protected override double DecimolesPerLiterInOneMolesPerCubicMeter => 1e-2;
+        protected override double FemtomolesPerLiterInOneMolesPerCubicMeter => 1e12;
         protected override double MolesPerLiterInOneMolesPerCubicMeter => 1e-3;
         protected override double MillimolesPerLiterInOneMolesPerCubicMeter => 1;
         protected override double MolesPerCubicMeterInOneMolesPerCubicMeter => 1;

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
@@ -40,6 +40,7 @@ namespace UnitsNet.Tests
     {
         protected abstract double CentimolesPerLiterInOneMolesPerCubicMeter { get; }
         protected abstract double DecimolesPerLiterInOneMolesPerCubicMeter { get; }
+        protected abstract double FemtomolesPerLiterInOneMolesPerCubicMeter { get; }
         protected abstract double MicromolesPerLiterInOneMolesPerCubicMeter { get; }
         protected abstract double MillimolesPerLiterInOneMolesPerCubicMeter { get; }
         protected abstract double MolesPerCubicMeterInOneMolesPerCubicMeter { get; }
@@ -50,6 +51,7 @@ namespace UnitsNet.Tests
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double CentimolesPerLiterTolerance { get { return 1e-5; } }
         protected virtual double DecimolesPerLiterTolerance { get { return 1e-5; } }
+        protected virtual double FemtomolesPerLiterTolerance { get { return 1e-5; } }
         protected virtual double MicromolesPerLiterTolerance { get { return 1e-5; } }
         protected virtual double MillimolesPerLiterTolerance { get { return 1e-5; } }
         protected virtual double MolesPerCubicMeterTolerance { get { return 1e-5; } }
@@ -66,6 +68,7 @@ namespace UnitsNet.Tests
                 MolarityUnit.CentimolesPerLiter => (CentimolesPerLiterInOneMolesPerCubicMeter, CentimolesPerLiterTolerance),
                 MolarityUnit.DecimolePerLiter => (DecimolesPerLiterInOneMolesPerCubicMeter, DecimolesPerLiterTolerance),
                 MolarityUnit.DecimolesPerLiter => (DecimolesPerLiterInOneMolesPerCubicMeter, DecimolesPerLiterTolerance),
+                MolarityUnit.FemtomolePerLiter => (FemtomolesPerLiterInOneMolesPerCubicMeter, FemtomolesPerLiterTolerance),
                 MolarityUnit.MicromolePerLiter => (MicromolesPerLiterInOneMolesPerCubicMeter, MicromolesPerLiterTolerance),
                 MolarityUnit.MicromolesPerLiter => (MicromolesPerLiterInOneMolesPerCubicMeter, MicromolesPerLiterTolerance),
                 MolarityUnit.MillimolePerLiter => (MillimolesPerLiterInOneMolesPerCubicMeter, MillimolesPerLiterTolerance),
@@ -88,6 +91,7 @@ namespace UnitsNet.Tests
             new object[] { MolarityUnit.CentimolesPerLiter },
             new object[] { MolarityUnit.DecimolePerLiter },
             new object[] { MolarityUnit.DecimolesPerLiter },
+            new object[] { MolarityUnit.FemtomolePerLiter },
             new object[] { MolarityUnit.MicromolePerLiter },
             new object[] { MolarityUnit.MicromolesPerLiter },
             new object[] { MolarityUnit.MillimolePerLiter },
@@ -178,6 +182,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(CentimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.CentimolesPerLiter, CentimolesPerLiterTolerance);
             AssertEx.EqualTolerance(DecimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.DecimolesPerLiter, DecimolesPerLiterTolerance);
             AssertEx.EqualTolerance(DecimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.DecimolesPerLiter, DecimolesPerLiterTolerance);
+            AssertEx.EqualTolerance(FemtomolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.FemtomolesPerLiter, FemtomolesPerLiterTolerance);
             AssertEx.EqualTolerance(MicromolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.MicromolesPerLiter, MicromolesPerLiterTolerance);
             AssertEx.EqualTolerance(MicromolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.MicromolesPerLiter, MicromolesPerLiterTolerance);
             AssertEx.EqualTolerance(MillimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.MillimolesPerLiter, MillimolesPerLiterTolerance);
@@ -211,53 +216,57 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity03.DecimolesPerLiter, DecimolesPerLiterTolerance);
             Assert.Equal(MolarityUnit.DecimolesPerLiter, quantity03.Unit);
 
-            var quantity04 = Molarity.From(1, MolarityUnit.MicromolePerLiter);
-            AssertEx.EqualTolerance(1, quantity04.MicromolesPerLiter, MicromolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.MicromolePerLiter, quantity04.Unit);
+            var quantity04 = Molarity.From(1, MolarityUnit.FemtomolePerLiter);
+            AssertEx.EqualTolerance(1, quantity04.FemtomolesPerLiter, FemtomolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.FemtomolePerLiter, quantity04.Unit);
 
-            var quantity05 = Molarity.From(1, MolarityUnit.MicromolesPerLiter);
+            var quantity05 = Molarity.From(1, MolarityUnit.MicromolePerLiter);
             AssertEx.EqualTolerance(1, quantity05.MicromolesPerLiter, MicromolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.MicromolesPerLiter, quantity05.Unit);
+            Assert.Equal(MolarityUnit.MicromolePerLiter, quantity05.Unit);
 
-            var quantity06 = Molarity.From(1, MolarityUnit.MillimolePerLiter);
-            AssertEx.EqualTolerance(1, quantity06.MillimolesPerLiter, MillimolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.MillimolePerLiter, quantity06.Unit);
+            var quantity06 = Molarity.From(1, MolarityUnit.MicromolesPerLiter);
+            AssertEx.EqualTolerance(1, quantity06.MicromolesPerLiter, MicromolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.MicromolesPerLiter, quantity06.Unit);
 
-            var quantity07 = Molarity.From(1, MolarityUnit.MillimolesPerLiter);
+            var quantity07 = Molarity.From(1, MolarityUnit.MillimolePerLiter);
             AssertEx.EqualTolerance(1, quantity07.MillimolesPerLiter, MillimolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.MillimolesPerLiter, quantity07.Unit);
+            Assert.Equal(MolarityUnit.MillimolePerLiter, quantity07.Unit);
 
-            var quantity08 = Molarity.From(1, MolarityUnit.MolePerCubicMeter);
-            AssertEx.EqualTolerance(1, quantity08.MolesPerCubicMeter, MolesPerCubicMeterTolerance);
-            Assert.Equal(MolarityUnit.MolePerCubicMeter, quantity08.Unit);
+            var quantity08 = Molarity.From(1, MolarityUnit.MillimolesPerLiter);
+            AssertEx.EqualTolerance(1, quantity08.MillimolesPerLiter, MillimolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.MillimolesPerLiter, quantity08.Unit);
 
-            var quantity09 = Molarity.From(1, MolarityUnit.MolePerLiter);
-            AssertEx.EqualTolerance(1, quantity09.MolesPerLiter, MolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.MolePerLiter, quantity09.Unit);
+            var quantity09 = Molarity.From(1, MolarityUnit.MolePerCubicMeter);
+            AssertEx.EqualTolerance(1, quantity09.MolesPerCubicMeter, MolesPerCubicMeterTolerance);
+            Assert.Equal(MolarityUnit.MolePerCubicMeter, quantity09.Unit);
 
-            var quantity10 = Molarity.From(1, MolarityUnit.MolesPerCubicMeter);
-            AssertEx.EqualTolerance(1, quantity10.MolesPerCubicMeter, MolesPerCubicMeterTolerance);
-            Assert.Equal(MolarityUnit.MolesPerCubicMeter, quantity10.Unit);
+            var quantity10 = Molarity.From(1, MolarityUnit.MolePerLiter);
+            AssertEx.EqualTolerance(1, quantity10.MolesPerLiter, MolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.MolePerLiter, quantity10.Unit);
 
-            var quantity11 = Molarity.From(1, MolarityUnit.MolesPerLiter);
-            AssertEx.EqualTolerance(1, quantity11.MolesPerLiter, MolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.MolesPerLiter, quantity11.Unit);
+            var quantity11 = Molarity.From(1, MolarityUnit.MolesPerCubicMeter);
+            AssertEx.EqualTolerance(1, quantity11.MolesPerCubicMeter, MolesPerCubicMeterTolerance);
+            Assert.Equal(MolarityUnit.MolesPerCubicMeter, quantity11.Unit);
 
-            var quantity12 = Molarity.From(1, MolarityUnit.NanomolePerLiter);
-            AssertEx.EqualTolerance(1, quantity12.NanomolesPerLiter, NanomolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.NanomolePerLiter, quantity12.Unit);
+            var quantity12 = Molarity.From(1, MolarityUnit.MolesPerLiter);
+            AssertEx.EqualTolerance(1, quantity12.MolesPerLiter, MolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.MolesPerLiter, quantity12.Unit);
 
-            var quantity13 = Molarity.From(1, MolarityUnit.NanomolesPerLiter);
+            var quantity13 = Molarity.From(1, MolarityUnit.NanomolePerLiter);
             AssertEx.EqualTolerance(1, quantity13.NanomolesPerLiter, NanomolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.NanomolesPerLiter, quantity13.Unit);
+            Assert.Equal(MolarityUnit.NanomolePerLiter, quantity13.Unit);
 
-            var quantity14 = Molarity.From(1, MolarityUnit.PicomolePerLiter);
-            AssertEx.EqualTolerance(1, quantity14.PicomolesPerLiter, PicomolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.PicomolePerLiter, quantity14.Unit);
+            var quantity14 = Molarity.From(1, MolarityUnit.NanomolesPerLiter);
+            AssertEx.EqualTolerance(1, quantity14.NanomolesPerLiter, NanomolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.NanomolesPerLiter, quantity14.Unit);
 
-            var quantity15 = Molarity.From(1, MolarityUnit.PicomolesPerLiter);
+            var quantity15 = Molarity.From(1, MolarityUnit.PicomolePerLiter);
             AssertEx.EqualTolerance(1, quantity15.PicomolesPerLiter, PicomolesPerLiterTolerance);
-            Assert.Equal(MolarityUnit.PicomolesPerLiter, quantity15.Unit);
+            Assert.Equal(MolarityUnit.PicomolePerLiter, quantity15.Unit);
+
+            var quantity16 = Molarity.From(1, MolarityUnit.PicomolesPerLiter);
+            AssertEx.EqualTolerance(1, quantity16.PicomolesPerLiter, PicomolesPerLiterTolerance);
+            Assert.Equal(MolarityUnit.PicomolesPerLiter, quantity16.Unit);
 
         }
 
@@ -282,6 +291,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(CentimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.CentimolesPerLiter), CentimolesPerLiterTolerance);
             AssertEx.EqualTolerance(DecimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.DecimolePerLiter), DecimolesPerLiterTolerance);
             AssertEx.EqualTolerance(DecimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.DecimolesPerLiter), DecimolesPerLiterTolerance);
+            AssertEx.EqualTolerance(FemtomolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.FemtomolePerLiter), FemtomolesPerLiterTolerance);
             AssertEx.EqualTolerance(MicromolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.MicromolePerLiter), MicromolesPerLiterTolerance);
             AssertEx.EqualTolerance(MicromolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.MicromolesPerLiter), MicromolesPerLiterTolerance);
             AssertEx.EqualTolerance(MillimolesPerLiterInOneMolesPerCubicMeter, molespercubicmeter.As(MolarityUnit.MillimolePerLiter), MillimolesPerLiterTolerance);
@@ -358,6 +368,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Molarity.FromCentimolesPerLiter(molespercubicmeter.CentimolesPerLiter).MolesPerCubicMeter, CentimolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.FromDecimolesPerLiter(molespercubicmeter.DecimolesPerLiter).MolesPerCubicMeter, DecimolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.FromDecimolesPerLiter(molespercubicmeter.DecimolesPerLiter).MolesPerCubicMeter, DecimolesPerLiterTolerance);
+            AssertEx.EqualTolerance(1, Molarity.FromFemtomolesPerLiter(molespercubicmeter.FemtomolesPerLiter).MolesPerCubicMeter, FemtomolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.FromMicromolesPerLiter(molespercubicmeter.MicromolesPerLiter).MolesPerCubicMeter, MicromolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.FromMicromolesPerLiter(molespercubicmeter.MicromolesPerLiter).MolesPerCubicMeter, MicromolesPerLiterTolerance);
             AssertEx.EqualTolerance(1, Molarity.FromMillimolesPerLiter(molespercubicmeter.MillimolesPerLiter).MolesPerCubicMeter, MillimolesPerLiterTolerance);
@@ -532,6 +543,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 cmol/L", new Molarity(1, MolarityUnit.CentimolesPerLiter).ToString());
                 Assert.Equal("1 dmol/L", new Molarity(1, MolarityUnit.DecimolePerLiter).ToString());
                 Assert.Equal("1 dmol/L", new Molarity(1, MolarityUnit.DecimolesPerLiter).ToString());
+                Assert.Equal("1 fmol/L", new Molarity(1, MolarityUnit.FemtomolePerLiter).ToString());
                 Assert.Equal("1 µmol/L", new Molarity(1, MolarityUnit.MicromolePerLiter).ToString());
                 Assert.Equal("1 µmol/L", new Molarity(1, MolarityUnit.MicromolesPerLiter).ToString());
                 Assert.Equal("1 mmol/L", new Molarity(1, MolarityUnit.MillimolePerLiter).ToString());
@@ -561,6 +573,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 cmol/L", new Molarity(1, MolarityUnit.CentimolesPerLiter).ToString(swedishCulture));
             Assert.Equal("1 dmol/L", new Molarity(1, MolarityUnit.DecimolePerLiter).ToString(swedishCulture));
             Assert.Equal("1 dmol/L", new Molarity(1, MolarityUnit.DecimolesPerLiter).ToString(swedishCulture));
+            Assert.Equal("1 fmol/L", new Molarity(1, MolarityUnit.FemtomolePerLiter).ToString(swedishCulture));
             Assert.Equal("1 µmol/L", new Molarity(1, MolarityUnit.MicromolePerLiter).ToString(swedishCulture));
             Assert.Equal("1 µmol/L", new Molarity(1, MolarityUnit.MicromolesPerLiter).ToString(swedishCulture));
             Assert.Equal("1 mmol/L", new Molarity(1, MolarityUnit.MillimolePerLiter).ToString(swedishCulture));

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/Molarity.g.cs
@@ -177,6 +177,11 @@ namespace UnitsNet
         public double DecimolesPerLiter => As(MolarityUnit.DecimolePerLiter);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MolarityUnit.FemtomolePerLiter"/>
+        /// </summary>
+        public double FemtomolesPerLiter => As(MolarityUnit.FemtomolePerLiter);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MolarityUnit.MicromolePerLiter"/>
         /// </summary>
         public double MicromolesPerLiter => As(MolarityUnit.MicromolePerLiter);
@@ -216,6 +221,7 @@ namespace UnitsNet
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.CentimolesPerLiter, new CultureInfo("en-US"), false, false, new string[]{"cmol/L", "cM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.DecimolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"dmol/L", "dM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.DecimolesPerLiter, new CultureInfo("en-US"), false, false, new string[]{"dmol/L", "dM"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.FemtomolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"fmol/L", "fM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.MicromolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"µmol/L", "µM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.MicromolesPerLiter, new CultureInfo("en-US"), false, false, new string[]{"µmol/L", "µM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.MillimolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"mmol/L", "mM"});
@@ -276,6 +282,17 @@ namespace UnitsNet
         {
             double value = (double) decimolesperliter;
             return new Molarity(value, MolarityUnit.DecimolePerLiter);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="Molarity"/> from <see cref="MolarityUnit.FemtomolePerLiter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static Molarity FromFemtomolesPerLiter(double femtomolesperliter)
+        {
+            double value = (double) femtomolesperliter;
+            return new Molarity(value, MolarityUnit.FemtomolePerLiter);
         }
 
         /// <summary>
@@ -638,6 +655,7 @@ namespace UnitsNet
                 case MolarityUnit.CentimolesPerLiter: return (_value / 1e-3) * 1e-2d;
                 case MolarityUnit.DecimolePerLiter: return (_value / 1e-3) * 1e-1d;
                 case MolarityUnit.DecimolesPerLiter: return (_value / 1e-3) * 1e-1d;
+                case MolarityUnit.FemtomolePerLiter: return (_value / 1e-3) * 1e-15d;
                 case MolarityUnit.MicromolePerLiter: return (_value / 1e-3) * 1e-6d;
                 case MolarityUnit.MicromolesPerLiter: return (_value / 1e-3) * 1e-6d;
                 case MolarityUnit.MillimolePerLiter: return (_value / 1e-3) * 1e-3d;
@@ -668,6 +686,7 @@ namespace UnitsNet
                 case MolarityUnit.CentimolesPerLiter: return (baseUnitValue * 1e-3) / 1e-2d;
                 case MolarityUnit.DecimolePerLiter: return (baseUnitValue * 1e-3) / 1e-1d;
                 case MolarityUnit.DecimolesPerLiter: return (baseUnitValue * 1e-3) / 1e-1d;
+                case MolarityUnit.FemtomolePerLiter: return (baseUnitValue * 1e-3) / 1e-15d;
                 case MolarityUnit.MicromolePerLiter: return (baseUnitValue * 1e-3) / 1e-6d;
                 case MolarityUnit.MicromolesPerLiter: return (baseUnitValue * 1e-3) / 1e-6d;
                 case MolarityUnit.MillimolePerLiter: return (baseUnitValue * 1e-3) / 1e-3d;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/MolarityUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/MolarityUnit.g.cs
@@ -32,6 +32,7 @@ namespace UnitsNet.Units
         DecimolePerLiter,
         [System.Obsolete("Use the singular unit instead.")]
         DecimolesPerLiter,
+        FemtomolePerLiter,
         MicromolePerLiter,
         [System.Obsolete("Use the singular unit instead.")]
         MicromolesPerLiter,

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -69,6 +69,7 @@ namespace UnitsNet
                     new UnitInfo<MolarityUnit>(MolarityUnit.CentimolesPerLiter, "CentimolesPerLiter", BaseUnits.Undefined),
                     new UnitInfo<MolarityUnit>(MolarityUnit.DecimolePerLiter, "DecimolesPerLiter", BaseUnits.Undefined),
                     new UnitInfo<MolarityUnit>(MolarityUnit.DecimolesPerLiter, "DecimolesPerLiter", BaseUnits.Undefined),
+                    new UnitInfo<MolarityUnit>(MolarityUnit.FemtomolePerLiter, "FemtomolesPerLiter", BaseUnits.Undefined),
                     new UnitInfo<MolarityUnit>(MolarityUnit.MicromolePerLiter, "MicromolesPerLiter", BaseUnits.Undefined),
                     new UnitInfo<MolarityUnit>(MolarityUnit.MicromolesPerLiter, "MicromolesPerLiter", BaseUnits.Undefined),
                     new UnitInfo<MolarityUnit>(MolarityUnit.MillimolePerLiter, "MillimolesPerLiter", BaseUnits.Undefined),
@@ -216,6 +217,11 @@ namespace UnitsNet
         public double DecimolesPerLiter => As(MolarityUnit.DecimolePerLiter);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MolarityUnit.FemtomolePerLiter"/>
+        /// </summary>
+        public double FemtomolesPerLiter => As(MolarityUnit.FemtomolePerLiter);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MolarityUnit.MicromolePerLiter"/>
         /// </summary>
         public double MicromolesPerLiter => As(MolarityUnit.MicromolePerLiter);
@@ -260,6 +266,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.CentimolesPerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-2d, MolarityUnit.CentimolesPerLiter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.DecimolePerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-1d, MolarityUnit.DecimolePerLiter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.DecimolesPerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-1d, MolarityUnit.DecimolesPerLiter));
+            unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.FemtomolePerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-15d, MolarityUnit.FemtomolePerLiter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.MicromolePerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-6d, MolarityUnit.MicromolePerLiter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.MicromolesPerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-6d, MolarityUnit.MicromolesPerLiter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MolesPerCubicMeter, MolarityUnit.MillimolePerLiter, quantity => new Molarity((quantity.Value * 1e-3) / 1e-3d, MolarityUnit.MillimolePerLiter));
@@ -280,6 +287,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.CentimolesPerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-2d, MolarityUnit.MolesPerCubicMeter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.DecimolePerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-1d, MolarityUnit.MolesPerCubicMeter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.DecimolesPerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-1d, MolarityUnit.MolesPerCubicMeter));
+            unitConverter.SetConversionFunction<Molarity>(MolarityUnit.FemtomolePerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-15d, MolarityUnit.MolesPerCubicMeter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MicromolePerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-6d, MolarityUnit.MolesPerCubicMeter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MicromolesPerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-6d, MolarityUnit.MolesPerCubicMeter));
             unitConverter.SetConversionFunction<Molarity>(MolarityUnit.MillimolePerLiter, MolarityUnit.MolesPerCubicMeter, quantity => new Molarity((quantity.Value / 1e-3) * 1e-3d, MolarityUnit.MolesPerCubicMeter));
@@ -299,6 +307,7 @@ namespace UnitsNet
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.CentimolesPerLiter, new CultureInfo("en-US"), false, false, new string[]{"cmol/L", "cM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.DecimolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"dmol/L", "dM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.DecimolesPerLiter, new CultureInfo("en-US"), false, false, new string[]{"dmol/L", "dM"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.FemtomolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"fmol/L", "fM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.MicromolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"µmol/L", "µM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.MicromolesPerLiter, new CultureInfo("en-US"), false, false, new string[]{"µmol/L", "µM"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MolarityUnit.MillimolePerLiter, new CultureInfo("en-US"), false, true, new string[]{"mmol/L", "mM"});
@@ -356,6 +365,16 @@ namespace UnitsNet
         {
             double value = (double) decimolesperliter;
             return new Molarity(value, MolarityUnit.DecimolePerLiter);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="Molarity"/> from <see cref="MolarityUnit.FemtomolePerLiter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Molarity FromFemtomolesPerLiter(QuantityValue femtomolesperliter)
+        {
+            double value = (double) femtomolesperliter;
+            return new Molarity(value, MolarityUnit.FemtomolePerLiter);
         }
 
         /// <summary>

--- a/UnitsNet/GeneratedCode/Units/MolarityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MolarityUnit.g.cs
@@ -32,6 +32,7 @@ namespace UnitsNet.Units
         DecimolePerLiter,
         [System.Obsolete("Use the singular unit instead.")]
         DecimolesPerLiter,
+        FemtomolePerLiter,
         MicromolePerLiter,
         [System.Obsolete("Use the singular unit instead.")]
         MicromolesPerLiter,


### PR DESCRIPTION
There exists a case where the Femto prefix should be used when dealing with Molarity. I believe this change should allow that with your library. If there's anything additional that needs to be done in terms of testing, please let me know. 

Kindest regards,

Brad.