### PR TITLE
Fixed tests without an explicit culture specification

### DIFF
--- a/UnitsNet.Tests/BaseUnitsTests.cs
+++ b/UnitsNet.Tests/BaseUnitsTests.cs
@@ -132,10 +132,23 @@ namespace UnitsNet.Tests
         [Fact]
         public void ToStringGivesExpectedResult()
         {
-            var siBaseUnits = new BaseUnits(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second,
-                ElectricCurrentUnit.Ampere, TemperatureUnit.Kelvin, AmountOfSubstanceUnit.Mole, LuminousIntensityUnit.Candela);
+            var siBaseUnits = new BaseUnits(LengthUnit.Meter,
+                MassUnit.Kilogram,
+                DurationUnit.Second,
+                ElectricCurrentUnit.Ampere,
+                TemperatureUnit.Kelvin,
+                AmountOfSubstanceUnit.Mole,
+                LuminousIntensityUnit.Candela);
 
-            Assert.Equal("[Length]: m, [Mass]: kg, [Time]: s, [Current]: A, [Temperature]: K, [Amount]: mol, [LuminousIntensity]: cd", siBaseUnits.ToString());
+            var m = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Meter);
+            var kg = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Kilogram);
+            var s = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(DurationUnit.Second);
+            var A = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(ElectricCurrentUnit.Ampere);
+            var K = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(TemperatureUnit.Kelvin);
+            var mol = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(AmountOfSubstanceUnit.Mole);
+            var cd = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LuminousIntensityUnit.Candela);
+
+            Assert.Equal($"[Length]: {m}, [Mass]: {kg}, [Time]: {s}, [Current]: {A}, [Temperature]: {K}, [Amount]: {mol}, [LuminousIntensity]: {cd}", siBaseUnits.ToString());
         }
 
         [Fact]

--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -192,7 +192,7 @@ namespace UnitsNet.Tests
         [InlineData("1000 мсек", 1, "ru-RU")]
         public void DurationFromStringUsingMultipleAbbreviationsParsedCorrectly(string textValue, double expectedSeconds, string? culture = null)
         {
-            var cultureInfo = culture == null ? null : new CultureInfo(culture);
+            var cultureInfo = culture == null ? CultureInfo.InvariantCulture : new CultureInfo(culture);
 
             AssertEx.EqualTolerance(expectedSeconds, Duration.Parse(textValue, cultureInfo).Seconds, SecondsTolerance);
         }

--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -2,6 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using System.Globalization;
 using UnitsNet.Units;
 using Xunit;
 
@@ -144,7 +145,7 @@ namespace UnitsNet.Tests
         public void ToStringReturnsCorrectNumberAndUnitWithDefaultUnitWhichIsMeter()
         {
             var meter = Length.FromMeters(5);
-            string meterString = meter.ToString();
+            string meterString = meter.ToString(CultureInfo.InvariantCulture);
             Assert.Equal("5 m", meterString);
         }
 
@@ -152,7 +153,7 @@ namespace UnitsNet.Tests
         public void ToStringReturnsCorrectNumberAndUnitWithCentimeterAsDefualtUnit()
         {
             var value = Length.From(2, LengthUnit.Centimeter);
-            string valueString = value.ToString();
+            string valueString = value.ToString(CultureInfo.InvariantCulture);
             Assert.Equal("2 cm", valueString);
         }
 

--- a/UnitsNet.Tests/CustomCode/ParseTests.cs
+++ b/UnitsNet.Tests/CustomCode/ParseTests.cs
@@ -96,8 +96,8 @@ namespace UnitsNet.Tests
         [Fact]
         public void ParseMultiWordAbbreviations()
         {
-            Assert.Equal(Mass.FromShortTons(333), Mass.Parse("333 short tn"));
-            Assert.Equal(Mass.FromLongTons(333), Mass.Parse("333 long tn"));
+            Assert.Equal(Mass.FromShortTons(333), Mass.Parse("333 short tn", CultureInfo.InvariantCulture));
+            Assert.Equal(Mass.FromLongTons(333), Mass.Parse("333 long tn", CultureInfo.InvariantCulture));
         }
 
         [Theory]

