### PR TITLE
update benchmarks to net6.0

### DIFF
--- a/.github/workflows/continious-benchmarking.yml
+++ b/.github/workflows/continious-benchmarking.yml
@@ -1,69 +1,69 @@
 name: UnitsNet Benchmarks (auto)
 on:
   push:
-    branches: [master]    
+    branches: [master]
     paths:
       - "UnitsNet/*"
       - "UnitsNet.Benchmark/*"
       - ".github/workflows/**"
       - ".github/actions/**"
-      
+
 env:
-  FRAMEWORK: net5.0 
+  FRAMEWORK: net6.0
   EXECUTION_OPTIONS: --iterationTime 500 --disableLogFile # see https://benchmarkdotnet.org/articles/guides/console-args.html
   BENCHMARK_PAGES_BRANCH: gh-pages
   BENCHMARK_DATA_FOLDER: benchmarks
-  
+
 jobs:
   benchmark:
     if: github.repository_owner == 'angularsen' # (by default) the workflow doesn't need to run in a fork
     runs-on: windows-latest # required by the older frameworks
     strategy:
       # max-parallel: 1 # is it better to avoid running in parallel?
-      matrix: 
-        runtime: ["netcoreapp50", "netcoreapp21", "net472"]        
+      matrix:
+        runtime: ["net6.0", "netcoreapp21", "net472"]
     steps:
-      - run: echo Starting benchmarks for ${{ matrix.runtime }} 
-      
+      - run: echo Starting benchmarks for ${{ matrix.runtime }}
+
       # checkout the current branch
-      - uses: actions/checkout@v2 
-      
+      - uses: actions/checkout@v2
+
       # we need all frameworks (even if only running one target at a time)
       - uses: actions/setup-dotnet@v1
-        with: 
-          dotnet-version: '2.1.x'
-            
+        with:
+          dotnet-version: "2.1.x"
+
       - uses: actions/setup-dotnet@v1
-        with: 
-          dotnet-version: '3.1.x'
-            
+        with:
+          dotnet-version: "3.1.x"
+
       - uses: actions/setup-dotnet@v1
-        with: 
-          dotnet-version: '5.0.x'
-            
-      # executing the benchmark for the current framework, placing the result in a corresponding sub-folder              
+        with:
+          dotnet-version: "5.0.x"
+
+      # executing the benchmark for the current framework, placing the result in a corresponding sub-folder
       - uses: ./.github/actions/run-benchmarks
         with:
           framework: ${{ env.FRAMEWORK }}
           runtimes: ${{ matrix.runtime }}
           output-folder: Artifacts/Benchmark/${{ matrix.runtime }}
           execution-options: ${{ env.EXECUTION_OPTIONS }}
-            
-      # saving the current artifact (downloadable until the expiration date of this action)        
+
+      # saving the current artifact (downloadable until the expiration date of this action)
       - name: Store benchmark artifact
         uses: actions/upload-artifact@v2
         with:
           name: UnitsNet Benchmarks (${{ matrix.runtime }})
           path: Artifacts/Benchmark/${{ matrix.runtime }}/results/
-          
+
   publish-results:
     needs: [benchmark]
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1 # cannot commit on the same branch in parallel
-      matrix: 
-        runtime: ["netcoreapp50", "netcoreapp21", "net472"]
-    steps:        
+      matrix:
+        runtime: ["net6.0", "netcoreapp21", "net472"]
+    steps:
       - name: Initializing git folder ️
         uses: actions/checkout@v2.3.1
 
@@ -71,8 +71,8 @@ jobs:
         uses: actions/download-artifact@v1
         with:
           name: UnitsNet Benchmarks (${{ matrix.runtime }})
-          path: ${{ matrix.runtime }}        
-        
+          path: ${{ matrix.runtime }}
+
       # publishing the current results to the benchmark-pages branch (overriding the previous result)
       - name: Saving benchmark results to ${{ env.BENCHMARK_PAGES_BRANCH }}/${{ env.BENCHMARK_DATA_FOLDER }}/${{ matrix.runtime }}/results
         uses: JamesIves/github-pages-deploy-action@4.1.1
@@ -81,22 +81,21 @@ jobs:
           branch: ${{ env.BENCHMARK_PAGES_BRANCH }}
           target-folder: ${{ env.BENCHMARK_DATA_FOLDER }}/${{ matrix.runtime }}/results
           commit-message: Automatic benchmark generation for ${{ github.sha }}
-      
+
       # appending to the running benchmark data on the benchmark-pages branch
       - name: Updating benchmark charts
         uses: starburst997/github-action-benchmark@v1.8.7
         with:
           name: UnitsNet Benchmarks (${{ matrix.runtime }})
