### PR TITLE
Fix Duration.ToTimeSpan() inaccuracy rounding to millisecond

### DIFF
--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -63,31 +63,15 @@ namespace UnitsNet.Tests.CustomCode
             AssertEx.EqualTolerance(duration.Seconds, timeSpan.TotalSeconds, 1e-3);
         }
 
-        [Fact]
-        public static void ToTimeSpanShouldNotDiscardOneTickDuration()
+        [Theory]
+        [InlineData(100, Units.DurationUnit.Nanosecond)]
+        [InlineData(1, Units.DurationUnit.Microsecond)]
+        [InlineData(1.234, Units.DurationUnit.Millisecond)]
+        public static void ToTimeSpanShouldNotRoundToMillisecond(double value, Units.DurationUnit unit)
         {
-            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
-            Duration duration = Duration.FromNanoseconds(100);
+            Duration duration = Duration.From(value, unit);
             TimeSpan timeSpan = duration.ToTimeSpan();
-            AssertEx.EqualTolerance(duration.Microseconds, (double)timeSpan.Ticks / ticksPerMicrosecond, 1e-10);
-        }
-
-        [Fact]
-        public static void ToTimeSpanShouldNotDiscardOneMicrosecondDuration()
-        {
-            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
-            Duration duration = Duration.FromMicroseconds(1);
-            TimeSpan timeSpan = duration.ToTimeSpan();
-            AssertEx.EqualTolerance(duration.Microseconds, (double)timeSpan.Ticks / ticksPerMicrosecond, 1e-10);
-        }
-
-        [Fact]
-        public static void ToTimeSpanShouldNotTruncateFractionalMillisecondsDuration()
-        {
-            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
-            Duration duration = Duration.FromMilliseconds(1.234);
-            TimeSpan timeSpan = duration.ToTimeSpan();
-            AssertEx.EqualTolerance(duration.Microseconds, (double)timeSpan.Ticks / ticksPerMicrosecond, 1e-10);
+            AssertEx.EqualTolerance(duration.Milliseconds, timeSpan.TotalMilliseconds, 1e-10);
         }
 
         [Fact]

--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -64,6 +64,33 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Fact]
+        public static void ToTimeSpanShouldNotDiscardOneTickDuration()
+        {
+            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+            Duration duration = Duration.FromNanoseconds(100);
+            TimeSpan timeSpan = duration.ToTimeSpan();
+            AssertEx.EqualTolerance(duration.Microseconds, (double)timeSpan.Ticks / ticksPerMicrosecond, 1e-10);
+        }
+
+        [Fact]
+        public static void ToTimeSpanShouldNotDiscardOneMicrosecondDuration()
+        {
+            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+            Duration duration = Duration.FromMicroseconds(1);
+            TimeSpan timeSpan = duration.ToTimeSpan();
+            AssertEx.EqualTolerance(duration.Microseconds, (double)timeSpan.Ticks / ticksPerMicrosecond, 1e-10);
+        }
+
+        [Fact]
+        public static void ToTimeSpanShouldNotTruncateFractionalMillisecondsDuration()
+        {
+            const long ticksPerMicrosecond = TimeSpan.TicksPerMillisecond / 1000;
+            Duration duration = Duration.FromMilliseconds(1.234);
+            TimeSpan timeSpan = duration.ToTimeSpan();
+            AssertEx.EqualTolerance(duration.Microseconds, (double)timeSpan.Ticks / ticksPerMicrosecond, 1e-10);
+        }
+
+        [Fact]
         public static void ExplicitCastToTimeSpanShouldReturnSameValue()
         {
             Duration duration = Duration.FromSeconds(60);

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net48</TargetFrameworks>
     <RootNamespace>UnitsNet.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>

--- a/UnitsNet/CustomCode/Quantities/Duration.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Duration.extra.cs
@@ -18,7 +18,7 @@ namespace UnitsNet
             if ( Seconds > TimeSpan.MaxValue.TotalSeconds ||
                 Seconds < TimeSpan.MinValue.TotalSeconds )
                 throw new ArgumentOutOfRangeException( nameof( Duration ), "The duration is too large or small to fit in a TimeSpan" );
-            return TimeSpan.FromSeconds( Seconds );
+            return TimeSpan.FromTicks((long)(Seconds * TimeSpan.TicksPerSecond));
         }
 
         /// <summary>Get <see cref="DateTime"/> from <see cref="DateTime"/> plus <see cref="Duration"/>.</summary>


### PR DESCRIPTION
When using .NET Framework (v4.8 in my case), the `TimeSpan.FromXXX` methods (like `FromSeconds` used in `Duration.ToTimeSpan()` up until now) round to the nearest millisecond, even though `TimeSpan`s are accurate to the tick (100 ns).

New unit tests before my fix:
![image](https://user-images.githubusercontent.com/30859615/160446373-c34f0a9a-dc28-4a01-b0b4-5c4ab692910c.png)

Unit tests after my fix:
![image](https://user-images.githubusercontent.com/30859615/160446396-2e007808-158e-4da3-b3f7-51ea277d7590.png)
