### PR TITLE
Upgrade .NET runtime to 6.0 for tests, CodeGen and Benchmark

### DIFF
--- a/.github/actions/run-benchmarks/action.yaml
+++ b/.github/actions/run-benchmarks/action.yaml
@@ -3,11 +3,11 @@ inputs:
   framework:
     description: 'The runtime version to use (e.g. net5.0)'
     required: false
-    default: 'net5.0'
+    default: 'net6.0'
   runtimes:
     description: 'The runtime version to use (e.g. netcoreapp31, net5.0)'
     required: false
-    default: 'net5.0'
+    default: 'net6.0'
   output-folder:
     description: 'The output folder for the benchmark (a results folder is created inside)'
     required: false

--- a/.github/workflows/continious-benchmarking.yml
+++ b/.github/workflows/continious-benchmarking.yml
@@ -9,7 +9,7 @@ on:
       - ".github/actions/**"
       
 env:
-  FRAMEWORK: net5.0 
+  FRAMEWORK: net6.0 
   EXECUTION_OPTIONS: --iterationTime 500 --disableLogFile # see https://benchmarkdotnet.org/articles/guides/console-args.html
   BENCHMARK_PAGES_BRANCH: gh-pages
   BENCHMARK_DATA_FOLDER: benchmarks
@@ -21,7 +21,7 @@ jobs:
     strategy:
       # max-parallel: 1 # is it better to avoid running in parallel?
       matrix: 
-        runtime: ["netcoreapp50", "netcoreapp21", "net472"]        
+        runtime: ["net6.0", "netcoreapp21", "net472"]        
     steps:
       - run: echo Starting benchmarks for ${{ matrix.runtime }} 
       

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -8,7 +8,7 @@ on:
         default: 'UnitsNet Benchmarks'
       runtimes:
         description: 'The runtime version to use (e.g. net472 net48 netcoreapp21 netcoreapp31 netcoreapp50)'
-        default: net472 netcoreapp21 netcoreapp50
+        default: net472 netcoreapp21 net6.0
         required: true
       exporters:
         description: 'The exporter(s) used for this run (GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML)'
@@ -29,7 +29,7 @@ on:
       comparison-baseline:
         description: 'Compare against a previous result (expecting a link to *-report-full.json)'
         required: true
-        default: 'https://angularsen.github.io/UnitsNet/benchmarks/netcoreapp50/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json'              
+        default: 'https://angularsen.github.io/UnitsNet/benchmarks/net6.0/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json'              
       comparison-threshold:
         description: 'The (comparison) threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s'
         required: false
@@ -40,7 +40,7 @@ on:
         default: 10               
       framework:
         description: 'The dotnet-version version to use (e.g. net5.0)'
-        default: 'net5.0'
+        default: 'net6.0'
         required: true     
 jobs:
   benchmark:

--- a/CodeGen/CodeGen.csproj
+++ b/CodeGen/CodeGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <!-- Allow compile with various nullability warnings until fixed. -->

--- a/UnitsNet.Benchmark/Scripts/json-export-all-runtimes.bat
+++ b/UnitsNet.Benchmark/Scripts/json-export-all-runtimes.bat
@@ -4,8 +4,8 @@ SET projectdir="%scriptdir%..\.."
 SET exportdir="%projectdir%\Artifacts\Benchmark"
 :: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
 dotnet run --project "%projectdir%/UnitsNet.Benchmark" -c Release ^
---framework net5.0 ^
---runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 netcoreapp50 ^
+--framework net6.0 ^
+--runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 net6.0 ^
 --artifacts=%exportdir% ^
 --exporters json ^
 --filter * ^
@@ -14,4 +14,4 @@ dotnet run --project "%projectdir%/UnitsNet.Benchmark" -c Release ^
 --join %1 %2 %3
 
 :: this runs fine, however there is currently no way of displaying multiple-lines-per-chart: see https://github.com/rhysd/github-action-benchmark/issues/18
-:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json
+:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net6.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json

--- a/UnitsNet.Benchmark/Scripts/json-export-net5.bat
+++ b/UnitsNet.Benchmark/Scripts/json-export-net5.bat
@@ -4,8 +4,8 @@ SET projectdir="%scriptdir%..\.."
 SET exportdir="%projectdir%\Artifacts\Benchmark"
 :: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
 dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
---framework net5.0 ^
---runtimes netcoreapp50 ^
+--framework net6.0 ^
+--runtimes net6.0 ^
 --artifacts=%exportdir% ^
 --exporters json ^
 --filter * ^
@@ -14,4 +14,4 @@ dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
 --join %1 %2 %3
 
 :: this runs fine, however there is currently no way of displaying multiple-lines-per-chart: see https://github.com/rhysd/github-action-benchmark/issues/18
-:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json
+:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net6.0 --runtimes netcoreapp31 net6.0 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json

--- a/UnitsNet.Benchmark/Scripts/r-plot-all-runtimes.bat
+++ b/UnitsNet.Benchmark/Scripts/r-plot-all-runtimes.bat
@@ -4,8 +4,8 @@ SET projectdir="%scriptdir%..\.."
 SET exportdir="%projectdir%\Artifacts\Benchmark"
 :: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
 dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
---framework net5.0 ^
---runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 netcoreapp50 ^
+--framework net6.0 ^
+--runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 net6.0 ^
 --artifacts=%exportdir% ^
 --exporters rplot ^
 --filter * ^

--- a/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
+++ b/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1;net48;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;netcoreapp2.1;net48;net472</TargetFrameworks>
     <Version>4.0.0.0</Version>
     <AssemblyVersion>4.0.0.0</AssemblyVersion> 
     <AssemblyTitle>UnitsNet.Benchmark</AssemblyTitle>

--- a/UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj
+++ b/UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>UnitsNet.NumberExtensions.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>

--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Serialization.JsonNet.CompatibilityTests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Serialization.JsonNet.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net48</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <RootNamespace>UnitsNet.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 # Don't build PR commits twice
 skip_branch_with_pr: true


### PR DESCRIPTION
.NET 5 is out of active support.

So I don't have it installed on my computer but I'm using .NET6 as it is an LTS version.

Therefore, I would suggest to upgrade things which are executed on the developer machine / CI (e.g. tests, benchmark, codegen) to .NET6 target framework.

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core