### PR TITLE
Implement direct conversion functions

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -1020,7 +1020,22 @@ namespace UnitsNet
             }}
 
             {_quantity.Name}? convertedOrNull = (Unit, unit) switch
-            {{
+            {{");
+
+            foreach(Unit unit in _quantity.Units)
+            {
+                foreach(var conversion in unit.Conversions)
+                {
+                    var func2 = conversion.Formula.Replace("{x}", "_value");
+                    Writer.WL($@"
+                ({_quantity.Name}Unit.{unit.SingularName}, {_unitEnumName}.{conversion.Target}) => new {_quantity.Name}({func2}, {_unitEnumName}.{conversion.Target}),");
+                }
+            }
+
+            if(_quantity.Units.Any(unit => unit.Conversions.Any()))
+                Writer.WL();
+
+            Writer.WL($@"
                 // {_quantity.Name}Unit -> BaseUnit");
 
             foreach (Unit unit in _quantity.Units)

--- a/CodeGen/JsonTypes/Conversions.cs
+++ b/CodeGen/JsonTypes/Conversions.cs
@@ -1,0 +1,19 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+
+namespace CodeGen.JsonTypes
+{
+    internal class Conversions
+    {
+        // 0649 Field is never assigned to
+#pragma warning disable 0649
+
+        public string Target = null!;
+        public string Formula = null!;
+
+        // 0649 Field is never assigned to
+#pragma warning restore 0649
+    }
+}

--- a/CodeGen/JsonTypes/Unit.cs
+++ b/CodeGen/JsonTypes/Unit.cs
@@ -11,6 +11,7 @@ namespace CodeGen.JsonTypes
 #pragma warning disable 0649
 
         public BaseUnits? BaseUnits;
+        public Conversions[] Conversions = Array.Empty<Conversions>();
         public string FromBaseToUnitFunc = null!;
         public string FromUnitToBaseFunc = null!;
         public Localization[] Localization = Array.Empty<Localization>();

--- a/Common/UnitDefinitions/Mass.json
+++ b/Common/UnitDefinitions/Mass.json
@@ -136,6 +136,12 @@
       "BaseUnits": {
         "M": "Ounce"
       },
+      "Conversions": [
+        {
+          "Target": "Pound",
+          "Formula": "{x} / 16.0"
+        }
+      ],
       "FromUnitToBaseFunc": "{x} * 0.028349523125",
       "FromBaseToUnitFunc": "{x} / 0.028349523125",
       "XmlDocSummary": "The international avoirdupois ounce (abbreviated oz) is defined as exactly 28.349523125 g under the international yard and pound agreement of 1959, signed by the United States and countries of the Commonwealth of Nations. 16 oz make up an avoirdupois pound.",

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -1197,6 +1197,8 @@ namespace UnitsNet
 
             Mass? convertedOrNull = (Unit, unit) switch
             {
+                (MassUnit.Ounce, MassUnit.Pound) => new Mass(_value / 16.0, MassUnit.Pound),
+
                 // MassUnit -> BaseUnit
                 (MassUnit.Centigram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-2d, MassUnit.Kilogram),
                 (MassUnit.Decagram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e1d, MassUnit.Kilogram),


### PR DESCRIPTION
Implementing direct conversion functions would help reduce error. Currently, to go from ounces to pounds, we go:
ounces -> kilograms -> pounds

This shows an example of going directly from ounces -> pounds.

Long term, we could move all FromUnitToBaseFunc/FromBaseToUnitFunc into this conversions array.

Just a quick example to show what's on my mind.