--- a/UnitsNet.Tests/CustomCode/StonePoundsTests.cs
+++ b/UnitsNet.Tests/CustomCode/StonePoundsTests.cs
@@ -31,13 +31,12 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void StonePoundsToString_FormatsNumberInDefaultCulture()
+        public void StonePoundsToString_FormatsNumberInCurrentCulture()
         {
-            Mass m = Mass.FromStonePounds(3500, 1);
-            StonePounds stonePounds = m.StonePounds;
-            string numberInCurrentCulture = 3500.ToString("n0", CultureInfo.InvariantCulture);
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+            StonePounds stonePounds = Mass.FromStonePounds(3500, 1).StonePounds;
 
-            Assert.Equal($"{numberInCurrentCulture} st 1 lb", stonePounds.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("3,500 st 1 lb", stonePounds.ToString());
         }
 
         // These cultures use a thin space in digit grouping

--- a/UnitsNet.Tests/CustomCode/StonePoundsTests.cs
+++ b/UnitsNet.Tests/CustomCode/StonePoundsTests.cs
@@ -35,9 +35,9 @@ namespace UnitsNet.Tests
         {
             Mass m = Mass.FromStonePounds(3500, 1);
             StonePounds stonePounds = m.StonePounds;
-            string numberInCurrentCulture =  3500.ToString("n0", CultureInfo.CurrentCulture); // Varies between machines, can't hard code it
+            string numberInCurrentCulture = 3500.ToString("n0", CultureInfo.InvariantCulture);
 
-            Assert.Equal($"{numberInCurrentCulture} st 1 lb", stonePounds.ToString());
+            Assert.Equal($"{numberInCurrentCulture} st 1 lb", stonePounds.ToString(CultureInfo.InvariantCulture));
         }
 
         // These cultures use a thin space in digit grouping

--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -2,6 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using System.Globalization;
 using Xunit;
 
 namespace UnitsNet.Tests
@@ -26,11 +27,11 @@ namespace UnitsNet.Tests
         [Fact]
         public void AFormatGetsAbbreviations()
         {
-            Assert.Equal(UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MyLength.Unit), MyLength.ToString("a"));
-            Assert.Equal(UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MyLength.Unit), MyLength.ToString("a0"));
+            Assert.Equal(UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a", CultureInfo.InvariantCulture));
+            Assert.Equal(UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a0", CultureInfo.InvariantCulture));
 
-            Assert.Equal(UnitAbbreviationsCache.Default.GetUnitAbbreviations(MyLength.Unit)[1], MyLength.ToString("a1"));
-            Assert.Equal(UnitAbbreviationsCache.Default.GetUnitAbbreviations(MyLength.Unit)[2], MyLength.ToString("a2"));
+            Assert.Equal(UnitAbbreviationsCache.Default.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[1], MyLength.ToString("a1", CultureInfo.InvariantCulture));
+            Assert.Equal(UnitAbbreviationsCache.Default.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[2], MyLength.ToString("a2", CultureInfo.InvariantCulture));
         }
 
         [Fact]

--- a/UnitsNet.Tests/QuantityTest.cs
+++ b/UnitsNet.Tests/QuantityTest.cs
@@ -135,30 +135,30 @@ namespace UnitsNet.Tests
         [Fact]
         public void TryParse_GivenInvalidQuantityType_ReturnsFalseAndNullQuantity()
         {
-            Assert.False(Quantity.TryParse(typeof(DummyIQuantity), "3.0 cm", out IQuantity? parsedLength));
+            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(DummyIQuantity), "3.0 cm", out IQuantity? parsedLength));
             Assert.Null(parsedLength);
         }
 
         [Fact]
         public void TryParse_GivenInvalidString_ReturnsFalseAndNullQuantity()
         {
-            Assert.False(Quantity.TryParse(typeof(Length), "x cm", out IQuantity? parsedLength));
+            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Length), "x cm", out IQuantity? parsedLength));
             Assert.Null(parsedLength);
 
-            Assert.False(Quantity.TryParse(typeof(Mass), "xt", out IQuantity? parsedMass));
+            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Mass), "xt", out IQuantity? parsedMass));
             Assert.Null(parsedMass);
 
-            Assert.False(Quantity.TryParse(typeof(Pressure), "foo", out IQuantity? parsedPressure));
+            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Pressure), "foo", out IQuantity? parsedPressure));
             Assert.Null(parsedPressure);
         }
 
         [Fact]
         public void TryParse_GivenValueAndUnit_ReturnsQuantity()
         {
-            Assert.True(Quantity.TryParse(typeof(Length), "3 cm", out IQuantity? parsedLength));
+            Assert.True(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Length), "3 cm", out IQuantity? parsedLength));
             Assert.Equal(Length.FromCentimeters(3), parsedLength);
 
