### PR TITLE
✨Fallback to invariant culture if cultures are not found

### DIFF
--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -213,29 +213,20 @@ namespace UnitsNet.Tests
         [Fact]
         public void GetDefaultAbbreviationFallsBackToUsEnglishCulture()
         {
-            var oldCurrentCulture = CultureInfo.CurrentCulture;
+            // CurrentCulture affects number formatting, such as comma or dot as decimal separator.
+            // CurrentCulture also affects localization of unit abbreviations.
+            // Zulu (South Africa)
+            var zuluCulture = CultureInfo.GetCultureInfo("zu-ZA");
+            // CultureInfo.CurrentCulture = zuluCulture;
 
-            try
-            {
-                // CurrentCulture affects number formatting, such as comma or dot as decimal separator.
-                // CurrentCulture affects localization, in this case the abbreviation.
-                // Zulu (South Africa)
-                var zuluCulture = CultureInfo.GetCultureInfo("zu-ZA");
-                CultureInfo.CurrentCulture = zuluCulture;
+            var abbreviationsCache = new UnitAbbreviationsCache();
+            abbreviationsCache.MapUnitToAbbreviation(CustomUnit.Unit1, AmericanCulture, "US english abbreviation for Unit1");
 
-                var abbreviationsCache = new UnitAbbreviationsCache();
-                abbreviationsCache.MapUnitToAbbreviation(CustomUnit.Unit1, AmericanCulture, "US english abbreviation for Unit1");
+            // Act
+            string abbreviation = abbreviationsCache.GetDefaultAbbreviation(CustomUnit.Unit1, zuluCulture);
 
-                // Act
-                string abbreviation = abbreviationsCache.GetDefaultAbbreviation(CustomUnit.Unit1, zuluCulture);
-
-                // Assert
-                Assert.Equal("US english abbreviation for Unit1", abbreviation);
-            }
-            finally
-            {
-                CultureInfo.CurrentCulture = oldCurrentCulture;
-            }
+            // Assert
+            Assert.Equal("US english abbreviation for Unit1", abbreviation);
         }
 
         [Fact]

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -25,7 +25,7 @@ namespace UnitsNet
         ///     culture, but no translation is defined, so we return the US English definition as a last resort. If it's not
         ///     defined there either, an exception is thrown.
         /// </example>
-        internal static readonly CultureInfo FallbackCulture = CultureInfo.GetCultureInfo("en-US");
+        internal static readonly CultureInfo FallbackCulture = CultureInfo.InvariantCulture;
 
         /// <summary>
         ///     The static instance used internally for ToString() and Parse() of quantities and units.

--- a/UnitsNet/InternalHelpers/CultureHelper.cs
+++ b/UnitsNet/InternalHelpers/CultureHelper.cs
@@ -1,0 +1,45 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+using System.Collections.Concurrent;
+using System.Globalization;
+
+namespace UnitsNet.InternalHelpers;
+
+/// <summary>
+///     Helper class for <see cref="CultureInfo"/> and related operations.
+/// </summary>
+internal static class CultureHelper
+{
+    private static readonly ConcurrentDictionary<string, CultureInfo> CultureCache = new();
+
+    /// <summary>
+    ///     Attempts to get the culture by name, with fallback to invariant culture if not found.<br/>
+    ///     <br/>
+    ///     This is particularly useful for Linux and Raspberry PI environments, where cultures may not always be installed.
+    ///     To simulate the behavior, set environment variable DOTNET_SYSTEM_GLOBALIZATION_INVARIANT='1' when running the application.
+    /// </summary>
+    /// <param name="cultureName">The culture name.</param>
+    /// <returns><see cref="CultureInfo.CurrentCulture"/> if given <c>null</c>, or the culture with the given name if the culture is available, otherwise <see cref="CultureInfo.InvariantCulture"/>.</returns>
+    internal static CultureInfo GetCultureOrInvariant(string? cultureName)
+    {
+        if (cultureName is null) return CultureInfo.CurrentCulture;
+
+        try
+        {
+            // Use cache to avoid exception and diagnostic log events every time.
+            return CultureCache.GetOrAdd(cultureName, CultureInfo.GetCultureInfo);
+        }
+        catch (CultureNotFoundException)
+        {
+            Console.Error.WriteLine($"Failed to get culture '{cultureName}', falling back to invariant culture.");
+            System.Diagnostics.Debug.WriteLine($"Failed to get culture '{cultureName}', falling back to invariant culture.");
+
+            // Cache it, to avoid exception next time.
+            CultureCache.TryAdd(cultureName, CultureInfo.InvariantCulture);
+
+            return CultureInfo.InvariantCulture;
+        }
+    }
+}

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -7,6 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
 using System.Linq;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Units;
 
 namespace UnitsNet
@@ -420,7 +421,7 @@ namespace UnitsNet
             if (!TryGetUnitType(quantityName, out Type? unitType))
                 throw new UnitNotFoundException($"The unit type for the given quantity was not found: {quantityName}");
 
-            var cultureInfo = string.IsNullOrWhiteSpace(culture) ? CultureInfo.CurrentCulture : CultureInfo.GetCultureInfo(culture);
+            var cultureInfo = CultureHelper.GetCultureOrInvariant(culture);
 
             var fromUnit = UnitParser.Default.Parse(fromUnitAbbrev, unitType, cultureInfo); // ex: ("m", LengthUnit) => LengthUnit.Meter
             var fromQuantity = Quantity.From(fromValue, fromUnit);
@@ -479,7 +480,7 @@ namespace UnitsNet
             if (!TryGetUnitType(quantityName, out Type? unitType))
                 return false;
 
-            var cultureInfo = string.IsNullOrWhiteSpace(culture) ? CultureInfo.CurrentCulture : CultureInfo.GetCultureInfo(culture);
+            var cultureInfo = CultureHelper.GetCultureOrInvariant(culture);
 
             if (!UnitParser.Default.TryParse(fromUnitAbbrev, unitType, cultureInfo, out Enum? fromUnit)) // ex: ("m", LengthUnit) => LengthUnit.Meter
                 return false;


### PR DESCRIPTION
Fixes #1238

Applications crashed when running on Linux or Raspberry PI systems if .NET cultures were not installed. 

Specifically, `UnitAbbreviationsCache.Default` threw an exception trying to instantiate the fallback `CultureInfo` with `en-US`.

### Changes
- Change fallback culture to `InvariantCulture`
- Add `CultureHelper.GetCultureOrInvariant()` to handle `CultureNotFoundException`
- Change `UnitInfo` to map invariant culture to `en-US` localization