### PR TITLE
Add picograms and femtograms

### DIFF
--- a/Common/UnitDefinitions/Mass.json
+++ b/Common/UnitDefinitions/Mass.json
@@ -14,7 +14,7 @@
       },
       "FromUnitToBaseFunc": "{x} / 1e3",
       "FromBaseToUnitFunc": "{x} * 1e3",
-      "Prefixes": [ "Nano", "Micro", "Milli", "Centi", "Deci", "Deca", "Hecto", "Kilo" ],
+      "Prefixes": [ "Femto", "Pico", "Nano", "Micro", "Milli", "Centi", "Deci", "Deca", "Hecto", "Kilo" ],
       "Localization": [
         {
           "Culture": "en-US",

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -789,7 +789,9 @@
     "Slug": 22,
     "SolarMass": 23,
     "Stone": 24,
-    "Tonne": 25
+    "Tonne": 25,
+    "Femtogram": 35,
+    "Picogram": 29
   },
   "MassConcentration": {
     "CentigramPerDeciliter": 1,

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/Mass.g.cs
@@ -100,6 +100,11 @@ namespace UnitsNet
         public double EarthMasses => As(MassUnit.EarthMass);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Femtogram"/>
+        /// </summary>
+        public double Femtograms => As(MassUnit.Femtogram);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Grain"/>
         /// </summary>
         public double Grains => As(MassUnit.Grain);
@@ -170,6 +175,11 @@ namespace UnitsNet
         public double Ounces => As(MassUnit.Ounce);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Picogram"/>
+        /// </summary>
+        public double Picograms => As(MassUnit.Picogram);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Pound"/>
         /// </summary>
         public double Pounds => As(MassUnit.Pound);
@@ -231,6 +241,12 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static Mass FromEarthMasses(double earthmasses) => new Mass(earthmasses, MassUnit.EarthMass);
+
+        /// <summary>
+        ///     Creates a <see cref="Mass"/> from <see cref="MassUnit.Femtogram"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Mass FromFemtograms(double femtograms) => new Mass(femtograms, MassUnit.Femtogram);
 
         /// <summary>
         ///     Creates a <see cref="Mass"/> from <see cref="MassUnit.Grain"/>.
@@ -315,6 +331,12 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static Mass FromOunces(double ounces) => new Mass(ounces, MassUnit.Ounce);
+
+        /// <summary>
+        ///     Creates a <see cref="Mass"/> from <see cref="MassUnit.Picogram"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Mass FromPicograms(double picograms) => new Mass(picograms, MassUnit.Picogram);
 
         /// <summary>
         ///     Creates a <see cref="Mass"/> from <see cref="MassUnit.Pound"/>.
@@ -402,6 +424,7 @@ namespace UnitsNet
                         MassUnit.Decagram => (_value / 1e3) * 1e1d,
                         MassUnit.Decigram => (_value / 1e3) * 1e-1d,
                         MassUnit.EarthMass => _value * 5.9722E+24,
+                        MassUnit.Femtogram => (_value / 1e3) * 1e-15d,
                         MassUnit.Grain => _value / 15432.358352941431,
                         MassUnit.Gram => _value / 1e3,
                         MassUnit.Hectogram => (_value / 1e3) * 1e2d,
@@ -416,6 +439,7 @@ namespace UnitsNet
                         MassUnit.Milligram => (_value / 1e3) * 1e-3d,
                         MassUnit.Nanogram => (_value / 1e3) * 1e-9d,
                         MassUnit.Ounce => _value * 0.028349523125,
+                        MassUnit.Picogram => (_value / 1e3) * 1e-12d,
                         MassUnit.Pound => _value * 0.45359237,
                         MassUnit.ShortHundredweight => _value / 0.022046226218487758,
                         MassUnit.ShortTon => _value * 9.0718474e2,
@@ -440,6 +464,7 @@ namespace UnitsNet
                         MassUnit.Decagram => (baseUnitValue * 1e3) / 1e1d,
                         MassUnit.Decigram => (baseUnitValue * 1e3) / 1e-1d,
                         MassUnit.EarthMass => baseUnitValue / 5.9722E+24,
+                        MassUnit.Femtogram => (baseUnitValue * 1e3) / 1e-15d,
                         MassUnit.Grain => baseUnitValue * 15432.358352941431,
                         MassUnit.Gram => baseUnitValue * 1e3,
                         MassUnit.Hectogram => (baseUnitValue * 1e3) / 1e2d,
@@ -454,6 +479,7 @@ namespace UnitsNet
                         MassUnit.Milligram => (baseUnitValue * 1e3) / 1e-3d,
                         MassUnit.Nanogram => (baseUnitValue * 1e3) / 1e-9d,
                         MassUnit.Ounce => baseUnitValue / 0.028349523125,
+                        MassUnit.Picogram => (baseUnitValue * 1e3) / 1e-12d,
                         MassUnit.Pound => baseUnitValue / 0.45359237,
                         MassUnit.ShortHundredweight => baseUnitValue * 0.022046226218487758,
                         MassUnit.ShortTon => baseUnitValue / 9.0718474e2,

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/MassUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/MassUnit.g.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Units
         /// </summary>
         /// <remarks>https://en.wikipedia.org/wiki/Earth_mass</remarks>
         EarthMass = 4,
+        Femtogram = 35,
 
         /// <summary>
         ///     A grain is a unit of measurement of mass, and in the troy weight, avoirdupois, and Apothecaries' system, equal to exactly 64.79891 milligrams.
@@ -68,6 +69,7 @@ namespace UnitsNet.Units
         /// </summary>
         /// <remarks>https://en.wikipedia.org/wiki/Ounce</remarks>
         Ounce = 18,
+        Picogram = 29,
 
         /// <summary>
         ///     The pound or pound-mass (abbreviations: lb, lbm) is a unit of mass used in the imperial, United States customary and other systems of measurement. A number of different definitions have been used, the most common today being the international avoirdupois pound which is legally defined as exactly 0.45359237 kilograms, and which is divided into 16 avoirdupois ounces.

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToMassExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToMassExtensionsTest.g.cs
@@ -41,6 +41,10 @@ namespace UnitsNet.Tests
             Assert.Equal(Mass.FromEarthMasses(2), 2.EarthMasses());
 
         [Fact]
+        public void NumberToFemtogramsTest() =>
+            Assert.Equal(Mass.FromFemtograms(2), 2.Femtograms());
+
+        [Fact]
         public void NumberToGrainsTest() =>
             Assert.Equal(Mass.FromGrains(2), 2.Grains());
 
@@ -95,6 +99,10 @@ namespace UnitsNet.Tests
         [Fact]
         public void NumberToOuncesTest() =>
             Assert.Equal(Mass.FromOunces(2), 2.Ounces());
+
+        [Fact]
+        public void NumberToPicogramsTest() =>
+            Assert.Equal(Mass.FromPicograms(2), 2.Picograms());
 
         [Fact]
         public void NumberToPoundsTest() =>

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToMassExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToMassExtensions.g.cs
@@ -44,6 +44,10 @@ namespace UnitsNet.NumberExtensions.NumberToMass
         public static Mass EarthMasses<T>(this T value) =>
             Mass.FromEarthMasses(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Mass.FromFemtograms(UnitsNet.QuantityValue)" />
+        public static Mass Femtograms<T>(this T value) =>
+            Mass.FromFemtograms(Convert.ToDouble(value));
+
         /// <inheritdoc cref="Mass.FromGrains(UnitsNet.QuantityValue)" />
         public static Mass Grains<T>(this T value) =>
             Mass.FromGrains(Convert.ToDouble(value));
@@ -99,6 +103,10 @@ namespace UnitsNet.NumberExtensions.NumberToMass
         /// <inheritdoc cref="Mass.FromOunces(UnitsNet.QuantityValue)" />
         public static Mass Ounces<T>(this T value) =>
             Mass.FromOunces(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="Mass.FromPicograms(UnitsNet.QuantityValue)" />
+        public static Mass Picograms<T>(this T value) =>
+            Mass.FromPicograms(Convert.ToDouble(value));
 
         /// <inheritdoc cref="Mass.FromPounds(UnitsNet.QuantityValue)" />
         public static Mass Pounds<T>(this T value) =>

--- a/UnitsNet.Tests/CustomCode/MassTests.cs
+++ b/UnitsNet.Tests/CustomCode/MassTests.cs
@@ -63,6 +63,10 @@ namespace UnitsNet.Tests
 
         protected override double SolarMassesInOneKilogram => 5.0264643347223100000000000E-31;
 
+        protected override double FemtogramsInOneKilogram => 1E18;
+
+        protected override double PicogramsInOneKilogram => 1E15;
+
         //protected override double SolarMassesTolerance => 0.1;
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet.Tests
         protected abstract double DecagramsInOneKilogram { get; }
         protected abstract double DecigramsInOneKilogram { get; }
         protected abstract double EarthMassesInOneKilogram { get; }
+        protected abstract double FemtogramsInOneKilogram { get; }
         protected abstract double GrainsInOneKilogram { get; }
         protected abstract double GramsInOneKilogram { get; }
         protected abstract double HectogramsInOneKilogram { get; }
@@ -56,6 +57,7 @@ namespace UnitsNet.Tests
         protected abstract double MilligramsInOneKilogram { get; }
         protected abstract double NanogramsInOneKilogram { get; }
         protected abstract double OuncesInOneKilogram { get; }
+        protected abstract double PicogramsInOneKilogram { get; }
         protected abstract double PoundsInOneKilogram { get; }
         protected abstract double ShortHundredweightInOneKilogram { get; }
         protected abstract double ShortTonsInOneKilogram { get; }
@@ -69,6 +71,7 @@ namespace UnitsNet.Tests
         protected virtual double DecagramsTolerance { get { return 1e-5; } }
         protected virtual double DecigramsTolerance { get { return 1e-5; } }
         protected virtual double EarthMassesTolerance { get { return 1e-5; } }
+        protected virtual double FemtogramsTolerance { get { return 1e-5; } }
         protected virtual double GrainsTolerance { get { return 1e-5; } }
         protected virtual double GramsTolerance { get { return 1e-5; } }
         protected virtual double HectogramsTolerance { get { return 1e-5; } }
@@ -83,6 +86,7 @@ namespace UnitsNet.Tests
         protected virtual double MilligramsTolerance { get { return 1e-5; } }
         protected virtual double NanogramsTolerance { get { return 1e-5; } }
         protected virtual double OuncesTolerance { get { return 1e-5; } }
+        protected virtual double PicogramsTolerance { get { return 1e-5; } }
         protected virtual double PoundsTolerance { get { return 1e-5; } }
         protected virtual double ShortHundredweightTolerance { get { return 1e-5; } }
         protected virtual double ShortTonsTolerance { get { return 1e-5; } }
@@ -100,6 +104,7 @@ namespace UnitsNet.Tests
                 MassUnit.Decagram => (DecagramsInOneKilogram, DecagramsTolerance),
                 MassUnit.Decigram => (DecigramsInOneKilogram, DecigramsTolerance),
                 MassUnit.EarthMass => (EarthMassesInOneKilogram, EarthMassesTolerance),
+                MassUnit.Femtogram => (FemtogramsInOneKilogram, FemtogramsTolerance),
                 MassUnit.Grain => (GrainsInOneKilogram, GrainsTolerance),
                 MassUnit.Gram => (GramsInOneKilogram, GramsTolerance),
                 MassUnit.Hectogram => (HectogramsInOneKilogram, HectogramsTolerance),
@@ -114,6 +119,7 @@ namespace UnitsNet.Tests
                 MassUnit.Milligram => (MilligramsInOneKilogram, MilligramsTolerance),
                 MassUnit.Nanogram => (NanogramsInOneKilogram, NanogramsTolerance),
                 MassUnit.Ounce => (OuncesInOneKilogram, OuncesTolerance),
+                MassUnit.Picogram => (PicogramsInOneKilogram, PicogramsTolerance),
                 MassUnit.Pound => (PoundsInOneKilogram, PoundsTolerance),
                 MassUnit.ShortHundredweight => (ShortHundredweightInOneKilogram, ShortHundredweightTolerance),
                 MassUnit.ShortTon => (ShortTonsInOneKilogram, ShortTonsTolerance),
@@ -131,6 +137,7 @@ namespace UnitsNet.Tests
             new object[] { MassUnit.Decagram },
             new object[] { MassUnit.Decigram },
             new object[] { MassUnit.EarthMass },
+            new object[] { MassUnit.Femtogram },
             new object[] { MassUnit.Grain },
             new object[] { MassUnit.Gram },
             new object[] { MassUnit.Hectogram },
@@ -145,6 +152,7 @@ namespace UnitsNet.Tests
             new object[] { MassUnit.Milligram },
             new object[] { MassUnit.Nanogram },
             new object[] { MassUnit.Ounce },
+            new object[] { MassUnit.Picogram },
             new object[] { MassUnit.Pound },
             new object[] { MassUnit.ShortHundredweight },
             new object[] { MassUnit.ShortTon },
@@ -218,6 +226,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DecagramsInOneKilogram, kilogram.Decagrams, DecagramsTolerance);
             AssertEx.EqualTolerance(DecigramsInOneKilogram, kilogram.Decigrams, DecigramsTolerance);
             AssertEx.EqualTolerance(EarthMassesInOneKilogram, kilogram.EarthMasses, EarthMassesTolerance);
+            AssertEx.EqualTolerance(FemtogramsInOneKilogram, kilogram.Femtograms, FemtogramsTolerance);
             AssertEx.EqualTolerance(GrainsInOneKilogram, kilogram.Grains, GrainsTolerance);
             AssertEx.EqualTolerance(GramsInOneKilogram, kilogram.Grams, GramsTolerance);
             AssertEx.EqualTolerance(HectogramsInOneKilogram, kilogram.Hectograms, HectogramsTolerance);
@@ -232,6 +241,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(MilligramsInOneKilogram, kilogram.Milligrams, MilligramsTolerance);
             AssertEx.EqualTolerance(NanogramsInOneKilogram, kilogram.Nanograms, NanogramsTolerance);
             AssertEx.EqualTolerance(OuncesInOneKilogram, kilogram.Ounces, OuncesTolerance);
+            AssertEx.EqualTolerance(PicogramsInOneKilogram, kilogram.Picograms, PicogramsTolerance);
             AssertEx.EqualTolerance(PoundsInOneKilogram, kilogram.Pounds, PoundsTolerance);
             AssertEx.EqualTolerance(ShortHundredweightInOneKilogram, kilogram.ShortHundredweight, ShortHundredweightTolerance);
             AssertEx.EqualTolerance(ShortTonsInOneKilogram, kilogram.ShortTons, ShortTonsTolerance);
@@ -260,89 +270,97 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity03.EarthMasses, EarthMassesTolerance);
             Assert.Equal(MassUnit.EarthMass, quantity03.Unit);
 
-            var quantity04 = Mass.From(1, MassUnit.Grain);
-            AssertEx.EqualTolerance(1, quantity04.Grains, GrainsTolerance);
-            Assert.Equal(MassUnit.Grain, quantity04.Unit);
+            var quantity04 = Mass.From(1, MassUnit.Femtogram);
+            AssertEx.EqualTolerance(1, quantity04.Femtograms, FemtogramsTolerance);
+            Assert.Equal(MassUnit.Femtogram, quantity04.Unit);
 
-            var quantity05 = Mass.From(1, MassUnit.Gram);
-            AssertEx.EqualTolerance(1, quantity05.Grams, GramsTolerance);
-            Assert.Equal(MassUnit.Gram, quantity05.Unit);
+            var quantity05 = Mass.From(1, MassUnit.Grain);
+            AssertEx.EqualTolerance(1, quantity05.Grains, GrainsTolerance);
+            Assert.Equal(MassUnit.Grain, quantity05.Unit);
 
-            var quantity06 = Mass.From(1, MassUnit.Hectogram);
-            AssertEx.EqualTolerance(1, quantity06.Hectograms, HectogramsTolerance);
-            Assert.Equal(MassUnit.Hectogram, quantity06.Unit);
+            var quantity06 = Mass.From(1, MassUnit.Gram);
+            AssertEx.EqualTolerance(1, quantity06.Grams, GramsTolerance);
+            Assert.Equal(MassUnit.Gram, quantity06.Unit);
 
-            var quantity07 = Mass.From(1, MassUnit.Kilogram);
-            AssertEx.EqualTolerance(1, quantity07.Kilograms, KilogramsTolerance);
-            Assert.Equal(MassUnit.Kilogram, quantity07.Unit);
+            var quantity07 = Mass.From(1, MassUnit.Hectogram);
+            AssertEx.EqualTolerance(1, quantity07.Hectograms, HectogramsTolerance);
+            Assert.Equal(MassUnit.Hectogram, quantity07.Unit);
 
-            var quantity08 = Mass.From(1, MassUnit.Kilopound);
-            AssertEx.EqualTolerance(1, quantity08.Kilopounds, KilopoundsTolerance);
-            Assert.Equal(MassUnit.Kilopound, quantity08.Unit);
+            var quantity08 = Mass.From(1, MassUnit.Kilogram);
+            AssertEx.EqualTolerance(1, quantity08.Kilograms, KilogramsTolerance);
+            Assert.Equal(MassUnit.Kilogram, quantity08.Unit);
 
-            var quantity09 = Mass.From(1, MassUnit.Kilotonne);
-            AssertEx.EqualTolerance(1, quantity09.Kilotonnes, KilotonnesTolerance);
-            Assert.Equal(MassUnit.Kilotonne, quantity09.Unit);
+            var quantity09 = Mass.From(1, MassUnit.Kilopound);
+            AssertEx.EqualTolerance(1, quantity09.Kilopounds, KilopoundsTolerance);
+            Assert.Equal(MassUnit.Kilopound, quantity09.Unit);
 
-            var quantity10 = Mass.From(1, MassUnit.LongHundredweight);
-            AssertEx.EqualTolerance(1, quantity10.LongHundredweight, LongHundredweightTolerance);
-            Assert.Equal(MassUnit.LongHundredweight, quantity10.Unit);
+            var quantity10 = Mass.From(1, MassUnit.Kilotonne);
+            AssertEx.EqualTolerance(1, quantity10.Kilotonnes, KilotonnesTolerance);
+            Assert.Equal(MassUnit.Kilotonne, quantity10.Unit);
 
-            var quantity11 = Mass.From(1, MassUnit.LongTon);
-            AssertEx.EqualTolerance(1, quantity11.LongTons, LongTonsTolerance);
-            Assert.Equal(MassUnit.LongTon, quantity11.Unit);
+            var quantity11 = Mass.From(1, MassUnit.LongHundredweight);
+            AssertEx.EqualTolerance(1, quantity11.LongHundredweight, LongHundredweightTolerance);
+            Assert.Equal(MassUnit.LongHundredweight, quantity11.Unit);
 
-            var quantity12 = Mass.From(1, MassUnit.Megapound);
-            AssertEx.EqualTolerance(1, quantity12.Megapounds, MegapoundsTolerance);
-            Assert.Equal(MassUnit.Megapound, quantity12.Unit);
+            var quantity12 = Mass.From(1, MassUnit.LongTon);
+            AssertEx.EqualTolerance(1, quantity12.LongTons, LongTonsTolerance);
+            Assert.Equal(MassUnit.LongTon, quantity12.Unit);
 
-            var quantity13 = Mass.From(1, MassUnit.Megatonne);
-            AssertEx.EqualTolerance(1, quantity13.Megatonnes, MegatonnesTolerance);
-            Assert.Equal(MassUnit.Megatonne, quantity13.Unit);
+            var quantity13 = Mass.From(1, MassUnit.Megapound);
+            AssertEx.EqualTolerance(1, quantity13.Megapounds, MegapoundsTolerance);
+            Assert.Equal(MassUnit.Megapound, quantity13.Unit);
 
-            var quantity14 = Mass.From(1, MassUnit.Microgram);
-            AssertEx.EqualTolerance(1, quantity14.Micrograms, MicrogramsTolerance);
-            Assert.Equal(MassUnit.Microgram, quantity14.Unit);
+            var quantity14 = Mass.From(1, MassUnit.Megatonne);
+            AssertEx.EqualTolerance(1, quantity14.Megatonnes, MegatonnesTolerance);
+            Assert.Equal(MassUnit.Megatonne, quantity14.Unit);
 
-            var quantity15 = Mass.From(1, MassUnit.Milligram);
-            AssertEx.EqualTolerance(1, quantity15.Milligrams, MilligramsTolerance);
-            Assert.Equal(MassUnit.Milligram, quantity15.Unit);
+            var quantity15 = Mass.From(1, MassUnit.Microgram);
+            AssertEx.EqualTolerance(1, quantity15.Micrograms, MicrogramsTolerance);
+            Assert.Equal(MassUnit.Microgram, quantity15.Unit);
 
-            var quantity16 = Mass.From(1, MassUnit.Nanogram);
-            AssertEx.EqualTolerance(1, quantity16.Nanograms, NanogramsTolerance);
-            Assert.Equal(MassUnit.Nanogram, quantity16.Unit);
+            var quantity16 = Mass.From(1, MassUnit.Milligram);
+            AssertEx.EqualTolerance(1, quantity16.Milligrams, MilligramsTolerance);
+            Assert.Equal(MassUnit.Milligram, quantity16.Unit);
 
-            var quantity17 = Mass.From(1, MassUnit.Ounce);
-            AssertEx.EqualTolerance(1, quantity17.Ounces, OuncesTolerance);
-            Assert.Equal(MassUnit.Ounce, quantity17.Unit);
+            var quantity17 = Mass.From(1, MassUnit.Nanogram);
+            AssertEx.EqualTolerance(1, quantity17.Nanograms, NanogramsTolerance);
+            Assert.Equal(MassUnit.Nanogram, quantity17.Unit);
 
-            var quantity18 = Mass.From(1, MassUnit.Pound);
-            AssertEx.EqualTolerance(1, quantity18.Pounds, PoundsTolerance);
-            Assert.Equal(MassUnit.Pound, quantity18.Unit);
+            var quantity18 = Mass.From(1, MassUnit.Ounce);
+            AssertEx.EqualTolerance(1, quantity18.Ounces, OuncesTolerance);
+            Assert.Equal(MassUnit.Ounce, quantity18.Unit);
 
-            var quantity19 = Mass.From(1, MassUnit.ShortHundredweight);
-            AssertEx.EqualTolerance(1, quantity19.ShortHundredweight, ShortHundredweightTolerance);
-            Assert.Equal(MassUnit.ShortHundredweight, quantity19.Unit);
+            var quantity19 = Mass.From(1, MassUnit.Picogram);
+            AssertEx.EqualTolerance(1, quantity19.Picograms, PicogramsTolerance);
+            Assert.Equal(MassUnit.Picogram, quantity19.Unit);
 
-            var quantity20 = Mass.From(1, MassUnit.ShortTon);
-            AssertEx.EqualTolerance(1, quantity20.ShortTons, ShortTonsTolerance);
-            Assert.Equal(MassUnit.ShortTon, quantity20.Unit);
+            var quantity20 = Mass.From(1, MassUnit.Pound);
+            AssertEx.EqualTolerance(1, quantity20.Pounds, PoundsTolerance);
+            Assert.Equal(MassUnit.Pound, quantity20.Unit);
 
-            var quantity21 = Mass.From(1, MassUnit.Slug);
-            AssertEx.EqualTolerance(1, quantity21.Slugs, SlugsTolerance);
-            Assert.Equal(MassUnit.Slug, quantity21.Unit);
+            var quantity21 = Mass.From(1, MassUnit.ShortHundredweight);
+            AssertEx.EqualTolerance(1, quantity21.ShortHundredweight, ShortHundredweightTolerance);
+            Assert.Equal(MassUnit.ShortHundredweight, quantity21.Unit);
 
-            var quantity22 = Mass.From(1, MassUnit.SolarMass);
-            AssertEx.EqualTolerance(1, quantity22.SolarMasses, SolarMassesTolerance);
-            Assert.Equal(MassUnit.SolarMass, quantity22.Unit);
+            var quantity22 = Mass.From(1, MassUnit.ShortTon);
+            AssertEx.EqualTolerance(1, quantity22.ShortTons, ShortTonsTolerance);
+            Assert.Equal(MassUnit.ShortTon, quantity22.Unit);
 
-            var quantity23 = Mass.From(1, MassUnit.Stone);
-            AssertEx.EqualTolerance(1, quantity23.Stone, StoneTolerance);
-            Assert.Equal(MassUnit.Stone, quantity23.Unit);
+            var quantity23 = Mass.From(1, MassUnit.Slug);
+            AssertEx.EqualTolerance(1, quantity23.Slugs, SlugsTolerance);
+            Assert.Equal(MassUnit.Slug, quantity23.Unit);
 
-            var quantity24 = Mass.From(1, MassUnit.Tonne);
-            AssertEx.EqualTolerance(1, quantity24.Tonnes, TonnesTolerance);
-            Assert.Equal(MassUnit.Tonne, quantity24.Unit);
+            var quantity24 = Mass.From(1, MassUnit.SolarMass);
+            AssertEx.EqualTolerance(1, quantity24.SolarMasses, SolarMassesTolerance);
+            Assert.Equal(MassUnit.SolarMass, quantity24.Unit);
+
+            var quantity25 = Mass.From(1, MassUnit.Stone);
+            AssertEx.EqualTolerance(1, quantity25.Stone, StoneTolerance);
+            Assert.Equal(MassUnit.Stone, quantity25.Unit);
+
+            var quantity26 = Mass.From(1, MassUnit.Tonne);
+            AssertEx.EqualTolerance(1, quantity26.Tonnes, TonnesTolerance);
+            Assert.Equal(MassUnit.Tonne, quantity26.Unit);
 
         }
 
@@ -367,6 +385,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(DecagramsInOneKilogram, kilogram.As(MassUnit.Decagram), DecagramsTolerance);
             AssertEx.EqualTolerance(DecigramsInOneKilogram, kilogram.As(MassUnit.Decigram), DecigramsTolerance);
             AssertEx.EqualTolerance(EarthMassesInOneKilogram, kilogram.As(MassUnit.EarthMass), EarthMassesTolerance);
+            AssertEx.EqualTolerance(FemtogramsInOneKilogram, kilogram.As(MassUnit.Femtogram), FemtogramsTolerance);
             AssertEx.EqualTolerance(GrainsInOneKilogram, kilogram.As(MassUnit.Grain), GrainsTolerance);
             AssertEx.EqualTolerance(GramsInOneKilogram, kilogram.As(MassUnit.Gram), GramsTolerance);
             AssertEx.EqualTolerance(HectogramsInOneKilogram, kilogram.As(MassUnit.Hectogram), HectogramsTolerance);
@@ -381,6 +400,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(MilligramsInOneKilogram, kilogram.As(MassUnit.Milligram), MilligramsTolerance);
             AssertEx.EqualTolerance(NanogramsInOneKilogram, kilogram.As(MassUnit.Nanogram), NanogramsTolerance);
             AssertEx.EqualTolerance(OuncesInOneKilogram, kilogram.As(MassUnit.Ounce), OuncesTolerance);
+            AssertEx.EqualTolerance(PicogramsInOneKilogram, kilogram.As(MassUnit.Picogram), PicogramsTolerance);
             AssertEx.EqualTolerance(PoundsInOneKilogram, kilogram.As(MassUnit.Pound), PoundsTolerance);
             AssertEx.EqualTolerance(ShortHundredweightInOneKilogram, kilogram.As(MassUnit.ShortHundredweight), ShortHundredweightTolerance);
             AssertEx.EqualTolerance(ShortTonsInOneKilogram, kilogram.As(MassUnit.ShortTon), ShortTonsTolerance);
@@ -478,6 +498,27 @@ namespace UnitsNet.Tests
                 var parsed = Mass.Parse("1 em", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.EarthMasses, EarthMassesTolerance);
                 Assert.Equal(MassUnit.EarthMass, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = Mass.Parse("1 fg", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.Femtograms, FemtogramsTolerance);
+                Assert.Equal(MassUnit.Femtogram, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = Mass.Parse("1 фг", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.Femtograms, FemtogramsTolerance);
+                Assert.Equal(MassUnit.Femtogram, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = Mass.Parse("1 飞克", CultureInfo.GetCultureInfo("zh-CN"));
+                AssertEx.EqualTolerance(1, parsed.Femtograms, FemtogramsTolerance);
+                Assert.Equal(MassUnit.Femtogram, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -769,6 +810,27 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsed = Mass.Parse("1 pg", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.Picograms, PicogramsTolerance);
+                Assert.Equal(MassUnit.Picogram, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = Mass.Parse("1 пг", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.Picograms, PicogramsTolerance);
+                Assert.Equal(MassUnit.Picogram, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = Mass.Parse("1 皮克", CultureInfo.GetCultureInfo("zh-CN"));
+                AssertEx.EqualTolerance(1, parsed.Picograms, PicogramsTolerance);
+                Assert.Equal(MassUnit.Picogram, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = Mass.Parse("1 lb", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.Pounds, PoundsTolerance);
                 Assert.Equal(MassUnit.Pound, parsed.Unit);
@@ -956,6 +1018,24 @@ namespace UnitsNet.Tests
                 Assert.True(Mass.TryParse("1 em", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.EarthMasses, EarthMassesTolerance);
                 Assert.Equal(MassUnit.EarthMass, parsed.Unit);
+            }
+
+            {
+                Assert.True(Mass.TryParse("1 fg", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Femtograms, FemtogramsTolerance);
+                Assert.Equal(MassUnit.Femtogram, parsed.Unit);
+            }
+
+            {
+                Assert.True(Mass.TryParse("1 фг", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Femtograms, FemtogramsTolerance);
+                Assert.Equal(MassUnit.Femtogram, parsed.Unit);
+            }
+
+            {
+                Assert.True(Mass.TryParse("1 飞克", CultureInfo.GetCultureInfo("zh-CN"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Femtograms, FemtogramsTolerance);
+                Assert.Equal(MassUnit.Femtogram, parsed.Unit);
             }
 
             {
@@ -1199,6 +1279,24 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(Mass.TryParse("1 pg", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Picograms, PicogramsTolerance);
+                Assert.Equal(MassUnit.Picogram, parsed.Unit);
+            }
+
+            {
+                Assert.True(Mass.TryParse("1 пг", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Picograms, PicogramsTolerance);
+                Assert.Equal(MassUnit.Picogram, parsed.Unit);
+            }
+
+            {
+                Assert.True(Mass.TryParse("1 皮克", CultureInfo.GetCultureInfo("zh-CN"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Picograms, PicogramsTolerance);
+                Assert.Equal(MassUnit.Picogram, parsed.Unit);
+            }
+
+            {
                 Assert.True(Mass.TryParse("1 lb", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.Pounds, PoundsTolerance);
                 Assert.Equal(MassUnit.Pound, parsed.Unit);
@@ -1351,6 +1449,24 @@ namespace UnitsNet.Tests
             {
                 var parsedUnit = Mass.ParseUnit("em", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(MassUnit.EarthMass, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = Mass.ParseUnit("fg", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(MassUnit.Femtogram, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = Mass.ParseUnit("фг", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(MassUnit.Femtogram, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = Mass.ParseUnit("飞克", CultureInfo.GetCultureInfo("zh-CN"));
+                Assert.Equal(MassUnit.Femtogram, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -1601,6 +1717,24 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsedUnit = Mass.ParseUnit("pg", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(MassUnit.Picogram, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = Mass.ParseUnit("пг", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(MassUnit.Picogram, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = Mass.ParseUnit("皮克", CultureInfo.GetCultureInfo("zh-CN"));
+                Assert.Equal(MassUnit.Picogram, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsedUnit = Mass.ParseUnit("lb", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(MassUnit.Pound, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -1760,6 +1894,21 @@ namespace UnitsNet.Tests
             {
                 Assert.True(Mass.TryParseUnit("em", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(MassUnit.EarthMass, parsedUnit);
+            }
+
+            {
+                Assert.True(Mass.TryParseUnit("fg", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(MassUnit.Femtogram, parsedUnit);
+            }
+
+            {
+                Assert.True(Mass.TryParseUnit("фг", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(MassUnit.Femtogram, parsedUnit);
+            }
+
+            {
+                Assert.True(Mass.TryParseUnit("飞克", CultureInfo.GetCultureInfo("zh-CN"), out var parsedUnit));
+                Assert.Equal(MassUnit.Femtogram, parsedUnit);
             }
 
             {
@@ -1963,6 +2112,21 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(Mass.TryParseUnit("pg", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(MassUnit.Picogram, parsedUnit);
+            }
+
+            {
+                Assert.True(Mass.TryParseUnit("пг", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(MassUnit.Picogram, parsedUnit);
+            }
+
+            {
+                Assert.True(Mass.TryParseUnit("皮克", CultureInfo.GetCultureInfo("zh-CN"), out var parsedUnit));
+                Assert.Equal(MassUnit.Picogram, parsedUnit);
+            }
+
+            {
                 Assert.True(Mass.TryParseUnit("lb", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(MassUnit.Pound, parsedUnit);
             }
@@ -2089,6 +2253,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Mass.FromDecagrams(kilogram.Decagrams).Kilograms, DecagramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromDecigrams(kilogram.Decigrams).Kilograms, DecigramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromEarthMasses(kilogram.EarthMasses).Kilograms, EarthMassesTolerance);
+            AssertEx.EqualTolerance(1, Mass.FromFemtograms(kilogram.Femtograms).Kilograms, FemtogramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromGrains(kilogram.Grains).Kilograms, GrainsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromGrams(kilogram.Grams).Kilograms, GramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromHectograms(kilogram.Hectograms).Kilograms, HectogramsTolerance);
@@ -2103,6 +2268,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Mass.FromMilligrams(kilogram.Milligrams).Kilograms, MilligramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromNanograms(kilogram.Nanograms).Kilograms, NanogramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromOunces(kilogram.Ounces).Kilograms, OuncesTolerance);
+            AssertEx.EqualTolerance(1, Mass.FromPicograms(kilogram.Picograms).Kilograms, PicogramsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromPounds(kilogram.Pounds).Kilograms, PoundsTolerance);
             AssertEx.EqualTolerance(1, Mass.FromShortHundredweight(kilogram.ShortHundredweight).Kilograms, ShortHundredweightTolerance);
             AssertEx.EqualTolerance(1, Mass.FromShortTons(kilogram.ShortTons).Kilograms, ShortTonsTolerance);
@@ -2261,6 +2427,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 dag", new Mass(1, MassUnit.Decagram).ToString());
                 Assert.Equal("1 dg", new Mass(1, MassUnit.Decigram).ToString());
                 Assert.Equal("1 em", new Mass(1, MassUnit.EarthMass).ToString());
+                Assert.Equal("1 fg", new Mass(1, MassUnit.Femtogram).ToString());
                 Assert.Equal("1 gr", new Mass(1, MassUnit.Grain).ToString());
                 Assert.Equal("1 g", new Mass(1, MassUnit.Gram).ToString());
                 Assert.Equal("1 hg", new Mass(1, MassUnit.Hectogram).ToString());
@@ -2275,6 +2442,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 mg", new Mass(1, MassUnit.Milligram).ToString());
                 Assert.Equal("1 ng", new Mass(1, MassUnit.Nanogram).ToString());
                 Assert.Equal("1 oz", new Mass(1, MassUnit.Ounce).ToString());
+                Assert.Equal("1 pg", new Mass(1, MassUnit.Picogram).ToString());
                 Assert.Equal("1 lb", new Mass(1, MassUnit.Pound).ToString());
                 Assert.Equal("1 cwt", new Mass(1, MassUnit.ShortHundredweight).ToString());
                 Assert.Equal("1 t (short)", new Mass(1, MassUnit.ShortTon).ToString());
@@ -2299,6 +2467,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 dag", new Mass(1, MassUnit.Decagram).ToString(swedishCulture));
             Assert.Equal("1 dg", new Mass(1, MassUnit.Decigram).ToString(swedishCulture));
             Assert.Equal("1 em", new Mass(1, MassUnit.EarthMass).ToString(swedishCulture));
+            Assert.Equal("1 fg", new Mass(1, MassUnit.Femtogram).ToString(swedishCulture));
             Assert.Equal("1 gr", new Mass(1, MassUnit.Grain).ToString(swedishCulture));
             Assert.Equal("1 g", new Mass(1, MassUnit.Gram).ToString(swedishCulture));
             Assert.Equal("1 hg", new Mass(1, MassUnit.Hectogram).ToString(swedishCulture));
@@ -2313,6 +2482,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mg", new Mass(1, MassUnit.Milligram).ToString(swedishCulture));
             Assert.Equal("1 ng", new Mass(1, MassUnit.Nanogram).ToString(swedishCulture));
             Assert.Equal("1 oz", new Mass(1, MassUnit.Ounce).ToString(swedishCulture));
+            Assert.Equal("1 pg", new Mass(1, MassUnit.Picogram).ToString(swedishCulture));
             Assert.Equal("1 lb", new Mass(1, MassUnit.Pound).ToString(swedishCulture));
             Assert.Equal("1 cwt", new Mass(1, MassUnit.ShortHundredweight).ToString(swedishCulture));
             Assert.Equal("1 t (short)", new Mass(1, MassUnit.ShortTon).ToString(swedishCulture));

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -69,6 +69,7 @@ namespace UnitsNet
                     new UnitInfo<MassUnit>(MassUnit.Decagram, "Decagrams", BaseUnits.Undefined),
                     new UnitInfo<MassUnit>(MassUnit.Decigram, "Decigrams", BaseUnits.Undefined),
                     new UnitInfo<MassUnit>(MassUnit.EarthMass, "EarthMasses", new BaseUnits(mass: MassUnit.EarthMass)),
+                    new UnitInfo<MassUnit>(MassUnit.Femtogram, "Femtograms", BaseUnits.Undefined),
                     new UnitInfo<MassUnit>(MassUnit.Grain, "Grains", new BaseUnits(mass: MassUnit.Grain)),
                     new UnitInfo<MassUnit>(MassUnit.Gram, "Grams", new BaseUnits(mass: MassUnit.Gram)),
                     new UnitInfo<MassUnit>(MassUnit.Hectogram, "Hectograms", BaseUnits.Undefined),
@@ -83,6 +84,7 @@ namespace UnitsNet
                     new UnitInfo<MassUnit>(MassUnit.Milligram, "Milligrams", BaseUnits.Undefined),
                     new UnitInfo<MassUnit>(MassUnit.Nanogram, "Nanograms", BaseUnits.Undefined),
                     new UnitInfo<MassUnit>(MassUnit.Ounce, "Ounces", new BaseUnits(mass: MassUnit.Ounce)),
+                    new UnitInfo<MassUnit>(MassUnit.Picogram, "Picograms", BaseUnits.Undefined),
                     new UnitInfo<MassUnit>(MassUnit.Pound, "Pounds", new BaseUnits(mass: MassUnit.Pound)),
                     new UnitInfo<MassUnit>(MassUnit.ShortHundredweight, "ShortHundredweight", new BaseUnits(mass: MassUnit.ShortHundredweight)),
                     new UnitInfo<MassUnit>(MassUnit.ShortTon, "ShortTons", new BaseUnits(mass: MassUnit.ShortTon)),
@@ -214,6 +216,11 @@ namespace UnitsNet
         public double EarthMasses => As(MassUnit.EarthMass);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Femtogram"/>
+        /// </summary>
+        public double Femtograms => As(MassUnit.Femtogram);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Grain"/>
         /// </summary>
         public double Grains => As(MassUnit.Grain);
@@ -284,6 +291,11 @@ namespace UnitsNet
         public double Ounces => As(MassUnit.Ounce);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Picogram"/>
+        /// </summary>
+        public double Picograms => As(MassUnit.Picogram);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="MassUnit.Pound"/>
         /// </summary>
         public double Pounds => As(MassUnit.Pound);
@@ -333,6 +345,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Mass>(MassUnit.Decagram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Decigram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.EarthMass, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
+            unitConverter.SetConversionFunction<Mass>(MassUnit.Femtogram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Grain, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Gram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Hectogram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
@@ -346,6 +359,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Mass>(MassUnit.Milligram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Nanogram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Ounce, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
+            unitConverter.SetConversionFunction<Mass>(MassUnit.Picogram, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Pound, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.ShortHundredweight, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.ShortTon, MassUnit.Kilogram, quantity => quantity.ToUnit(MassUnit.Kilogram));
@@ -362,6 +376,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Decagram, quantity => quantity.ToUnit(MassUnit.Decagram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Decigram, quantity => quantity.ToUnit(MassUnit.Decigram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.EarthMass, quantity => quantity.ToUnit(MassUnit.EarthMass));
+            unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Femtogram, quantity => quantity.ToUnit(MassUnit.Femtogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Grain, quantity => quantity.ToUnit(MassUnit.Grain));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Gram, quantity => quantity.ToUnit(MassUnit.Gram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Hectogram, quantity => quantity.ToUnit(MassUnit.Hectogram));
@@ -375,6 +390,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Milligram, quantity => quantity.ToUnit(MassUnit.Milligram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Nanogram, quantity => quantity.ToUnit(MassUnit.Nanogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Ounce, quantity => quantity.ToUnit(MassUnit.Ounce));
+            unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Picogram, quantity => quantity.ToUnit(MassUnit.Picogram));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.Pound, quantity => quantity.ToUnit(MassUnit.Pound));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.ShortHundredweight, quantity => quantity.ToUnit(MassUnit.ShortHundredweight));
             unitConverter.SetConversionFunction<Mass>(MassUnit.Kilogram, MassUnit.ShortTon, quantity => quantity.ToUnit(MassUnit.ShortTon));
@@ -396,6 +412,9 @@ namespace UnitsNet
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Decigram, new CultureInfo("ru-RU"), false, true, new string[]{"дг"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Decigram, new CultureInfo("zh-CN"), false, true, new string[]{"分克"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.EarthMass, new CultureInfo("en-US"), false, true, new string[]{"em"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Femtogram, new CultureInfo("en-US"), false, true, new string[]{"fg"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Femtogram, new CultureInfo("ru-RU"), false, true, new string[]{"фг"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Femtogram, new CultureInfo("zh-CN"), false, true, new string[]{"飞克"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Grain, new CultureInfo("en-US"), false, true, new string[]{"gr"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Gram, new CultureInfo("en-US"), false, true, new string[]{"g"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Gram, new CultureInfo("ru-RU"), false, true, new string[]{"г"});
@@ -433,6 +452,9 @@ namespace UnitsNet
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Nanogram, new CultureInfo("zh-CN"), false, true, new string[]{"纳克"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Ounce, new CultureInfo("en-US"), false, true, new string[]{"oz"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Ounce, new CultureInfo("zh-CN"), false, true, new string[]{"盎司"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Picogram, new CultureInfo("en-US"), false, true, new string[]{"pg"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Picogram, new CultureInfo("ru-RU"), false, true, new string[]{"пг"});
+            unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Picogram, new CultureInfo("zh-CN"), false, true, new string[]{"皮克"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Pound, new CultureInfo("en-US"), false, true, new string[]{"lb", "lbs", "lbm"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Pound, new CultureInfo("ru-RU"), false, true, new string[]{"фунт"});
             unitAbbreviationsCache.PerformAbbreviationMapping(MassUnit.Pound, new CultureInfo("zh-CN"), false, true, new string[]{"磅"});
@@ -511,6 +533,16 @@ namespace UnitsNet
         {
             double value = (double) earthmasses;
             return new Mass(value, MassUnit.EarthMass);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="Mass"/> from <see cref="MassUnit.Femtogram"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Mass FromFemtograms(QuantityValue femtograms)
+        {
+            double value = (double) femtograms;
+            return new Mass(value, MassUnit.Femtogram);
         }
 
         /// <summary>
@@ -651,6 +683,16 @@ namespace UnitsNet
         {
             double value = (double) ounces;
             return new Mass(value, MassUnit.Ounce);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="Mass"/> from <see cref="MassUnit.Picogram"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Mass FromPicograms(QuantityValue picograms)
+        {
+            double value = (double) picograms;
+            return new Mass(value, MassUnit.Picogram);
         }
 
         /// <summary>
@@ -1202,6 +1244,7 @@ namespace UnitsNet
                 (MassUnit.Decagram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e1d, MassUnit.Kilogram),
                 (MassUnit.Decigram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-1d, MassUnit.Kilogram),
                 (MassUnit.EarthMass, MassUnit.Kilogram) => new Mass(_value * 5.9722E+24, MassUnit.Kilogram),
+                (MassUnit.Femtogram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-15d, MassUnit.Kilogram),
                 (MassUnit.Grain, MassUnit.Kilogram) => new Mass(_value / 15432.358352941431, MassUnit.Kilogram),
                 (MassUnit.Gram, MassUnit.Kilogram) => new Mass(_value / 1e3, MassUnit.Kilogram),
                 (MassUnit.Hectogram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e2d, MassUnit.Kilogram),
@@ -1215,6 +1258,7 @@ namespace UnitsNet
                 (MassUnit.Milligram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-3d, MassUnit.Kilogram),
                 (MassUnit.Nanogram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-9d, MassUnit.Kilogram),
                 (MassUnit.Ounce, MassUnit.Kilogram) => new Mass(_value * 0.028349523125, MassUnit.Kilogram),
+                (MassUnit.Picogram, MassUnit.Kilogram) => new Mass((_value / 1e3) * 1e-12d, MassUnit.Kilogram),
                 (MassUnit.Pound, MassUnit.Kilogram) => new Mass(_value * 0.45359237, MassUnit.Kilogram),
                 (MassUnit.ShortHundredweight, MassUnit.Kilogram) => new Mass(_value / 0.022046226218487758, MassUnit.Kilogram),
                 (MassUnit.ShortTon, MassUnit.Kilogram) => new Mass(_value * 9.0718474e2, MassUnit.Kilogram),
@@ -1228,6 +1272,7 @@ namespace UnitsNet
                 (MassUnit.Kilogram, MassUnit.Decagram) => new Mass((_value * 1e3) / 1e1d, MassUnit.Decagram),
                 (MassUnit.Kilogram, MassUnit.Decigram) => new Mass((_value * 1e3) / 1e-1d, MassUnit.Decigram),
                 (MassUnit.Kilogram, MassUnit.EarthMass) => new Mass(_value / 5.9722E+24, MassUnit.EarthMass),
+                (MassUnit.Kilogram, MassUnit.Femtogram) => new Mass((_value * 1e3) / 1e-15d, MassUnit.Femtogram),
                 (MassUnit.Kilogram, MassUnit.Grain) => new Mass(_value * 15432.358352941431, MassUnit.Grain),
                 (MassUnit.Kilogram, MassUnit.Gram) => new Mass(_value * 1e3, MassUnit.Gram),
                 (MassUnit.Kilogram, MassUnit.Hectogram) => new Mass((_value * 1e3) / 1e2d, MassUnit.Hectogram),
@@ -1241,6 +1286,7 @@ namespace UnitsNet
                 (MassUnit.Kilogram, MassUnit.Milligram) => new Mass((_value * 1e3) / 1e-3d, MassUnit.Milligram),
                 (MassUnit.Kilogram, MassUnit.Nanogram) => new Mass((_value * 1e3) / 1e-9d, MassUnit.Nanogram),
                 (MassUnit.Kilogram, MassUnit.Ounce) => new Mass(_value / 0.028349523125, MassUnit.Ounce),
+                (MassUnit.Kilogram, MassUnit.Picogram) => new Mass((_value * 1e3) / 1e-12d, MassUnit.Picogram),
                 (MassUnit.Kilogram, MassUnit.Pound) => new Mass(_value / 0.45359237, MassUnit.Pound),
                 (MassUnit.Kilogram, MassUnit.ShortHundredweight) => new Mass(_value * 0.022046226218487758, MassUnit.ShortHundredweight),
                 (MassUnit.Kilogram, MassUnit.ShortTon) => new Mass(_value / 9.0718474e2, MassUnit.ShortTon),

--- a/UnitsNet/GeneratedCode/Units/MassUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/MassUnit.g.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Units
         /// </summary>
         /// <remarks>https://en.wikipedia.org/wiki/Earth_mass</remarks>
         EarthMass = 4,
+        Femtogram = 35,
 
         /// <summary>
         ///     A grain is a unit of measurement of mass, and in the troy weight, avoirdupois, and Apothecaries' system, equal to exactly 64.79891 milligrams.
@@ -68,6 +69,7 @@ namespace UnitsNet.Units
         /// </summary>
         /// <remarks>https://en.wikipedia.org/wiki/Ounce</remarks>
         Ounce = 18,
+        Picogram = 29,
 
         /// <summary>
         ///     The pound or pound-mass (abbreviations: lb, lbm) is a unit of mass used in the imperial, United States customary and other systems of measurement. A number of different definitions have been used, the most common today being the international avoirdupois pound which is legally defined as exactly 0.45359237 kilograms, and which is divided into 16 avoirdupois ounces.


### PR DESCRIPTION
Including picograms and femtograms in existing mass units is essential for accurate laboratory measurements and data analysis. These units are widely used in research.