### PR TITLE
samples: ⬆️ UnitsNet 4.7.0 to 5.0.9

### DIFF
--- a/Samples/MvvmSample.Wpf/MvvmSample.Wpf/Converters/UnitToStringConverter.cs
+++ b/Samples/MvvmSample.Wpf/MvvmSample.Wpf/Converters/UnitToStringConverter.cs
@@ -36,8 +36,7 @@ namespace WpfMVVMSample.Converters
 
             IQuantity quantityInUnit = quantity.ToUnit(unitEnumValue);
 
-            return quantityInUnit.ToString(null, significantDigits);
-
+            return quantityInUnit.ToString($"s{significantDigits}", null);
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/Samples/MvvmSample.Wpf/MvvmSample.Wpf/MvvmSample.Wpf.csproj
+++ b/Samples/MvvmSample.Wpf/MvvmSample.Wpf/MvvmSample.Wpf.csproj
@@ -82,8 +82,8 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="UnitsNet, Version=4.0.0.0, Culture=neutral, PublicKeyToken=f8601875a1f041da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\UnitsNet.4.7.0\lib\net40\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=5.0.0.0, Culture=neutral, PublicKeyToken=f8601875a1f041da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\UnitsNet.5.9.0\lib\netstandard2.0\UnitsNet.dll</HintPath>
     </Reference>
     <Reference Include="Unity.Abstractions, Version=3.3.1.0, Culture=neutral, PublicKeyToken=6d32ff45e0ccc69f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Unity.Abstractions.3.3.1\lib\net47\Unity.Abstractions.dll</HintPath>

--- a/Samples/MvvmSample.Wpf/MvvmSample.Wpf/packages.config
+++ b/Samples/MvvmSample.Wpf/MvvmSample.Wpf/packages.config
@@ -10,7 +10,7 @@
   <package id="System.Security.Permissions" version="4.5.0" targetFramework="net471" />
   <package id="System.Security.Principal.Windows" version="4.5.1" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
-  <package id="UnitsNet" version="4.7.0" targetFramework="net471" />
+  <package id="UnitsNet" version="5.9.0" targetFramework="net48" />
   <package id="Unity" version="5.8.11" targetFramework="net471" />
   <package id="Unity.Abstractions" version="3.3.1" targetFramework="net471" />
   <package id="Unity.Container" version="5.8.11" targetFramework="net471" />

