### PR TITLE
💚⬆️ Fix build hang by upgrading dotcover

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "jetbrains.dotcover.globaltool": {
+      "version": "2022.2.3",
+      "commands": [
+        "dotnet-dotcover"
+      ]
+    }
+  }
+}

--- a/UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj
+++ b/UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj
@@ -31,7 +31,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2019.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
+++ b/UnitsNet.Serialization.JsonNet.CompatibilityTests/UnitsNet.Serialization.JsonNet.CompatibilityTests.csproj
@@ -23,7 +23,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2019.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -21,7 +21,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2019.1.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -31,7 +31,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
-    <DotNetCliToolReference Include="JetBrains.dotCover.CommandLineTools" Version="2019.1.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hoping to fix hang issue and very slow builds on CI and locally, only seen when running build.bat, which runs tests with JetBrains dotcover. Local testing of upgrade seems to indicate this helps a lot.

- Upgrade from 2019.1.3 to 2022.2.3.
- Replace nuget refs with tool manifest.