### PR TITLE
codegen: 🐛 Fix consistent ordering of units

### DIFF
--- a/CodeGen/Generators/QuantityJsonFilesParser.cs
+++ b/CodeGen/Generators/QuantityJsonFilesParser.cs
@@ -60,7 +60,7 @@ namespace CodeGen.Generators
 
         private static void OrderUnitsByName(Quantity quantity)
         {
-            quantity.Units = quantity.Units.OrderBy(u => u.SingularName).ToArray();
+            quantity.Units = quantity.Units.OrderBy(u => u.SingularName, StringComparer.OrdinalIgnoreCase).ToArray();
         }
 
         private static void FixConversionFunctionsForDecimalValueTypes(Quantity quantity)


### PR DESCRIPTION
The ordering seemed to vary on computers resulting in annoying diffs for PRs.
Fixed by specifying the string comparer, assuming the default was affected by the system's culture.

Verified fix in a recent PR where running codegen locally resulted in a diff. With this fix, there was no diff.