### PR TITLE
Add operator Energy divided by time to get Power

### DIFF
--- a/UnitsNet.Tests/CustomCode/EnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/EnergyTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System;
 using UnitsNet.Units;
 using Xunit;
 
@@ -104,6 +105,20 @@ namespace UnitsNet.Tests.CustomCode
 
             Assert.Equal(2110.11170524, inSI.Value);
             Assert.Equal(EnergyUnit.Joule, inSI.Unit);
+        }
+
+        [Fact]
+        public void EnergyDividedByTimeSpanEqualsPower()
+        {
+            Power p = Energy.FromWattHours(10) / TimeSpan.FromHours(2);
+            Assert.Equal(5, p.Watts);
+        }
+
+        [Fact]
+        public void EnergyDividedByDurationEqualsPower()
+        {
+            Power p = Energy.FromWattHours(20) / Duration.FromHours(5);
+            Assert.Equal(4, p.Watts);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/Energy.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Energy.extra.cs
@@ -1,0 +1,22 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+
+namespace UnitsNet
+{
+    public partial struct Energy
+    {
+        /// <summary>Get <see cref="Power"/> from <see cref="Energy"/> divided by <see cref="TimeSpan"/>.</summary>
+        public static Power operator /(Energy energy, TimeSpan time)
+        {
+            return Power.FromWatts(energy.Joules / time.TotalSeconds);
+        }
+
+        /// <summary>Get <see cref="Power"/> from <see cref="Energy"/> divided by <see cref="Duration"/>.</summary>
+        public static Power operator /(Energy energy, Duration duration)
+        {
+            return Power.FromWatts(energy.Joules / duration.Seconds);
+        }
+    }
+}


### PR DESCRIPTION
Add division operators to `Energy` to divide by `TimeSpan` and `Duration` to get `Power`.  These are reciprocals of the multiplication operators that `Power` already has.