-            Assert.True(Quantity.TryParse(typeof(Mass), "03t", out IQuantity? parsedMass));
+            Assert.True(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Mass), "03t", out IQuantity? parsedMass));
             Assert.Equal(Mass.FromTonnes(3), parsedMass);
 
             Assert.True(Quantity.TryParse(NumberFormatInfo.InvariantInfo, typeof(Pressure), "3.0 Mbar", out IQuantity? parsedPressure));

--- a/UnitsNet.Tests/QuantityTest.cs
+++ b/UnitsNet.Tests/QuantityTest.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using UnitsNet.Units;
 using Xunit;
+using static System.Globalization.CultureInfo;
 
 namespace UnitsNet.Tests
 {
@@ -103,9 +104,9 @@ namespace UnitsNet.Tests
         [Fact]
         public void Parse_GivenValueAndUnit_ReturnsQuantity()
         {
-            Assert.Equal(Length.FromCentimeters(3), Quantity.Parse(CultureInfo.InvariantCulture, typeof(Length), "3 cm"));
-            Assert.Equal(Mass.FromTonnes(3), Quantity.Parse(CultureInfo.InvariantCulture, typeof(Mass), "03t"));
-            Assert.Equal(Pressure.FromMegabars(3), Quantity.Parse(CultureInfo.InvariantCulture, typeof(Pressure), "3.0 Mbar"));
+            Assert.Equal(Length.FromCentimeters(3), Quantity.Parse(InvariantCulture, typeof(Length), "3 cm"));
+            Assert.Equal(Mass.FromTonnes(3), Quantity.Parse(InvariantCulture, typeof(Mass), "03t"));
+            Assert.Equal(Pressure.FromMegabars(3), Quantity.Parse(InvariantCulture, typeof(Pressure), "3.0 Mbar"));
         }
 
         [Fact]
@@ -135,30 +136,30 @@ namespace UnitsNet.Tests
         [Fact]
         public void TryParse_GivenInvalidQuantityType_ReturnsFalseAndNullQuantity()
         {
-            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(DummyIQuantity), "3.0 cm", out IQuantity? parsedLength));
+            Assert.False(Quantity.TryParse(InvariantCulture, typeof(DummyIQuantity), "3.0 cm", out IQuantity? parsedLength));
             Assert.Null(parsedLength);
         }
 
         [Fact]
         public void TryParse_GivenInvalidString_ReturnsFalseAndNullQuantity()
         {
-            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Length), "x cm", out IQuantity? parsedLength));
+            Assert.False(Quantity.TryParse(InvariantCulture, typeof(Length), "x cm", out IQuantity? parsedLength));
             Assert.Null(parsedLength);
 
-            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Mass), "xt", out IQuantity? parsedMass));
+            Assert.False(Quantity.TryParse(InvariantCulture, typeof(Mass), "xt", out IQuantity? parsedMass));
             Assert.Null(parsedMass);
 
-            Assert.False(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Pressure), "foo", out IQuantity? parsedPressure));
+            Assert.False(Quantity.TryParse(InvariantCulture, typeof(Pressure), "foo", out IQuantity? parsedPressure));
             Assert.Null(parsedPressure);
         }
 
         [Fact]
         public void TryParse_GivenValueAndUnit_ReturnsQuantity()
         {
-            Assert.True(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Length), "3 cm", out IQuantity? parsedLength));
+            Assert.True(Quantity.TryParse(InvariantCulture, typeof(Length), "3 cm", out IQuantity? parsedLength));
             Assert.Equal(Length.FromCentimeters(3), parsedLength);
 
-            Assert.True(Quantity.TryParse(CultureInfo.InvariantCulture, typeof(Mass), "03t", out IQuantity? parsedMass));
+            Assert.True(Quantity.TryParse(InvariantCulture, typeof(Mass), "03t", out IQuantity? parsedMass));
             Assert.Equal(Mass.FromTonnes(3), parsedMass);
 
             Assert.True(Quantity.TryParse(NumberFormatInfo.InvariantInfo, typeof(Pressure), "3.0 Mbar", out IQuantity? parsedPressure));

