### PR TITLE
Add Energy divided by Power equals TimeSpan operator

### DIFF
--- a/UnitsNet.Tests/CustomCode/EnergyTests.cs
+++ b/UnitsNet.Tests/CustomCode/EnergyTests.cs
@@ -122,6 +122,13 @@ namespace UnitsNet.Tests.CustomCode
         }
 
         [Fact]
+        public void EnergyDividedByPowerEqualsDuration()
+        {
+            Duration d = Energy.FromKilowattHours(100) / Power.FromKilowatts(20);
+            Assert.Equal(5, d.Hours);
+        }
+
+        [Fact]
         public void EnergyTimesFrequencyEqualsPower()
         {
             Power p = Energy.FromJoules(25) * Frequency.FromPerSecond(5);

--- a/UnitsNet/CustomCode/Quantities/Energy.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Energy.extra.cs
@@ -19,6 +19,12 @@ namespace UnitsNet
             return Power.FromWatts(energy.Joules / duration.Seconds);
         }
 
+        /// <summary>Get <see cref="Duration"/> from <see cref="Energy"/> divided by <see cref="Power"/>.</summary>
+        public static Duration operator /(Energy energy, Power power)
+        {
+            return Duration.FromSeconds(energy.Joules / power.Watts);
+        }
+
         /// <summary>Get <see cref="Power"/> from <see cref="Energy"/> times <see cref="Frequency"/>.</summary>
         public static Power operator *(Energy energy, Frequency frequency)
         {
@@ -42,13 +48,13 @@ namespace UnitsNet
         {
             return TemperatureDelta.FromKelvins(energy.Joules / entropy.JoulesPerKelvin);
         }
-        
+
         /// <summary>Get <see cref="SpecificEnergy"/> from <see cref="Energy"/> divided by <see cref="Mass"/> </summary>
         public static SpecificEnergy operator /(Energy energy, Mass mass)
         {
             return SpecificEnergy.FromJoulesPerKilogram(energy.Joules / mass.Kilograms);
         }
-        
+
         /// <summary>Get <see cref="Mass"/> from <see cref="Energy"/> divided by <see cref="SpecificEnergy"/>.</summary>
         public static Mass operator /(Energy energy, SpecificEnergy specificEnergy)
         {


### PR DESCRIPTION
This is useful in the context of battery charging. If you have an empty battery with
a capacity of 100 kwH and you connect it to a 20kw power supply, you might want
to know how long it will take to fully charge (5 hours) by doing energy / power.

Example
```
            var electricCurrent = ElectricCurrent.FromAmperes(32);
            var electricPotential = ElectricPotential.FromVolts(230);
            var chargingPower = electricCurrent * electricPotential;
            var batteryCapacity = Energy.FromKilowattHours(1000);

            TimeSpan chargingTime = batteryCapacity / chargingPower;
```