### PR TITLE
✨Add UnitsNetSetup to hold global static state

### DIFF
--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -45,7 +45,7 @@ namespace UnitsNet.Serialization.JsonNet
         /// </summary>
         /// <param name="comparer">The comparer used to compare the property/quantity names (e.g. StringComparer.OrdinalIgnoreCase) </param>
         public AbbreviatedUnitsConverter(IEqualityComparer<string?> comparer)
-            : this(new Dictionary<string, QuantityInfo>(Quantity.ByName, comparer), UnitAbbreviationsCache.Default, comparer)
+            : this(new Dictionary<string, QuantityInfo>(Quantity.ByName, comparer), UnitsNetSetup.Default.UnitAbbreviations, comparer)
         {
         }
 

--- a/UnitsNet.Tests/AlphabeticalOrderer.cs
+++ b/UnitsNet.Tests/AlphabeticalOrderer.cs
@@ -1,0 +1,29 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.Collections.Generic;
+using System.Linq;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace UnitsNet.Tests;
+
+/// <summary>
+///     Useful for debugging tests where a particular order of tests is required.
+/// </summary>
+/// <example>
+/// Add the attribute to your test class:
+/// <code>
+/// <![CDATA[
+/// [TestCaseOrderer(
+/// ordererTypeName: "UnitsNet.Tests.AlphabeticalOrderer",
+/// ordererAssemblyName: "UnitsNet.Tests")]
+/// ]]>
+/// </code>
+/// </example>
+public class AlphabeticalOrderer : ITestCaseOrderer
+{
+    public IEnumerable<TTestCase> OrderTestCases<TTestCase>(
+        IEnumerable<TTestCase> testCases) where TTestCase : ITestCase =>
+        testCases.OrderBy(testCase => testCase.TestMethod.Method.Name);
+}

--- a/UnitsNet.Tests/BaseUnitsTests.cs
+++ b/UnitsNet.Tests/BaseUnitsTests.cs
@@ -140,13 +140,14 @@ namespace UnitsNet.Tests
                 AmountOfSubstanceUnit.Mole,
                 LuminousIntensityUnit.Candela);
 
-            var m = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LengthUnit.Meter);
-            var kg = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MassUnit.Kilogram);
-            var s = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(DurationUnit.Second);
-            var A = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(ElectricCurrentUnit.Ampere);
-            var K = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(TemperatureUnit.Kelvin);
-            var mol = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(AmountOfSubstanceUnit.Mole);
-            var cd = UnitAbbreviationsCache.Default.GetDefaultAbbreviation(LuminousIntensityUnit.Candela);
+            UnitAbbreviationsCache cache = UnitsNetSetup.Default.UnitAbbreviations;
+            var m = cache.GetDefaultAbbreviation(LengthUnit.Meter);
+            var kg = cache.GetDefaultAbbreviation(MassUnit.Kilogram);
+            var s = cache.GetDefaultAbbreviation(DurationUnit.Second);
+            var A = cache.GetDefaultAbbreviation(ElectricCurrentUnit.Ampere);
+            var K = cache.GetDefaultAbbreviation(TemperatureUnit.Kelvin);
+            var mol = cache.GetDefaultAbbreviation(AmountOfSubstanceUnit.Mole);
+            var cd = cache.GetDefaultAbbreviation(LuminousIntensityUnit.Candela);
 
             Assert.Equal($"[Length]: {m}, [Mass]: {kg}, [Time]: {s}, [Current]: {A}, [Temperature]: {K}, [Amount]: {mol}, [LuminousIntensity]: {cd}", siBaseUnits.ToString());
         }