--- a/UnitsNet.Tests/QuantityTypeConverterTest.cs
+++ b/UnitsNet.Tests/QuantityTypeConverterTest.cs
@@ -160,7 +160,7 @@ namespace UnitsNet.Tests
 
             var convertedQuantity = (string?)converter.ConvertTo(length, typeof(string));
 
-            Assert.Equal("1 m", convertedQuantity);
+            Assert.Equal(Length.FromMeters(1).ToString(), convertedQuantity);
         }
 
         [Fact]
@@ -245,7 +245,7 @@ namespace UnitsNet.Tests
             string convertedQuantityDefaultCulture = (string)converter.ConvertTo(length, typeof(string))!;
             string convertedQuantitySpecificCulture = (string)converter.ConvertTo(context, Culture, length, typeof(string))!;
 
-            Assert.Equal("1 m", convertedQuantityDefaultCulture);
+            Assert.Equal(Length.FromMeters(1).ToString(), convertedQuantityDefaultCulture);
             Assert.Equal("10 dm", convertedQuantitySpecificCulture);
         }
 

--- a/UnitsNet.Tests/QuantityTypeConverterTest.cs
+++ b/UnitsNet.Tests/QuantityTypeConverterTest.cs
@@ -242,10 +242,12 @@ namespace UnitsNet.Tests
             });
             Length length = Length.FromMeters(1);
 
-            string convertedQuantityDefaultCulture = (string)converter.ConvertTo(length, typeof(string))!;
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
+
+            string convertedQuantityCurrentCulture = (string)converter.ConvertTo(length, typeof(string))!;
             string convertedQuantitySpecificCulture = (string)converter.ConvertTo(context, Culture, length, typeof(string))!;
 
-            Assert.Equal(Length.FromMeters(1).ToString(), convertedQuantityDefaultCulture);
+            Assert.Equal("1 m", convertedQuantityCurrentCulture);
             Assert.Equal("10 dm", convertedQuantitySpecificCulture);
         }
 

