### PR TITLE
Add Mass for .NET nanoFramework

### DIFF
--- a/Build/build-pack-nano-nugets.psm1
+++ b/Build/build-pack-nano-nugets.psm1
@@ -19,6 +19,7 @@ function Invoke-Build-NanoNugets {
   & $nuget pack "$root\UnitsNet.NanoFramework\GeneratedCode\VolumeConcentration\UnitsNet.NanoFramework.VolumeConcentration.nuspec" -Verbosity detailed -OutputDirectory "$nugetOutDir"
   & $nuget pack "$root\UnitsNet.NanoFramework\GeneratedCode\Power\UnitsNet.NanoFramework.Power.nuspec" -Verbosity detailed -OutputDirectory "$nugetOutDir"
   & $nuget pack "$root\UnitsNet.NanoFramework\GeneratedCode\Density\UnitsNet.NanoFramework.Density.nuspec" -Verbosity detailed -OutputDirectory "$nugetOutDir"
+  & $nuget pack "$root\UnitsNet.NanoFramework\GeneratedCode\Mass\UnitsNet.NanoFramework.Mass.nuspec" -Verbosity detailed -OutputDirectory "$nugetOutDir"
 
 }
 


### PR DESCRIPTION
Adding Mass for .NET nanoFramework as new bindings requires it.