--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -27,11 +27,12 @@ namespace UnitsNet.Tests
         [Fact]
         public void AFormatGetsAbbreviations()
         {
-            Assert.Equal(UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a", CultureInfo.InvariantCulture));
-            Assert.Equal(UnitAbbreviationsCache.Default.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a0", CultureInfo.InvariantCulture));
+            UnitAbbreviationsCache cache = UnitsNetSetup.Default.UnitAbbreviations;
+            Assert.Equal(cache.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a", CultureInfo.InvariantCulture));
+            Assert.Equal(cache.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a0", CultureInfo.InvariantCulture));
 
-            Assert.Equal(UnitAbbreviationsCache.Default.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[1], MyLength.ToString("a1", CultureInfo.InvariantCulture));
-            Assert.Equal(UnitAbbreviationsCache.Default.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[2], MyLength.ToString("a2", CultureInfo.InvariantCulture));
+            Assert.Equal(cache.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[1], MyLength.ToString("a1", CultureInfo.InvariantCulture));
+            Assert.Equal(cache.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[2], MyLength.ToString("a2", CultureInfo.InvariantCulture));
         }
 
         [Fact]

--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -230,6 +230,24 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void MapUnitToAbbreviation_DoesNotAffectOtherCacheInstances()
+        {
+            var culture = AmericanCulture;
+            var unit = AreaUnit.SquareMeter;
+
+            var cache1 = new UnitAbbreviationsCache();
+            cache1.MapUnitToAbbreviation(unit, culture, "m^2");
+
+            var cache2 = new UnitAbbreviationsCache();
+            cache2.MapUnitToAbbreviation(unit, culture, "m2");
+
+            Assert.Equal(new[] { "m²", "m^2" }, cache1.GetUnitAbbreviations(unit, culture));
+            Assert.Equal(new[] { "m²", "m2" }, cache2.GetUnitAbbreviations(unit, culture));
+            Assert.Equal("m²", cache1.GetDefaultAbbreviation(unit, culture));
+            Assert.Equal("m²", cache2.GetDefaultAbbreviation(unit, culture));
+        }
+
+        [Fact]
         public void MapUnitToAbbreviation_AddCustomUnit_DoesNotOverrideDefaultAbbreviationForAlreadyMappedUnits()
         {
             var cache = new UnitAbbreviationsCache();

--- a/UnitsNet/CustomCode/Quantity.cs
+++ b/UnitsNet/CustomCode/Quantity.cs
@@ -9,15 +9,7 @@ namespace UnitsNet
 {
     public partial class Quantity
     {
-        static Quantity()
-        {
-            Default = new QuantityInfoLookup();
-        }
-
-        private static QuantityInfoLookup Default
-        {
-            get;
-        }
+        private static QuantityInfoLookup Default => UnitsNetSetup.Default.QuantityInfoLookup;
 
         /// <summary>
         /// All enum value names of <see cref="Infos"/>, such as "Length" and "Mass".

--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -37,7 +37,8 @@ namespace UnitsNet
         /// <summary>
         ///     The default instance of <see cref="QuantityParser"/>, which uses <see cref="UnitAbbreviationsCache.Default"/> unit abbreviations.
         /// </summary>
-        public static QuantityParser Default { get; }
+        [Obsolete("Use UnitsNetSetup.Default.QuantityParser instead.")]
+        public static QuantityParser Default => UnitsNetSetup.Default.QuantityParser;
 
         /// <summary>
         ///     Creates an instance of <see cref="QuantityParser"/>, optionally specifying an <see cref="UnitAbbreviationsCache"/>
@@ -48,11 +49,6 @@ namespace UnitsNet
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
             _unitParser = new UnitParser(_unitAbbreviationsCache);
-        }
-
-        static QuantityParser()
-        {
-            Default = new QuantityParser(UnitAbbreviationsCache.Default);
         }
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -3,8 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using System.Resources;
 using UnitsNet.Units;
 
 // ReSharper disable once CheckNamespace
@@ -33,7 +35,14 @@ namespace UnitsNet
         [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
         public static UnitAbbreviationsCache Default => UnitsNetSetup.Default.UnitAbbreviations;
 
+        private readonly object _syncRoot = new();
+
         private QuantityInfoLookup QuantityInfoLookup { get; }
+
+        /// <summary>
+        /// Culture name to abbreviations. To add a custom default abbreviation, add to the beginning of the list.
+        /// </summary>
+        private IDictionary<AbbreviationMapKey, IReadOnlyList<string>> AbbreviationsMap { get; } = new Dictionary<AbbreviationMapKey, IReadOnlyList<string>>();
 
         /// <summary>
         ///     Create an instance of the cache and load all the abbreviations defined in the library.
@@ -82,7 +91,7 @@ namespace UnitsNet
         /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         public void MapUnitToAbbreviation<TUnitType>(TUnitType unit, params string[] abbreviations) where TUnitType : Enum
         {
-            PerformAbbreviationMapping(unit, CultureInfo.CurrentCulture, false, true, abbreviations);
+            PerformAbbreviationMapping(unit, CultureInfo.CurrentCulture, false, abbreviations);
         }
 
         /// <summary>
@@ -95,7 +104,7 @@ namespace UnitsNet
         /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         public void MapUnitToDefaultAbbreviation<TUnitType>(TUnitType unit, string abbreviation) where TUnitType : Enum
         {
-            PerformAbbreviationMapping(unit, CultureInfo.CurrentCulture, true, true, abbreviation);
+            PerformAbbreviationMapping(unit, CultureInfo.CurrentCulture, true, abbreviation);
         }
 
         /// <summary>
@@ -109,7 +118,7 @@ namespace UnitsNet
         /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         public void MapUnitToAbbreviation<TUnitType>(TUnitType unit, IFormatProvider? formatProvider, params string[] abbreviations) where TUnitType : Enum
         {
-            PerformAbbreviationMapping(unit, formatProvider, false, true, abbreviations);
+            PerformAbbreviationMapping(unit, formatProvider, false, abbreviations);
         }
 
         /// <summary>
@@ -123,7 +132,7 @@ namespace UnitsNet
         /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         public void MapUnitToDefaultAbbreviation<TUnitType>(TUnitType unit, IFormatProvider? formatProvider, string abbreviation) where TUnitType : Enum
         {
-            PerformAbbreviationMapping(unit, formatProvider, true, true, abbreviation);
+            PerformAbbreviationMapping(unit, formatProvider, true, abbreviation);
         }
 
         /// <summary>
@@ -138,7 +147,7 @@ namespace UnitsNet
         public void MapUnitToAbbreviation(Type unitType, int unitValue, IFormatProvider? formatProvider, params string[] abbreviations)
         {
             var enumValue = (Enum)Enum.ToObject(unitType, unitValue);
-            PerformAbbreviationMapping(enumValue, formatProvider, false, true, abbreviations);
+            PerformAbbreviationMapping(enumValue, formatProvider, false, abbreviations);
         }
 
         /// <summary>
@@ -153,18 +162,18 @@ namespace UnitsNet
         public void MapUnitToDefaultAbbreviation(Type unitType, int unitValue, IFormatProvider? formatProvider, string abbreviation)
         {
             var enumValue = (Enum)Enum.ToObject(unitType, unitValue);
-            PerformAbbreviationMapping(enumValue, formatProvider, true, true, abbreviation);
+            PerformAbbreviationMapping(enumValue, formatProvider, true, abbreviation);
         }
 
-        internal void PerformAbbreviationMapping(Enum unitValue, IFormatProvider? formatProvider, bool setAsDefault, bool allowAbbreviationLookup, params string[] abbreviations)
+        private void PerformAbbreviationMapping(Enum unitValue, IFormatProvider? formatProvider, bool setAsDefault, params string[] abbreviations)
         {
-            if(!QuantityInfoLookup.TryGetUnitInfo(unitValue, out var unitInfo))
+            if(!QuantityInfoLookup.TryGetUnitInfo(unitValue, out UnitInfo? unitInfo))
             {
                 unitInfo = new UnitInfo(unitValue, unitValue.ToString(), BaseUnits.Undefined);
                 QuantityInfoLookup.AddUnitInfo(unitValue, unitInfo);
             }
 
-            unitInfo.AddAbbreviation(formatProvider, setAsDefault, allowAbbreviationLookup, abbreviations);
+            AddAbbreviation(unitInfo, formatProvider, setAsDefault, abbreviations);
         }
 
         /// <summary>
@@ -177,7 +186,7 @@ namespace UnitsNet
         /// <returns>The default unit abbreviation string.</returns>
         public string GetDefaultAbbreviation<TUnitType>(TUnitType unit, IFormatProvider? formatProvider = null) where TUnitType : Enum
         {
-            var unitType = typeof(TUnitType);
+            Type unitType = typeof(TUnitType);
             return GetDefaultAbbreviation(unitType, Convert.ToInt32(unit), formatProvider);
         }
 
@@ -219,10 +228,9 @@ namespace UnitsNet
         {
             formatProvider ??= CultureInfo.CurrentCulture;
 
-            if(TryGetUnitAbbreviations(unitType, unitValue, formatProvider, out var abbreviations))
-                return abbreviations;
-            else
-                throw new NotImplementedException($"No abbreviation is specified for {unitType.Name} with numeric value {unitValue}.");
+            return TryGetUnitAbbreviations(unitType, unitValue, formatProvider, out var abbreviations)
+                ? abbreviations
+                : throw new NotImplementedException($"No abbreviation is specified for {unitType.Name} with numeric value {unitValue}.");
         }
 
         /// <summary>
@@ -240,7 +248,7 @@ namespace UnitsNet
 
             if(QuantityInfoLookup.TryGetUnitInfo(enumInstance, out var unitInfo))
             {
-                abbreviations = unitInfo.GetAbbreviations(formatProvider!).ToArray();
+                abbreviations = GetAbbreviations(unitInfo, formatProvider!).ToArray();
                 return true;
             }
             else
@@ -281,5 +289,177 @@ namespace UnitsNet
 
             return ret;
         }
+
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="unitInfo"></param>
+        /// <param name="formatProvider"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public IReadOnlyList<string> GetAbbreviations(UnitInfo unitInfo, IFormatProvider? formatProvider = null)
+        {
+            if (formatProvider is not CultureInfo)
+                formatProvider = CultureInfo.CurrentCulture;
+
+            var culture = (CultureInfo)formatProvider;
+            var cultureName = GetCultureNameOrEnglish(culture);
+
+            AbbreviationMapKey key = GetAbbreviationMapKey(unitInfo, cultureName);
+            if (!AbbreviationsMap.TryGetValue(key, out IReadOnlyList<string>? abbreviations))
+                AbbreviationsMap[key] = abbreviations = ReadAbbreviationsFromResourceFile(unitInfo.QuantityName, unitInfo.PluralName, culture);
+
+            return abbreviations.Count == 0 && !culture.Equals(FallbackCulture)
+                ? GetAbbreviations(unitInfo, FallbackCulture)
+                : abbreviations;
+        }
+
+        /// <summary>
+        ///     Add unit abbreviation for the given <paramref name="unitInfo"/>, such as "kg" for <see cref="MassUnit.Kilogram"/>.
+        /// </summary>
+        /// <param name="unitInfo">The unit to add for.</param>
+        /// <param name="formatProvider">The culture this abbreviation is for, defaults to <see cref="CultureInfo.CurrentCulture"/>.</param>
+        /// <param name="setAsDefault">Whether to set as the primary/default unit abbreviation used by ToString().</param>
+        /// <param name="abbreviations">One or more abbreviations to add.</param>
+        private void AddAbbreviation(UnitInfo unitInfo, IFormatProvider? formatProvider, bool setAsDefault,
+            params string[] abbreviations)
+        {
+            if (formatProvider is not CultureInfo)
+                formatProvider = CultureInfo.CurrentCulture;
+
+            var culture = (CultureInfo)formatProvider;
+            var cultureName = GetCultureNameOrEnglish(culture);
+
+            // Restrict concurrency on writes.
+            // By using ConcurrencyDictionary and immutable IReadOnlyList instances, we don't need to lock on reads.
+            lock(_syncRoot)
+            {
+                var currentAbbreviationsList = new List<string>(GetAbbreviations(unitInfo, culture));
+
+                foreach (var abbreviation in abbreviations)
+                {
+                    if (!currentAbbreviationsList.Contains(abbreviation))
+                    {
+                        if (setAsDefault)
+                            currentAbbreviationsList.Insert(0, abbreviation);
+                        else
+                            currentAbbreviationsList.Add(abbreviation);
+                    }
+                }
+
+                AbbreviationMapKey key = GetAbbreviationMapKey(unitInfo, cultureName);
+                AbbreviationsMap[key] = currentAbbreviationsList.AsReadOnly();
+            }
+        }
+
+        private static AbbreviationMapKey GetAbbreviationMapKey(UnitInfo unitInfo, string cultureName)
+        {
+            // TODO Enforce quantity name for custom units, optional value was required for backwards compatibility in v5.
+            // TODO Support non-enum units, using quantity name and unit name instead.
+            var unitTypeName = unitInfo.Value.GetType().FullName ?? throw new InvalidOperationException("Could not resolve unit enum type name."); // .QuantityName ?? "MissingQuantityName";
+
+            return new AbbreviationMapKey(
+                UnitTypeName: unitTypeName,
+                UnitName: unitInfo.Name,
+                CultureName: cultureName);
+        }
+
+        private static string GetCultureNameOrEnglish(CultureInfo culture)
+        {
+            // Fallback culture is invariant to support DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1,
+            // but we need to map that to the primary localization, English.
+            return culture.Equals(CultureInfo.InvariantCulture)
+                ? "en-US"
+                : culture.Name;
+        }
+
+        private IReadOnlyList<string> ReadAbbreviationsFromResourceFile(string? quantityName, string unitPluralName, CultureInfo culture)
+        {
+            var abbreviationsList = new List<string>();
+
+            if (quantityName is null) return abbreviationsList.AsReadOnly();
+
+            string resourceName = $"UnitsNet.GeneratedCode.Resources.{quantityName}";
+            var resourceManager = new ResourceManager(resourceName, GetType().Assembly);
+
+            var abbreviationsString = resourceManager.GetString(unitPluralName, culture);
+            if(abbreviationsString is not null)
+                abbreviationsList.AddRange(abbreviationsString.Split(','));
+
+            return abbreviationsList.AsReadOnly();
+        }
+
+#if NETCOREAPP
+        /// <summary>
+        ///     Key for looking up unit abbreviations for a given unit and culture.
+        /// </summary>
+        /// <remarks>
+        ///     TODO Use quantity name instead of unit enum name, as part of moving from enums to string-based lookups.
+        /// </remarks>
+        /// <param name="UnitTypeName">The unit enum type name, such as "UnitsNet.Units.LengthUnit" or "MyApp.HowMuchUnit".</param>
+        /// <param name="UnitName">The unit name, such as "Centimeter".</param>
+        /// <param name="CultureName">The culture name, such as "en-US".</param>
+        [SuppressMessage("ReSharper", "NotAccessedPositionalProperty.Local", Justification = "Only used for hashing and equality.")]
+        private record AbbreviationMapKey(string UnitTypeName, string UnitName, string CultureName);
+#else
+        /// <summary>
+        ///     Key for looking up unit abbreviations for a given unit and culture.
+        /// </summary>
+        /// <remarks>
+        ///     TODO Use quantity name instead of unit enum name, as part of moving from enums to string-based lookups.
+        /// </remarks>
+        private class AbbreviationMapKey : IEquatable<AbbreviationMapKey>
+        {
+            /// <summary>
+            ///     The unit enum type name, such as "UnitsNet.Units.LengthUnit" or "MyApp.HowMuchUnit".
+            /// </summary>
+            public string UnitTypeName { get; }
+
+            /// <summary>
+            ///     The unit name, such as "Centimeter".
+            /// </summary>
+            public string UnitName { get; }
+
+            /// <summary>
+            ///     The culture name, such as "en-US".
+            /// </summary>
+            public string CultureName { get; }
+
+            [SuppressMessage("ReSharper", "InconsistentNaming", Justification = "Matches record naming.")]
+            public AbbreviationMapKey(string UnitTypeName, string UnitName, string CultureName)
+            {
+                this.UnitTypeName = UnitTypeName;
+                this.UnitName = UnitName;
+                this.CultureName = CultureName;
+            }
+
+            public bool Equals(AbbreviationMapKey? other)
+            {
+                if (ReferenceEquals(null, other)) return false;
+                if (ReferenceEquals(this, other)) return true;
+                return UnitTypeName == other.UnitTypeName && UnitName == other.UnitName && CultureName == other.CultureName;
+            }
+
+            public override bool Equals(object? obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                if (obj.GetType() != GetType()) return false;
+                return Equals((AbbreviationMapKey)obj);
+            }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    int hashCode = UnitTypeName.GetHashCode();
+                    hashCode = (hashCode * 397) ^ UnitName.GetHashCode();
+                    hashCode = (hashCode * 397) ^ CultureName.GetHashCode();
+                    return hashCode;
+                }
+            }
+        }
+#endif
+
     }
 }

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -30,22 +30,47 @@ namespace UnitsNet
         /// <summary>
         ///     The static instance used internally for ToString() and Parse() of quantities and units.
         /// </summary>
-        public static UnitAbbreviationsCache Default { get; }
+        [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
+        public static UnitAbbreviationsCache Default => UnitsNetSetup.Default.UnitAbbreviations;
 
         private QuantityInfoLookup QuantityInfoLookup { get; }
 
         /// <summary>
         ///     Create an instance of the cache and load all the abbreviations defined in the library.
         /// </summary>
+        // TODO Change this to create an empty cache in v6: https://github.com/angularsen/UnitsNet/issues/1200
+        [Obsolete("Use CreateDefault() instead to create an instance that loads the built-in units. The default ctor will change to create an empty cache in UnitsNet v6.")]
         public UnitAbbreviationsCache()
+            : this(new QuantityInfoLookup(Quantity.ByName.Values))
         {
-            QuantityInfoLookup= new QuantityInfoLookup();
         }
 
-        static UnitAbbreviationsCache()
+        /// <summary>
+        ///     Creates an instance of the cache and load all the abbreviations defined in the library.
+        /// </summary>
+        /// <remarks>
+        ///     Access type is <c>internal</c> until this class is matured and ready for external use.
+        /// </remarks>
+        internal UnitAbbreviationsCache(QuantityInfoLookup quantityInfoLookup)
         {
-            Default = new UnitAbbreviationsCache();
+            QuantityInfoLookup = quantityInfoLookup;
         }
+
+        /// <summary>
+        ///     Create an instance with empty cache.
+        /// </summary>
+        /// <remarks>
+        ///     Workaround until v6 changes the default ctor to create an empty cache.<br/>
+        /// </remarks>
+        /// <returns>Instance with empty cache.</returns>
+        // TODO Remove in v6: https://github.com/angularsen/UnitsNet/issues/1200
+        public static UnitAbbreviationsCache CreateEmpty() => new(new QuantityInfoLookup(new List<QuantityInfo>()));
+
+        /// <summary>
+        ///     Create an instance of the cache and load all the built-in unit abbreviations defined in the library.
+        /// </summary>
+        /// <returns>Instance with default abbreviations cache.</returns>
+        public static UnitAbbreviationsCache CreateDefault() => new(new QuantityInfoLookup(Quantity.ByName.Values));
 
         /// <summary>
         /// Adds one or more unit abbreviation for the given unit enum value.

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -23,20 +23,17 @@ namespace UnitsNet
         ///     The default static instance used internally to parse quantities and units using the
         ///     default abbreviations cache for all units and abbreviations defined in the library.
         /// </summary>
-        public static UnitParser Default { get; }
+        [Obsolete("Use UnitsNetSetup.Default.UnitParser instead.")]
+        public static UnitParser Default => UnitsNetSetup.Default.UnitParser;
 
         /// <summary>
         ///     Create a parser using the given unit abbreviations cache.
         /// </summary>
         /// <param name="unitAbbreviationsCache"></param>
+        // TODO Change this to not fallback to built-in units abbreviations when given null, in v6: https://github.com/angularsen/UnitsNet/issues/1200
         public UnitParser(UnitAbbreviationsCache? unitAbbreviationsCache)
         {
             _unitAbbreviationsCache = unitAbbreviationsCache ?? UnitAbbreviationsCache.Default;
-        }
-
-        static UnitParser()
-        {
-            Default = new UnitParser(UnitAbbreviationsCache.Default);
         }
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -1,0 +1,85 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.Collections.Generic;
+using UnitsNet.Units;
+
+namespace UnitsNet;
+
+/// <summary>
+///     UnitsNet setup of quantities, units, unit abbreviations and conversion functions.<br />
+///     <br />
+///     For normal use, <see cref="Default" /> is used and can be manipulated to add new units or change default unit
+///     abbreviations.<br />
+///     Alternatively, a setup instance may be provided for most static methods, such as
+///     <see cref="Quantity.Parse(System.Type,string)" /> and
+///     <see cref="QuantityFormatter.Format{TUnitType}(UnitsNet.IQuantity{TUnitType},string)" />.
+/// </summary>
+public sealed class UnitsNetSetup
+{
+    static UnitsNetSetup()
+    {
+        var unitConverter = UnitConverter.CreateDefault();
+        ICollection<QuantityInfo> quantityInfos = Quantity.ByName.Values;
+
+        Default = new UnitsNetSetup(quantityInfos, unitConverter);
+    }
+
+    /// <summary>
+    ///     Create a new UnitsNet setup with the given quantities, their units and unit conversion functions between units.
+    /// </summary>
+    /// <param name="quantityInfos">The quantities and their units to support for unit conversions, Parse() and ToString().</param>
+    /// <param name="unitConverter">The unit converter instance.</param>
+    public UnitsNetSetup(ICollection<QuantityInfo> quantityInfos, UnitConverter unitConverter)
+    {
+        var quantityInfoLookup = new QuantityInfoLookup(quantityInfos);
+        var unitAbbreviations = new UnitAbbreviationsCache(quantityInfoLookup);
+
+        UnitConverter = unitConverter;
+        UnitAbbreviations = unitAbbreviations;
+        UnitParser = new UnitParser(unitAbbreviations);
+        QuantityParser = new QuantityParser(unitAbbreviations);
+        QuantityInfoLookup = quantityInfoLookup;
+    }
+
+    /// <summary>
+    ///     The global default UnitsNet setup of quantities, units, unit abbreviations and conversion functions.
+    ///     This setup is used by default in static Parse and ToString methods of quantities unless a setup instance is
+    ///     provided.
+    /// </summary>
+    /// <remarks>
+    ///     Manipulating this instance, such as adding new units or changing default unit abbreviations, will affect most
+    ///     usages of UnitsNet in the
+    ///     current AppDomain since the typical use is via static members and not providing a setup instance.
+    /// </remarks>
+    public static UnitsNetSetup Default { get; }
+
+    /// <summary>
+    ///     Converts between units of a quantity, such as from meters to centimeters of a given length.
+    /// </summary>
+    public UnitConverter UnitConverter { get; }
+
+    /// <summary>
+    ///     Maps unit enums to unit abbreviation strings for one or more cultures, used by ToString() and Parse() methods of
+    ///     quantities.
+    /// </summary>
+    public UnitAbbreviationsCache UnitAbbreviations { get; }
+
+    /// <summary>
+    ///     Parses units from strings, such as <see cref="LengthUnit.Centimeter" /> from "cm".
+    /// </summary>
+    public UnitParser UnitParser { get; }
+
+    /// <summary>
+    ///     Parses quantities from strings, such as parsing <see cref="Mass" /> from "1.2 kg".
+    /// </summary>
+    internal QuantityParser QuantityParser { get; }
+
+    /// <summary>
+    ///     The quantities and units that are loaded.
+    /// </summary>
+    /// <remarks>
+    ///     Access type is <c>internal</c> until this class is matured and ready for external use.
+    /// </remarks>
+    internal QuantityInfoLookup QuantityInfoLookup { get; }
+}

--- a/UnitsNet/QuantityInfoLookup.cs
+++ b/UnitsNet/QuantityInfoLookup.cs
@@ -9,24 +9,27 @@ namespace UnitsNet
     /// <summary>
     /// A collection of <see cref="QuantityInfo"/>.
     /// </summary>
-    public class QuantityInfoLookup
+    /// <remarks>
+    ///     Access type is <c>internal</c> until this class is matured and ready for external use.
+    /// </remarks>
+    internal class QuantityInfoLookup
     {
-        private readonly Lazy<QuantityInfo[]> InfosLazy;
-        private readonly Lazy<Dictionary<(Type, string), UnitInfo>> UnitTypeAndNameToUnitInfoLazy;
+        private readonly Lazy<QuantityInfo[]> _infosLazy;
+        private readonly Lazy<Dictionary<(Type, string), UnitInfo>> _unitTypeAndNameToUnitInfoLazy;
 
         /// <summary>
         /// New instance.
         /// </summary>
-        public QuantityInfoLookup()
+        /// <param name="quantityInfos"></param>
+        public QuantityInfoLookup(ICollection<QuantityInfo> quantityInfos)
         {
-            ICollection<QuantityInfo> quantityInfos = Quantity.ByName.Values;
             Names = quantityInfos.Select(qt => qt.Name).ToArray();
 
-            InfosLazy = new Lazy<QuantityInfo[]>(() => quantityInfos
+            _infosLazy = new Lazy<QuantityInfo[]>(() => quantityInfos
                 .OrderBy(quantityInfo => quantityInfo.Name)
                 .ToArray());
 
-            UnitTypeAndNameToUnitInfoLazy = new Lazy<Dictionary<(Type, string), UnitInfo>>(() =>
+            _unitTypeAndNameToUnitInfoLazy = new Lazy<Dictionary<(Type, string), UnitInfo>>(() =>
             {
                 return Infos
                     .SelectMany(quantityInfo => quantityInfo.UnitInfos
@@ -45,18 +48,18 @@ namespace UnitsNet
         /// <summary>
         /// All quantity information objects, such as <see cref="Length.Info"/> and <see cref="Mass.Info"/>.
         /// </summary>
-        public QuantityInfo[] Infos => InfosLazy.Value;
+        public QuantityInfo[] Infos => _infosLazy.Value;
 
         /// <summary>
         /// Get <see cref="UnitInfo"/> for a given unit enum value.
         /// </summary>
-        public UnitInfo GetUnitInfo(Enum unitEnum) => UnitTypeAndNameToUnitInfoLazy.Value[(unitEnum.GetType(), unitEnum.ToString())];
+        public UnitInfo GetUnitInfo(Enum unitEnum) => _unitTypeAndNameToUnitInfoLazy.Value[(unitEnum.GetType(), unitEnum.ToString())];
 
         /// <summary>
         /// Try to get <see cref="UnitInfo"/> for a given unit enum value.
         /// </summary>
         public bool TryGetUnitInfo(Enum unitEnum, [NotNullWhen(true)] out UnitInfo? unitInfo) =>
-            UnitTypeAndNameToUnitInfoLazy.Value.TryGetValue((unitEnum.GetType(), unitEnum.ToString()), out unitInfo);
+            _unitTypeAndNameToUnitInfoLazy.Value.TryGetValue((unitEnum.GetType(), unitEnum.ToString()), out unitInfo);
 
         /// <summary>
         ///
@@ -65,7 +68,7 @@ namespace UnitsNet
         /// <param name="unitInfo"></param>
         public void AddUnitInfo(Enum unit, UnitInfo unitInfo)
         {
-            UnitTypeAndNameToUnitInfoLazy.Value.Add((unit.GetType(), unit.ToString()), unitInfo);
+            _unitTypeAndNameToUnitInfoLazy.Value.Add((unit.GetType(), unit.ToString()), unitInfo);
         }
 
         /// <summary>
@@ -77,6 +80,7 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">Unit value is not a know unit enum type.</exception>
         public IQuantity From(QuantityValue value, Enum unit)
         {
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
             return Quantity.TryFrom(value, unit, out IQuantity? quantity)
                 ? quantity
                 : throw new UnitNotFoundException($"Unit value {unit} of type {unit.GetType()} is not a known unit enum type. Expected types like UnitsNet.Units.LengthUnit. Did you pass in a custom enum type defined outside the UnitsNet library?");
@@ -93,6 +97,7 @@ namespace UnitsNet
                 return false;
             }
 
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
             return Quantity.TryFrom((QuantityValue)value, unit, out quantity);
         }
 
@@ -112,6 +117,7 @@ namespace UnitsNet
             if (!typeof(IQuantity).IsAssignableFrom(quantityType))
                 throw new ArgumentException($"Type {quantityType} must be of type UnitsNet.IQuantity.");
 
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
             if (Quantity.TryParse(formatProvider, quantityType, quantityString, out IQuantity? quantity))
                 return quantity;
 
@@ -119,8 +125,11 @@ namespace UnitsNet
         }
 
         /// <inheritdoc cref="Quantity.TryParse(IFormatProvider,System.Type,string,out UnitsNet.IQuantity)"/>
-        public bool TryParse(Type quantityType, string quantityString, [NotNullWhen(true)] out IQuantity? quantity) =>
-            Quantity.TryParse(null, quantityType, quantityString, out quantity);
+        public bool TryParse(Type quantityType, string quantityString, [NotNullWhen(true)] out IQuantity? quantity)
+        {
+            // TODO Support custom units, currently only hardcoded built-in quantities are supported.
+            return Quantity.TryParse(null, quantityType, quantityString, out quantity);
+        }
 
         /// <summary>
         ///     Get a list of quantities that has the given base dimensions.
@@ -128,7 +137,7 @@ namespace UnitsNet
         /// <param name="baseDimensions">The base dimensions to match.</param>
         public IEnumerable<QuantityInfo> GetQuantitiesWithBaseDimensions(BaseDimensions baseDimensions)
         {
-            return InfosLazy.Value.Where(info => info.BaseDimensions.Equals(baseDimensions));
+            return _infosLazy.Value.Where(info => info.BaseDimensions.Equals(baseDimensions));
         }
     }
 }

--- a/UnitsNet/QuantityInfoLookup.cs
+++ b/UnitsNet/QuantityInfoLookup.cs
@@ -51,6 +51,31 @@ namespace UnitsNet
         public QuantityInfo[] Infos => _infosLazy.Value;
 
         /// <summary>
+        /// Gets the <see cref="QuantityInfo"/> for a given unit.
+        /// </summary>
+        public QuantityInfo GetQuantityInfo(UnitInfo unitInfo)
+        {
+            Type unitType = unitInfo.Value.GetType();
+            return _infosLazy.Value.First(i => i.UnitType == unitType);
+        }
+
+        /// <summary>
+        /// Try to get the <see cref="QuantityInfo"/> for a given unit.
+        /// </summary>
+        public bool TryGetQuantityInfo(UnitInfo unitInfo, [NotNullWhen(true)] out QuantityInfo? quantityInfo)
+        {
+            Type unitType = unitInfo.Value.GetType();
+            if (_infosLazy.Value.FirstOrDefault(i => i.UnitType == unitType) is { } qi)
+            {
+                quantityInfo = qi;
+                return true;
+            }
+
+            quantityInfo = default;
+            return false;
+        }
+
+        /// <summary>
         /// Get <see cref="UnitInfo"/> for a given unit enum value.
         /// </summary>
         public UnitInfo GetUnitInfo(Enum unitEnum) => _unitTypeAndNameToUnitInfoLazy.Value[(unitEnum.GetType(), unitEnum.ToString())];

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -39,13 +39,8 @@ namespace UnitsNet
         /// The static instance used by Units.NET to convert between units. Modify this to add/remove conversion functions at runtime, such
         /// as adding your own third-party units and quantities to convert between.
         /// </summary>
-        public static UnitConverter Default { get; }
-
-        static UnitConverter()
-        {
-            Default = new UnitConverter();
-            RegisterDefaultConversions(Default);
-        }
+        [Obsolete("Use UnitsNetSetup.Default.UnitConverter instead.")]
+        public static UnitConverter Default => UnitsNetSetup.Default.UnitConverter;
 
         /// <summary>
         /// Creates a new <see cref="UnitConverter"/> instance.
@@ -62,6 +57,18 @@ namespace UnitsNet
         public UnitConverter(UnitConverter other)
         {
             ConversionFunctions = new ConcurrentDictionary<ConversionFunctionLookupKey, ConversionFunction>(other.ConversionFunctions);
+        }
+
+        /// <summary>
+        ///     Create an instance of the unit converter with all the built-in unit conversions defined in the library.
+        /// </summary>
+        /// <returns>The unit converter.</returns>
+        public static UnitConverter CreateDefault()
+        {
+            var unitConverter = new UnitConverter();
+            RegisterDefaultConversions(unitConverter);
+
+            return unitConverter;
         }
 
         private ConcurrentDictionary<ConversionFunctionLookupKey, ConversionFunction> ConversionFunctions

--- a/UnitsNet/UnitInfo.cs
+++ b/UnitsNet/UnitInfo.cs
@@ -2,10 +2,6 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Resources;
 using UnitsNet.Units;
 
 namespace UnitsNet
@@ -21,8 +17,6 @@ namespace UnitsNet
     /// </remarks>
     public class UnitInfo
     {
-        private readonly object _syncRoot = new();
-
         /// <summary>
         /// Creates an instance of the UnitInfo class.
         /// </summary>
@@ -35,8 +29,6 @@ namespace UnitsNet
             Name = value.ToString();
             PluralName = pluralName;
             BaseUnits = baseUnits ?? throw new ArgumentNullException(nameof(baseUnits));
-
-            AbbreviationsMap = new ConcurrentDictionary<string, Lazy<IReadOnlyList<string>>>();
         }
 
         /// <summary>
@@ -72,97 +64,10 @@ namespace UnitsNet
         /// </summary>
         public BaseUnits BaseUnits { get; }
 
-        private string? QuantityName { get; }
-
         /// <summary>
-        /// Culture name to abbreviations. To add a custom default abbreviation, add to the beginning of the list.
+        /// Name of the quantity this unit belongs to. May be null for custom units.
         /// </summary>
-        private IDictionary<string, Lazy<IReadOnlyList<string>>> AbbreviationsMap { get; }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="formatProvider"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
-        public IReadOnlyList<string> GetAbbreviations(IFormatProvider? formatProvider = null)
-        {
-            if(formatProvider is null || formatProvider is not CultureInfo)
-                formatProvider = CultureInfo.CurrentCulture;
-
-            var culture = (CultureInfo)formatProvider;
-            var cultureName = GetCultureNameOrEnglish(culture);
-
-            if(!AbbreviationsMap.TryGetValue(cultureName, out var abbreviations))
-                AbbreviationsMap[cultureName] = abbreviations = new Lazy<IReadOnlyList<string>>(() => ReadAbbreviationsFromResourceFile(culture));
-
-            if(abbreviations.Value.Count == 0 && !culture.Equals(UnitAbbreviationsCache.FallbackCulture))
-                return GetAbbreviations(UnitAbbreviationsCache.FallbackCulture);
-            else
-                return abbreviations.Value;
-        }
-
-        /// <summary>
-        ///
-        /// </summary>
-        /// <param name="formatProvider"></param>
-        /// <param name="setAsDefault"></param>
-        /// <param name="allowAbbreviationLookup"></param>
-        /// <param name="abbreviations"></param>
-        public void AddAbbreviation(IFormatProvider? formatProvider, bool setAsDefault, bool allowAbbreviationLookup, params string[] abbreviations)
-        {
-            if(formatProvider is null || formatProvider is not CultureInfo)
-                formatProvider = CultureInfo.CurrentCulture;
-
-            var culture = (CultureInfo)formatProvider;
-            var cultureName = GetCultureNameOrEnglish(culture);
-
-            // Restrict concurrency on writes.
-            // By using ConcurrencyDictionary and immutable IReadOnlyList instances, we don't need to lock on reads.
-            lock(_syncRoot)
-            {
-                var currentAbbreviationsList = new List<string>(GetAbbreviations(culture));
-
-                foreach(var abbreviation in abbreviations)
-                {
-                    if(!currentAbbreviationsList.Contains(abbreviation))
-                    {
-                        if(setAsDefault)
-                            currentAbbreviationsList.Insert(0, abbreviation);
-                        else
-                            currentAbbreviationsList.Add(abbreviation);
-                    }
-                }
-
-                AbbreviationsMap[cultureName] = new Lazy<IReadOnlyList<string>>(() => currentAbbreviationsList.AsReadOnly());
-            }
-        }
-
-        private static string GetCultureNameOrEnglish(CultureInfo culture)
-        {
-            // Fallback culture is invariant to support DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1,
-            // but we need to map that to the primary localization, English.
-            return culture.Equals(CultureInfo.InvariantCulture)
-                ? "en-US"
-                : culture.Name;
-        }
-
-        private IReadOnlyList<string> ReadAbbreviationsFromResourceFile(CultureInfo culture)
-        {
-            var abbreviationsList = new List<string>();
-
-            if(QuantityName is not null)
-            {
-                string resourceName = $"UnitsNet.GeneratedCode.Resources.{QuantityName}";
-                var resourceManager = new ResourceManager(resourceName, GetType().Assembly);
-
-                var abbreviationsString = resourceManager.GetString(PluralName, culture);
-                if(abbreviationsString is not null)
-                    abbreviationsList.AddRange(abbreviationsString.Split(','));
-            }
-
-            return abbreviationsList.AsReadOnly();
-        }
+        public string? QuantityName { get; }
     }
 
     /// <inheritdoc cref="UnitInfo" />


### PR DESCRIPTION
Added `UnitsNetSetup` to gather global state in a single place as a singleton, with the possibility of passing instances of it to static methods later to override the defaults.

This way, state is no longer scattered among multiple classes that depend on each other in non-obvious ways and where initialization order has caused issues up until now.

### Changes
- Add `UnitsNetSetup` to hold global state as a singleton property `Default` that controls default state initialization.
  - Add properties for all "services" that depend on global state: `UnitConverter, UnitAbbreviationsCache, UnitParser, QuantityParser`
- Forward all other `Default` singleton properties from these services to `UnitsNetSetup.Default` and mark obsolete
- Add some TODOs where it seems functionality is missing

### Testing
❌ Still running into a handful of flaky tests due to racing conditions. 
This was a regression in #1210, but still not fixed.
Will investigate and fix in separate PR.

```
UnitAbbreviationsCacheTests.AllUnitsImplementToStringForInvariantCulture
UnitAbbreviationsCacheTests.MapUnitToAbbreviation_AddCustomUnit_DoesNotOverrideDefaultAbbreviationForAlreadyMappedUnits
```