### PR TITLE
Update install of nanoFramework build components

### DIFF
--- a/Build/init.ps1
+++ b/Build/init.ps1
@@ -23,29 +23,59 @@ if (!(Test-Path "$msbuildPath/nanoFramework")) {
   Write-Host "Installing .NET nanoFramework VS extension..."
 
   [System.Net.WebClient]$webClient = New-Object System.Net.WebClient
-  $webClient.UseDefaultCredentials = $true
+  $webClient.Headers.Add("User-Agent", "request")
+  $webClient.Headers.Add("Accept", "application/vnd.github.v3+json")
 
-  $vsixFeedXml = Join-Path -Path $tempDir -ChildPath "vs-extension-feed.xml"
-  $webClient.DownloadFile("http://vsixgallery.com/feed/author/nanoframework", $vsixFeedXml)
-  [xml]$feedDetails = Get-Content $vsixFeedXml
+  $releaseList = $webClient.DownloadString('https://api.github.com/repos/nanoframework/nf-Visual-Studio-extension/tags')
 
-  foreach ($entry in $feedDetails.feed.entry)
+  if($releaseList -match '"(?<VS2022_version>v2022\.\d+\.\d+\.\d+)')
   {
-      if($entry.id -eq '455f2be5-bb07-451e-b351-a9faf3018dc9')
-      {
-          $extensionUrl = $entry.content.src
-          $extensionVersion = $entry.Vsix.Version
-          break
-      }
+      $vs2022Tag =  $Matches.VS2022_version
   }
+
+  if($releaseList -match '"(?<VS2019_version>v2019\.\d+\.\d+\.\d+)')
+  {
+      $vs2019Tag =  $Matches.VS2019_version
+  }
+
+  # Find which VS version is installed
+  $VsWherePath = "${env:PROGRAMFILES(X86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+
+  Write-Output "VsWherePath is: $VsWherePath"
+
+  $VsInstance = $(&$VSWherePath -latest -property displayName)
+
+  Write-Output "Latest VS is: $VsInstance"
+
+  # Get extension details according to VS version, starting from VS2022 down to VS2019
+  if($vsInstance.Contains('2022'))
+  {
+      $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2022Tag/nanoFramework.Tools.VS2022.Extension.vsix"
+      $vsixPath = Join-Path  $tempDir "nanoFramework.Tools.VS2022.Extension.zip"
+      $extensionVersion = $vs2022Tag
+  }
+  elseif($vsInstance.Contains('2019'))
+  {
+      $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2019Tag/nanoFramework.Tools.VS2019.Extension.vsix"
+      $vsixPath = Join-Path  $tempDir "nanoFramework.Tools.VS2019.Extension.zip"
+      $extensionVersion = $vs2019Tag
+  }
+
+  Write-Output "Downloading visx..." -NoNewline
+
+  # download VS extension
+  Write-Debug "Download VSIX file from $extensionUrl to $vsixPath"
+  $webClient.DownloadFile($extensionUrl, $vsixPath)
+
+  $outputPath = "$tempDir\nf-extension"
 
   $vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"
   $webClient.DownloadFile($extensionUrl,$vsixPath)
-  Expand-Archive -LiteralPath $vsixPath -DestinationPath $tempDir\nf-extension\ | Write-Host
+  Expand-Archive -LiteralPath $vsixPath -DestinationPath $outputPath | Write-Host
 
-  Copy-Item -Path "$tempDir\nf-extension\`$MSBuild\nanoFramework" -Destination $msbuildPath -Recurse
+  Copy-Item -Path "$outputPath\`$MSBuild\nanoFramework" -Destination $msbuildPath -Recurse
 
-  Write-Host "Installed VS extension v$extensionVersion"
+  Write-Host "Installed VS extension $extensionVersion"
 }
 
 # Cleanup


### PR DESCRIPTION
- Dropping VSIX gallery as source of msbuild components. Replacing with GitHub version which is a much more reliable source.