-          tool: 'benchmarkdotnet'
+          tool: "benchmarkdotnet"
           output-file-path: ${{ matrix.runtime }}/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json
           gh-pages-branch: ${{ env.BENCHMARK_PAGES_BRANCH }}
           benchmark-data-dir-path: ${{ env.BENCHMARK_DATA_FOLDER }}/${{ matrix.runtime }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
-          alert-threshold: '200%'
+          alert-threshold: "200%"
           comment-always: true
           comment-on-alert: true
           fail-on-alert: false
-          alert-comment-cc-users: '@lipchev'
-     
+          alert-comment-cc-users: "@lipchev"

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -3,67 +3,67 @@ on:
   workflow_dispatch:
     inputs:
       benchmark-name:
-        description: 'A name given for this benchmark'
+        description: "A name given for this benchmark"
         required: false
-        default: 'UnitsNet Benchmarks'
+        default: "UnitsNet Benchmarks"
       runtimes:
-        description: 'The runtime version to use (e.g. net472 net48 netcoreapp21 netcoreapp31 netcoreapp50)'
-        default: net472 netcoreapp21 netcoreapp50
+        description: "The runtime version to use (e.g. net472 net48 netcoreapp21 netcoreapp31 net6.0)"
+        default: net472 netcoreapp21 net6.0
         required: true
       exporters:
-        description: 'The exporter(s) used for this run (GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML)'
+        description: "The exporter(s) used for this run (GitHub/StackOverflow/RPlot/CSV/JSON/HTML/XML)"
         required: false
         default: fulljson rplot
       filter:
-        description: 'An optional class filter to apply'
+        description: "An optional class filter to apply"
         required: false
-        default: '*'
+        default: "*"
       categories:
-        description: 'An optional categories filter to apply'
+        description: "An optional categories filter to apply"
         required: false
-        default: ''
+        default: ""
       execution-options:
-        description: 'Any additional parameters passed to the benchmark'
+        description: "Any additional parameters passed to the benchmark"
         required: false
-        default: --disableLogFile     
+        default: --disableLogFile
       comparison-baseline:
-        description: 'Compare against a previous result (expecting a link to *-report-full.json)'
+        description: "Compare against a previous result (expecting a link to *-report-full.json)"
         required: true
-        default: 'https://angularsen.github.io/UnitsNet/benchmarks/netcoreapp50/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json'              
+        default: "https://angularsen.github.io/UnitsNet/benchmarks/netcoreapp50/results/UnitsNet.Benchmark.UnitsNetBenchmarks-report-full.json"
       comparison-threshold:
-        description: 'The (comparison) threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s'
+        description: "The (comparison) threshold for Statistical Test. Examples: 5%, 10ms, 100ns, 1s"
         required: false
-        default: '1%'      
+        default: "1%"
       comparison-top:
-        description: 'Filter the comparison to the top/bottom N results'
+        description: "Filter the comparison to the top/bottom N results"
         required: false
-        default: 10               
+        default: 10
       framework:
-        description: 'The dotnet-version version to use (e.g. net5.0)'
-        default: 'net5.0'
-        required: true     
+        description: "The dotnet-version version to use (e.g. net6.0)"
+        default: "net6.0"
+        required: true
 jobs:
   benchmark:
     env:
       OUTPUT_FOLDER: Artifacts/Benchmarks/${{ github.event.inputs.benchmark-name }}
     runs-on: windows-latest
-    steps:      
+    steps:
       # checkout the current branch
-      - uses: actions/checkout@v2 
-      
+      - uses: actions/checkout@v2
+
       # we need all frameworks (even if only running one target at a time)
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '2.1.x'
-            
+          dotnet-version: "2.1.x"
+
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
-            
+          dotnet-version: "3.1.x"
+
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.0.x'
-            
+          dotnet-version: "5.0.x"
+
       # executing the benchmark for the current framework(s), placing the result in the output-folder
       - uses: ./.github/actions/run-benchmarks
         with:
@@ -73,70 +73,69 @@ jobs:
           filter: ${{ github.event.inputs.filter }}
           categories: ${{ github.event.inputs.categories }}
           execution-options: ${{ github.event.inputs.execution-options }}
-            
-      # saving the current artifact (downloadable until the expiration date of this action)        
+
+      # saving the current artifact (downloadable until the expiration date of this action)
       - name: Store benchmark result
         uses: actions/upload-artifact@v2
         with:
           name: ${{ github.event.inputs.benchmark-name }} (${{ github.event.inputs.runtimes }})
           path: ${{ env.OUTPUT_FOLDER }}/results
-          if-no-files-found: error 
-          
+          if-no-files-found: error
+
   compare-results:
     if: ${{ endsWith(github.event.inputs.comparison-baseline, '-report-full.json') }}
     env:
       OUPUT_NAME: Baseline vs ${{ github.event.inputs.benchmark-name }} (${{ github.event.inputs.runtimes }})
     needs: [benchmark]
     runs-on: ubuntu-latest
-    steps:                    
-      # The baseline results are downloaded into a 'baseline' folder.  
+    steps:
+      # The baseline results are downloaded into a 'baseline' folder.
       - name: Download Baseline
         uses: carlosperate/download-file-action@v1.0.3
         with:
           file-url: ${{ github.event.inputs.comparison-baseline }}
           location: baseline
-      
-      # The benchmark results are downloaded into a 'runtime' folder.  
-      - name: Download Artifacts 
+
+      # The benchmark results are downloaded into a 'runtime' folder.
+      - name: Download Artifacts
         uses: actions/download-artifact@v1
         with:
           name: ${{ github.event.inputs.benchmark-name }} (${{ github.event.inputs.runtimes }})
-          path: results    
-          
+          path: results
+
       # The benchmark comparer is currently taken from dotnet/performance/src/tools/ResultsComparer (hoping that a 'tool' would eventually be made available)
       - name: Download ResultsComparer
         uses: actions/checkout@v2
         with:
           repository: dotnet/performance
           path: comparer
-                  
+
       - uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
-              
+          dotnet-version: "3.1.x"
+
       - run: mkdir -p artifacts
-      
+
       # Executing the comparer, placing the result in a 'comparison' folder (as well as creating a summary from the output)
       - name: Running the ResultsComparer
         env:
-          PERFLAB_TARGET_FRAMEWORKS: netcoreapp3.1
-        run: > 
+          PERFLAB_TARGET_FRAMEWORKS: net6.0
+        run: >
           dotnet run --project 'comparer/src/tools/ResultsComparer' -c Release
-          --framework netcoreapp31
+          --framework net6.0
           --base baseline --diff results 
           --csv "artifacts/${{ env.OUPUT_NAME }}.csv"
           --xml "artifacts/${{ env.OUPUT_NAME }}.xml"
           --threshold ${{ github.event.inputs.comparison-threshold }} 
           --top ${{ github.event.inputs.comparison-top }} 
           > "artifacts/${{ env.OUPUT_NAME }}.md"
-      
+
       - name: Summary
         run: cat "artifacts/${{ env.OUPUT_NAME }}.md"
-      
-      # saving the current artifacts (downloadable until the expiration date of this action)        
+
+      # saving the current artifacts (downloadable until the expiration date of this action)
       - name: Store comparison result
         uses: actions/upload-artifact@v2
         with:
           name: ${{ env.OUPUT_NAME }}
           path: artifacts
-          

--- a/CodeGen/CodeGen.csproj
+++ b/CodeGen/CodeGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <!-- Allow compile with various nullability warnings until fixed. -->

--- a/UnitsNet.Benchmark/Scripts/json-export-all-runtimes.bat
+++ b/UnitsNet.Benchmark/Scripts/json-export-all-runtimes.bat
@@ -4,8 +4,8 @@ SET projectdir="%scriptdir%..\.."
 SET exportdir="%projectdir%\Artifacts\Benchmark"
 :: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
 dotnet run --project "%projectdir%/UnitsNet.Benchmark" -c Release ^
---framework net5.0 ^
---runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 netcoreapp50 ^
+--framework net6.0 ^
+--runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 net6.0 ^
 --artifacts=%exportdir% ^
 --exporters json ^
 --filter * ^
@@ -14,4 +14,4 @@ dotnet run --project "%projectdir%/UnitsNet.Benchmark" -c Release ^
 --join %1 %2 %3
 
 :: this runs fine, however there is currently no way of displaying multiple-lines-per-chart: see https://github.com/rhysd/github-action-benchmark/issues/18
-:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json
+:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net6.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json

--- a/UnitsNet.Benchmark/Scripts/json-export-net5.bat
+++ b/UnitsNet.Benchmark/Scripts/json-export-net5.bat
@@ -5,7 +5,7 @@ SET exportdir="%projectdir%\Artifacts\Benchmark"
 :: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
 dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
 --framework net5.0 ^
---runtimes netcoreapp50 ^
+--runtimes net5.0 ^
 --artifacts=%exportdir% ^
 --exporters json ^
 --filter * ^
@@ -14,4 +14,4 @@ dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
 --join %1 %2 %3
 
 :: this runs fine, however there is currently no way of displaying multiple-lines-per-chart: see https://github.com/rhysd/github-action-benchmark/issues/18
-:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 netcoreapp50 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json
+:: dotnet run --project "%scriptdir%/UnitsNet.Benchmark" -c Release -f net5.0 --runtimes netcoreapp31 net5.0 --filter ** --artifacts="%scriptdir%/Artifacts/Benchmark" --exporters json

--- a/UnitsNet.Benchmark/Scripts/r-plot-all-runtimes.bat
+++ b/UnitsNet.Benchmark/Scripts/r-plot-all-runtimes.bat
@@ -5,7 +5,7 @@ SET exportdir="%projectdir%\Artifacts\Benchmark"
 :: this fails on the build server (also tested with the nightly benchmark.net package: 0.12.1.1533): possibly related to https://github.com/dotnet/BenchmarkDotNet/issues/1487
 dotnet run --project "%projectdir%\UnitsNet.Benchmark" -c Release ^
 --framework net5.0 ^
---runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 netcoreapp50 ^
+--runtimes net472 net48 netcoreapp2.1 netcoreapp3.1 net6.0 ^
 --artifacts=%exportdir% ^
 --exporters rplot ^
 --filter * ^


### PR DESCRIPTION
.net 5 has reached its end of life and [framework name](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks) for .net 5 and above is `netX.Y` rather than `netcoreappX.Y`