### PR TITLE
1 mile is 1609.344 metres

### DIFF
--- a/Common/UnitDefinitions/Length.json
+++ b/Common/UnitDefinitions/Length.json
@@ -36,8 +36,8 @@
       "BaseUnits": {
         "L": "Mile"
       },
-      "FromUnitToBaseFunc": "{x} * 1609.34",
-      "FromBaseToUnitFunc": "{x} / 1609.34",
+      "FromUnitToBaseFunc": "{x} * 1609.344",
+      "FromBaseToUnitFunc": "{x} / 1609.344",
       "Localization": [
         {
           "Culture": "en-US",


### PR DESCRIPTION
A mile is 1609.344 metres instead of 1609.34 metres, according to this Wikipedia article:
https://en.wikipedia.org/wiki/Mile

"The statute mile was standardised between the British Commonwealth and the United States by an international agreement in 1959, when it was formally redefined with respect to SI units as exactly 1,609.344 metres (1.609344 km)."