--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -152,21 +152,21 @@ namespace UnitsNet.Tests
         [Fact]
         public void AllUnitsImplementToStringForInvariantCulture()
         {
-            Assert.Equal("1 °", Angle.FromDegrees(1).ToString());
-            Assert.Equal("1 m²", Area.FromSquareMeters(1).ToString());
-            Assert.Equal("1 V", ElectricPotential.FromVolts(1).ToString());
-            Assert.Equal("1 N", Force.FromNewtons(1).ToString());
-            Assert.Equal("1 m", Length.FromMeters(1).ToString());
-            Assert.Equal("1 kg", Mass.FromKilograms(1).ToString());
-            Assert.Equal("1 Pa", Pressure.FromPascals(1).ToString());
-            Assert.Equal("1 rad/s", RotationalSpeed.FromRadiansPerSecond(1).ToString());
-            Assert.Equal("1 K", Temperature.FromKelvins(1).ToString());
-            Assert.Equal("1 N·m", Torque.FromNewtonMeters(1).ToString());
-            Assert.Equal("1 m³", Volume.FromCubicMeters(1).ToString());
-            Assert.Equal("1 m³/s", VolumeFlow.FromCubicMetersPerSecond(1).ToString());
+            Assert.Equal("1 °", Angle.FromDegrees(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 m²", Area.FromSquareMeters(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 V", ElectricPotential.FromVolts(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 N", Force.FromNewtons(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 m", Length.FromMeters(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 kg", Mass.FromKilograms(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 Pa", Pressure.FromPascals(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 rad/s", RotationalSpeed.FromRadiansPerSecond(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 K", Temperature.FromKelvins(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 N·m", Torque.FromNewtonMeters(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 m³", Volume.FromCubicMeters(1).ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("1 m³/s", VolumeFlow.FromCubicMetersPerSecond(1).ToString(CultureInfo.InvariantCulture));
 
-            Assert.Equal("2 ft 3 in", Length.FromFeetInches(2, 3).FeetInches.ToString());
-            Assert.Equal("3 st 7 lb", Mass.FromStonePounds(3, 7).StonePounds.ToString());
+            Assert.Equal("2 ft 3 in", Length.FromFeetInches(2, 3).FeetInches.ToString(CultureInfo.InvariantCulture));
+            Assert.Equal("3 st 7 lb", Mass.FromStonePounds(3, 7).StonePounds.ToString(CultureInfo.InvariantCulture));
         }
 
         [Fact]
@@ -244,7 +244,7 @@ namespace UnitsNet.Tests
             var cache = new UnitAbbreviationsCache();
             cache.MapUnitToAbbreviation(AreaUnit.SquareMeter, AmericanCulture, "m^2");
 
-            Assert.Equal("m²", cache.GetDefaultAbbreviation(AreaUnit.SquareMeter));
+            Assert.Equal("m²", cache.GetDefaultAbbreviation(AreaUnit.SquareMeter, AmericanCulture));
         }
 
         [Fact]

--- a/UnitsNet.Tests/UnitConverterTest.cs
+++ b/UnitsNet.Tests/UnitConverterTest.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System.Globalization;
 using UnitsNet.Tests.CustomQuantities;
 using UnitsNet.Units;
 using Xunit;
@@ -208,24 +209,23 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData(1, "UnknownQuantity", "m", "cm")]
-        [InlineData(1, "Length", "UnknownFromUnit", "cm")]
-        [InlineData(1, "Length", "m", "UnknownToUnit")]
-        public void TryConvertByAbbreviation_ReturnsFalseForInvalidInput(double inputValue, string quantityTypeName, string fromUnit, string toUnit)
+        [InlineData(1, "UnknownQuantity", "m", "cm", "en-US")]
+        [InlineData(1, "Length", "UnknownFromUnit", "cm", "en-US")]
+        [InlineData(1, "Length", "m", "UnknownToUnit", "en-US")]
+        public void TryConvertByAbbreviation_ReturnsFalseForInvalidInput(double inputValue, string quantityTypeName, string fromUnit, string toUnit, string culture)
         {
-            Assert.False(UnitConverter.TryConvertByAbbreviation(inputValue, quantityTypeName, fromUnit, toUnit, out double result));
+            Assert.False(UnitConverter.TryConvertByAbbreviation(inputValue, quantityTypeName, fromUnit, toUnit, out double result, culture));
             Assert.Equal(0, result);
         }
 
         [Theory]
-        [InlineData(0, 0, "Length", "m", "cm")]
-        [InlineData(100, 1, "Length", "m", "cm")]
-        [InlineData(1, 1000, "Mass", "g", "kg")]
-        [InlineData(1000, 1, "ElectricCurrent", "kA", "A")]
-        public void TryConvertByAbbreviation_ReturnsTrueOnSuccessAndOutputsResult(double expectedValue, double inputValue, string quantityTypeName, string fromUnit,
-            string toUnit)
+        [InlineData(0, 0, "Length", "m", "cm", "en-US")]
+        [InlineData(100, 1, "Length", "m", "cm", "en-US")]
+        [InlineData(1, 1000, "Mass", "g", "kg", "en-US")]
+        [InlineData(1000, 1, "ElectricCurrent", "kA", "A", "en-US")]
+        public void TryConvertByAbbreviation_ReturnsTrueOnSuccessAndOutputsResult(double expectedValue, double inputValue, string quantityTypeName, string fromUnit, string toUnit, string culture)
         {
-            Assert.True(UnitConverter.TryConvertByAbbreviation(inputValue, quantityTypeName, fromUnit, toUnit, out double result), "TryConvertByAbbreviation() return value.");
+            Assert.True(UnitConverter.TryConvertByAbbreviation(inputValue, quantityTypeName, fromUnit, toUnit, out double result, culture), "TryConvertByAbbreviation() return value.");
             Assert.Equal(expectedValue, result);
         }
     }

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -107,7 +107,7 @@ namespace UnitsNet.Tests
             var exception1 = Assert.Throws<AmbiguousUnitParseException>(() => UnitParser.Default.Parse<LengthUnit>("pt"));
 
             // Act 2
-            var exception2 = Assert.Throws<AmbiguousUnitParseException>(() => Length.Parse("1 pt"));
+            var exception2 = Assert.Throws<AmbiguousUnitParseException>(() => Length.Parse("1 pt", CultureInfo.InvariantCulture));
 
             // Assert
             Assert.Equal("Cannot parse \"pt\" since it could be either of these: DtpPoint, PrinterPoint", exception1.Message);


### PR DESCRIPTION
I fixed all the tests that didn't pass due to a non-English operating system.
I didn't change the test logic.

I didn't make any changes to the core code of the library, so this PR doesn't need a separate version.

Also, I can't guarantee that I've fixed all cases of missing culture.
For example, the test Assert.False("5 m" != "6 м") could return a false result not because 5 != 6, but because _meter_ is not a _метр_.