### PR TITLE
Fix StackOverflowException converting unit for default(TQuantity)

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -985,13 +985,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit({_quantity.Name}Unit unit, out {_quantity.Name}? converted)
         {{
-            if (_unit == unit)
+            if (Unit == unit)
             {{
                 converted = this;
                 return true;
             }}
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {{
                 // {_quantity.Name}Unit -> BaseUnit");
 

--- a/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
@@ -396,6 +396,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }}
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit({_unitEnumName} unit)
+        {{
+            var quantity = default({_quantity.Name});
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }}
+
         [Fact]
         public void ConversionRoundTrip()
         {{

--- a/Common/UnitDefinitions/PressureChangeRate.json
+++ b/Common/UnitDefinitions/PressureChangeRate.json
@@ -50,11 +50,11 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "mmHg/s" ],
+          "Abbreviations": [ "mmHg/s" ]
         },
         {
           "Culture": "ru-RU",
-          "Abbreviations": [ "mmHg/с" ],
+          "Abbreviations": [ "mmHg/с" ]
         }
       ]
     },

--- a/UnitsNet.Tests/CustomCode/FuelEfficiencyTests.cs
+++ b/UnitsNet.Tests/CustomCode/FuelEfficiencyTests.cs
@@ -18,6 +18,8 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using UnitsNet.Units;
+using Xunit;
 
 namespace UnitsNet.Tests.CustomCode
 {
@@ -28,5 +30,12 @@ namespace UnitsNet.Tests.CustomCode
         protected override double LitersPer100KilometersInOneLiterPer100Kilometers => 1;
         protected override double MilesPerUkGallonInOneLiterPer100Kilometers => 282.4809363;
         protected override double MilesPerUsGallonInOneLiterPer100Kilometers => 235.2145833;
+        
+        [Theory(Skip = "Conversion from 0 km/L results in infinity")]
+        [MemberData(nameof(UnitTypes))]
+        public override void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(FuelEfficiencyUnit unit)
+        {
+            base.ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(unit);
+        }
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AccelerationTestsBase.g.cs
@@ -1038,6 +1038,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AccelerationUnit unit)
+        {
+            var quantity = default(Acceleration);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AmountOfSubstanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AmountOfSubstanceTestsBase.g.cs
@@ -714,6 +714,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AmountOfSubstanceUnit unit)
+        {
+            var quantity = default(AmountOfSubstance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AmplitudeRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AmplitudeRatioTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AmplitudeRatioUnit unit)
+        {
+            var quantity = default(AmplitudeRatio);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
@@ -1298,6 +1298,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AngleUnit unit)
+        {
+            var quantity = default(Angle);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ApparentEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ApparentEnergyTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ApparentEnergyUnit unit)
+        {
+            var quantity = default(ApparentEnergy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ApparentPowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ApparentPowerTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ApparentPowerUnit unit)
+        {
+            var quantity = default(ApparentPower);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaDensityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AreaDensityUnit unit)
+        {
+            var quantity = default(AreaDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaMomentOfInertiaTestsBase.g.cs
@@ -574,6 +574,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AreaMomentOfInertiaUnit unit)
+        {
+            var quantity = default(AreaMomentOfInertia);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaTestsBase.g.cs
@@ -1328,6 +1328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(AreaUnit unit)
+        {
+            var quantity = default(Area);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/BitRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/BitRateTestsBase.g.cs
@@ -1397,6 +1397,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(BitRateUnit unit)
+        {
+            var quantity = default(BitRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/BrakeSpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/BrakeSpecificFuelConsumptionTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(BrakeSpecificFuelConsumptionUnit unit)
+        {
+            var quantity = default(BrakeSpecificFuelConsumption);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CapacitanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CapacitanceTestsBase.g.cs
@@ -442,6 +442,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(CapacitanceUnit unit)
+        {
+            var quantity = default(Capacitance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
@@ -400,6 +400,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(CoefficientOfThermalExpansionUnit unit)
+        {
+            var quantity = default(CoefficientOfThermalExpansion);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CompressibilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CompressibilityTestsBase.g.cs
@@ -632,6 +632,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(CompressibilityUnit unit)
+        {
+            var quantity = default(Compressibility);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DensityTestsBase.g.cs
@@ -2056,6 +2056,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(DensityUnit unit)
+        {
+            var quantity = default(Density);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
@@ -1776,6 +1776,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(DurationUnit unit)
+        {
+            var quantity = default(Duration);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
@@ -638,6 +638,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(DynamicViscosityUnit unit)
+        {
+            var quantity = default(DynamicViscosity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricAdmittanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricAdmittanceTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricAdmittanceUnit unit)
+        {
+            var quantity = default(ElectricAdmittance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeDensityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricChargeDensityUnit unit)
+        {
+            var quantity = default(ElectricChargeDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeTestsBase.g.cs
@@ -448,6 +448,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricChargeUnit unit)
+        {
+            var quantity = default(ElectricCharge);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductanceTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricConductanceUnit unit)
+        {
+            var quantity = default(ElectricConductance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
@@ -430,6 +430,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricConductivityUnit unit)
+        {
+            var quantity = default(ElectricConductivity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentDensityTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricCurrentDensityUnit unit)
+        {
+            var quantity = default(ElectricCurrentDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricCurrentGradientUnit unit)
+        {
+            var quantity = default(ElectricCurrentGradient);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentTestsBase.g.cs
@@ -476,6 +476,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricCurrentUnit unit)
+        {
+            var quantity = default(ElectricCurrent);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricFieldTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricFieldUnit unit)
+        {
+            var quantity = default(ElectricField);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricInductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricInductanceTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricInductanceUnit unit)
+        {
+            var quantity = default(ElectricInductance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialAcTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialAcTestsBase.g.cs
@@ -374,6 +374,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricPotentialAcUnit unit)
+        {
+            var quantity = default(ElectricPotentialAc);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialChangeRateTestsBase.g.cs
@@ -818,6 +818,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricPotentialChangeRateUnit unit)
+        {
+            var quantity = default(ElectricPotentialChangeRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialDcTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialDcTestsBase.g.cs
@@ -374,6 +374,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricPotentialDcUnit unit)
+        {
+            var quantity = default(ElectricPotentialDc);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialTestsBase.g.cs
@@ -472,6 +472,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricPotentialUnit unit)
+        {
+            var quantity = default(ElectricPotential);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistanceTestsBase.g.cs
@@ -408,6 +408,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricResistanceUnit unit)
+        {
+            var quantity = default(ElectricResistance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistivityTestsBase.g.cs
@@ -658,6 +658,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricResistivityUnit unit)
+        {
+            var quantity = default(ElectricResistivity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSurfaceChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSurfaceChargeDensityTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ElectricSurfaceChargeDensityUnit unit)
+        {
+            var quantity = default(ElectricSurfaceChargeDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyTestsBase.g.cs
@@ -1932,6 +1932,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(EnergyUnit unit)
+        {
+            var quantity = default(Energy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EntropyTestsBase.g.cs
@@ -464,6 +464,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(EntropyUnit unit)
+        {
+            var quantity = default(Entropy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceChangeRateTestsBase.g.cs
@@ -832,6 +832,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ForceChangeRateUnit unit)
+        {
+            var quantity = default(ForceChangeRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForcePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForcePerLengthTestsBase.g.cs
@@ -1692,6 +1692,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ForcePerLengthUnit unit)
+        {
+            var quantity = default(ForcePerLength);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
@@ -1150,6 +1150,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ForceUnit unit)
+        {
+            var quantity = default(Force);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
@@ -768,6 +768,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(FrequencyUnit unit)
+        {
+            var quantity = default(Frequency);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FuelEfficiencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FuelEfficiencyTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(FuelEfficiencyUnit unit)
+        {
+            var quantity = default(FuelEfficiency);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/HeatFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/HeatFluxTestsBase.g.cs
@@ -862,6 +862,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(HeatFluxUnit unit)
+        {
+            var quantity = default(HeatFlux);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/HeatTransferCoefficientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/HeatTransferCoefficientTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(HeatTransferCoefficientUnit unit)
+        {
+            var quantity = default(HeatTransferCoefficient);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IlluminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IlluminanceTestsBase.g.cs
@@ -340,6 +340,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(IlluminanceUnit unit)
+        {
+            var quantity = default(Illuminance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/InformationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/InformationTestsBase.g.cs
@@ -799,6 +799,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(InformationUnit unit)
+        {
+            var quantity = default(Information);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IrradianceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IrradianceTestsBase.g.cs
@@ -658,6 +658,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(IrradianceUnit unit)
+        {
+            var quantity = default(Irradiance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IrradiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IrradiationTestsBase.g.cs
@@ -464,6 +464,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(IrradiationUnit unit)
+        {
+            var quantity = default(Irradiation);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/JerkTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/JerkTestsBase.g.cs
@@ -864,6 +864,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(JerkUnit unit)
+        {
+            var quantity = default(Jerk);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/KinematicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/KinematicViscosityTestsBase.g.cs
@@ -724,6 +724,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(KinematicViscosityUnit unit)
+        {
+            var quantity = default(KinematicViscosity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LapseRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LapseRateTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LapseRateUnit unit)
+        {
+            var quantity = default(LapseRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
@@ -2254,6 +2254,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LengthUnit unit)
+        {
+            var quantity = default(Length);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LevelTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LevelTestsBase.g.cs
@@ -294,6 +294,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LevelUnit unit)
+        {
+            var quantity = default(Level);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LinearDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LinearDensityTestsBase.g.cs
@@ -702,6 +702,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LinearDensityUnit unit)
+        {
+            var quantity = default(LinearDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LinearPowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LinearPowerDensityTestsBase.g.cs
@@ -966,6 +966,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LinearPowerDensityUnit unit)
+        {
+            var quantity = default(LinearPowerDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminanceTestsBase.g.cs
@@ -566,6 +566,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LuminanceUnit unit)
+        {
+            var quantity = default(Luminance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminosityTestsBase.g.cs
@@ -658,6 +658,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LuminosityUnit unit)
+        {
+            var quantity = default(Luminosity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousFluxTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LuminousFluxUnit unit)
+        {
+            var quantity = default(LuminousFlux);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousIntensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousIntensityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(LuminousIntensityUnit unit)
+        {
+            var quantity = default(LuminousIntensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFieldTestsBase.g.cs
@@ -430,6 +430,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MagneticFieldUnit unit)
+        {
+            var quantity = default(MagneticField);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFluxTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MagneticFluxUnit unit)
+        {
+            var quantity = default(MagneticFlux);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagnetizationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagnetizationTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MagnetizationUnit unit)
+        {
+            var quantity = default(Magnetization);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassConcentrationTestsBase.g.cs
@@ -1988,6 +1988,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MassConcentrationUnit unit)
+        {
+            var quantity = default(MassConcentration);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFlowTestsBase.g.cs
@@ -1590,6 +1590,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MassFlowUnit unit)
+        {
+            var quantity = default(MassFlow);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFluxTestsBase.g.cs
@@ -634,6 +634,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MassFluxUnit unit)
+        {
+            var quantity = default(MassFlux);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
@@ -1066,6 +1066,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MassFractionUnit unit)
+        {
+            var quantity = default(MassFraction);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassMomentOfInertiaTestsBase.g.cs
@@ -1178,6 +1178,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MassMomentOfInertiaUnit unit)
+        {
+            var quantity = default(MassMomentOfInertia);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
@@ -2064,6 +2064,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MassUnit unit)
+        {
+            var quantity = default(Mass);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEnergyTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MolarEnergyUnit unit)
+        {
+            var quantity = default(MolarEnergy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEntropyTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MolarEntropyUnit unit)
+        {
+            var quantity = default(MolarEntropy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarMassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarMassTestsBase.g.cs
@@ -922,6 +922,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MolarMassUnit unit)
+        {
+            var quantity = default(MolarMass);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
@@ -623,6 +623,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(MolarityUnit unit)
+        {
+            var quantity = default(Molarity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PermeabilityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PermeabilityUnit unit)
+        {
+            var quantity = default(Permeability);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PermittivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PermittivityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PermittivityUnit unit)
+        {
+            var quantity = default(Permittivity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PorousMediumPermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PorousMediumPermeabilityTestsBase.g.cs
@@ -396,6 +396,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PorousMediumPermeabilityUnit unit)
+        {
+            var quantity = default(PorousMediumPermeability);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerDensityTestsBase.g.cs
@@ -1634,6 +1634,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PowerDensityUnit unit)
+        {
+            var quantity = default(PowerDensity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerRatioTestsBase.g.cs
@@ -318,6 +318,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PowerRatioUnit unit)
+        {
+            var quantity = default(PowerRatio);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerTestsBase.g.cs
@@ -1091,6 +1091,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PowerUnit unit)
+        {
+            var quantity = default(Power);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
@@ -1326,6 +1326,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PressureChangeRateUnit unit)
+        {
+            var quantity = default(PressureChangeRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureTestsBase.g.cs
@@ -2674,6 +2674,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(PressureUnit unit)
+        {
+            var quantity = default(Pressure);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioChangeRateTestsBase.g.cs
@@ -294,6 +294,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RatioChangeRateUnit unit)
+        {
+            var quantity = default(RatioChangeRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
@@ -430,6 +430,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RatioUnit unit)
+        {
+            var quantity = default(Ratio);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReactiveEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReactiveEnergyTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ReactiveEnergyUnit unit)
+        {
+            var quantity = default(ReactiveEnergy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReactivePowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReactivePowerTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ReactivePowerUnit unit)
+        {
+            var quantity = default(ReactivePower);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalAreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalAreaTestsBase.g.cs
@@ -600,6 +600,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ReciprocalAreaUnit unit)
+        {
+            var quantity = default(ReciprocalArea);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalLengthTestsBase.g.cs
@@ -806,6 +806,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ReciprocalLengthUnit unit)
+        {
+            var quantity = default(ReciprocalLength);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RelativeHumidityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RelativeHumidityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RelativeHumidityUnit unit)
+        {
+            var quantity = default(RelativeHumidity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalAccelerationTestsBase.g.cs
@@ -386,6 +386,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RotationalAccelerationUnit unit)
+        {
+            var quantity = default(RotationalAcceleration);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalSpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalSpeedTestsBase.g.cs
@@ -1100,6 +1100,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RotationalSpeedUnit unit)
+        {
+            var quantity = default(RotationalSpeed);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessPerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessPerLengthTestsBase.g.cs
@@ -588,6 +588,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RotationalStiffnessPerLengthUnit unit)
+        {
+            var quantity = default(RotationalStiffnessPerLength);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessTestsBase.g.cs
@@ -2832,6 +2832,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(RotationalStiffnessUnit unit)
+        {
+            var quantity = default(RotationalStiffness);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ScalarUnit unit)
+        {
+            var quantity = default(Scalar);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SolidAngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SolidAngleTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SolidAngleUnit unit)
+        {
+            var quantity = default(SolidAngle);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEnergyTestsBase.g.cs
@@ -1212,6 +1212,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SpecificEnergyUnit unit)
+        {
+            var quantity = default(SpecificEnergy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEntropyTestsBase.g.cs
@@ -556,6 +556,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SpecificEntropyUnit unit)
+        {
+            var quantity = default(SpecificEntropy);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificFuelConsumptionTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SpecificFuelConsumptionUnit unit)
+        {
+            var quantity = default(SpecificFuelConsumption);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificVolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificVolumeTestsBase.g.cs
@@ -328,6 +328,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SpecificVolumeUnit unit)
+        {
+            var quantity = default(SpecificVolume);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificWeightTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificWeightTestsBase.g.cs
@@ -804,6 +804,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SpecificWeightUnit unit)
+        {
+            var quantity = default(SpecificWeight);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpeedTestsBase.g.cs
@@ -2068,6 +2068,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(SpeedUnit unit)
+        {
+            var quantity = default(Speed);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
@@ -532,6 +532,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(StandardVolumeFlowUnit unit)
+        {
+            var quantity = default(StandardVolumeFlow);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureChangeRateTestsBase.g.cs
@@ -566,6 +566,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TemperatureChangeRateUnit unit)
+        {
+            var quantity = default(TemperatureChangeRate);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureDeltaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureDeltaTestsBase.g.cs
@@ -532,6 +532,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TemperatureDeltaUnit unit)
+        {
+            var quantity = default(TemperatureDelta);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
@@ -362,6 +362,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TemperatureGradientUnit unit)
+        {
+            var quantity = default(TemperatureGradient);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureTestsBase.g.cs
@@ -566,6 +566,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TemperatureUnit unit)
+        {
+            var quantity = default(Temperature);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalConductivityTestsBase.g.cs
@@ -294,6 +294,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ThermalConductivityUnit unit)
+        {
+            var quantity = default(ThermalConductivity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
@@ -430,6 +430,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(ThermalResistanceUnit unit)
+        {
+            var quantity = default(ThermalResistance);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TorquePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TorquePerLengthTestsBase.g.cs
@@ -1012,6 +1012,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TorquePerLengthUnit unit)
+        {
+            var quantity = default(TorquePerLength);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TorqueTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TorqueTestsBase.g.cs
@@ -1148,6 +1148,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TorqueUnit unit)
+        {
+            var quantity = default(Torque);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TurbidityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TurbidityTestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(TurbidityUnit unit)
+        {
+            var quantity = default(Turbidity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VitaminATestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VitaminATestsBase.g.cs
@@ -260,6 +260,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VitaminAUnit unit)
+        {
+            var quantity = default(VitaminA);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
@@ -930,6 +930,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VolumeConcentrationUnit unit)
+        {
+            var quantity = default(VolumeConcentration);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowPerAreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowPerAreaTestsBase.g.cs
@@ -294,6 +294,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VolumeFlowPerAreaUnit unit)
+        {
+            var quantity = default(VolumeFlowPerArea);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
@@ -3996,6 +3996,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VolumeFlowUnit unit)
+        {
+            var quantity = default(VolumeFlow);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumePerLengthTestsBase.g.cs
@@ -464,6 +464,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VolumePerLengthUnit unit)
+        {
+            var quantity = default(VolumePerLength);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
@@ -2990,6 +2990,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VolumeUnit unit)
+        {
+            var quantity = default(Volume);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumetricHeatCapacityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumetricHeatCapacityTestsBase.g.cs
@@ -532,6 +532,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(VolumetricHeatCapacityUnit unit)
+        {
+            var quantity = default(VolumetricHeatCapacity);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/WarpingMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/WarpingMomentOfInertiaTestsBase.g.cs
@@ -574,6 +574,15 @@ namespace UnitsNet.Tests
             Assert.Equal(converted.Unit, unit);
         }
 
+        [Theory]
+        [MemberData(nameof(UnitTypes))]
+        public virtual void ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit(WarpingMomentOfInertiaUnit unit)
+        {
+            var quantity = default(WarpingMomentOfInertia);
+            var converted = quantity.ToUnit(unit);
+            Assert.Equal(converted.Unit, unit);
+        }
+
         [Fact]
         public void ConversionRoundTrip()
         {

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -936,13 +936,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AccelerationUnit unit, out Acceleration? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AccelerationUnit -> BaseUnit
                 (AccelerationUnit.CentimeterPerSecondSquared, AccelerationUnit.MeterPerSecondSquared) => new Acceleration((_value) * 1e-2d, AccelerationUnit.MeterPerSecondSquared),

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -941,13 +941,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AmountOfSubstanceUnit unit, out AmountOfSubstance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AmountOfSubstanceUnit -> BaseUnit
                 (AmountOfSubstanceUnit.Centimole, AmountOfSubstanceUnit.Mole) => new AmountOfSubstance((_value) * 1e-2d, AmountOfSubstanceUnit.Mole),

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -740,13 +740,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AmplitudeRatioUnit unit, out AmplitudeRatio? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AmplitudeRatioUnit -> BaseUnit
                 (AmplitudeRatioUnit.DecibelMicrovolt, AmplitudeRatioUnit.DecibelVolt) => new AmplitudeRatio(_value - 120, AmplitudeRatioUnit.DecibelVolt),

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -972,13 +972,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AngleUnit unit, out Angle? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AngleUnit -> BaseUnit
                 (AngleUnit.Arcminute, AngleUnit.Degree) => new Angle(_value / 60, AngleUnit.Degree),

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ApparentEnergyUnit unit, out ApparentEnergy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ApparentEnergyUnit -> BaseUnit
                 (ApparentEnergyUnit.KilovoltampereHour, ApparentEnergyUnit.VoltampereHour) => new ApparentEnergy((_value) * 1e3d, ApparentEnergyUnit.VoltampereHour),

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -732,13 +732,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ApparentPowerUnit unit, out ApparentPower? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ApparentPowerUnit -> BaseUnit
                 (ApparentPowerUnit.Gigavoltampere, ApparentPowerUnit.Voltampere) => new ApparentPower((_value) * 1e9d, ApparentPowerUnit.Voltampere),

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -949,13 +949,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AreaUnit unit, out Area? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AreaUnit -> BaseUnit
                 (AreaUnit.Acre, AreaUnit.SquareMeter) => new Area(_value * 4046.85642, AreaUnit.SquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -675,13 +675,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AreaDensityUnit unit, out AreaDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AreaDensityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -770,13 +770,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(AreaMomentOfInertiaUnit unit, out AreaMomentOfInertia? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // AreaMomentOfInertiaUnit -> BaseUnit
                 (AreaMomentOfInertiaUnit.CentimeterToTheFourth, AreaMomentOfInertiaUnit.MeterToTheFourth) => new AreaMomentOfInertia(_value / 1e8, AreaMomentOfInertiaUnit.MeterToTheFourth),

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -1158,13 +1158,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(BitRateUnit unit, out BitRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // BitRateUnit -> BaseUnit
                 (BitRateUnit.BytePerSecond, BitRateUnit.BitPerSecond) => new BitRate(_value * 8m, BitRateUnit.BitPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(BrakeSpecificFuelConsumptionUnit unit, out BrakeSpecificFuelConsumption? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // BrakeSpecificFuelConsumptionUnit -> BaseUnit
                 (BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule) => new BrakeSpecificFuelConsumption(_value / 3.6e9, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule),

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -792,13 +792,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(CapacitanceUnit unit, out Capacitance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // CapacitanceUnit -> BaseUnit
                 (CapacitanceUnit.Kilofarad, CapacitanceUnit.Farad) => new Capacitance((_value) * 1e3d, CapacitanceUnit.Farad),

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(CoefficientOfThermalExpansionUnit unit, out CoefficientOfThermalExpansion? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // CoefficientOfThermalExpansionUnit -> BaseUnit
                 (CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -789,13 +789,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(CompressibilityUnit unit, out Compressibility? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // CompressibilityUnit -> BaseUnit
                 (CompressibilityUnit.InverseAtmosphere, CompressibilityUnit.InversePascal) => new Compressibility(_value * 101325, CompressibilityUnit.InversePascal),

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -1632,13 +1632,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(DensityUnit unit, out Density? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // DensityUnit -> BaseUnit
                 (DensityUnit.CentigramPerDeciliter, DensityUnit.KilogramPerCubicMeter) => new Density((_value / 1e-1) * 1e-2d, DensityUnit.KilogramPerCubicMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -875,13 +875,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(DurationUnit unit, out Duration? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // DurationUnit -> BaseUnit
                 (DurationUnit.Day, DurationUnit.Second) => new Duration(_value * 24 * 3600, DurationUnit.Second),

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -849,13 +849,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(DynamicViscosityUnit unit, out DynamicViscosity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // DynamicViscosityUnit -> BaseUnit
                 (DynamicViscosityUnit.Centipoise, DynamicViscosityUnit.NewtonSecondPerMeterSquared) => new DynamicViscosity((_value / 10) * 1e-2d, DynamicViscosityUnit.NewtonSecondPerMeterSquared),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -732,13 +732,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricAdmittanceUnit unit, out ElectricAdmittance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricAdmittanceUnit -> BaseUnit
                 (ElectricAdmittanceUnit.Microsiemens, ElectricAdmittanceUnit.Siemens) => new ElectricAdmittance((_value) * 1e-6d, ElectricAdmittanceUnit.Siemens),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -754,13 +754,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricChargeUnit unit, out ElectricCharge? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricChargeUnit -> BaseUnit
                 (ElectricChargeUnit.AmpereHour, ElectricChargeUnit.Coulomb) => new ElectricCharge(_value / 2.77777777777e-4, ElectricChargeUnit.Coulomb),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricChargeDensityUnit unit, out ElectricChargeDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricChargeDensityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -716,13 +716,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricConductanceUnit unit, out ElectricConductance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricConductanceUnit -> BaseUnit
                 (ElectricConductanceUnit.Microsiemens, ElectricConductanceUnit.Siemens) => new ElectricConductance((_value) * 1e-6d, ElectricConductanceUnit.Siemens),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -773,13 +773,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricConductivityUnit unit, out ElectricConductivity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricConductivityUnit -> BaseUnit
                 (ElectricConductivityUnit.MicrosiemensPerCentimeter, ElectricConductivityUnit.SiemensPerMeter) => new ElectricConductivity((_value * 1e2) * 1e-6d, ElectricConductivityUnit.SiemensPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -808,13 +808,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricCurrentUnit unit, out ElectricCurrent? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricCurrentUnit -> BaseUnit
                 (ElectricCurrentUnit.Centiampere, ElectricCurrentUnit.Ampere) => new ElectricCurrent((_value) * 1e-2d, ElectricCurrentUnit.Ampere),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -716,13 +716,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricCurrentDensityUnit unit, out ElectricCurrentDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricCurrentDensityUnit -> BaseUnit
                 (ElectricCurrentDensityUnit.AmperePerSquareFoot, ElectricCurrentDensityUnit.AmperePerSquareMeter) => new ElectricCurrentDensity(_value * 1.0763910416709722e1, ElectricCurrentDensityUnit.AmperePerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -732,13 +732,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricCurrentGradientUnit unit, out ElectricCurrentGradient? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricCurrentGradientUnit -> BaseUnit
                 (ElectricCurrentGradientUnit.AmperePerMicrosecond, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient(_value * 1E6, ElectricCurrentGradientUnit.AmperePerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricFieldUnit unit, out ElectricField? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricFieldUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -735,13 +735,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricInductanceUnit unit, out ElectricInductance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricInductanceUnit -> BaseUnit
                 (ElectricInductanceUnit.Microhenry, ElectricInductanceUnit.Henry) => new ElectricInductance((_value) * 1e-6d, ElectricInductanceUnit.Henry),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -756,13 +756,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricPotentialUnit unit, out ElectricPotential? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricPotentialUnit -> BaseUnit
                 (ElectricPotentialUnit.Kilovolt, ElectricPotentialUnit.Volt) => new ElectricPotential((_value) * 1e3d, ElectricPotentialUnit.Volt),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -751,13 +751,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricPotentialAcUnit unit, out ElectricPotentialAc? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricPotentialAcUnit -> BaseUnit
                 (ElectricPotentialAcUnit.KilovoltAc, ElectricPotentialAcUnit.VoltAc) => new ElectricPotentialAc((_value) * 1e3d, ElectricPotentialAcUnit.VoltAc),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -1036,13 +1036,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricPotentialChangeRateUnit unit, out ElectricPotentialChangeRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricPotentialChangeRateUnit -> BaseUnit
                 (ElectricPotentialChangeRateUnit.KilovoltPerHour, ElectricPotentialChangeRateUnit.VoltPerSecond) => new ElectricPotentialChangeRate((_value / 3600) * 1e3d, ElectricPotentialChangeRateUnit.VoltPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -751,13 +751,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricPotentialDcUnit unit, out ElectricPotentialDc? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricPotentialDcUnit -> BaseUnit
                 (ElectricPotentialDcUnit.KilovoltDc, ElectricPotentialDcUnit.VoltDc) => new ElectricPotentialDc((_value) * 1e3d, ElectricPotentialDcUnit.VoltDc),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -770,13 +770,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricResistanceUnit unit, out ElectricResistance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricResistanceUnit -> BaseUnit
                 (ElectricResistanceUnit.Gigaohm, ElectricResistanceUnit.Ohm) => new ElectricResistance((_value) * 1e9d, ElectricResistanceUnit.Ohm),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -925,13 +925,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricResistivityUnit unit, out ElectricResistivity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricResistivityUnit -> BaseUnit
                 (ElectricResistivityUnit.KiloohmCentimeter, ElectricResistivityUnit.OhmMeter) => new ElectricResistivity((_value / 100) * 1e3d, ElectricResistivityUnit.OhmMeter),

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -716,13 +716,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ElectricSurfaceChargeDensityUnit unit, out ElectricSurfaceChargeDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ElectricSurfaceChargeDensityUnit -> BaseUnit
                 (ElectricSurfaceChargeDensityUnit.CoulombPerSquareCentimeter, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter) => new ElectricSurfaceChargeDensity(_value * 1.0e4, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -1361,13 +1361,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(EnergyUnit unit, out Energy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // EnergyUnit -> BaseUnit
                 (EnergyUnit.BritishThermalUnit, EnergyUnit.Joule) => new Energy(_value * 1055.05585262, EnergyUnit.Joule),

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -789,13 +789,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(EntropyUnit unit, out Entropy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // EntropyUnit -> BaseUnit
                 (EntropyUnit.CaloriePerKelvin, EntropyUnit.JoulePerKelvin) => new Entropy(_value * 4.184, EntropyUnit.JoulePerKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -954,13 +954,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ForceUnit unit, out Force? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ForceUnit -> BaseUnit
                 (ForceUnit.Decanewton, ForceUnit.Newton) => new Force((_value) * 1e1d, ForceUnit.Newton),

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -941,13 +941,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ForceChangeRateUnit unit, out ForceChangeRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ForceChangeRateUnit -> BaseUnit
                 (ForceChangeRateUnit.CentinewtonPerSecond, ForceChangeRateUnit.NewtonPerSecond) => new ForceChangeRate((_value) * 1e-2d, ForceChangeRateUnit.NewtonPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -1384,13 +1384,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ForcePerLengthUnit unit, out ForcePerLength? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ForcePerLengthUnit -> BaseUnit
                 (ForcePerLengthUnit.CentinewtonPerCentimeter, ForcePerLengthUnit.NewtonPerMeter) => new ForcePerLength((_value * 1e2) * 1e-2d, ForcePerLengthUnit.NewtonPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -872,13 +872,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(FrequencyUnit unit, out Frequency? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // FrequencyUnit -> BaseUnit
                 (FrequencyUnit.BeatPerMinute, FrequencyUnit.Hertz) => new Frequency(_value / 60, FrequencyUnit.Hertz),

--- a/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
@@ -735,13 +735,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(FuelEfficiencyUnit unit, out FuelEfficiency? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // FuelEfficiencyUnit -> BaseUnit
                 (FuelEfficiencyUnit.KilometerPerLiter, FuelEfficiencyUnit.LiterPer100Kilometers) => new FuelEfficiency(100 / _value, FuelEfficiencyUnit.LiterPer100Kilometers),

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -998,13 +998,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(HeatFluxUnit unit, out HeatFlux? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // HeatFluxUnit -> BaseUnit
                 (HeatFluxUnit.BtuPerHourSquareFoot, HeatFluxUnit.WattPerSquareMeter) => new HeatFlux(_value * 3.15459075, HeatFluxUnit.WattPerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(HeatTransferCoefficientUnit unit, out HeatTransferCoefficient? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // HeatTransferCoefficientUnit -> BaseUnit
                 (HeatTransferCoefficientUnit.BtuPerSquareFootDegreeFahrenheit, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin) => new HeatTransferCoefficient(_value * 5.6782633411134878, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -735,13 +735,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(IlluminanceUnit unit, out Illuminance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // IlluminanceUnit -> BaseUnit
                 (IlluminanceUnit.Kilolux, IlluminanceUnit.Lux) => new Illuminance((_value) * 1e3d, IlluminanceUnit.Lux),

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -1155,13 +1155,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(InformationUnit unit, out Information? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // InformationUnit -> BaseUnit
                 (InformationUnit.Byte, InformationUnit.Bit) => new Information(_value * 8m, InformationUnit.Bit),

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -922,13 +922,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(IrradianceUnit unit, out Irradiance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // IrradianceUnit -> BaseUnit
                 (IrradianceUnit.KilowattPerSquareCentimeter, IrradianceUnit.WattPerSquareMeter) => new Irradiance((_value * 10000) * 1e3d, IrradianceUnit.WattPerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -792,13 +792,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(IrradiationUnit unit, out Irradiation? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // IrradiationUnit -> BaseUnit
                 (IrradiationUnit.JoulePerSquareCentimeter, IrradiationUnit.JoulePerSquareMeter) => new Irradiation(_value * 1e4, IrradiationUnit.JoulePerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
@@ -876,13 +876,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(JerkUnit unit, out Jerk? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // JerkUnit -> BaseUnit
                 (JerkUnit.CentimeterPerSecondCubed, JerkUnit.MeterPerSecondCubed) => new Jerk((_value) * 1e-2d, JerkUnit.MeterPerSecondCubed),

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -838,13 +838,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(KinematicViscosityUnit unit, out KinematicViscosity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // KinematicViscosityUnit -> BaseUnit
                 (KinematicViscosityUnit.Centistokes, KinematicViscosityUnit.SquareMeterPerSecond) => new KinematicViscosity((_value / 1e4) * 1e-2d, KinematicViscosityUnit.SquareMeterPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LapseRate.g.cs
@@ -676,13 +676,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LapseRateUnit unit, out LapseRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LapseRateUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -1372,13 +1372,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LengthUnit unit, out Length? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LengthUnit -> BaseUnit
                 (LengthUnit.Angstrom, LengthUnit.Meter) => new Length(_value * 1e-10, LengthUnit.Meter),

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -702,13 +702,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LevelUnit unit, out Level? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LevelUnit -> BaseUnit
                 (LevelUnit.Neper, LevelUnit.Decibel) => new Level((1 / 0.115129254) * _value, LevelUnit.Decibel),

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -925,13 +925,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LinearDensityUnit unit, out LinearDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LinearDensityUnit -> BaseUnit
                 (LinearDensityUnit.GramPerCentimeter, LinearDensityUnit.KilogramPerMeter) => new LinearDensity(_value * 1e-1, LinearDensityUnit.KilogramPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -1134,13 +1134,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LinearPowerDensityUnit unit, out LinearPowerDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LinearPowerDensityUnit -> BaseUnit
                 (LinearPowerDensityUnit.GigawattPerCentimeter, LinearPowerDensityUnit.WattPerMeter) => new LinearPowerDensity((_value * 1e2) * 1e9d, LinearPowerDensityUnit.WattPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
@@ -849,13 +849,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LuminanceUnit unit, out Luminance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LuminanceUnit -> BaseUnit
                 (LuminanceUnit.CandelaPerSquareFoot, LuminanceUnit.CandelaPerSquareMeter) => new Luminance(_value* 1.07639e1, LuminanceUnit.CandelaPerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -925,13 +925,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LuminosityUnit unit, out Luminosity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LuminosityUnit -> BaseUnit
                 (LuminosityUnit.Decawatt, LuminosityUnit.Watt) => new Luminosity((_value) * 1e1d, LuminosityUnit.Watt),

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LuminousFluxUnit unit, out LuminousFlux? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LuminousFluxUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(LuminousIntensityUnit unit, out LuminousIntensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // LuminousIntensityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -773,13 +773,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MagneticFieldUnit unit, out MagneticField? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MagneticFieldUnit -> BaseUnit
                 (MagneticFieldUnit.Gauss, MagneticFieldUnit.Tesla) => new MagneticField(_value / 1e4, MagneticFieldUnit.Tesla),

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MagneticFluxUnit unit, out MagneticFlux? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MagneticFluxUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MagnetizationUnit unit, out Magnetization? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MagnetizationUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -1166,13 +1166,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MassUnit unit, out Mass? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MassUnit -> BaseUnit
                 (MassUnit.Centigram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-2d, MassUnit.Kilogram),

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -1594,13 +1594,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MassConcentrationUnit unit, out MassConcentration? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MassConcentrationUnit -> BaseUnit
                 (MassConcentrationUnit.CentigramPerDeciliter, MassConcentrationUnit.KilogramPerCubicMeter) => new MassConcentration((_value / 1e-1) * 1e-2d, MassConcentrationUnit.KilogramPerCubicMeter),

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -1285,13 +1285,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MassFlowUnit unit, out MassFlow? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MassFlowUnit -> BaseUnit
                 (MassFlowUnit.CentigramPerDay, MassFlowUnit.GramPerSecond) => new MassFlow((_value / 86400) * 1e-2d, MassFlowUnit.GramPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -884,13 +884,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MassFluxUnit unit, out MassFlux? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MassFluxUnit -> BaseUnit
                 (MassFluxUnit.GramPerHourPerSquareCentimeter, MassFluxUnit.KilogramPerSecondPerSquareMeter) => new MassFlux(_value / 3.6e2, MassFluxUnit.KilogramPerSecondPerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
@@ -1115,13 +1115,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MassFractionUnit unit, out MassFraction? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MassFractionUnit -> BaseUnit
                 (MassFractionUnit.CentigramPerGram, MassFractionUnit.DecimalFraction) => new MassFraction((_value) * 1e-2d, MassFractionUnit.DecimalFraction),

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -1188,13 +1188,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MassMomentOfInertiaUnit unit, out MassMomentOfInertia? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MassMomentOfInertiaUnit -> BaseUnit
                 (MassMomentOfInertiaUnit.GramSquareCentimeter, MassMomentOfInertiaUnit.KilogramSquareMeter) => new MassMomentOfInertia(_value / 1e7, MassMomentOfInertiaUnit.KilogramSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MolarEnergyUnit unit, out MolarEnergy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MolarEnergyUnit -> BaseUnit
                 (MolarEnergyUnit.KilojoulePerMole, MolarEnergyUnit.JoulePerMole) => new MolarEnergy((_value) * 1e3d, MolarEnergyUnit.JoulePerMole),

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MolarEntropyUnit unit, out MolarEntropy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MolarEntropyUnit -> BaseUnit
                 (MolarEntropyUnit.KilojoulePerMoleKelvin, MolarEntropyUnit.JoulePerMoleKelvin) => new MolarEntropy((_value) * 1e3d, MolarEntropyUnit.JoulePerMoleKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -896,13 +896,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MolarMassUnit unit, out MolarMass? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MolarMassUnit -> BaseUnit
                 (MolarMassUnit.CentigramPerMole, MolarMassUnit.KilogramPerMole) => new MolarMass((_value / 1e3) * 1e-2d, MolarMassUnit.KilogramPerMole),

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -862,13 +862,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(MolarityUnit unit, out Molarity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // MolarityUnit -> BaseUnit
                 (MolarityUnit.CentimolePerLiter, MolarityUnit.MolesPerCubicMeter) => new Molarity((_value / 1e-3) * 1e-2d, MolarityUnit.MolesPerCubicMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PermeabilityUnit unit, out Permeability? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PermeabilityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PermittivityUnit unit, out Permittivity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PermittivityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
@@ -754,13 +754,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PorousMediumPermeabilityUnit unit, out PorousMediumPermeability? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PorousMediumPermeabilityUnit -> BaseUnit
                 (PorousMediumPermeabilityUnit.Darcy, PorousMediumPermeabilityUnit.SquareMeter) => new PorousMediumPermeability(_value * 9.869233e-13, PorousMediumPermeabilityUnit.SquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -1155,13 +1155,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PowerUnit unit, out Power? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PowerUnit -> BaseUnit
                 (PowerUnit.BoilerHorsepower, PowerUnit.Watt) => new Power(_value * 9812.5m, PowerUnit.Watt),

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -1492,13 +1492,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PowerDensityUnit unit, out PowerDensity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PowerDensityUnit -> BaseUnit
                 (PowerDensityUnit.DecawattPerCubicFoot, PowerDensityUnit.WattPerCubicMeter) => new PowerDensity((_value * 3.531466672148859e1) * 1e1d, PowerDensityUnit.WattPerCubicMeter),

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -702,13 +702,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PowerRatioUnit unit, out PowerRatio? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PowerRatioUnit -> BaseUnit
                 (PowerRatioUnit.DecibelMilliwatt, PowerRatioUnit.DecibelWatt) => new PowerRatio(_value - 30, PowerRatioUnit.DecibelWatt),

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -1580,13 +1580,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PressureUnit unit, out Pressure? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PressureUnit -> BaseUnit
                 (PressureUnit.Atmosphere, PressureUnit.Pascal) => new Pressure(_value * 1.01325 * 1e5, PressureUnit.Pascal),

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -936,13 +936,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(PressureChangeRateUnit unit, out PressureChangeRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // PressureChangeRateUnit -> BaseUnit
                 (PressureChangeRateUnit.AtmospherePerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value * 1.01325 * 1e5, PressureChangeRateUnit.PascalPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -770,13 +770,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RatioUnit unit, out Ratio? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RatioUnit -> BaseUnit
                 (RatioUnit.PartPerBillion, RatioUnit.DecimalFraction) => new Ratio(_value / 1e9, RatioUnit.DecimalFraction),

--- a/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
@@ -694,13 +694,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RatioChangeRateUnit unit, out RatioChangeRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RatioChangeRateUnit -> BaseUnit
                 (RatioChangeRateUnit.PercentPerSecond, RatioChangeRateUnit.DecimalFractionPerSecond) => new RatioChangeRate(_value / 1e2, RatioChangeRateUnit.DecimalFractionPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ReactiveEnergyUnit unit, out ReactiveEnergy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ReactiveEnergyUnit -> BaseUnit
                 (ReactiveEnergyUnit.KilovoltampereReactiveHour, ReactiveEnergyUnit.VoltampereReactiveHour) => new ReactiveEnergy((_value) * 1e3d, ReactiveEnergyUnit.VoltampereReactiveHour),

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -732,13 +732,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ReactivePowerUnit unit, out ReactivePower? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ReactivePowerUnit -> BaseUnit
                 (ReactivePowerUnit.GigavoltampereReactive, ReactivePowerUnit.VoltampereReactive) => new ReactivePower((_value) * 1e9d, ReactivePowerUnit.VoltampereReactive),

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -868,13 +868,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ReciprocalAreaUnit unit, out ReciprocalArea? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ReciprocalAreaUnit -> BaseUnit
                 (ReciprocalAreaUnit.InverseSquareCentimeter, ReciprocalAreaUnit.InverseSquareMeter) => new ReciprocalArea(_value / 1e-4, ReciprocalAreaUnit.InverseSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -849,13 +849,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ReciprocalLengthUnit unit, out ReciprocalLength? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ReciprocalLengthUnit -> BaseUnit
                 (ReciprocalLengthUnit.InverseCentimeter, ReciprocalLengthUnit.InverseMeter) => new ReciprocalLength(_value * 1e2, ReciprocalLengthUnit.InverseMeter),

--- a/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
@@ -675,13 +675,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RelativeHumidityUnit unit, out RelativeHumidity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RelativeHumidityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -732,13 +732,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RotationalAccelerationUnit unit, out RotationalAcceleration? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RotationalAccelerationUnit -> BaseUnit
                 (RotationalAccelerationUnit.DegreePerSecondSquared, RotationalAccelerationUnit.RadianPerSecondSquared) => new RotationalAcceleration((Math.PI / 180) * _value, RotationalAccelerationUnit.RadianPerSecondSquared),

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -915,13 +915,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RotationalSpeedUnit unit, out RotationalSpeed? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RotationalSpeedUnit -> BaseUnit
                 (RotationalSpeedUnit.CentiradianPerSecond, RotationalSpeedUnit.RadianPerSecond) => new RotationalSpeed((_value) * 1e-2d, RotationalSpeedUnit.RadianPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -1283,13 +1283,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RotationalStiffnessUnit unit, out RotationalStiffness? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RotationalStiffnessUnit -> BaseUnit
                 (RotationalStiffnessUnit.CentinewtonMeterPerDegree, RotationalStiffnessUnit.NewtonMeterPerRadian) => new RotationalStiffness((_value * (180 / Math.PI)) * 1e-2d, RotationalStiffnessUnit.NewtonMeterPerRadian),

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -751,13 +751,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(RotationalStiffnessPerLengthUnit unit, out RotationalStiffnessPerLength? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // RotationalStiffnessPerLengthUnit -> BaseUnit
                 (RotationalStiffnessPerLengthUnit.KilonewtonMeterPerRadianPerMeter, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter) => new RotationalStiffnessPerLength((_value) * 1e3d, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -675,13 +675,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ScalarUnit unit, out Scalar? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ScalarUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SolidAngleUnit unit, out SolidAngle? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SolidAngleUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -1210,13 +1210,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SpecificEnergyUnit unit, out SpecificEnergy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SpecificEnergyUnit -> BaseUnit
                 (SpecificEnergyUnit.BtuPerPound, SpecificEnergyUnit.JoulePerKilogram) => new SpecificEnergy(_value * 2326.000075362, SpecificEnergyUnit.JoulePerKilogram),

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -827,13 +827,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SpecificEntropyUnit unit, out SpecificEntropy? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SpecificEntropyUnit -> BaseUnit
                 (SpecificEntropyUnit.BtuPerPoundFahrenheit, SpecificEntropyUnit.JoulePerKilogramKelvin) => new SpecificEntropy(_value * 4.1868e3, SpecificEntropyUnit.JoulePerKilogramKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
@@ -735,13 +735,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SpecificFuelConsumptionUnit unit, out SpecificFuelConsumption? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SpecificFuelConsumptionUnit -> BaseUnit
                 (SpecificFuelConsumptionUnit.KilogramPerKilogramForceHour, SpecificFuelConsumptionUnit.GramPerKiloNewtonSecond) => new SpecificFuelConsumption(_value * 28.33, SpecificFuelConsumptionUnit.GramPerKiloNewtonSecond),

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -713,13 +713,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SpecificVolumeUnit unit, out SpecificVolume? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SpecificVolumeUnit -> BaseUnit
                 (SpecificVolumeUnit.CubicFootPerPound, SpecificVolumeUnit.CubicMeterPerKilogram) => new SpecificVolume(_value / 16.01846353, SpecificVolumeUnit.CubicMeterPerKilogram),

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -982,13 +982,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SpecificWeightUnit unit, out SpecificWeight? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SpecificWeightUnit -> BaseUnit
                 (SpecificWeightUnit.KilogramForcePerCubicCentimeter, SpecificWeightUnit.NewtonPerCubicMeter) => new SpecificWeight(_value * 9.80665e6, SpecificWeightUnit.NewtonPerCubicMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -1307,13 +1307,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(SpeedUnit unit, out Speed? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // SpeedUnit -> BaseUnit
                 (SpeedUnit.CentimeterPerHour, SpeedUnit.MeterPerSecond) => new Speed((_value / 3600) * 1e-2d, SpeedUnit.MeterPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -827,13 +827,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(StandardVolumeFlowUnit unit, out StandardVolumeFlow? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // StandardVolumeFlowUnit -> BaseUnit
                 (StandardVolumeFlowUnit.StandardCubicCentimeterPerMinute, StandardVolumeFlowUnit.StandardCubicMeterPerSecond) => new StandardVolumeFlow(_value / 6e7, StandardVolumeFlowUnit.StandardCubicMeterPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -800,13 +800,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TemperatureUnit unit, out Temperature? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TemperatureUnit -> BaseUnit
                 (TemperatureUnit.DegreeCelsius, TemperatureUnit.Kelvin) => new Temperature(_value + 273.15, TemperatureUnit.Kelvin),

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -846,13 +846,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TemperatureChangeRateUnit unit, out TemperatureChangeRate? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TemperatureChangeRateUnit -> BaseUnit
                 (TemperatureChangeRateUnit.CentidegreeCelsiusPerSecond, TemperatureChangeRateUnit.DegreeCelsiusPerSecond) => new TemperatureChangeRate((_value) * 1e-2d, TemperatureChangeRateUnit.DegreeCelsiusPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -827,13 +827,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TemperatureDeltaUnit unit, out TemperatureDelta? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TemperatureDeltaUnit -> BaseUnit
                 (TemperatureDeltaUnit.DegreeCelsius, TemperatureDeltaUnit.Kelvin) => new TemperatureDelta(_value, TemperatureDeltaUnit.Kelvin),

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -732,13 +732,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TemperatureGradientUnit unit, out TemperatureGradient? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TemperatureGradientUnit -> BaseUnit
                 (TemperatureGradientUnit.DegreeCelsiusPerKilometer, TemperatureGradientUnit.KelvinPerMeter) => new TemperatureGradient(_value / 1e3, TemperatureGradientUnit.KelvinPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -697,13 +697,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ThermalConductivityUnit unit, out ThermalConductivity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ThermalConductivityUnit -> BaseUnit
                 (ThermalConductivityUnit.BtuPerHourFootFahrenheit, ThermalConductivityUnit.WattPerMeterKelvin) => new ThermalConductivity(_value * 1.73073467, ThermalConductivityUnit.WattPerMeterKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -770,13 +770,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(ThermalResistanceUnit unit, out ThermalResistance? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // ThermalResistanceUnit -> BaseUnit
                 (ThermalResistanceUnit.HourSquareFeetDegreeFahrenheitPerBtu, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt) => new ThermalResistance(_value * 176.1121482159839, ThermalResistanceUnit.SquareMeterKelvinPerKilowatt),

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -1134,13 +1134,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TorqueUnit unit, out Torque? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TorqueUnit -> BaseUnit
                 (TorqueUnit.GramForceCentimeter, TorqueUnit.NewtonMeter) => new Torque(_value * 9.80665e-5, TorqueUnit.NewtonMeter),

--- a/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
@@ -1058,13 +1058,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TorquePerLengthUnit unit, out TorquePerLength? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TorquePerLengthUnit -> BaseUnit
                 (TorquePerLengthUnit.KilogramForceCentimeterPerMeter, TorquePerLengthUnit.NewtonMeterPerMeter) => new TorquePerLength(_value * 0.0980665019960652, TorquePerLengthUnit.NewtonMeterPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
@@ -678,13 +678,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(TurbidityUnit unit, out Turbidity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // TurbidityUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -675,13 +675,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VitaminAUnit unit, out VitaminA? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VitaminAUnit -> BaseUnit
 

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -1691,13 +1691,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VolumeUnit unit, out Volume? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VolumeUnit -> BaseUnit
                 (VolumeUnit.AcreFoot, VolumeUnit.CubicMeter) => new Volume(_value / 0.000810714, VolumeUnit.CubicMeter),

--- a/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
@@ -1039,13 +1039,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VolumeConcentrationUnit unit, out VolumeConcentration? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VolumeConcentrationUnit -> BaseUnit
                 (VolumeConcentrationUnit.CentilitersPerLiter, VolumeConcentrationUnit.DecimalFraction) => new VolumeConcentration((_value) * 1e-2d, VolumeConcentrationUnit.DecimalFraction),

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -1861,13 +1861,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VolumeFlowUnit unit, out VolumeFlow? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VolumeFlowUnit -> BaseUnit
                 (VolumeFlowUnit.AcreFootPerDay, VolumeFlowUnit.CubicMeterPerSecond) => new VolumeFlow(_value / 70.0457, VolumeFlowUnit.CubicMeterPerSecond),

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
@@ -694,13 +694,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VolumeFlowPerAreaUnit unit, out VolumeFlowPerArea? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VolumeFlowPerAreaUnit -> BaseUnit
                 (VolumeFlowPerAreaUnit.CubicFootPerMinutePerSquareFoot, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter) => new VolumeFlowPerArea(_value / 196.850394, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter),

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -789,13 +789,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VolumePerLengthUnit unit, out VolumePerLength? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VolumePerLengthUnit -> BaseUnit
                 (VolumePerLengthUnit.CubicYardPerFoot, VolumePerLengthUnit.CubicMeterPerMeter) => new VolumePerLength(_value * 2.50838208, VolumePerLengthUnit.CubicMeterPerMeter),

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -830,13 +830,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(VolumetricHeatCapacityUnit unit, out VolumetricHeatCapacity? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // VolumetricHeatCapacityUnit -> BaseUnit
                 (VolumetricHeatCapacityUnit.BtuPerCubicFootDegreeFahrenheit, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin) => new VolumetricHeatCapacity(_value / 1.4910660e-5, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin),

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -770,13 +770,13 @@ namespace UnitsNet
         /// <returns>True if successful, otherwise false.</returns>
         private bool TryToUnit(WarpingMomentOfInertiaUnit unit, out WarpingMomentOfInertia? converted)
         {
-            if (_unit == unit)
+            if (Unit == unit)
             {
                 converted = this;
                 return true;
             }
 
-            converted = (_unit, unit) switch
+            converted = (Unit, unit) switch
             {
                 // WarpingMomentOfInertiaUnit -> BaseUnit
                 (WarpingMomentOfInertiaUnit.CentimeterToTheSixth, WarpingMomentOfInertiaUnit.MeterToTheSixth) => new WarpingMomentOfInertia(_value / 1e12, WarpingMomentOfInertiaUnit.MeterToTheSixth),


### PR DESCRIPTION
Fixes #1118  and #1116 

- replacing the use of the nullable `_unit` field in the `TryToUnit` funtion
- added `ToUnit_FromDefaultQuantity_ReturnsQuantityWithGivenUnit` - a test for converting from `default(TQuantity)`, skipped for FuelEfficieny due to the resulting division by zero
- removed extra commas from the PressureChangeRate.json (reported as errors by the designer..)