--- a/Samples/UnitConverter.Console/UnitConverter.Console.csproj
+++ b/Samples/UnitConverter.Console/UnitConverter.Console.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="UnitsNet" Version="5.0.0-alpha001" />
+      <PackageReference Include="UnitsNet" Version="5.9.0" />
     </ItemGroup>
 
 </Project>

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/IMainWindowVm.cs
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/IMainWindowVm.cs
@@ -11,9 +11,9 @@ namespace UnitsNet.Samples.UnitConverter.Wpf
     /// </summary>
     public interface IMainWindowVm : INotifyPropertyChanged
     {
-        ReadOnlyObservableCollection<QuantityType> Quantities { get; }
+        ReadOnlyObservableCollection<string> Quantities { get; }
         ReadOnlyObservableCollection<UnitListItem> Units { get; }
-        QuantityType SelectedQuantity { get; set; }
+        string SelectedQuantity { get; set; }
 
         [CanBeNull]
         UnitListItem SelectedFromUnit { get; set; }

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/MainWindow.xaml
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/MainWindow.xaml
@@ -23,16 +23,16 @@
         </Grid.RowDefinitions>
 
         <GroupBox Header="Quantity" VerticalContentAlignment="Stretch" HorizontalContentAlignment="Stretch" Grid.RowSpan="2">
-            <ListBox 
-                 ItemsSource="{Binding Path=Quantities}" 
+            <ListBox
+                 ItemsSource="{Binding Path=Quantities}"
                  SelectedItem="{Binding SelectedQuantity, Mode=TwoWay}"
                  SelectionChanged="Selector_OnSelectionChanged" />
         </GroupBox>
 
         <GroupBox Header="From" Grid.Row="0" Grid.Column="1">
             <Grid>
-                <ListBox 
-                 ItemsSource="{Binding Path=Units}" 
+                <ListBox
+                 ItemsSource="{Binding Path=Units}"
                  DisplayMemberPath="Text"
                  SelectedItem="{Binding SelectedFromUnit, Mode=TwoWay}" />
             </Grid>
@@ -40,14 +40,14 @@
 
         <GroupBox Header="To" Grid.Row="0" Grid.Column="3">
             <Grid>
-                <ListBox 
-                 ItemsSource="{Binding Path=Units}" 
+                <ListBox
+                 ItemsSource="{Binding Path=Units}"
                  DisplayMemberPath="Text"
                  SelectedItem="{Binding SelectedToUnit, Mode=TwoWay}" />
             </Grid>
         </GroupBox>
 
-        
+
         <WrapPanel Grid.Row="1" Grid.Column="0" Margin="10">
             <!--Placeholder-->
         </WrapPanel>

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/MainWindowDesignVM.cs
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/MainWindowDesignVM.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using System.Windows.Input;
 
 namespace UnitsNet.Samples.UnitConverter.Wpf
@@ -15,17 +14,17 @@ namespace UnitsNet.Samples.UnitConverter.Wpf
     {
         public MainWindowDesignVm()
         {
-            Quantities = ToReadOnly(Quantity.Types);
+            Quantities = ToReadOnly(Quantity.Infos.Select(i => i.Name));
             Units = ToReadOnly(Length.Units.Select(u => new UnitListItem(u)));
-            SelectedQuantity = QuantityType.Length;
+            SelectedQuantity = Length.Info.Name;
             SelectedFromUnit = Units[1];
             SelectedToUnit = Units[2];
         }
 
 
-        public ReadOnlyObservableCollection<QuantityType> Quantities { get; }
+        public ReadOnlyObservableCollection<string> Quantities { get; }
         public ReadOnlyObservableCollection<UnitListItem> Units { get; }
-        public QuantityType SelectedQuantity { get; set; }
+        public string SelectedQuantity { get; set; }
         public UnitListItem SelectedFromUnit { get; set; }
         public UnitListItem SelectedToUnit { get; set; }
 

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/MainWindowVM.cs
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/MainWindowVM.cs
@@ -21,7 +21,7 @@ namespace UnitsNet.Samples.UnitConverter.Wpf
 
         [CanBeNull] private UnitListItem _selectedFromUnit;
 
-        private QuantityType _selectedQuantity;
+        private string _selectedQuantity;
 
         [CanBeNull] private UnitListItem _selectedToUnit;
 
@@ -29,7 +29,7 @@ namespace UnitsNet.Samples.UnitConverter.Wpf
 
         public MainWindowVm()
         {
-            Quantities = ToReadOnly(Quantity.Types);
+            Quantities = ToReadOnly(Quantity.Infos.Select(i => i.Name));
 
             _units = new ObservableCollection<UnitListItem>();
             Units = new ReadOnlyObservableCollection<UnitListItem>(_units);
@@ -38,15 +38,15 @@ namespace UnitsNet.Samples.UnitConverter.Wpf
             FromValue = 1;
             SwapCommand = new DelegateCommand(Swap);
 
-            OnSelectedQuantity(QuantityType.Length);
+            OnSelectedQuantity(Length.Info.Name);
         }
 
         public ICommand SwapCommand { get; }
 
-        public ReadOnlyObservableCollection<QuantityType> Quantities { get; }
+        public ReadOnlyObservableCollection<string> Quantities { get; }
         public ReadOnlyObservableCollection<UnitListItem> Units { get; }
 
-        public QuantityType SelectedQuantity
+        public string SelectedQuantity
         {
             get => _selectedQuantity;
             set
@@ -138,12 +138,12 @@ namespace UnitsNet.Samples.UnitConverter.Wpf
             ToValue = Convert.ToDecimal(convertedValue);
         }
 
-        private void OnSelectedQuantity(QuantityType quantityType)
+        private void OnSelectedQuantity(string quantityName)
         {
-            QuantityInfo quantityInfo = Quantity.GetInfo(quantityType);
+            QuantityInfo quantityInfo = Quantity.ByName[quantityName];
 
             _units.Clear();
-            foreach (Enum unitValue in quantityInfo.Units)
+            foreach (Enum unitValue in quantityInfo.UnitInfos.Select(ui => ui.Value))
             {
                 _units.Add(new UnitListItem(unitValue));
             }

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/UnitConverter.Wpf.csproj
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/UnitConverter.Wpf.csproj
@@ -61,8 +61,8 @@
     <Reference Include="System.Xaml">
       <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
-    <Reference Include="UnitsNet, Version=4.0.0.0, Culture=neutral, PublicKeyToken=f8601875a1f041da, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\UnitsNet.4.7.0\lib\net40\UnitsNet.dll</HintPath>
+    <Reference Include="UnitsNet, Version=5.0.0.0, Culture=neutral, PublicKeyToken=f8601875a1f041da, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\UnitsNet.5.9.0\lib\netstandard2.0\UnitsNet.dll</HintPath>
     </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/packages.config
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/packages.config
@@ -3,5 +3,5 @@
   <package id="ControlzEx" version="3.0.2.4" targetFramework="net471" />
   <package id="MahApps.Metro" version="1.6.5" targetFramework="net471" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net471" />
-  <package id="UnitsNet" version="4.7.0" targetFramework="net471" />
+  <package id="UnitsNet" version="5.9.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Main breaking change was the removal of `QuantityType` enum, replaced with quantity names instead.