### PR TITLE
Fix QuantityTypeConverter ignoring given CurrentCulture without DisplayAsAttribute

### DIFF
--- a/UnitsNet.Tests/QuantityTypeConverterTest.cs
+++ b/UnitsNet.Tests/QuantityTypeConverterTest.cs
@@ -251,6 +251,24 @@ namespace UnitsNet.Tests
             Assert.Equal("10 dm", convertedQuantitySpecificCulture);
         }
 
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ConvertTo_GivenCurrentCulture_ReturnValueFormattedAccordingToGivenCulture(bool useDisplayAsAttribute)
+        {
+            QuantityTypeConverter<Length> converter = new();
+            var attributes = useDisplayAsAttribute ? new Attribute[] { new DisplayAsUnitAttribute(Units.LengthUnit.Meter) } : Array.Empty<Attribute>();
+            ITypeDescriptorContext context = new TypeDescriptorContext("SomeMemberName", attributes);
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("de-AT"); // uses comma as decimal separator
+            CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture; // uses dot as decimal separator
+            Length length = Length.FromMeters(1.5);
+            string expectedResult = length.ToString(CultureInfo.CurrentCulture);
+
+            string convertedQuantity = (string)converter.ConvertTo(context, CultureInfo.CurrentCulture, length, typeof(string));
+
+            Assert.Equal(expectedResult, convertedQuantity);
+        }
+
         [Fact]
         public void ConvertFrom_GivenDefaultUnitAttributeWithWrongUnitType_ThrowsArgumentException()
         {

--- a/UnitsNet/QuantityTypeConverter.cs
+++ b/UnitsNet/QuantityTypeConverter.cs
@@ -218,15 +218,22 @@ namespace UnitsNet
         {
             DisplayAsUnitAttribute? displayAsUnit = GetAttribute<DisplayAsUnitAttribute>(context);
 
-            if (value is IQuantity qvalue && destinationType == typeof(string) && displayAsUnit != null)
+            if (value is not IQuantity qvalue || destinationType != typeof(string))
             {
-                if (displayAsUnit.UnitType != null)
-                    return qvalue.ToUnit(displayAsUnit.UnitType).ToString(displayAsUnit.Format, culture);
-                else
-                    return qvalue.ToString(displayAsUnit.Format, culture);
+                return base.ConvertTo(context, culture, value, destinationType);
             }
 
-            return base.ConvertTo(context, culture, value, destinationType);
+            if (displayAsUnit == null)
+            {
+                return qvalue.ToString(culture);
+            }
+
+            if (displayAsUnit.UnitType == null)
+            {
+                return qvalue.ToString(displayAsUnit.Format, culture);
+            }
+
+            return qvalue.ToUnit(displayAsUnit.UnitType).ToString(displayAsUnit.Format, culture);
         }
     }
 }


### PR DESCRIPTION
Hi,

I've noticed a bug in the `QuantityTypeConverter` while using it in a PropertyGrid.

When `CultureInfo.CurrentCulture` and `CultureInfo.CurrentUICulture` differ, like in my case where CurrentCulture is de-AT (German uses a comma as decimal separator) and CurrentUICulture is en-US (dot as decimal separator), it happens that if the `QuantityTypeConverter` is given `CultureInfo.CurrentCulture` as culture when no `DisplayAsAttribute` is present in the context, `QuantityTypeConverter` calls the base implementation `TypeConverter.ConvertTo` which only passes the given culture to `ToString` if it's not equal to the CurrentCulture ([see](https://github.com/dotnet/runtime/blob/731b2c0b457ae7bc433dcca2e4fd57d3cd56d3cb/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/TypeConverter.cs#L124)). This results in the parameterless `ToString` method of the quantity being called, which uses `CultureInfo.CurrentUICulture`.
```
public override string ToString()
{
    return ToString("g");
}
public string ToString(string format)
{
    return ToString(format, CultureInfo.CurrentUICulture);
}
```

I have changed `QuantityTypeConverter` to always pass the given culture now.

New unit test before bugfix:
![image](https://user-images.githubusercontent.com/30859615/168332885-839e69f7-3810-495a-8d7f-5f61c9ec2930.png)

After bugfix:
![image](https://user-images.githubusercontent.com/30859615/168332919-6635d77d-8f0f-4b78-aa66-49d074e114e9.png)

