### PR TITLE
Add ElectricConductivity.SiemensPerCentimeter

### DIFF
--- a/Common/UnitDefinitions/ElectricConductivity.json
+++ b/Common/UnitDefinitions/ElectricConductivity.json
@@ -51,6 +51,19 @@
           "Abbreviations": [ "S/ft" ]
         }
       ]
+    },
+    {
+      "SingularName": "SiemensPerCentimeter",
+      "PluralName": "SiemensPerCentimeter",
+      "FromUnitToBaseFunc": "{x} * 1e2",
+      "FromBaseToUnitFunc": "{x} / 1e2",
+      "Prefixes": ["Micro", "Milli"],
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "S/cm" ]
+        }
+      ]
     }
   ]
 }

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -261,7 +261,10 @@
   "ElectricConductivity": {
     "SiemensPerFoot": 1,
     "SiemensPerInch": 2,
-    "SiemensPerMeter": 3
+    "SiemensPerMeter": 3,
+    "MicrosiemensPerCentimeter": 6,
+    "MillisiemensPerCentimeter": 12,
+    "SiemensPerCentimeter": 13
   },
   "ElectricCurrent": {
     "Ampere": 1,

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -83,6 +83,21 @@ namespace UnitsNet
         #region Conversion Properties
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.MicrosiemensPerCentimeter"/>
+        /// </summary>
+        public double MicrosiemensPerCentimeter => As(ElectricConductivityUnit.MicrosiemensPerCentimeter);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.MillisiemensPerCentimeter"/>
+        /// </summary>
+        public double MillisiemensPerCentimeter => As(ElectricConductivityUnit.MillisiemensPerCentimeter);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.SiemensPerCentimeter"/>
+        /// </summary>
+        public double SiemensPerCentimeter => As(ElectricConductivityUnit.SiemensPerCentimeter);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.SiemensPerFoot"/>
         /// </summary>
         public double SiemensPerFoot => As(ElectricConductivityUnit.SiemensPerFoot);
@@ -100,6 +115,24 @@ namespace UnitsNet
         #endregion
 
         #region Static Factory Methods
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.MicrosiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricConductivity FromMicrosiemensPerCentimeter(double microsiemenspercentimeter) => new ElectricConductivity(microsiemenspercentimeter, ElectricConductivityUnit.MicrosiemensPerCentimeter);
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.MillisiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricConductivity FromMillisiemensPerCentimeter(double millisiemenspercentimeter) => new ElectricConductivity(millisiemenspercentimeter, ElectricConductivityUnit.MillisiemensPerCentimeter);
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.SiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricConductivity FromSiemensPerCentimeter(double siemenspercentimeter) => new ElectricConductivity(siemenspercentimeter, ElectricConductivityUnit.SiemensPerCentimeter);
 
         /// <summary>
         ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.SiemensPerFoot"/>.
@@ -159,6 +192,9 @@ namespace UnitsNet
         {
             return Unit switch
             {
+                ElectricConductivityUnit.MicrosiemensPerCentimeter => (_value * 1e2) * 1e-6d,
+                ElectricConductivityUnit.MillisiemensPerCentimeter => (_value * 1e2) * 1e-3d,
+                ElectricConductivityUnit.SiemensPerCentimeter => _value * 1e2,
                 ElectricConductivityUnit.SiemensPerFoot => _value * 3.2808398950131234,
                 ElectricConductivityUnit.SiemensPerInch => _value * 3.937007874015748e1,
                 ElectricConductivityUnit.SiemensPerMeter => _value,
@@ -175,6 +211,9 @@ namespace UnitsNet
 
             return unit switch
             {
+                ElectricConductivityUnit.MicrosiemensPerCentimeter => (baseUnitValue / 1e2) / 1e-6d,
+                ElectricConductivityUnit.MillisiemensPerCentimeter => (baseUnitValue / 1e2) / 1e-3d,
+                ElectricConductivityUnit.SiemensPerCentimeter => baseUnitValue / 1e2,
                 ElectricConductivityUnit.SiemensPerFoot => baseUnitValue / 3.2808398950131234,
                 ElectricConductivityUnit.SiemensPerInch => baseUnitValue / 3.937007874015748e1,
                 ElectricConductivityUnit.SiemensPerMeter => baseUnitValue,

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/ElectricConductivityUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/ElectricConductivityUnit.g.cs
@@ -26,6 +26,9 @@ namespace UnitsNet.Units
     public enum ElectricConductivityUnit
     {
         Undefined = 0,
+        MicrosiemensPerCentimeter = 6,
+        MillisiemensPerCentimeter = 12,
+        SiemensPerCentimeter = 13,
         SiemensPerFoot = 1,
         SiemensPerInch = 2,
         SiemensPerMeter = 3,

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToElectricConductivityExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToElectricConductivityExtensionsTest.g.cs
@@ -25,6 +25,18 @@ namespace UnitsNet.Tests
     public class NumberToElectricConductivityExtensionsTests
     {
         [Fact]
+        public void NumberToMicrosiemensPerCentimeterTest() =>
+            Assert.Equal(ElectricConductivity.FromMicrosiemensPerCentimeter(2), 2.MicrosiemensPerCentimeter());
+
+        [Fact]
+        public void NumberToMillisiemensPerCentimeterTest() =>
+            Assert.Equal(ElectricConductivity.FromMillisiemensPerCentimeter(2), 2.MillisiemensPerCentimeter());
+
+        [Fact]
+        public void NumberToSiemensPerCentimeterTest() =>
+            Assert.Equal(ElectricConductivity.FromSiemensPerCentimeter(2), 2.SiemensPerCentimeter());
+
+        [Fact]
         public void NumberToSiemensPerFootTest() =>
             Assert.Equal(ElectricConductivity.FromSiemensPerFoot(2), 2.SiemensPerFoot());
 

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToElectricConductivityExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToElectricConductivityExtensions.g.cs
@@ -28,6 +28,18 @@ namespace UnitsNet.NumberExtensions.NumberToElectricConductivity
     /// </summary>
     public static class NumberToElectricConductivityExtensions
     {
+        /// <inheritdoc cref="ElectricConductivity.FromMicrosiemensPerCentimeter(UnitsNet.QuantityValue)" />
+        public static ElectricConductivity MicrosiemensPerCentimeter<T>(this T value) =>
+            ElectricConductivity.FromMicrosiemensPerCentimeter(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="ElectricConductivity.FromMillisiemensPerCentimeter(UnitsNet.QuantityValue)" />
+        public static ElectricConductivity MillisiemensPerCentimeter<T>(this T value) =>
+            ElectricConductivity.FromMillisiemensPerCentimeter(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="ElectricConductivity.FromSiemensPerCentimeter(UnitsNet.QuantityValue)" />
+        public static ElectricConductivity SiemensPerCentimeter<T>(this T value) =>
+            ElectricConductivity.FromSiemensPerCentimeter(Convert.ToDouble(value));
+
         /// <inheritdoc cref="ElectricConductivity.FromSiemensPerFoot(UnitsNet.QuantityValue)" />
         public static ElectricConductivity SiemensPerFoot<T>(this T value) =>
             ElectricConductivity.FromSiemensPerFoot(Convert.ToDouble(value));

--- a/UnitsNet.Tests/CustomCode/ElectricConductivityTests.cs
+++ b/UnitsNet.Tests/CustomCode/ElectricConductivityTests.cs
@@ -33,6 +33,9 @@ namespace UnitsNet.Tests.CustomCode
         protected override double SiemensPerMeterInOneSiemensPerMeter => 1;
         protected override double SiemensPerInchInOneSiemensPerMeter => 2.54e-2;
         protected override double SiemensPerFootInOneSiemensPerMeter => 3.048e-1;
+        protected override double SiemensPerCentimeterInOneSiemensPerMeter => 1e-2;
+        protected override double MillisiemensPerCentimeterInOneSiemensPerMeter => 1e1;
+        protected override double MicrosiemensPerCentimeterInOneSiemensPerMeter => 1e4;
 
         [Theory]
         [InlineData( -1.0, -1.0 )]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
@@ -38,11 +38,17 @@ namespace UnitsNet.Tests
 // ReSharper disable once PartialTypeWithSinglePart
     public abstract partial class ElectricConductivityTestsBase : QuantityTestsBase
     {
+        protected abstract double MicrosiemensPerCentimeterInOneSiemensPerMeter { get; }
+        protected abstract double MillisiemensPerCentimeterInOneSiemensPerMeter { get; }
+        protected abstract double SiemensPerCentimeterInOneSiemensPerMeter { get; }
         protected abstract double SiemensPerFootInOneSiemensPerMeter { get; }
         protected abstract double SiemensPerInchInOneSiemensPerMeter { get; }
         protected abstract double SiemensPerMeterInOneSiemensPerMeter { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
+        protected virtual double MicrosiemensPerCentimeterTolerance { get { return 1e-5; } }
+        protected virtual double MillisiemensPerCentimeterTolerance { get { return 1e-5; } }
+        protected virtual double SiemensPerCentimeterTolerance { get { return 1e-5; } }
         protected virtual double SiemensPerFootTolerance { get { return 1e-5; } }
         protected virtual double SiemensPerInchTolerance { get { return 1e-5; } }
         protected virtual double SiemensPerMeterTolerance { get { return 1e-5; } }
@@ -52,6 +58,9 @@ namespace UnitsNet.Tests
         {
             return unit switch
             {
+                ElectricConductivityUnit.MicrosiemensPerCentimeter => (MicrosiemensPerCentimeterInOneSiemensPerMeter, MicrosiemensPerCentimeterTolerance),
+                ElectricConductivityUnit.MillisiemensPerCentimeter => (MillisiemensPerCentimeterInOneSiemensPerMeter, MillisiemensPerCentimeterTolerance),
+                ElectricConductivityUnit.SiemensPerCentimeter => (SiemensPerCentimeterInOneSiemensPerMeter, SiemensPerCentimeterTolerance),
                 ElectricConductivityUnit.SiemensPerFoot => (SiemensPerFootInOneSiemensPerMeter, SiemensPerFootTolerance),
                 ElectricConductivityUnit.SiemensPerInch => (SiemensPerInchInOneSiemensPerMeter, SiemensPerInchTolerance),
                 ElectricConductivityUnit.SiemensPerMeter => (SiemensPerMeterInOneSiemensPerMeter, SiemensPerMeterTolerance),
@@ -61,6 +70,9 @@ namespace UnitsNet.Tests
 
         public static IEnumerable<object[]> UnitTypes = new List<object[]>
         {
+            new object[] { ElectricConductivityUnit.MicrosiemensPerCentimeter },
+            new object[] { ElectricConductivityUnit.MillisiemensPerCentimeter },
+            new object[] { ElectricConductivityUnit.SiemensPerCentimeter },
             new object[] { ElectricConductivityUnit.SiemensPerFoot },
             new object[] { ElectricConductivityUnit.SiemensPerInch },
             new object[] { ElectricConductivityUnit.SiemensPerMeter },
@@ -138,6 +150,9 @@ namespace UnitsNet.Tests
         public void SiemensPerMeterToElectricConductivityUnits()
         {
             ElectricConductivity siemenspermeter = ElectricConductivity.FromSiemensPerMeter(1);
+            AssertEx.EqualTolerance(MicrosiemensPerCentimeterInOneSiemensPerMeter, siemenspermeter.MicrosiemensPerCentimeter, MicrosiemensPerCentimeterTolerance);
+            AssertEx.EqualTolerance(MillisiemensPerCentimeterInOneSiemensPerMeter, siemenspermeter.MillisiemensPerCentimeter, MillisiemensPerCentimeterTolerance);
+            AssertEx.EqualTolerance(SiemensPerCentimeterInOneSiemensPerMeter, siemenspermeter.SiemensPerCentimeter, SiemensPerCentimeterTolerance);
             AssertEx.EqualTolerance(SiemensPerFootInOneSiemensPerMeter, siemenspermeter.SiemensPerFoot, SiemensPerFootTolerance);
             AssertEx.EqualTolerance(SiemensPerInchInOneSiemensPerMeter, siemenspermeter.SiemensPerInch, SiemensPerInchTolerance);
             AssertEx.EqualTolerance(SiemensPerMeterInOneSiemensPerMeter, siemenspermeter.SiemensPerMeter, SiemensPerMeterTolerance);
@@ -146,17 +161,29 @@ namespace UnitsNet.Tests
         [Fact]
         public void From_ValueAndUnit_ReturnsQuantityWithSameValueAndUnit()
         {
-            var quantity00 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerFoot);
-            AssertEx.EqualTolerance(1, quantity00.SiemensPerFoot, SiemensPerFootTolerance);
-            Assert.Equal(ElectricConductivityUnit.SiemensPerFoot, quantity00.Unit);
+            var quantity00 = ElectricConductivity.From(1, ElectricConductivityUnit.MicrosiemensPerCentimeter);
+            AssertEx.EqualTolerance(1, quantity00.MicrosiemensPerCentimeter, MicrosiemensPerCentimeterTolerance);
+            Assert.Equal(ElectricConductivityUnit.MicrosiemensPerCentimeter, quantity00.Unit);
 
-            var quantity01 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerInch);
-            AssertEx.EqualTolerance(1, quantity01.SiemensPerInch, SiemensPerInchTolerance);
-            Assert.Equal(ElectricConductivityUnit.SiemensPerInch, quantity01.Unit);
+            var quantity01 = ElectricConductivity.From(1, ElectricConductivityUnit.MillisiemensPerCentimeter);
+            AssertEx.EqualTolerance(1, quantity01.MillisiemensPerCentimeter, MillisiemensPerCentimeterTolerance);
+            Assert.Equal(ElectricConductivityUnit.MillisiemensPerCentimeter, quantity01.Unit);
 
-            var quantity02 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerMeter);
-            AssertEx.EqualTolerance(1, quantity02.SiemensPerMeter, SiemensPerMeterTolerance);
-            Assert.Equal(ElectricConductivityUnit.SiemensPerMeter, quantity02.Unit);
+            var quantity02 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerCentimeter);
+            AssertEx.EqualTolerance(1, quantity02.SiemensPerCentimeter, SiemensPerCentimeterTolerance);
+            Assert.Equal(ElectricConductivityUnit.SiemensPerCentimeter, quantity02.Unit);
+
+            var quantity03 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerFoot);
+            AssertEx.EqualTolerance(1, quantity03.SiemensPerFoot, SiemensPerFootTolerance);
+            Assert.Equal(ElectricConductivityUnit.SiemensPerFoot, quantity03.Unit);
+
+            var quantity04 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerInch);
+            AssertEx.EqualTolerance(1, quantity04.SiemensPerInch, SiemensPerInchTolerance);
+            Assert.Equal(ElectricConductivityUnit.SiemensPerInch, quantity04.Unit);
+
+            var quantity05 = ElectricConductivity.From(1, ElectricConductivityUnit.SiemensPerMeter);
+            AssertEx.EqualTolerance(1, quantity05.SiemensPerMeter, SiemensPerMeterTolerance);
+            Assert.Equal(ElectricConductivityUnit.SiemensPerMeter, quantity05.Unit);
 
         }
 
@@ -177,6 +204,9 @@ namespace UnitsNet.Tests
         public void As()
         {
             var siemenspermeter = ElectricConductivity.FromSiemensPerMeter(1);
+            AssertEx.EqualTolerance(MicrosiemensPerCentimeterInOneSiemensPerMeter, siemenspermeter.As(ElectricConductivityUnit.MicrosiemensPerCentimeter), MicrosiemensPerCentimeterTolerance);
+            AssertEx.EqualTolerance(MillisiemensPerCentimeterInOneSiemensPerMeter, siemenspermeter.As(ElectricConductivityUnit.MillisiemensPerCentimeter), MillisiemensPerCentimeterTolerance);
+            AssertEx.EqualTolerance(SiemensPerCentimeterInOneSiemensPerMeter, siemenspermeter.As(ElectricConductivityUnit.SiemensPerCentimeter), SiemensPerCentimeterTolerance);
             AssertEx.EqualTolerance(SiemensPerFootInOneSiemensPerMeter, siemenspermeter.As(ElectricConductivityUnit.SiemensPerFoot), SiemensPerFootTolerance);
             AssertEx.EqualTolerance(SiemensPerInchInOneSiemensPerMeter, siemenspermeter.As(ElectricConductivityUnit.SiemensPerInch), SiemensPerInchTolerance);
             AssertEx.EqualTolerance(SiemensPerMeterInOneSiemensPerMeter, siemenspermeter.As(ElectricConductivityUnit.SiemensPerMeter), SiemensPerMeterTolerance);
@@ -204,6 +234,27 @@ namespace UnitsNet.Tests
         {
             try
             {
+                var parsed = ElectricConductivity.Parse("1 µS/cm", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MicrosiemensPerCentimeter, MicrosiemensPerCentimeterTolerance);
+                Assert.Equal(ElectricConductivityUnit.MicrosiemensPerCentimeter, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = ElectricConductivity.Parse("1 mS/cm", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MillisiemensPerCentimeter, MillisiemensPerCentimeterTolerance);
+                Assert.Equal(ElectricConductivityUnit.MillisiemensPerCentimeter, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = ElectricConductivity.Parse("1 S/cm", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.SiemensPerCentimeter, SiemensPerCentimeterTolerance);
+                Assert.Equal(ElectricConductivityUnit.SiemensPerCentimeter, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = ElectricConductivity.Parse("1 S/ft", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.SiemensPerFoot, SiemensPerFootTolerance);
                 Assert.Equal(ElectricConductivityUnit.SiemensPerFoot, parsed.Unit);
@@ -229,6 +280,24 @@ namespace UnitsNet.Tests
         public void TryParse()
         {
             {
+                Assert.True(ElectricConductivity.TryParse("1 µS/cm", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MicrosiemensPerCentimeter, MicrosiemensPerCentimeterTolerance);
+                Assert.Equal(ElectricConductivityUnit.MicrosiemensPerCentimeter, parsed.Unit);
+            }
+
+            {
+                Assert.True(ElectricConductivity.TryParse("1 mS/cm", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillisiemensPerCentimeter, MillisiemensPerCentimeterTolerance);
+                Assert.Equal(ElectricConductivityUnit.MillisiemensPerCentimeter, parsed.Unit);
+            }
+
+            {
+                Assert.True(ElectricConductivity.TryParse("1 S/cm", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.SiemensPerCentimeter, SiemensPerCentimeterTolerance);
+                Assert.Equal(ElectricConductivityUnit.SiemensPerCentimeter, parsed.Unit);
+            }
+
+            {
                 Assert.True(ElectricConductivity.TryParse("1 S/ft", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.SiemensPerFoot, SiemensPerFootTolerance);
                 Assert.Equal(ElectricConductivityUnit.SiemensPerFoot, parsed.Unit);
@@ -253,6 +322,24 @@ namespace UnitsNet.Tests
         {
             try
             {
+                var parsedUnit = ElectricConductivity.ParseUnit("µS/cm", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(ElectricConductivityUnit.MicrosiemensPerCentimeter, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = ElectricConductivity.ParseUnit("mS/cm", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(ElectricConductivityUnit.MillisiemensPerCentimeter, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = ElectricConductivity.ParseUnit("S/cm", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(ElectricConductivityUnit.SiemensPerCentimeter, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsedUnit = ElectricConductivity.ParseUnit("S/ft", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(ElectricConductivityUnit.SiemensPerFoot, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -274,6 +361,21 @@ namespace UnitsNet.Tests
         [Fact]
         public void TryParseUnit()
         {
+            {
+                Assert.True(ElectricConductivity.TryParseUnit("µS/cm", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(ElectricConductivityUnit.MicrosiemensPerCentimeter, parsedUnit);
+            }
+
+            {
+                Assert.True(ElectricConductivity.TryParseUnit("mS/cm", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(ElectricConductivityUnit.MillisiemensPerCentimeter, parsedUnit);
+            }
+
+            {
+                Assert.True(ElectricConductivity.TryParseUnit("S/cm", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(ElectricConductivityUnit.SiemensPerCentimeter, parsedUnit);
+            }
+
             {
                 Assert.True(ElectricConductivity.TryParseUnit("S/ft", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(ElectricConductivityUnit.SiemensPerFoot, parsedUnit);
@@ -332,6 +434,9 @@ namespace UnitsNet.Tests
         public void ConversionRoundTrip()
         {
             ElectricConductivity siemenspermeter = ElectricConductivity.FromSiemensPerMeter(1);
+            AssertEx.EqualTolerance(1, ElectricConductivity.FromMicrosiemensPerCentimeter(siemenspermeter.MicrosiemensPerCentimeter).SiemensPerMeter, MicrosiemensPerCentimeterTolerance);
+            AssertEx.EqualTolerance(1, ElectricConductivity.FromMillisiemensPerCentimeter(siemenspermeter.MillisiemensPerCentimeter).SiemensPerMeter, MillisiemensPerCentimeterTolerance);
+            AssertEx.EqualTolerance(1, ElectricConductivity.FromSiemensPerCentimeter(siemenspermeter.SiemensPerCentimeter).SiemensPerMeter, SiemensPerCentimeterTolerance);
             AssertEx.EqualTolerance(1, ElectricConductivity.FromSiemensPerFoot(siemenspermeter.SiemensPerFoot).SiemensPerMeter, SiemensPerFootTolerance);
             AssertEx.EqualTolerance(1, ElectricConductivity.FromSiemensPerInch(siemenspermeter.SiemensPerInch).SiemensPerMeter, SiemensPerInchTolerance);
             AssertEx.EqualTolerance(1, ElectricConductivity.FromSiemensPerMeter(siemenspermeter.SiemensPerMeter).SiemensPerMeter, SiemensPerMeterTolerance);
@@ -493,6 +598,9 @@ namespace UnitsNet.Tests
             var prevCulture = Thread.CurrentThread.CurrentUICulture;
             Thread.CurrentThread.CurrentUICulture = CultureInfo.GetCultureInfo("en-US");
             try {
+                Assert.Equal("1 µS/cm", new ElectricConductivity(1, ElectricConductivityUnit.MicrosiemensPerCentimeter).ToString());
+                Assert.Equal("1 mS/cm", new ElectricConductivity(1, ElectricConductivityUnit.MillisiemensPerCentimeter).ToString());
+                Assert.Equal("1 S/cm", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerCentimeter).ToString());
                 Assert.Equal("1 S/ft", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerFoot).ToString());
                 Assert.Equal("1 S/in", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerInch).ToString());
                 Assert.Equal("1 S/m", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerMeter).ToString());
@@ -509,6 +617,9 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
+            Assert.Equal("1 µS/cm", new ElectricConductivity(1, ElectricConductivityUnit.MicrosiemensPerCentimeter).ToString(swedishCulture));
+            Assert.Equal("1 mS/cm", new ElectricConductivity(1, ElectricConductivityUnit.MillisiemensPerCentimeter).ToString(swedishCulture));
+            Assert.Equal("1 S/cm", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerCentimeter).ToString(swedishCulture));
             Assert.Equal("1 S/ft", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerFoot).ToString(swedishCulture));
             Assert.Equal("1 S/in", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerInch).ToString(swedishCulture));
             Assert.Equal("1 S/m", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerMeter).ToString(swedishCulture));

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -167,6 +167,21 @@ namespace UnitsNet
         #region Conversion Properties
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.MicrosiemensPerCentimeter"/>
+        /// </summary>
+        public double MicrosiemensPerCentimeter => As(ElectricConductivityUnit.MicrosiemensPerCentimeter);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.MillisiemensPerCentimeter"/>
+        /// </summary>
+        public double MillisiemensPerCentimeter => As(ElectricConductivityUnit.MillisiemensPerCentimeter);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.SiemensPerCentimeter"/>
+        /// </summary>
+        public double SiemensPerCentimeter => As(ElectricConductivityUnit.SiemensPerCentimeter);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.SiemensPerFoot"/>
         /// </summary>
         public double SiemensPerFoot => As(ElectricConductivityUnit.SiemensPerFoot);
@@ -187,6 +202,9 @@ namespace UnitsNet
 
         internal static void MapGeneratedLocalizations(UnitAbbreviationsCache unitAbbreviationsCache)
         {
+            unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.MicrosiemensPerCentimeter, new CultureInfo("en-US"), false, true, new string[]{"µS/cm"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.MillisiemensPerCentimeter, new CultureInfo("en-US"), false, true, new string[]{"mS/cm"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerCentimeter, new CultureInfo("en-US"), false, true, new string[]{"S/cm"});
             unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerFoot, new CultureInfo("en-US"), false, true, new string[]{"S/ft"});
             unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerInch, new CultureInfo("en-US"), false, true, new string[]{"S/in"});
             unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerMeter, new CultureInfo("en-US"), false, true, new string[]{"S/m"});
@@ -217,6 +235,39 @@ namespace UnitsNet
         #endregion
 
         #region Static Factory Methods
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.MicrosiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static ElectricConductivity FromMicrosiemensPerCentimeter(double microsiemenspercentimeter)
+        {
+            double value = (double) microsiemenspercentimeter;
+            return new ElectricConductivity(value, ElectricConductivityUnit.MicrosiemensPerCentimeter);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.MillisiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static ElectricConductivity FromMillisiemensPerCentimeter(double millisiemenspercentimeter)
+        {
+            double value = (double) millisiemenspercentimeter;
+            return new ElectricConductivity(value, ElectricConductivityUnit.MillisiemensPerCentimeter);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.SiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Windows.Foundation.Metadata.DefaultOverload]
+        public static ElectricConductivity FromSiemensPerCentimeter(double siemenspercentimeter)
+        {
+            double value = (double) siemenspercentimeter;
+            return new ElectricConductivity(value, ElectricConductivityUnit.SiemensPerCentimeter);
+        }
 
         /// <summary>
         ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.SiemensPerFoot"/>.
@@ -541,6 +592,9 @@ namespace UnitsNet
         {
             switch(Unit)
             {
+                case ElectricConductivityUnit.MicrosiemensPerCentimeter: return (_value * 1e2) * 1e-6d;
+                case ElectricConductivityUnit.MillisiemensPerCentimeter: return (_value * 1e2) * 1e-3d;
+                case ElectricConductivityUnit.SiemensPerCentimeter: return _value * 1e2;
                 case ElectricConductivityUnit.SiemensPerFoot: return _value * 3.2808398950131234;
                 case ElectricConductivityUnit.SiemensPerInch: return _value * 3.937007874015748e1;
                 case ElectricConductivityUnit.SiemensPerMeter: return _value;
@@ -558,6 +612,9 @@ namespace UnitsNet
 
             switch(unit)
             {
+                case ElectricConductivityUnit.MicrosiemensPerCentimeter: return (baseUnitValue / 1e2) / 1e-6d;
+                case ElectricConductivityUnit.MillisiemensPerCentimeter: return (baseUnitValue / 1e2) / 1e-3d;
+                case ElectricConductivityUnit.SiemensPerCentimeter: return baseUnitValue / 1e2;
                 case ElectricConductivityUnit.SiemensPerFoot: return baseUnitValue / 3.2808398950131234;
                 case ElectricConductivityUnit.SiemensPerInch: return baseUnitValue / 3.937007874015748e1;
                 case ElectricConductivityUnit.SiemensPerMeter: return baseUnitValue;

--- a/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/ElectricConductivityUnit.g.cs
+++ b/UnitsNet.WindowsRuntimeComponent/GeneratedCode/Units/ElectricConductivityUnit.g.cs
@@ -26,6 +26,9 @@ namespace UnitsNet.Units
     public enum ElectricConductivityUnit
     {
         Undefined = 0,
+        MicrosiemensPerCentimeter,
+        MillisiemensPerCentimeter,
+        SiemensPerCentimeter,
         SiemensPerFoot,
         SiemensPerInch,
         SiemensPerMeter,

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -65,6 +65,9 @@ namespace UnitsNet
             Info = new QuantityInfo<ElectricConductivityUnit>("ElectricConductivity",
                 new UnitInfo<ElectricConductivityUnit>[]
                 {
+                    new UnitInfo<ElectricConductivityUnit>(ElectricConductivityUnit.MicrosiemensPerCentimeter, "MicrosiemensPerCentimeter", BaseUnits.Undefined),
+                    new UnitInfo<ElectricConductivityUnit>(ElectricConductivityUnit.MillisiemensPerCentimeter, "MillisiemensPerCentimeter", BaseUnits.Undefined),
+                    new UnitInfo<ElectricConductivityUnit>(ElectricConductivityUnit.SiemensPerCentimeter, "SiemensPerCentimeter", BaseUnits.Undefined),
                     new UnitInfo<ElectricConductivityUnit>(ElectricConductivityUnit.SiemensPerFoot, "SiemensPerFoot", BaseUnits.Undefined),
                     new UnitInfo<ElectricConductivityUnit>(ElectricConductivityUnit.SiemensPerInch, "SiemensPerInch", BaseUnits.Undefined),
                     new UnitInfo<ElectricConductivityUnit>(ElectricConductivityUnit.SiemensPerMeter, "SiemensPerMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere)),
@@ -193,6 +196,21 @@ namespace UnitsNet
         #region Conversion Properties
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.MicrosiemensPerCentimeter"/>
+        /// </summary>
+        public double MicrosiemensPerCentimeter => As(ElectricConductivityUnit.MicrosiemensPerCentimeter);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.MillisiemensPerCentimeter"/>
+        /// </summary>
+        public double MillisiemensPerCentimeter => As(ElectricConductivityUnit.MillisiemensPerCentimeter);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.SiemensPerCentimeter"/>
+        /// </summary>
+        public double SiemensPerCentimeter => As(ElectricConductivityUnit.SiemensPerCentimeter);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricConductivityUnit.SiemensPerFoot"/>
         /// </summary>
         public double SiemensPerFoot => As(ElectricConductivityUnit.SiemensPerFoot);
@@ -218,6 +236,9 @@ namespace UnitsNet
         internal static void RegisterDefaultConversions(UnitConverter unitConverter)
         {
             // Register in unit converter: BaseUnit -> ElectricConductivityUnit
+            unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerMeter, ElectricConductivityUnit.MicrosiemensPerCentimeter, quantity => new ElectricConductivity((quantity.Value / 1e2) / 1e-6d, ElectricConductivityUnit.MicrosiemensPerCentimeter));
+            unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerMeter, ElectricConductivityUnit.MillisiemensPerCentimeter, quantity => new ElectricConductivity((quantity.Value / 1e2) / 1e-3d, ElectricConductivityUnit.MillisiemensPerCentimeter));
+            unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerMeter, ElectricConductivityUnit.SiemensPerCentimeter, quantity => new ElectricConductivity(quantity.Value / 1e2, ElectricConductivityUnit.SiemensPerCentimeter));
             unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerMeter, ElectricConductivityUnit.SiemensPerFoot, quantity => new ElectricConductivity(quantity.Value / 3.2808398950131234, ElectricConductivityUnit.SiemensPerFoot));
             unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerMeter, ElectricConductivityUnit.SiemensPerInch, quantity => new ElectricConductivity(quantity.Value / 3.937007874015748e1, ElectricConductivityUnit.SiemensPerInch));
 
@@ -225,12 +246,18 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerMeter, ElectricConductivityUnit.SiemensPerMeter, quantity => quantity);
 
             // Register in unit converter: ElectricConductivityUnit -> BaseUnit
+            unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.MicrosiemensPerCentimeter, ElectricConductivityUnit.SiemensPerMeter, quantity => new ElectricConductivity((quantity.Value * 1e2) * 1e-6d, ElectricConductivityUnit.SiemensPerMeter));
+            unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.MillisiemensPerCentimeter, ElectricConductivityUnit.SiemensPerMeter, quantity => new ElectricConductivity((quantity.Value * 1e2) * 1e-3d, ElectricConductivityUnit.SiemensPerMeter));
+            unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerCentimeter, ElectricConductivityUnit.SiemensPerMeter, quantity => new ElectricConductivity(quantity.Value * 1e2, ElectricConductivityUnit.SiemensPerMeter));
             unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerFoot, ElectricConductivityUnit.SiemensPerMeter, quantity => new ElectricConductivity(quantity.Value * 3.2808398950131234, ElectricConductivityUnit.SiemensPerMeter));
             unitConverter.SetConversionFunction<ElectricConductivity>(ElectricConductivityUnit.SiemensPerInch, ElectricConductivityUnit.SiemensPerMeter, quantity => new ElectricConductivity(quantity.Value * 3.937007874015748e1, ElectricConductivityUnit.SiemensPerMeter));
         }
 
         internal static void MapGeneratedLocalizations(UnitAbbreviationsCache unitAbbreviationsCache)
         {
+            unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.MicrosiemensPerCentimeter, new CultureInfo("en-US"), false, true, new string[]{"µS/cm"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.MillisiemensPerCentimeter, new CultureInfo("en-US"), false, true, new string[]{"mS/cm"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerCentimeter, new CultureInfo("en-US"), false, true, new string[]{"S/cm"});
             unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerFoot, new CultureInfo("en-US"), false, true, new string[]{"S/ft"});
             unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerInch, new CultureInfo("en-US"), false, true, new string[]{"S/in"});
             unitAbbreviationsCache.PerformAbbreviationMapping(ElectricConductivityUnit.SiemensPerMeter, new CultureInfo("en-US"), false, true, new string[]{"S/m"});
@@ -260,6 +287,36 @@ namespace UnitsNet
         #endregion
 
         #region Static Factory Methods
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.MicrosiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricConductivity FromMicrosiemensPerCentimeter(QuantityValue microsiemenspercentimeter)
+        {
+            double value = (double) microsiemenspercentimeter;
+            return new ElectricConductivity(value, ElectricConductivityUnit.MicrosiemensPerCentimeter);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.MillisiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricConductivity FromMillisiemensPerCentimeter(QuantityValue millisiemenspercentimeter)
+        {
+            double value = (double) millisiemenspercentimeter;
+            return new ElectricConductivity(value, ElectricConductivityUnit.MillisiemensPerCentimeter);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.SiemensPerCentimeter"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricConductivity FromSiemensPerCentimeter(QuantityValue siemenspercentimeter)
+        {
+            double value = (double) siemenspercentimeter;
+            return new ElectricConductivity(value, ElectricConductivityUnit.SiemensPerCentimeter);
+        }
 
         /// <summary>
         ///     Creates a <see cref="ElectricConductivity"/> from <see cref="ElectricConductivityUnit.SiemensPerFoot"/>.

--- a/UnitsNet/GeneratedCode/Units/ElectricConductivityUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricConductivityUnit.g.cs
@@ -26,6 +26,9 @@ namespace UnitsNet.Units
     public enum ElectricConductivityUnit
     {
         Undefined = 0,
+        MicrosiemensPerCentimeter = 6,
+        MillisiemensPerCentimeter = 12,
+        SiemensPerCentimeter = 13,
         SiemensPerFoot = 1,
         SiemensPerInch = 2,
         SiemensPerMeter = 3,


### PR DESCRIPTION
Common unit for electrical conductivity in water quality sensors is the microsiemen per centimeter.

Added SiemenPerCentiMeter as well as the milli and micro prefixes.