### PR TITLE
Add units to ElectricCurrentGradient, PressureChangeRate

### DIFF
--- a/Common/UnitDefinitions/ElectricCurrentGradient.json
+++ b/Common/UnitDefinitions/ElectricCurrentGradient.json
@@ -10,12 +10,34 @@
     {
       "SingularName": "AmperePerSecond",
       "PluralName": "AmperesPerSecond",
+      "BaseUnits": {
+        "T": "Second",
+        "I": "Ampere"
+      },
       "FromUnitToBaseFunc": "{x}",
       "FromBaseToUnitFunc": "{x}",
+      "Prefixes": [ "Milli" ],
       "Localization": [
         {
           "Culture": "en-US",
           "Abbreviations": [ "A/s" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "AmperePerMinute",
+      "PluralName": "AmperesPerMinute",
+      "BaseUnits": {
+        "T": "Minute",
+        "I": "Ampere"
+      },
+      "FromUnitToBaseFunc": "{x} / 60",
+      "FromBaseToUnitFunc": "{x} * 60",
+      "Prefixes": [ "Milli" ],
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "A/min" ]
         }
       ]
     },

--- a/Common/UnitDefinitions/PressureChangeRate.json
+++ b/Common/UnitDefinitions/PressureChangeRate.json
@@ -42,7 +42,7 @@
         }
       ]
     },
-	{
+    {
       "SingularName": "MillimeterOfMercuryPerSecond",
       "PluralName": "MillimetersOfMercuryPerSecond",
       "FromUnitToBaseFunc": "{x} * 133.322",
@@ -74,7 +74,7 @@
         }
       ]
     },
-	    {
+    {
       "SingularName": "PoundForcePerSquareInchPerSecond",
       "PluralName": "PoundsForcePerSquareInchPerSecond",
       "FromUnitToBaseFunc": "{x} * 6.894757293168361e3",
@@ -109,6 +109,40 @@
           "Culture": "ru-RU",
           "Abbreviations": [ "psi/мин", "lb/in²/мин" ],
           "AbbreviationsForPrefixes": { "Kilo": [ "ksi/мин", "kipf/in²/мин" ]}
+        }
+      ]
+    },
+    {
+      "SingularName": "BarPerSecond",
+      "PluralName": "BarsPerSecond",
+      "FromUnitToBaseFunc": "{x} * 1e5",
+      "FromBaseToUnitFunc": "{x} / 1e5",
+      "Prefixes": [ "Milli" ],
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "bar/s" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "бар/с" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "BarPerMinute",
+      "PluralName": "BarsPerMinute",
+      "FromUnitToBaseFunc": "{x} * 1e5 / 60",
+      "FromBaseToUnitFunc": "{x} / 1e5 * 60",
+      "Prefixes": [ "Milli" ],
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "bar/min" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "бар/мин" ]
         }
       ]
     }

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -298,7 +298,10 @@
     "AmperePerMicrosecond": 1,
     "AmperePerMillisecond": 2,
     "AmperePerNanosecond": 3,
-    "AmperePerSecond": 4
+    "AmperePerSecond": 4,
+    "AmperePerMinute": 11,
+    "MilliamperePerMinute": 6,
+    "MilliamperePerSecond": 14
   },
   "ElectricField": {
     "VoltPerMeter": 1
@@ -1153,7 +1156,11 @@
     "PascalPerMinute": 11,
     "PascalPerSecond": 12,
     "PoundForcePerSquareInchPerMinute": 13,
-    "PoundForcePerSquareInchPerSecond": 14
+    "PoundForcePerSquareInchPerSecond": 14,
+    "BarPerMinute": 16,
+    "BarPerSecond": 23,
+    "MillibarPerMinute": 24,
+    "MillibarPerSecond": 20
   },
   "Ratio": {
     "DecimalFraction": 1,

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -90,6 +90,11 @@ namespace UnitsNet
         public double AmperesPerMillisecond => As(ElectricCurrentGradientUnit.AmperePerMillisecond);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.AmperePerMinute"/>
+        /// </summary>
+        public double AmperesPerMinute => As(ElectricCurrentGradientUnit.AmperePerMinute);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.AmperePerNanosecond"/>
         /// </summary>
         public double AmperesPerNanosecond => As(ElectricCurrentGradientUnit.AmperePerNanosecond);
@@ -98,6 +103,16 @@ namespace UnitsNet
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.AmperePerSecond"/>
         /// </summary>
         public double AmperesPerSecond => As(ElectricCurrentGradientUnit.AmperePerSecond);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.MilliamperePerMinute"/>
+        /// </summary>
+        public double MilliamperesPerMinute => As(ElectricCurrentGradientUnit.MilliamperePerMinute);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.MilliamperePerSecond"/>
+        /// </summary>
+        public double MilliamperesPerSecond => As(ElectricCurrentGradientUnit.MilliamperePerSecond);
 
         #endregion
 
@@ -116,6 +131,12 @@ namespace UnitsNet
         public static ElectricCurrentGradient FromAmperesPerMillisecond(double amperespermillisecond) => new ElectricCurrentGradient(amperespermillisecond, ElectricCurrentGradientUnit.AmperePerMillisecond);
 
         /// <summary>
+        ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.AmperePerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricCurrentGradient FromAmperesPerMinute(double amperesperminute) => new ElectricCurrentGradient(amperesperminute, ElectricCurrentGradientUnit.AmperePerMinute);
+
+        /// <summary>
         ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.AmperePerNanosecond"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
@@ -126,6 +147,18 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static ElectricCurrentGradient FromAmperesPerSecond(double amperespersecond) => new ElectricCurrentGradient(amperespersecond, ElectricCurrentGradientUnit.AmperePerSecond);
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.MilliamperePerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricCurrentGradient FromMilliamperesPerMinute(double milliamperesperminute) => new ElectricCurrentGradient(milliamperesperminute, ElectricCurrentGradientUnit.MilliamperePerMinute);
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.MilliamperePerSecond"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricCurrentGradient FromMilliamperesPerSecond(double milliamperespersecond) => new ElectricCurrentGradient(milliamperespersecond, ElectricCurrentGradientUnit.MilliamperePerSecond);
 
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="ElectricCurrentGradientUnit" /> to <see cref="ElectricCurrentGradient" />.
@@ -169,8 +202,11 @@ namespace UnitsNet
                     {
                         ElectricCurrentGradientUnit.AmperePerMicrosecond => _value * 1E6,
                         ElectricCurrentGradientUnit.AmperePerMillisecond => _value * 1E3,
+                        ElectricCurrentGradientUnit.AmperePerMinute => _value / 60,
                         ElectricCurrentGradientUnit.AmperePerNanosecond => _value * 1E9,
                         ElectricCurrentGradientUnit.AmperePerSecond => _value,
+                        ElectricCurrentGradientUnit.MilliamperePerMinute => (_value / 60) * 1e-3d,
+                        ElectricCurrentGradientUnit.MilliamperePerSecond => (_value) * 1e-3d,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to base units.")
                     };
                     }
@@ -186,8 +222,11 @@ namespace UnitsNet
                     {
                         ElectricCurrentGradientUnit.AmperePerMicrosecond => baseUnitValue / 1E6,
                         ElectricCurrentGradientUnit.AmperePerMillisecond => baseUnitValue / 1E3,
+                        ElectricCurrentGradientUnit.AmperePerMinute => baseUnitValue * 60,
                         ElectricCurrentGradientUnit.AmperePerNanosecond => baseUnitValue / 1E9,
                         ElectricCurrentGradientUnit.AmperePerSecond => baseUnitValue,
+                        ElectricCurrentGradientUnit.MilliamperePerMinute => (baseUnitValue * 60) / 1e-3d,
+                        ElectricCurrentGradientUnit.MilliamperePerSecond => (baseUnitValue) / 1e-3d,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to {unit}.")
                     };
                     }

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -85,6 +85,16 @@ namespace UnitsNet
         public double AtmospheresPerSecond => As(PressureChangeRateUnit.AtmospherePerSecond);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.BarPerMinute"/>
+        /// </summary>
+        public double BarsPerMinute => As(PressureChangeRateUnit.BarPerMinute);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.BarPerSecond"/>
+        /// </summary>
+        public double BarsPerSecond => As(PressureChangeRateUnit.BarPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.KilopascalPerMinute"/>
         /// </summary>
         public double KilopascalsPerMinute => As(PressureChangeRateUnit.KilopascalPerMinute);
@@ -125,6 +135,16 @@ namespace UnitsNet
         public double MegapoundsForcePerSquareInchPerSecond => As(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.MillibarPerMinute"/>
+        /// </summary>
+        public double MillibarsPerMinute => As(PressureChangeRateUnit.MillibarPerMinute);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.MillibarPerSecond"/>
+        /// </summary>
+        public double MillibarsPerSecond => As(PressureChangeRateUnit.MillibarPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.MillimeterOfMercuryPerSecond"/>
         /// </summary>
         public double MillimetersOfMercuryPerSecond => As(PressureChangeRateUnit.MillimeterOfMercuryPerSecond);
@@ -158,6 +178,18 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static PressureChangeRate FromAtmospheresPerSecond(double atmospherespersecond) => new PressureChangeRate(atmospherespersecond, PressureChangeRateUnit.AtmospherePerSecond);
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.BarPerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromBarsPerMinute(double barsperminute) => new PressureChangeRate(barsperminute, PressureChangeRateUnit.BarPerMinute);
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.BarPerSecond"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromBarsPerSecond(double barspersecond) => new PressureChangeRate(barspersecond, PressureChangeRateUnit.BarPerSecond);
 
         /// <summary>
         ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.KilopascalPerMinute"/>.
@@ -206,6 +238,18 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static PressureChangeRate FromMegapoundsForcePerSquareInchPerSecond(double megapoundsforcepersquareinchpersecond) => new PressureChangeRate(megapoundsforcepersquareinchpersecond, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond);
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.MillibarPerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromMillibarsPerMinute(double millibarsperminute) => new PressureChangeRate(millibarsperminute, PressureChangeRateUnit.MillibarPerMinute);
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.MillibarPerSecond"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromMillibarsPerSecond(double millibarspersecond) => new PressureChangeRate(millibarspersecond, PressureChangeRateUnit.MillibarPerSecond);
 
         /// <summary>
         ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.MillimeterOfMercuryPerSecond"/>.
@@ -278,6 +322,8 @@ namespace UnitsNet
                     return Unit switch
                     {
                         PressureChangeRateUnit.AtmospherePerSecond => _value * 1.01325 * 1e5,
+                        PressureChangeRateUnit.BarPerMinute => _value * 1e5 / 60,
+                        PressureChangeRateUnit.BarPerSecond => _value * 1e5,
                         PressureChangeRateUnit.KilopascalPerMinute => (_value / 60) * 1e3d,
                         PressureChangeRateUnit.KilopascalPerSecond => (_value) * 1e3d,
                         PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute => (_value * 6.894757293168361e3 / 60) * 1e3d,
@@ -286,6 +332,8 @@ namespace UnitsNet
                         PressureChangeRateUnit.MegapascalPerSecond => (_value) * 1e6d,
                         PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute => (_value * 6.894757293168361e3 / 60) * 1e6d,
                         PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond => (_value * 6.894757293168361e3) * 1e6d,
+                        PressureChangeRateUnit.MillibarPerMinute => (_value * 1e5 / 60) * 1e-3d,
+                        PressureChangeRateUnit.MillibarPerSecond => (_value * 1e5) * 1e-3d,
                         PressureChangeRateUnit.MillimeterOfMercuryPerSecond => _value * 133.322,
                         PressureChangeRateUnit.PascalPerMinute => _value / 60,
                         PressureChangeRateUnit.PascalPerSecond => _value,
@@ -305,6 +353,8 @@ namespace UnitsNet
                     return unit switch
                     {
                         PressureChangeRateUnit.AtmospherePerSecond => baseUnitValue / (1.01325 * 1e5),
+                        PressureChangeRateUnit.BarPerMinute => baseUnitValue / 1e5 * 60,
+                        PressureChangeRateUnit.BarPerSecond => baseUnitValue / 1e5,
                         PressureChangeRateUnit.KilopascalPerMinute => (baseUnitValue * 60) / 1e3d,
                         PressureChangeRateUnit.KilopascalPerSecond => (baseUnitValue) / 1e3d,
                         PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute => (baseUnitValue / 6.894757293168361e3 * 60) / 1e3d,
@@ -313,6 +363,8 @@ namespace UnitsNet
                         PressureChangeRateUnit.MegapascalPerSecond => (baseUnitValue) / 1e6d,
                         PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute => (baseUnitValue / 6.894757293168361e3 * 60) / 1e6d,
                         PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond => (baseUnitValue / 6.894757293168361e3) / 1e6d,
+                        PressureChangeRateUnit.MillibarPerMinute => (baseUnitValue / 1e5 * 60) / 1e-3d,
+                        PressureChangeRateUnit.MillibarPerSecond => (baseUnitValue / 1e5) / 1e-3d,
                         PressureChangeRateUnit.MillimeterOfMercuryPerSecond => baseUnitValue / 133.322,
                         PressureChangeRateUnit.PascalPerMinute => baseUnitValue * 60,
                         PressureChangeRateUnit.PascalPerSecond => baseUnitValue,

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/ElectricCurrentGradientUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/ElectricCurrentGradientUnit.g.cs
@@ -27,8 +27,11 @@ namespace UnitsNet.Units
     {
         AmperePerMicrosecond = 1,
         AmperePerMillisecond = 2,
+        AmperePerMinute = 11,
         AmperePerNanosecond = 3,
         AmperePerSecond = 4,
+        MilliamperePerMinute = 6,
+        MilliamperePerSecond = 14,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/PressureChangeRateUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/PressureChangeRateUnit.g.cs
@@ -26,6 +26,8 @@ namespace UnitsNet.Units
     public enum PressureChangeRateUnit
     {
         AtmospherePerSecond = 1,
+        BarPerMinute = 16,
+        BarPerSecond = 23,
         KilopascalPerMinute = 2,
         KilopascalPerSecond = 3,
         KilopoundForcePerSquareInchPerMinute = 4,
@@ -34,6 +36,8 @@ namespace UnitsNet.Units
         MegapascalPerSecond = 7,
         MegapoundForcePerSquareInchPerMinute = 8,
         MegapoundForcePerSquareInchPerSecond = 9,
+        MillibarPerMinute = 24,
+        MillibarPerSecond = 20,
         MillimeterOfMercuryPerSecond = 10,
         PascalPerMinute = 11,
         PascalPerSecond = 12,

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToElectricCurrentGradientExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToElectricCurrentGradientExtensionsTest.g.cs
@@ -33,12 +33,24 @@ namespace UnitsNet.Tests
             Assert.Equal(ElectricCurrentGradient.FromAmperesPerMillisecond(2), 2.AmperesPerMillisecond());
 
         [Fact]
+        public void NumberToAmperesPerMinuteTest() =>
+            Assert.Equal(ElectricCurrentGradient.FromAmperesPerMinute(2), 2.AmperesPerMinute());
+
+        [Fact]
         public void NumberToAmperesPerNanosecondTest() =>
             Assert.Equal(ElectricCurrentGradient.FromAmperesPerNanosecond(2), 2.AmperesPerNanosecond());
 
         [Fact]
         public void NumberToAmperesPerSecondTest() =>
             Assert.Equal(ElectricCurrentGradient.FromAmperesPerSecond(2), 2.AmperesPerSecond());
+
+        [Fact]
+        public void NumberToMilliamperesPerMinuteTest() =>
+            Assert.Equal(ElectricCurrentGradient.FromMilliamperesPerMinute(2), 2.MilliamperesPerMinute());
+
+        [Fact]
+        public void NumberToMilliamperesPerSecondTest() =>
+            Assert.Equal(ElectricCurrentGradient.FromMilliamperesPerSecond(2), 2.MilliamperesPerSecond());
 
     }
 }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToPressureChangeRateExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToPressureChangeRateExtensionsTest.g.cs
@@ -29,6 +29,14 @@ namespace UnitsNet.Tests
             Assert.Equal(PressureChangeRate.FromAtmospheresPerSecond(2), 2.AtmospheresPerSecond());
 
         [Fact]
+        public void NumberToBarsPerMinuteTest() =>
+            Assert.Equal(PressureChangeRate.FromBarsPerMinute(2), 2.BarsPerMinute());
+
+        [Fact]
+        public void NumberToBarsPerSecondTest() =>
+            Assert.Equal(PressureChangeRate.FromBarsPerSecond(2), 2.BarsPerSecond());
+
+        [Fact]
         public void NumberToKilopascalsPerMinuteTest() =>
             Assert.Equal(PressureChangeRate.FromKilopascalsPerMinute(2), 2.KilopascalsPerMinute());
 
@@ -59,6 +67,14 @@ namespace UnitsNet.Tests
         [Fact]
         public void NumberToMegapoundsForcePerSquareInchPerSecondTest() =>
             Assert.Equal(PressureChangeRate.FromMegapoundsForcePerSquareInchPerSecond(2), 2.MegapoundsForcePerSquareInchPerSecond());
+
+        [Fact]
+        public void NumberToMillibarsPerMinuteTest() =>
+            Assert.Equal(PressureChangeRate.FromMillibarsPerMinute(2), 2.MillibarsPerMinute());
+
+        [Fact]
+        public void NumberToMillibarsPerSecondTest() =>
+            Assert.Equal(PressureChangeRate.FromMillibarsPerSecond(2), 2.MillibarsPerSecond());
 
         [Fact]
         public void NumberToMillimetersOfMercuryPerSecondTest() =>

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToElectricCurrentGradientExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToElectricCurrentGradientExtensions.g.cs
@@ -36,6 +36,10 @@ namespace UnitsNet.NumberExtensions.NumberToElectricCurrentGradient
         public static ElectricCurrentGradient AmperesPerMillisecond<T>(this T value) =>
             ElectricCurrentGradient.FromAmperesPerMillisecond(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerMinute(UnitsNet.QuantityValue)" />
+        public static ElectricCurrentGradient AmperesPerMinute<T>(this T value) =>
+            ElectricCurrentGradient.FromAmperesPerMinute(Convert.ToDouble(value));
+
         /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerNanosecond(UnitsNet.QuantityValue)" />
         public static ElectricCurrentGradient AmperesPerNanosecond<T>(this T value) =>
             ElectricCurrentGradient.FromAmperesPerNanosecond(Convert.ToDouble(value));
@@ -43,6 +47,14 @@ namespace UnitsNet.NumberExtensions.NumberToElectricCurrentGradient
         /// <inheritdoc cref="ElectricCurrentGradient.FromAmperesPerSecond(UnitsNet.QuantityValue)" />
         public static ElectricCurrentGradient AmperesPerSecond<T>(this T value) =>
             ElectricCurrentGradient.FromAmperesPerSecond(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="ElectricCurrentGradient.FromMilliamperesPerMinute(UnitsNet.QuantityValue)" />
+        public static ElectricCurrentGradient MilliamperesPerMinute<T>(this T value) =>
+            ElectricCurrentGradient.FromMilliamperesPerMinute(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="ElectricCurrentGradient.FromMilliamperesPerSecond(UnitsNet.QuantityValue)" />
+        public static ElectricCurrentGradient MilliamperesPerSecond<T>(this T value) =>
+            ElectricCurrentGradient.FromMilliamperesPerSecond(Convert.ToDouble(value));
 
     }
 }

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToPressureChangeRateExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToPressureChangeRateExtensions.g.cs
@@ -32,6 +32,14 @@ namespace UnitsNet.NumberExtensions.NumberToPressureChangeRate
         public static PressureChangeRate AtmospheresPerSecond<T>(this T value) =>
             PressureChangeRate.FromAtmospheresPerSecond(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="PressureChangeRate.FromBarsPerMinute(UnitsNet.QuantityValue)" />
+        public static PressureChangeRate BarsPerMinute<T>(this T value) =>
+            PressureChangeRate.FromBarsPerMinute(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="PressureChangeRate.FromBarsPerSecond(UnitsNet.QuantityValue)" />
+        public static PressureChangeRate BarsPerSecond<T>(this T value) =>
+            PressureChangeRate.FromBarsPerSecond(Convert.ToDouble(value));
+
         /// <inheritdoc cref="PressureChangeRate.FromKilopascalsPerMinute(UnitsNet.QuantityValue)" />
         public static PressureChangeRate KilopascalsPerMinute<T>(this T value) =>
             PressureChangeRate.FromKilopascalsPerMinute(Convert.ToDouble(value));
@@ -63,6 +71,14 @@ namespace UnitsNet.NumberExtensions.NumberToPressureChangeRate
         /// <inheritdoc cref="PressureChangeRate.FromMegapoundsForcePerSquareInchPerSecond(UnitsNet.QuantityValue)" />
         public static PressureChangeRate MegapoundsForcePerSquareInchPerSecond<T>(this T value) =>
             PressureChangeRate.FromMegapoundsForcePerSquareInchPerSecond(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="PressureChangeRate.FromMillibarsPerMinute(UnitsNet.QuantityValue)" />
+        public static PressureChangeRate MillibarsPerMinute<T>(this T value) =>
+            PressureChangeRate.FromMillibarsPerMinute(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="PressureChangeRate.FromMillibarsPerSecond(UnitsNet.QuantityValue)" />
+        public static PressureChangeRate MillibarsPerSecond<T>(this T value) =>
+            PressureChangeRate.FromMillibarsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="PressureChangeRate.FromMillimetersOfMercuryPerSecond(UnitsNet.QuantityValue)" />
         public static PressureChangeRate MillimetersOfMercuryPerSecond<T>(this T value) =>

--- a/UnitsNet.Tests/CustomCode/ElectricCurrentGradientTests.cs
+++ b/UnitsNet.Tests/CustomCode/ElectricCurrentGradientTests.cs
@@ -27,10 +27,14 @@ namespace UnitsNet.Tests.CustomCode
 {
     public class ElectricCurrentGradientTests : ElectricCurrentGradientTestsBase
     {
-        protected override bool SupportsSIUnitSystem => false;
+        protected override bool SupportsSIUnitSystem => true;
         protected override double AmperesPerSecondInOneAmperePerSecond => 1;
         protected override double AmperesPerMillisecondInOneAmperePerSecond => 1e-03;
         protected override double AmperesPerMicrosecondInOneAmperePerSecond => 1e-06;
         protected override double AmperesPerNanosecondInOneAmperePerSecond => 1e-09;
+
+        protected override double AmperesPerMinuteInOneAmperePerSecond => 60;
+        protected override double MilliamperesPerMinuteInOneAmperePerSecond => 6e4;
+        protected override double MilliamperesPerSecondInOneAmperePerSecond => 1e3;
     }
 }

--- a/UnitsNet.Tests/CustomCode/ElectricCurrentGradientTests.cs
+++ b/UnitsNet.Tests/CustomCode/ElectricCurrentGradientTests.cs
@@ -23,6 +23,8 @@
 
 using System;
 
+using Xunit;
+
 namespace UnitsNet.Tests.CustomCode
 {
     public class ElectricCurrentGradientTests : ElectricCurrentGradientTestsBase
@@ -36,5 +38,19 @@ namespace UnitsNet.Tests.CustomCode
         protected override double AmperesPerMinuteInOneAmperePerSecond => 60;
         protected override double MilliamperesPerMinuteInOneAmperePerSecond => 6e4;
         protected override double MilliamperesPerSecondInOneAmperePerSecond => 1e3;
+
+        [Fact]
+        public void ElectricCurrentGradientTimesDurationEqualsElectricCurrent()
+        {
+            ElectricCurrent electricCurrent = ElectricCurrentGradient.FromAmperesPerSecond(10) * Duration.FromSeconds(2);
+            Assert.Equal(ElectricCurrent.FromAmperes(20) ,electricCurrent);
+        }
+
+        [Fact]
+        public void ElectricCurrentGradientTimesTimeSpanEqualsElectricCurrent()
+        {
+            ElectricCurrent electricCurrent = ElectricCurrentGradient.FromAmperesPerSecond(10) * TimeSpan.FromSeconds(2);
+            Assert.Equal(ElectricCurrent.FromAmperes(20), electricCurrent);
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/ElectricCurrentTests.cs
+++ b/UnitsNet.Tests/CustomCode/ElectricCurrentTests.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System;
+
 using Xunit;
 
 namespace UnitsNet.Tests
@@ -51,6 +53,20 @@ namespace UnitsNet.Tests
         {
             ElectricCharge ah = ElectricCurrent.FromAmperes(4) * Duration.FromHours(5);
             Assert.Equal(20, ah.AmpereHours);
+        }
+
+        [Fact]
+        public void ElectricCurrentDividedByDurationEqualsElectricCurrentGradient()
+        {
+            ElectricCurrentGradient electricCurrentGradient = ElectricCurrent.FromAmperes(10) / Duration.FromSeconds(2);
+            Assert.Equal(ElectricCurrentGradient.FromAmperesPerSecond(5), electricCurrentGradient);
+        }
+
+        [Fact]
+        public void ElectricCurrentDividedByTimeSpanEqualsElectricCurrentGradient()
+        {
+            ElectricCurrentGradient electricCurrentGradient = ElectricCurrent.FromAmperes(10) / TimeSpan.FromSeconds(2);
+            Assert.Equal(ElectricCurrentGradient.FromAmperesPerSecond(5), electricCurrentGradient);
         }
     }
 }

--- a/UnitsNet.Tests/CustomCode/PressureChangeRateTests.cs
+++ b/UnitsNet.Tests/CustomCode/PressureChangeRateTests.cs
@@ -1,12 +1,16 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System;
+
+using Xunit;
+
 namespace UnitsNet.Tests
 {
     public class PressureChangeRateTests : PressureChangeRateTestsBase
     {
         protected override bool SupportsSIUnitSystem => false;
-        protected override double AtmospheresPerSecondInOnePascalPerSecond => 9.8692*1E-6;
+        protected override double AtmospheresPerSecondInOnePascalPerSecond => 9.8692 * 1E-6;
 
         protected override double KilopascalsPerSecondInOnePascalPerSecond => 1e-3;
 
@@ -41,5 +45,19 @@ namespace UnitsNet.Tests
         protected override double MillibarsPerMinuteInOnePascalPerSecond => 0.6;
 
         protected override double MillibarsPerSecondInOnePascalPerSecond => 1e-2;
+
+        [Fact]
+        public void PressureChangeRateTimesDurationEqualsPressure()
+        {
+            Pressure pressure = PressureChangeRate.FromPascalsPerSecond(500) * Duration.FromSeconds(2);
+            Assert.Equal(Pressure.FromPascals(1000), pressure);
+        }
+
+        [Fact]
+        public void PressureChangeRateTimesTimeSpanEqualsPressure()
+        {
+            Pressure pressure = PressureChangeRate.FromPascalsPerSecond(500) * TimeSpan.FromSeconds(2);
+            Assert.Equal(Pressure.FromPascals(1000), pressure);
+        }
     }
 }

--- a/UnitsNet.Tests/CustomCode/PressureChangeRateTests.cs
+++ b/UnitsNet.Tests/CustomCode/PressureChangeRateTests.cs
@@ -33,5 +33,13 @@ namespace UnitsNet.Tests
         protected override double PascalsPerMinuteInOnePascalPerSecond => 60;
 
         protected override double MillimetersOfMercuryPerSecondInOnePascalPerSecond => 7.500637554192106e-3;
+
+        protected override double BarsPerMinuteInOnePascalPerSecond => 6e-4;
+
+        protected override double BarsPerSecondInOnePascalPerSecond => 1e-5;
+
+        protected override double MillibarsPerMinuteInOnePascalPerSecond => 0.6;
+
+        protected override double MillibarsPerSecondInOnePascalPerSecond => 1e-2;
     }
 }

--- a/UnitsNet.Tests/CustomCode/PressureTests.cs
+++ b/UnitsNet.Tests/CustomCode/PressureTests.cs
@@ -248,5 +248,19 @@ namespace UnitsNet.Tests
             Force force = Pressure.FromPascals(200) / ReciprocalArea.FromInverseSquareMeters(5);
             Assert.Equal(force, Force.FromNewtons(40));
         }
+
+        [Fact]
+        public void PressureDividedByDurationEqualsPressureChangeRate()
+        {
+            PressureChangeRate pressureChangeRate = Pressure.FromPascals(500) / Duration.FromSeconds(2);
+            Assert.Equal(PressureChangeRate.FromPascalsPerSecond(250), pressureChangeRate);
+        }
+
+        [Fact]
+        public void PressureDividedByTimeSpanEqualsPressurechangeRate()
+        {
+            PressureChangeRate pressureChangeRate = Pressure.FromPascals(50) / TimeSpan.FromSeconds(5);
+            Assert.Equal(PressureChangeRate.FromPascalsPerSecond(10), pressureChangeRate);
+        }
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
@@ -59,7 +59,7 @@ namespace UnitsNet.Tests
             Assertion(3, ElectricConductivityUnit.SiemensPerMeter, Quantity.From(3, ElectricConductivityUnit.SiemensPerMeter));
             Assertion(3, ElectricCurrentUnit.Picoampere, Quantity.From(3, ElectricCurrentUnit.Picoampere));
             Assertion(3, ElectricCurrentDensityUnit.AmperePerSquareMeter, Quantity.From(3, ElectricCurrentDensityUnit.AmperePerSquareMeter));
-            Assertion(3, ElectricCurrentGradientUnit.AmperePerSecond, Quantity.From(3, ElectricCurrentGradientUnit.AmperePerSecond));
+            Assertion(3, ElectricCurrentGradientUnit.MilliamperePerSecond, Quantity.From(3, ElectricCurrentGradientUnit.MilliamperePerSecond));
             Assertion(3, ElectricFieldUnit.VoltPerMeter, Quantity.From(3, ElectricFieldUnit.VoltPerMeter));
             Assertion(3, ElectricInductanceUnit.Picohenry, Quantity.From(3, ElectricInductanceUnit.Picohenry));
             Assertion(3, ElectricPotentialUnit.Volt, Quantity.From(3, ElectricPotentialUnit.Volt));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
@@ -40,14 +40,20 @@ namespace UnitsNet.Tests
     {
         protected abstract double AmperesPerMicrosecondInOneAmperePerSecond { get; }
         protected abstract double AmperesPerMillisecondInOneAmperePerSecond { get; }
+        protected abstract double AmperesPerMinuteInOneAmperePerSecond { get; }
         protected abstract double AmperesPerNanosecondInOneAmperePerSecond { get; }
         protected abstract double AmperesPerSecondInOneAmperePerSecond { get; }
+        protected abstract double MilliamperesPerMinuteInOneAmperePerSecond { get; }
+        protected abstract double MilliamperesPerSecondInOneAmperePerSecond { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double AmperesPerMicrosecondTolerance { get { return 1e-5; } }
         protected virtual double AmperesPerMillisecondTolerance { get { return 1e-5; } }
+        protected virtual double AmperesPerMinuteTolerance { get { return 1e-5; } }
         protected virtual double AmperesPerNanosecondTolerance { get { return 1e-5; } }
         protected virtual double AmperesPerSecondTolerance { get { return 1e-5; } }
+        protected virtual double MilliamperesPerMinuteTolerance { get { return 1e-5; } }
+        protected virtual double MilliamperesPerSecondTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         protected (double UnitsInBaseUnit, double Tolerence) GetConversionFactor(ElectricCurrentGradientUnit unit)
@@ -56,8 +62,11 @@ namespace UnitsNet.Tests
             {
                 ElectricCurrentGradientUnit.AmperePerMicrosecond => (AmperesPerMicrosecondInOneAmperePerSecond, AmperesPerMicrosecondTolerance),
                 ElectricCurrentGradientUnit.AmperePerMillisecond => (AmperesPerMillisecondInOneAmperePerSecond, AmperesPerMillisecondTolerance),
+                ElectricCurrentGradientUnit.AmperePerMinute => (AmperesPerMinuteInOneAmperePerSecond, AmperesPerMinuteTolerance),
                 ElectricCurrentGradientUnit.AmperePerNanosecond => (AmperesPerNanosecondInOneAmperePerSecond, AmperesPerNanosecondTolerance),
                 ElectricCurrentGradientUnit.AmperePerSecond => (AmperesPerSecondInOneAmperePerSecond, AmperesPerSecondTolerance),
+                ElectricCurrentGradientUnit.MilliamperePerMinute => (MilliamperesPerMinuteInOneAmperePerSecond, MilliamperesPerMinuteTolerance),
+                ElectricCurrentGradientUnit.MilliamperePerSecond => (MilliamperesPerSecondInOneAmperePerSecond, MilliamperesPerSecondTolerance),
                 _ => throw new NotSupportedException()
             };
         }
@@ -66,8 +75,11 @@ namespace UnitsNet.Tests
         {
             new object[] { ElectricCurrentGradientUnit.AmperePerMicrosecond },
             new object[] { ElectricCurrentGradientUnit.AmperePerMillisecond },
+            new object[] { ElectricCurrentGradientUnit.AmperePerMinute },
             new object[] { ElectricCurrentGradientUnit.AmperePerNanosecond },
             new object[] { ElectricCurrentGradientUnit.AmperePerSecond },
+            new object[] { ElectricCurrentGradientUnit.MilliamperePerMinute },
+            new object[] { ElectricCurrentGradientUnit.MilliamperePerSecond },
         };
 
         [Fact]
@@ -132,8 +144,11 @@ namespace UnitsNet.Tests
             ElectricCurrentGradient amperepersecond = ElectricCurrentGradient.FromAmperesPerSecond(1);
             AssertEx.EqualTolerance(AmperesPerMicrosecondInOneAmperePerSecond, amperepersecond.AmperesPerMicrosecond, AmperesPerMicrosecondTolerance);
             AssertEx.EqualTolerance(AmperesPerMillisecondInOneAmperePerSecond, amperepersecond.AmperesPerMillisecond, AmperesPerMillisecondTolerance);
+            AssertEx.EqualTolerance(AmperesPerMinuteInOneAmperePerSecond, amperepersecond.AmperesPerMinute, AmperesPerMinuteTolerance);
             AssertEx.EqualTolerance(AmperesPerNanosecondInOneAmperePerSecond, amperepersecond.AmperesPerNanosecond, AmperesPerNanosecondTolerance);
             AssertEx.EqualTolerance(AmperesPerSecondInOneAmperePerSecond, amperepersecond.AmperesPerSecond, AmperesPerSecondTolerance);
+            AssertEx.EqualTolerance(MilliamperesPerMinuteInOneAmperePerSecond, amperepersecond.MilliamperesPerMinute, MilliamperesPerMinuteTolerance);
+            AssertEx.EqualTolerance(MilliamperesPerSecondInOneAmperePerSecond, amperepersecond.MilliamperesPerSecond, MilliamperesPerSecondTolerance);
         }
 
         [Fact]
@@ -147,13 +162,25 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity01.AmperesPerMillisecond, AmperesPerMillisecondTolerance);
             Assert.Equal(ElectricCurrentGradientUnit.AmperePerMillisecond, quantity01.Unit);
 
-            var quantity02 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.AmperePerNanosecond);
-            AssertEx.EqualTolerance(1, quantity02.AmperesPerNanosecond, AmperesPerNanosecondTolerance);
-            Assert.Equal(ElectricCurrentGradientUnit.AmperePerNanosecond, quantity02.Unit);
+            var quantity02 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.AmperePerMinute);
+            AssertEx.EqualTolerance(1, quantity02.AmperesPerMinute, AmperesPerMinuteTolerance);
+            Assert.Equal(ElectricCurrentGradientUnit.AmperePerMinute, quantity02.Unit);
 
-            var quantity03 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.AmperePerSecond);
-            AssertEx.EqualTolerance(1, quantity03.AmperesPerSecond, AmperesPerSecondTolerance);
-            Assert.Equal(ElectricCurrentGradientUnit.AmperePerSecond, quantity03.Unit);
+            var quantity03 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.AmperePerNanosecond);
+            AssertEx.EqualTolerance(1, quantity03.AmperesPerNanosecond, AmperesPerNanosecondTolerance);
+            Assert.Equal(ElectricCurrentGradientUnit.AmperePerNanosecond, quantity03.Unit);
+
+            var quantity04 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.AmperePerSecond);
+            AssertEx.EqualTolerance(1, quantity04.AmperesPerSecond, AmperesPerSecondTolerance);
+            Assert.Equal(ElectricCurrentGradientUnit.AmperePerSecond, quantity04.Unit);
+
+            var quantity05 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.MilliamperePerMinute);
+            AssertEx.EqualTolerance(1, quantity05.MilliamperesPerMinute, MilliamperesPerMinuteTolerance);
+            Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerMinute, quantity05.Unit);
+
+            var quantity06 = ElectricCurrentGradient.From(1, ElectricCurrentGradientUnit.MilliamperePerSecond);
+            AssertEx.EqualTolerance(1, quantity06.MilliamperesPerSecond, MilliamperesPerSecondTolerance);
+            Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerSecond, quantity06.Unit);
 
         }
 
@@ -176,8 +203,11 @@ namespace UnitsNet.Tests
             var amperepersecond = ElectricCurrentGradient.FromAmperesPerSecond(1);
             AssertEx.EqualTolerance(AmperesPerMicrosecondInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.AmperePerMicrosecond), AmperesPerMicrosecondTolerance);
             AssertEx.EqualTolerance(AmperesPerMillisecondInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.AmperePerMillisecond), AmperesPerMillisecondTolerance);
+            AssertEx.EqualTolerance(AmperesPerMinuteInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.AmperePerMinute), AmperesPerMinuteTolerance);
             AssertEx.EqualTolerance(AmperesPerNanosecondInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.AmperePerNanosecond), AmperesPerNanosecondTolerance);
             AssertEx.EqualTolerance(AmperesPerSecondInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.AmperePerSecond), AmperesPerSecondTolerance);
+            AssertEx.EqualTolerance(MilliamperesPerMinuteInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.MilliamperePerMinute), MilliamperesPerMinuteTolerance);
+            AssertEx.EqualTolerance(MilliamperesPerSecondInOneAmperePerSecond, amperepersecond.As(ElectricCurrentGradientUnit.MilliamperePerSecond), MilliamperesPerSecondTolerance);
         }
 
         [Fact]
@@ -216,6 +246,13 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsed = ElectricCurrentGradient.Parse("1 A/min", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.AmperesPerMinute, AmperesPerMinuteTolerance);
+                Assert.Equal(ElectricCurrentGradientUnit.AmperePerMinute, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = ElectricCurrentGradient.Parse("1 A/ns", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.AmperesPerNanosecond, AmperesPerNanosecondTolerance);
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerNanosecond, parsed.Unit);
@@ -226,6 +263,20 @@ namespace UnitsNet.Tests
                 var parsed = ElectricCurrentGradient.Parse("1 A/s", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.AmperesPerSecond, AmperesPerSecondTolerance);
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = ElectricCurrentGradient.Parse("1 mA/min", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MilliamperesPerMinute, MilliamperesPerMinuteTolerance);
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerMinute, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = ElectricCurrentGradient.Parse("1 mA/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MilliamperesPerSecond, MilliamperesPerSecondTolerance);
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerSecond, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
         }
@@ -246,6 +297,12 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(ElectricCurrentGradient.TryParse("1 A/min", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.AmperesPerMinute, AmperesPerMinuteTolerance);
+                Assert.Equal(ElectricCurrentGradientUnit.AmperePerMinute, parsed.Unit);
+            }
+
+            {
                 Assert.True(ElectricCurrentGradient.TryParse("1 A/ns", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.AmperesPerNanosecond, AmperesPerNanosecondTolerance);
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerNanosecond, parsed.Unit);
@@ -255,6 +312,18 @@ namespace UnitsNet.Tests
                 Assert.True(ElectricCurrentGradient.TryParse("1 A/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.AmperesPerSecond, AmperesPerSecondTolerance);
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(ElectricCurrentGradient.TryParse("1 mA/min", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MilliamperesPerMinute, MilliamperesPerMinuteTolerance);
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerMinute, parsed.Unit);
+            }
+
+            {
+                Assert.True(ElectricCurrentGradient.TryParse("1 mA/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MilliamperesPerSecond, MilliamperesPerSecondTolerance);
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerSecond, parsed.Unit);
             }
 
         }
@@ -276,6 +345,12 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsedUnit = ElectricCurrentGradient.ParseUnit("A/min", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(ElectricCurrentGradientUnit.AmperePerMinute, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsedUnit = ElectricCurrentGradient.ParseUnit("A/ns", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerNanosecond, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -284,6 +359,18 @@ namespace UnitsNet.Tests
             {
                 var parsedUnit = ElectricCurrentGradient.ParseUnit("A/s", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = ElectricCurrentGradient.ParseUnit("mA/min", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerMinute, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = ElectricCurrentGradient.ParseUnit("mA/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerSecond, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
         }
@@ -302,6 +389,11 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(ElectricCurrentGradient.TryParseUnit("A/min", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(ElectricCurrentGradientUnit.AmperePerMinute, parsedUnit);
+            }
+
+            {
                 Assert.True(ElectricCurrentGradient.TryParseUnit("A/ns", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerNanosecond, parsedUnit);
             }
@@ -309,6 +401,16 @@ namespace UnitsNet.Tests
             {
                 Assert.True(ElectricCurrentGradient.TryParseUnit("A/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(ElectricCurrentGradientUnit.AmperePerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(ElectricCurrentGradient.TryParseUnit("mA/min", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerMinute, parsedUnit);
+            }
+
+            {
+                Assert.True(ElectricCurrentGradient.TryParseUnit("mA/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(ElectricCurrentGradientUnit.MilliamperePerSecond, parsedUnit);
             }
 
         }
@@ -361,8 +463,11 @@ namespace UnitsNet.Tests
             ElectricCurrentGradient amperepersecond = ElectricCurrentGradient.FromAmperesPerSecond(1);
             AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromAmperesPerMicrosecond(amperepersecond.AmperesPerMicrosecond).AmperesPerSecond, AmperesPerMicrosecondTolerance);
             AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromAmperesPerMillisecond(amperepersecond.AmperesPerMillisecond).AmperesPerSecond, AmperesPerMillisecondTolerance);
+            AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromAmperesPerMinute(amperepersecond.AmperesPerMinute).AmperesPerSecond, AmperesPerMinuteTolerance);
             AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromAmperesPerNanosecond(amperepersecond.AmperesPerNanosecond).AmperesPerSecond, AmperesPerNanosecondTolerance);
             AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromAmperesPerSecond(amperepersecond.AmperesPerSecond).AmperesPerSecond, AmperesPerSecondTolerance);
+            AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromMilliamperesPerMinute(amperepersecond.MilliamperesPerMinute).AmperesPerSecond, MilliamperesPerMinuteTolerance);
+            AssertEx.EqualTolerance(1, ElectricCurrentGradient.FromMilliamperesPerSecond(amperepersecond.MilliamperesPerSecond).AmperesPerSecond, MilliamperesPerSecondTolerance);
         }
 
         [Fact]
@@ -512,8 +617,11 @@ namespace UnitsNet.Tests
             try {
                 Assert.Equal("1 A/μs", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerMicrosecond).ToString());
                 Assert.Equal("1 A/ms", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerMillisecond).ToString());
+                Assert.Equal("1 A/min", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerMinute).ToString());
                 Assert.Equal("1 A/ns", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerNanosecond).ToString());
                 Assert.Equal("1 A/s", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerSecond).ToString());
+                Assert.Equal("1 mA/min", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.MilliamperePerMinute).ToString());
+                Assert.Equal("1 mA/s", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.MilliamperePerSecond).ToString());
             }
             finally
             {
@@ -529,8 +637,11 @@ namespace UnitsNet.Tests
 
             Assert.Equal("1 A/μs", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerMicrosecond).ToString(swedishCulture));
             Assert.Equal("1 A/ms", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerMillisecond).ToString(swedishCulture));
+            Assert.Equal("1 A/min", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerMinute).ToString(swedishCulture));
             Assert.Equal("1 A/ns", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerNanosecond).ToString(swedishCulture));
             Assert.Equal("1 A/s", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerSecond).ToString(swedishCulture));
+            Assert.Equal("1 mA/min", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.MilliamperePerMinute).ToString(swedishCulture));
+            Assert.Equal("1 mA/s", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.MilliamperePerSecond).ToString(swedishCulture));
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
@@ -39,6 +39,8 @@ namespace UnitsNet.Tests
     public abstract partial class PressureChangeRateTestsBase : QuantityTestsBase
     {
         protected abstract double AtmospheresPerSecondInOnePascalPerSecond { get; }
+        protected abstract double BarsPerMinuteInOnePascalPerSecond { get; }
+        protected abstract double BarsPerSecondInOnePascalPerSecond { get; }
         protected abstract double KilopascalsPerMinuteInOnePascalPerSecond { get; }
         protected abstract double KilopascalsPerSecondInOnePascalPerSecond { get; }
         protected abstract double KilopoundsForcePerSquareInchPerMinuteInOnePascalPerSecond { get; }
@@ -47,6 +49,8 @@ namespace UnitsNet.Tests
         protected abstract double MegapascalsPerSecondInOnePascalPerSecond { get; }
         protected abstract double MegapoundsForcePerSquareInchPerMinuteInOnePascalPerSecond { get; }
         protected abstract double MegapoundsForcePerSquareInchPerSecondInOnePascalPerSecond { get; }
+        protected abstract double MillibarsPerMinuteInOnePascalPerSecond { get; }
+        protected abstract double MillibarsPerSecondInOnePascalPerSecond { get; }
         protected abstract double MillimetersOfMercuryPerSecondInOnePascalPerSecond { get; }
         protected abstract double PascalsPerMinuteInOnePascalPerSecond { get; }
         protected abstract double PascalsPerSecondInOnePascalPerSecond { get; }
@@ -55,6 +59,8 @@ namespace UnitsNet.Tests
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double AtmospheresPerSecondTolerance { get { return 1e-5; } }
+        protected virtual double BarsPerMinuteTolerance { get { return 1e-5; } }
+        protected virtual double BarsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double KilopascalsPerMinuteTolerance { get { return 1e-5; } }
         protected virtual double KilopascalsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double KilopoundsForcePerSquareInchPerMinuteTolerance { get { return 1e-5; } }
@@ -63,6 +69,8 @@ namespace UnitsNet.Tests
         protected virtual double MegapascalsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double MegapoundsForcePerSquareInchPerMinuteTolerance { get { return 1e-5; } }
         protected virtual double MegapoundsForcePerSquareInchPerSecondTolerance { get { return 1e-5; } }
+        protected virtual double MillibarsPerMinuteTolerance { get { return 1e-5; } }
+        protected virtual double MillibarsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double MillimetersOfMercuryPerSecondTolerance { get { return 1e-5; } }
         protected virtual double PascalsPerMinuteTolerance { get { return 1e-5; } }
         protected virtual double PascalsPerSecondTolerance { get { return 1e-5; } }
@@ -75,6 +83,8 @@ namespace UnitsNet.Tests
             return unit switch
             {
                 PressureChangeRateUnit.AtmospherePerSecond => (AtmospheresPerSecondInOnePascalPerSecond, AtmospheresPerSecondTolerance),
+                PressureChangeRateUnit.BarPerMinute => (BarsPerMinuteInOnePascalPerSecond, BarsPerMinuteTolerance),
+                PressureChangeRateUnit.BarPerSecond => (BarsPerSecondInOnePascalPerSecond, BarsPerSecondTolerance),
                 PressureChangeRateUnit.KilopascalPerMinute => (KilopascalsPerMinuteInOnePascalPerSecond, KilopascalsPerMinuteTolerance),
                 PressureChangeRateUnit.KilopascalPerSecond => (KilopascalsPerSecondInOnePascalPerSecond, KilopascalsPerSecondTolerance),
                 PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute => (KilopoundsForcePerSquareInchPerMinuteInOnePascalPerSecond, KilopoundsForcePerSquareInchPerMinuteTolerance),
@@ -83,6 +93,8 @@ namespace UnitsNet.Tests
                 PressureChangeRateUnit.MegapascalPerSecond => (MegapascalsPerSecondInOnePascalPerSecond, MegapascalsPerSecondTolerance),
                 PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute => (MegapoundsForcePerSquareInchPerMinuteInOnePascalPerSecond, MegapoundsForcePerSquareInchPerMinuteTolerance),
                 PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond => (MegapoundsForcePerSquareInchPerSecondInOnePascalPerSecond, MegapoundsForcePerSquareInchPerSecondTolerance),
+                PressureChangeRateUnit.MillibarPerMinute => (MillibarsPerMinuteInOnePascalPerSecond, MillibarsPerMinuteTolerance),
+                PressureChangeRateUnit.MillibarPerSecond => (MillibarsPerSecondInOnePascalPerSecond, MillibarsPerSecondTolerance),
                 PressureChangeRateUnit.MillimeterOfMercuryPerSecond => (MillimetersOfMercuryPerSecondInOnePascalPerSecond, MillimetersOfMercuryPerSecondTolerance),
                 PressureChangeRateUnit.PascalPerMinute => (PascalsPerMinuteInOnePascalPerSecond, PascalsPerMinuteTolerance),
                 PressureChangeRateUnit.PascalPerSecond => (PascalsPerSecondInOnePascalPerSecond, PascalsPerSecondTolerance),
@@ -95,6 +107,8 @@ namespace UnitsNet.Tests
         public static IEnumerable<object[]> UnitTypes = new List<object[]>
         {
             new object[] { PressureChangeRateUnit.AtmospherePerSecond },
+            new object[] { PressureChangeRateUnit.BarPerMinute },
+            new object[] { PressureChangeRateUnit.BarPerSecond },
             new object[] { PressureChangeRateUnit.KilopascalPerMinute },
             new object[] { PressureChangeRateUnit.KilopascalPerSecond },
             new object[] { PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute },
@@ -103,6 +117,8 @@ namespace UnitsNet.Tests
             new object[] { PressureChangeRateUnit.MegapascalPerSecond },
             new object[] { PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute },
             new object[] { PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond },
+            new object[] { PressureChangeRateUnit.MillibarPerMinute },
+            new object[] { PressureChangeRateUnit.MillibarPerSecond },
             new object[] { PressureChangeRateUnit.MillimeterOfMercuryPerSecond },
             new object[] { PressureChangeRateUnit.PascalPerMinute },
             new object[] { PressureChangeRateUnit.PascalPerSecond },
@@ -171,6 +187,8 @@ namespace UnitsNet.Tests
         {
             PressureChangeRate pascalpersecond = PressureChangeRate.FromPascalsPerSecond(1);
             AssertEx.EqualTolerance(AtmospheresPerSecondInOnePascalPerSecond, pascalpersecond.AtmospheresPerSecond, AtmospheresPerSecondTolerance);
+            AssertEx.EqualTolerance(BarsPerMinuteInOnePascalPerSecond, pascalpersecond.BarsPerMinute, BarsPerMinuteTolerance);
+            AssertEx.EqualTolerance(BarsPerSecondInOnePascalPerSecond, pascalpersecond.BarsPerSecond, BarsPerSecondTolerance);
             AssertEx.EqualTolerance(KilopascalsPerMinuteInOnePascalPerSecond, pascalpersecond.KilopascalsPerMinute, KilopascalsPerMinuteTolerance);
             AssertEx.EqualTolerance(KilopascalsPerSecondInOnePascalPerSecond, pascalpersecond.KilopascalsPerSecond, KilopascalsPerSecondTolerance);
             AssertEx.EqualTolerance(KilopoundsForcePerSquareInchPerMinuteInOnePascalPerSecond, pascalpersecond.KilopoundsForcePerSquareInchPerMinute, KilopoundsForcePerSquareInchPerMinuteTolerance);
@@ -179,6 +197,8 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(MegapascalsPerSecondInOnePascalPerSecond, pascalpersecond.MegapascalsPerSecond, MegapascalsPerSecondTolerance);
             AssertEx.EqualTolerance(MegapoundsForcePerSquareInchPerMinuteInOnePascalPerSecond, pascalpersecond.MegapoundsForcePerSquareInchPerMinute, MegapoundsForcePerSquareInchPerMinuteTolerance);
             AssertEx.EqualTolerance(MegapoundsForcePerSquareInchPerSecondInOnePascalPerSecond, pascalpersecond.MegapoundsForcePerSquareInchPerSecond, MegapoundsForcePerSquareInchPerSecondTolerance);
+            AssertEx.EqualTolerance(MillibarsPerMinuteInOnePascalPerSecond, pascalpersecond.MillibarsPerMinute, MillibarsPerMinuteTolerance);
+            AssertEx.EqualTolerance(MillibarsPerSecondInOnePascalPerSecond, pascalpersecond.MillibarsPerSecond, MillibarsPerSecondTolerance);
             AssertEx.EqualTolerance(MillimetersOfMercuryPerSecondInOnePascalPerSecond, pascalpersecond.MillimetersOfMercuryPerSecond, MillimetersOfMercuryPerSecondTolerance);
             AssertEx.EqualTolerance(PascalsPerMinuteInOnePascalPerSecond, pascalpersecond.PascalsPerMinute, PascalsPerMinuteTolerance);
             AssertEx.EqualTolerance(PascalsPerSecondInOnePascalPerSecond, pascalpersecond.PascalsPerSecond, PascalsPerSecondTolerance);
@@ -193,57 +213,73 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity00.AtmospheresPerSecond, AtmospheresPerSecondTolerance);
             Assert.Equal(PressureChangeRateUnit.AtmospherePerSecond, quantity00.Unit);
 
-            var quantity01 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopascalPerMinute);
-            AssertEx.EqualTolerance(1, quantity01.KilopascalsPerMinute, KilopascalsPerMinuteTolerance);
-            Assert.Equal(PressureChangeRateUnit.KilopascalPerMinute, quantity01.Unit);
+            var quantity01 = PressureChangeRate.From(1, PressureChangeRateUnit.BarPerMinute);
+            AssertEx.EqualTolerance(1, quantity01.BarsPerMinute, BarsPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.BarPerMinute, quantity01.Unit);
 
-            var quantity02 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopascalPerSecond);
-            AssertEx.EqualTolerance(1, quantity02.KilopascalsPerSecond, KilopascalsPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.KilopascalPerSecond, quantity02.Unit);
+            var quantity02 = PressureChangeRate.From(1, PressureChangeRateUnit.BarPerSecond);
+            AssertEx.EqualTolerance(1, quantity02.BarsPerSecond, BarsPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.BarPerSecond, quantity02.Unit);
 
-            var quantity03 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute);
-            AssertEx.EqualTolerance(1, quantity03.KilopoundsForcePerSquareInchPerMinute, KilopoundsForcePerSquareInchPerMinuteTolerance);
-            Assert.Equal(PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute, quantity03.Unit);
+            var quantity03 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopascalPerMinute);
+            AssertEx.EqualTolerance(1, quantity03.KilopascalsPerMinute, KilopascalsPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.KilopascalPerMinute, quantity03.Unit);
 
-            var quantity04 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopoundForcePerSquareInchPerSecond);
-            AssertEx.EqualTolerance(1, quantity04.KilopoundsForcePerSquareInchPerSecond, KilopoundsForcePerSquareInchPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.KilopoundForcePerSquareInchPerSecond, quantity04.Unit);
+            var quantity04 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopascalPerSecond);
+            AssertEx.EqualTolerance(1, quantity04.KilopascalsPerSecond, KilopascalsPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.KilopascalPerSecond, quantity04.Unit);
 
-            var quantity05 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapascalPerMinute);
-            AssertEx.EqualTolerance(1, quantity05.MegapascalsPerMinute, MegapascalsPerMinuteTolerance);
-            Assert.Equal(PressureChangeRateUnit.MegapascalPerMinute, quantity05.Unit);
+            var quantity05 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute);
+            AssertEx.EqualTolerance(1, quantity05.KilopoundsForcePerSquareInchPerMinute, KilopoundsForcePerSquareInchPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute, quantity05.Unit);
 
-            var quantity06 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapascalPerSecond);
-            AssertEx.EqualTolerance(1, quantity06.MegapascalsPerSecond, MegapascalsPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.MegapascalPerSecond, quantity06.Unit);
+            var quantity06 = PressureChangeRate.From(1, PressureChangeRateUnit.KilopoundForcePerSquareInchPerSecond);
+            AssertEx.EqualTolerance(1, quantity06.KilopoundsForcePerSquareInchPerSecond, KilopoundsForcePerSquareInchPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.KilopoundForcePerSquareInchPerSecond, quantity06.Unit);
 
-            var quantity07 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute);
-            AssertEx.EqualTolerance(1, quantity07.MegapoundsForcePerSquareInchPerMinute, MegapoundsForcePerSquareInchPerMinuteTolerance);
-            Assert.Equal(PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute, quantity07.Unit);
+            var quantity07 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapascalPerMinute);
+            AssertEx.EqualTolerance(1, quantity07.MegapascalsPerMinute, MegapascalsPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.MegapascalPerMinute, quantity07.Unit);
 
-            var quantity08 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond);
-            AssertEx.EqualTolerance(1, quantity08.MegapoundsForcePerSquareInchPerSecond, MegapoundsForcePerSquareInchPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond, quantity08.Unit);
+            var quantity08 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapascalPerSecond);
+            AssertEx.EqualTolerance(1, quantity08.MegapascalsPerSecond, MegapascalsPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.MegapascalPerSecond, quantity08.Unit);
 
-            var quantity09 = PressureChangeRate.From(1, PressureChangeRateUnit.MillimeterOfMercuryPerSecond);
-            AssertEx.EqualTolerance(1, quantity09.MillimetersOfMercuryPerSecond, MillimetersOfMercuryPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, quantity09.Unit);
+            var quantity09 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute);
+            AssertEx.EqualTolerance(1, quantity09.MegapoundsForcePerSquareInchPerMinute, MegapoundsForcePerSquareInchPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute, quantity09.Unit);
 
-            var quantity10 = PressureChangeRate.From(1, PressureChangeRateUnit.PascalPerMinute);
-            AssertEx.EqualTolerance(1, quantity10.PascalsPerMinute, PascalsPerMinuteTolerance);
-            Assert.Equal(PressureChangeRateUnit.PascalPerMinute, quantity10.Unit);
+            var quantity10 = PressureChangeRate.From(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond);
+            AssertEx.EqualTolerance(1, quantity10.MegapoundsForcePerSquareInchPerSecond, MegapoundsForcePerSquareInchPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond, quantity10.Unit);
 
-            var quantity11 = PressureChangeRate.From(1, PressureChangeRateUnit.PascalPerSecond);
-            AssertEx.EqualTolerance(1, quantity11.PascalsPerSecond, PascalsPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.PascalPerSecond, quantity11.Unit);
+            var quantity11 = PressureChangeRate.From(1, PressureChangeRateUnit.MillibarPerMinute);
+            AssertEx.EqualTolerance(1, quantity11.MillibarsPerMinute, MillibarsPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, quantity11.Unit);
 
-            var quantity12 = PressureChangeRate.From(1, PressureChangeRateUnit.PoundForcePerSquareInchPerMinute);
-            AssertEx.EqualTolerance(1, quantity12.PoundsForcePerSquareInchPerMinute, PoundsForcePerSquareInchPerMinuteTolerance);
-            Assert.Equal(PressureChangeRateUnit.PoundForcePerSquareInchPerMinute, quantity12.Unit);
+            var quantity12 = PressureChangeRate.From(1, PressureChangeRateUnit.MillibarPerSecond);
+            AssertEx.EqualTolerance(1, quantity12.MillibarsPerSecond, MillibarsPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, quantity12.Unit);
 
-            var quantity13 = PressureChangeRate.From(1, PressureChangeRateUnit.PoundForcePerSquareInchPerSecond);
-            AssertEx.EqualTolerance(1, quantity13.PoundsForcePerSquareInchPerSecond, PoundsForcePerSquareInchPerSecondTolerance);
-            Assert.Equal(PressureChangeRateUnit.PoundForcePerSquareInchPerSecond, quantity13.Unit);
+            var quantity13 = PressureChangeRate.From(1, PressureChangeRateUnit.MillimeterOfMercuryPerSecond);
+            AssertEx.EqualTolerance(1, quantity13.MillimetersOfMercuryPerSecond, MillimetersOfMercuryPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, quantity13.Unit);
+
+            var quantity14 = PressureChangeRate.From(1, PressureChangeRateUnit.PascalPerMinute);
+            AssertEx.EqualTolerance(1, quantity14.PascalsPerMinute, PascalsPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.PascalPerMinute, quantity14.Unit);
+
+            var quantity15 = PressureChangeRate.From(1, PressureChangeRateUnit.PascalPerSecond);
+            AssertEx.EqualTolerance(1, quantity15.PascalsPerSecond, PascalsPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.PascalPerSecond, quantity15.Unit);
+
+            var quantity16 = PressureChangeRate.From(1, PressureChangeRateUnit.PoundForcePerSquareInchPerMinute);
+            AssertEx.EqualTolerance(1, quantity16.PoundsForcePerSquareInchPerMinute, PoundsForcePerSquareInchPerMinuteTolerance);
+            Assert.Equal(PressureChangeRateUnit.PoundForcePerSquareInchPerMinute, quantity16.Unit);
+
+            var quantity17 = PressureChangeRate.From(1, PressureChangeRateUnit.PoundForcePerSquareInchPerSecond);
+            AssertEx.EqualTolerance(1, quantity17.PoundsForcePerSquareInchPerSecond, PoundsForcePerSquareInchPerSecondTolerance);
+            Assert.Equal(PressureChangeRateUnit.PoundForcePerSquareInchPerSecond, quantity17.Unit);
 
         }
 
@@ -265,6 +301,8 @@ namespace UnitsNet.Tests
         {
             var pascalpersecond = PressureChangeRate.FromPascalsPerSecond(1);
             AssertEx.EqualTolerance(AtmospheresPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.AtmospherePerSecond), AtmospheresPerSecondTolerance);
+            AssertEx.EqualTolerance(BarsPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.BarPerMinute), BarsPerMinuteTolerance);
+            AssertEx.EqualTolerance(BarsPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.BarPerSecond), BarsPerSecondTolerance);
             AssertEx.EqualTolerance(KilopascalsPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.KilopascalPerMinute), KilopascalsPerMinuteTolerance);
             AssertEx.EqualTolerance(KilopascalsPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.KilopascalPerSecond), KilopascalsPerSecondTolerance);
             AssertEx.EqualTolerance(KilopoundsForcePerSquareInchPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute), KilopoundsForcePerSquareInchPerMinuteTolerance);
@@ -273,6 +311,8 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(MegapascalsPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.MegapascalPerSecond), MegapascalsPerSecondTolerance);
             AssertEx.EqualTolerance(MegapoundsForcePerSquareInchPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute), MegapoundsForcePerSquareInchPerMinuteTolerance);
             AssertEx.EqualTolerance(MegapoundsForcePerSquareInchPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond), MegapoundsForcePerSquareInchPerSecondTolerance);
+            AssertEx.EqualTolerance(MillibarsPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.MillibarPerMinute), MillibarsPerMinuteTolerance);
+            AssertEx.EqualTolerance(MillibarsPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.MillibarPerSecond), MillibarsPerSecondTolerance);
             AssertEx.EqualTolerance(MillimetersOfMercuryPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.MillimeterOfMercuryPerSecond), MillimetersOfMercuryPerSecondTolerance);
             AssertEx.EqualTolerance(PascalsPerMinuteInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.PascalPerMinute), PascalsPerMinuteTolerance);
             AssertEx.EqualTolerance(PascalsPerSecondInOnePascalPerSecond, pascalpersecond.As(PressureChangeRateUnit.PascalPerSecond), PascalsPerSecondTolerance);
@@ -312,6 +352,34 @@ namespace UnitsNet.Tests
                 var parsed = PressureChangeRate.Parse("1 атм/с", CultureInfo.GetCultureInfo("ru-RU"));
                 AssertEx.EqualTolerance(1, parsed.AtmospheresPerSecond, AtmospheresPerSecondTolerance);
                 Assert.Equal(PressureChangeRateUnit.AtmospherePerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 bar/min", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.BarsPerMinute, BarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 бар/мин", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.BarsPerMinute, BarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 bar/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.BarsPerSecond, BarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 бар/с", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.BarsPerSecond, BarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -484,6 +552,34 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsed = PressureChangeRate.Parse("1 mbar/min", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerMinute, MillibarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 мбар/мин", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerMinute, MillibarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 mbar/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerSecond, MillibarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = PressureChangeRate.Parse("1 мбар/с", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerSecond, MillibarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = PressureChangeRate.Parse("1 mmHg/s", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.MillimetersOfMercuryPerSecond, MillimetersOfMercuryPerSecondTolerance);
                 Assert.Equal(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, parsed.Unit);
@@ -595,6 +691,30 @@ namespace UnitsNet.Tests
                 Assert.True(PressureChangeRate.TryParse("1 атм/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.AtmospheresPerSecond, AtmospheresPerSecondTolerance);
                 Assert.Equal(PressureChangeRateUnit.AtmospherePerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 bar/min", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.BarsPerMinute, BarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 бар/мин", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.BarsPerMinute, BarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 bar/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.BarsPerSecond, BarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 бар/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.BarsPerSecond, BarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsed.Unit);
             }
 
             {
@@ -742,6 +862,30 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(PressureChangeRate.TryParse("1 mbar/min", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerMinute, MillibarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 мбар/мин", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerMinute, MillibarsPerMinuteTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 mbar/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerSecond, MillibarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParse("1 мбар/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillibarsPerSecond, MillibarsPerSecondTolerance);
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsed.Unit);
+            }
+
+            {
                 Assert.True(PressureChangeRate.TryParse("1 mmHg/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.MillimetersOfMercuryPerSecond, MillimetersOfMercuryPerSecondTolerance);
                 Assert.Equal(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, parsed.Unit);
@@ -840,6 +984,30 @@ namespace UnitsNet.Tests
             {
                 var parsedUnit = PressureChangeRate.ParseUnit("атм/с", CultureInfo.GetCultureInfo("ru-RU"));
                 Assert.Equal(PressureChangeRateUnit.AtmospherePerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("bar/min", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("бар/мин", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("bar/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("бар/с", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -988,6 +1156,30 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsedUnit = PressureChangeRate.ParseUnit("mbar/min", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("мбар/мин", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("mbar/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = PressureChangeRate.ParseUnit("мбар/с", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsedUnit = PressureChangeRate.ParseUnit("mmHg/s", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -1083,6 +1275,26 @@ namespace UnitsNet.Tests
             {
                 Assert.True(PressureChangeRate.TryParseUnit("атм/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
                 Assert.Equal(PressureChangeRateUnit.AtmospherePerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("bar/min", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("бар/мин", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.BarPerMinute, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("bar/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("бар/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.BarPerSecond, parsedUnit);
             }
 
             {
@@ -1206,6 +1418,26 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(PressureChangeRate.TryParseUnit("mbar/min", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("мбар/мин", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerMinute, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("mbar/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(PressureChangeRate.TryParseUnit("мбар/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(PressureChangeRateUnit.MillibarPerSecond, parsedUnit);
+            }
+
+            {
                 Assert.True(PressureChangeRate.TryParseUnit("mmHg/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, parsedUnit);
             }
@@ -1324,6 +1556,8 @@ namespace UnitsNet.Tests
         {
             PressureChangeRate pascalpersecond = PressureChangeRate.FromPascalsPerSecond(1);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromAtmospheresPerSecond(pascalpersecond.AtmospheresPerSecond).PascalsPerSecond, AtmospheresPerSecondTolerance);
+            AssertEx.EqualTolerance(1, PressureChangeRate.FromBarsPerMinute(pascalpersecond.BarsPerMinute).PascalsPerSecond, BarsPerMinuteTolerance);
+            AssertEx.EqualTolerance(1, PressureChangeRate.FromBarsPerSecond(pascalpersecond.BarsPerSecond).PascalsPerSecond, BarsPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromKilopascalsPerMinute(pascalpersecond.KilopascalsPerMinute).PascalsPerSecond, KilopascalsPerMinuteTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromKilopascalsPerSecond(pascalpersecond.KilopascalsPerSecond).PascalsPerSecond, KilopascalsPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromKilopoundsForcePerSquareInchPerMinute(pascalpersecond.KilopoundsForcePerSquareInchPerMinute).PascalsPerSecond, KilopoundsForcePerSquareInchPerMinuteTolerance);
@@ -1332,6 +1566,8 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, PressureChangeRate.FromMegapascalsPerSecond(pascalpersecond.MegapascalsPerSecond).PascalsPerSecond, MegapascalsPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromMegapoundsForcePerSquareInchPerMinute(pascalpersecond.MegapoundsForcePerSquareInchPerMinute).PascalsPerSecond, MegapoundsForcePerSquareInchPerMinuteTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromMegapoundsForcePerSquareInchPerSecond(pascalpersecond.MegapoundsForcePerSquareInchPerSecond).PascalsPerSecond, MegapoundsForcePerSquareInchPerSecondTolerance);
+            AssertEx.EqualTolerance(1, PressureChangeRate.FromMillibarsPerMinute(pascalpersecond.MillibarsPerMinute).PascalsPerSecond, MillibarsPerMinuteTolerance);
+            AssertEx.EqualTolerance(1, PressureChangeRate.FromMillibarsPerSecond(pascalpersecond.MillibarsPerSecond).PascalsPerSecond, MillibarsPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromMillimetersOfMercuryPerSecond(pascalpersecond.MillimetersOfMercuryPerSecond).PascalsPerSecond, MillimetersOfMercuryPerSecondTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromPascalsPerMinute(pascalpersecond.PascalsPerMinute).PascalsPerSecond, PascalsPerMinuteTolerance);
             AssertEx.EqualTolerance(1, PressureChangeRate.FromPascalsPerSecond(pascalpersecond.PascalsPerSecond).PascalsPerSecond, PascalsPerSecondTolerance);
@@ -1485,6 +1721,8 @@ namespace UnitsNet.Tests
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             try {
                 Assert.Equal("1 atm/s", new PressureChangeRate(1, PressureChangeRateUnit.AtmospherePerSecond).ToString());
+                Assert.Equal("1 bar/min", new PressureChangeRate(1, PressureChangeRateUnit.BarPerMinute).ToString());
+                Assert.Equal("1 bar/s", new PressureChangeRate(1, PressureChangeRateUnit.BarPerSecond).ToString());
                 Assert.Equal("1 kPa/min", new PressureChangeRate(1, PressureChangeRateUnit.KilopascalPerMinute).ToString());
                 Assert.Equal("1 kPa/s", new PressureChangeRate(1, PressureChangeRateUnit.KilopascalPerSecond).ToString());
                 Assert.Equal("1 ksi/min", new PressureChangeRate(1, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute).ToString());
@@ -1493,6 +1731,8 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 MPa/s", new PressureChangeRate(1, PressureChangeRateUnit.MegapascalPerSecond).ToString());
                 Assert.Equal("1 Mpsi/min", new PressureChangeRate(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute).ToString());
                 Assert.Equal("1 Mpsi/s", new PressureChangeRate(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond).ToString());
+                Assert.Equal("1 mbar/min", new PressureChangeRate(1, PressureChangeRateUnit.MillibarPerMinute).ToString());
+                Assert.Equal("1 mbar/s", new PressureChangeRate(1, PressureChangeRateUnit.MillibarPerSecond).ToString());
                 Assert.Equal("1 mmHg/s", new PressureChangeRate(1, PressureChangeRateUnit.MillimeterOfMercuryPerSecond).ToString());
                 Assert.Equal("1 Pa/min", new PressureChangeRate(1, PressureChangeRateUnit.PascalPerMinute).ToString());
                 Assert.Equal("1 Pa/s", new PressureChangeRate(1, PressureChangeRateUnit.PascalPerSecond).ToString());
@@ -1512,6 +1752,8 @@ namespace UnitsNet.Tests
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
             Assert.Equal("1 atm/s", new PressureChangeRate(1, PressureChangeRateUnit.AtmospherePerSecond).ToString(swedishCulture));
+            Assert.Equal("1 bar/min", new PressureChangeRate(1, PressureChangeRateUnit.BarPerMinute).ToString(swedishCulture));
+            Assert.Equal("1 bar/s", new PressureChangeRate(1, PressureChangeRateUnit.BarPerSecond).ToString(swedishCulture));
             Assert.Equal("1 kPa/min", new PressureChangeRate(1, PressureChangeRateUnit.KilopascalPerMinute).ToString(swedishCulture));
             Assert.Equal("1 kPa/s", new PressureChangeRate(1, PressureChangeRateUnit.KilopascalPerSecond).ToString(swedishCulture));
             Assert.Equal("1 ksi/min", new PressureChangeRate(1, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute).ToString(swedishCulture));
@@ -1520,6 +1762,8 @@ namespace UnitsNet.Tests
             Assert.Equal("1 MPa/s", new PressureChangeRate(1, PressureChangeRateUnit.MegapascalPerSecond).ToString(swedishCulture));
             Assert.Equal("1 Mpsi/min", new PressureChangeRate(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute).ToString(swedishCulture));
             Assert.Equal("1 Mpsi/s", new PressureChangeRate(1, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond).ToString(swedishCulture));
+            Assert.Equal("1 mbar/min", new PressureChangeRate(1, PressureChangeRateUnit.MillibarPerMinute).ToString(swedishCulture));
+            Assert.Equal("1 mbar/s", new PressureChangeRate(1, PressureChangeRateUnit.MillibarPerSecond).ToString(swedishCulture));
             Assert.Equal("1 mmHg/s", new PressureChangeRate(1, PressureChangeRateUnit.MillimeterOfMercuryPerSecond).ToString(swedishCulture));
             Assert.Equal("1 Pa/min", new PressureChangeRate(1, PressureChangeRateUnit.PascalPerMinute).ToString(swedishCulture));
             Assert.Equal("1 Pa/s", new PressureChangeRate(1, PressureChangeRateUnit.PascalPerSecond).ToString(swedishCulture));

--- a/UnitsNet/CustomCode/Quantities/ElectricCurrent.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/ElectricCurrent.extra.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System;
+
 namespace UnitsNet
 {
     public partial struct ElectricCurrent
@@ -23,6 +25,18 @@ namespace UnitsNet
         public static ElectricCharge operator *(ElectricCurrent current, Duration time)
         {
             return ElectricCharge.FromAmpereHours(current.Amperes * time.Hours);
+        }
+
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrent"/> divided by <see cref="Duration"/>.</summary>
+        public static ElectricCurrentGradient operator /(ElectricCurrent current, Duration duration)
+        {
+            return ElectricCurrentGradient.FromAmperesPerSecond(current.Amperes / duration.Seconds);
+        }
+
+        /// <summary>Get <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrent"/> divided by <see cref="TimeSpan"/>.</summary>
+        public static ElectricCurrentGradient operator /(ElectricCurrent current, TimeSpan timeSpan)
+        {
+            return ElectricCurrentGradient.FromAmperesPerSecond(current.Amperes / timeSpan.TotalSeconds);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/ElectricCurrentGradient.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/ElectricCurrentGradient.extra.cs
@@ -1,0 +1,22 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+
+namespace UnitsNet
+{
+    public partial struct ElectricCurrentGradient
+    {
+        /// <summary>Get <see cref="ElectricCurrent"/> from <see cref="ElectricCurrentGradient"/> times <see cref="Duration"/>.</summary>
+        public static ElectricCurrent operator *(ElectricCurrentGradient currentGradient, Duration duration)
+        {
+            return ElectricCurrent.FromAmperes(currentGradient.AmperesPerSecond * duration.Seconds);
+        }
+
+        /// <summary>Get <see cref="ElectricCurrent"/> from <see cref="ElectricCurrentGradient"/> times <see cref="TimeSpan"/>.</summary>
+        public static ElectricCurrent operator *(ElectricCurrentGradient currentGradient, TimeSpan timeSpan)
+        {
+            return ElectricCurrent.FromAmperes(currentGradient.AmperesPerSecond * timeSpan.TotalSeconds);
+        }
+    }
+}

--- a/UnitsNet/CustomCode/Quantities/Pressure.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Pressure.extra.cs
@@ -1,6 +1,8 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
+using System;
+
 namespace UnitsNet
 {
     public partial struct Pressure
@@ -39,6 +41,18 @@ namespace UnitsNet
         public static Force operator /(Pressure pressure, ReciprocalArea reciprocalArea)
         {
             return new Force(pressure.Pascals / reciprocalArea.InverseSquareMeters, UnitsNet.Units.ForceUnit.Newton);
+        }
+
+        /// <summary>Get <see cref="PressureChangeRate"/> from <see cref="Pressure"/> divided by <see cref="TimeSpan"/> </summary>
+        public static PressureChangeRate operator /(Pressure pressure, TimeSpan timeSpan)
+        {
+            return new PressureChangeRate(pressure.Pascals / timeSpan.TotalSeconds , UnitsNet.Units.PressureChangeRateUnit.PascalPerSecond);
+        }
+
+        /// <summary>Get <see cref="PressureChangeRate"/> from <see cref="Pressure"/> divided by <see cref="Duration"/> </summary>
+        public static PressureChangeRate operator /(Pressure pressure, Duration duration)
+        {
+            return new PressureChangeRate(pressure.Pascals / duration.Seconds, UnitsNet.Units.PressureChangeRateUnit.PascalPerSecond);
         }
     }
 }

--- a/UnitsNet/CustomCode/Quantities/PressureChangeRate.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/PressureChangeRate.extra.cs
@@ -1,0 +1,22 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System;
+
+namespace UnitsNet
+{
+    public partial struct PressureChangeRate
+    {
+        /// <summary>Get <see cref="Pressure"/> from <see cref="PressureChangeRate"/> times <see cref="TimeSpan"/> </summary>
+        public static Pressure operator *(PressureChangeRate pressureChangeRate, TimeSpan timeSpan)
+        {
+            return new Pressure(pressureChangeRate.PascalsPerSecond * timeSpan.TotalSeconds , UnitsNet.Units.PressureUnit.Pascal);
+        }
+
+        /// <summary>Get <see cref="Pressure"/> from <see cref="PressureChangeRate"/> times <see cref="Duration"/> </summary>
+        public static Pressure operator *(PressureChangeRate pressureChangeRate, Duration duration)
+        {
+            return new Pressure(pressureChangeRate.PascalsPerSecond * duration.Seconds, UnitsNet.Units.PressureUnit.Pascal);
+        }
+    }
+}

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -67,8 +67,11 @@ namespace UnitsNet
                 {
                     new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.AmperePerMicrosecond, "AmperesPerMicrosecond", new BaseUnits(time: DurationUnit.Microsecond, current: ElectricCurrentUnit.Ampere), "ElectricCurrentGradient"),
                     new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.AmperePerMillisecond, "AmperesPerMillisecond", new BaseUnits(time: DurationUnit.Millisecond, current: ElectricCurrentUnit.Ampere), "ElectricCurrentGradient"),
+                    new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.AmperePerMinute, "AmperesPerMinute", new BaseUnits(time: DurationUnit.Minute, current: ElectricCurrentUnit.Ampere), "ElectricCurrentGradient"),
                     new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.AmperePerNanosecond, "AmperesPerNanosecond", new BaseUnits(time: DurationUnit.Nanosecond, current: ElectricCurrentUnit.Ampere), "ElectricCurrentGradient"),
-                    new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.AmperePerSecond, "AmperesPerSecond", BaseUnits.Undefined, "ElectricCurrentGradient"),
+                    new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.AmperePerSecond, "AmperesPerSecond", new BaseUnits(time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere), "ElectricCurrentGradient"),
+                    new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.MilliamperePerMinute, "MilliamperesPerMinute", BaseUnits.Undefined, "ElectricCurrentGradient"),
+                    new UnitInfo<ElectricCurrentGradientUnit>(ElectricCurrentGradientUnit.MilliamperePerSecond, "MilliamperesPerSecond", BaseUnits.Undefined, "ElectricCurrentGradient"),
                 },
                 BaseUnit, Zero, BaseDimensions);
 
@@ -183,6 +186,11 @@ namespace UnitsNet
         public double AmperesPerMillisecond => As(ElectricCurrentGradientUnit.AmperePerMillisecond);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.AmperePerMinute"/>
+        /// </summary>
+        public double AmperesPerMinute => As(ElectricCurrentGradientUnit.AmperePerMinute);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.AmperePerNanosecond"/>
         /// </summary>
         public double AmperesPerNanosecond => As(ElectricCurrentGradientUnit.AmperePerNanosecond);
@@ -191,6 +199,16 @@ namespace UnitsNet
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.AmperePerSecond"/>
         /// </summary>
         public double AmperesPerSecond => As(ElectricCurrentGradientUnit.AmperePerSecond);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.MilliamperePerMinute"/>
+        /// </summary>
+        public double MilliamperesPerMinute => As(ElectricCurrentGradientUnit.MilliamperePerMinute);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="ElectricCurrentGradientUnit.MilliamperePerSecond"/>
+        /// </summary>
+        public double MilliamperesPerSecond => As(ElectricCurrentGradientUnit.MilliamperePerSecond);
 
         #endregion
 
@@ -205,7 +223,10 @@ namespace UnitsNet
             // Register in unit converter: ElectricCurrentGradientUnit -> BaseUnit
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerMicrosecond, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerSecond));
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerMillisecond, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerSecond));
+            unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerMinute, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerSecond));
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerNanosecond, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerSecond));
+            unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.MilliamperePerMinute, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerSecond));
+            unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.MilliamperePerSecond, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerSecond));
 
             // Register in unit converter: BaseUnit <-> BaseUnit
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerSecond, quantity => quantity);
@@ -213,7 +234,10 @@ namespace UnitsNet
             // Register in unit converter: BaseUnit -> ElectricCurrentGradientUnit
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerMicrosecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerMicrosecond));
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerMillisecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerMillisecond));
+            unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerMinute, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerMinute));
             unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerNanosecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.AmperePerNanosecond));
+            unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.MilliamperePerMinute, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.MilliamperePerMinute));
+            unitConverter.SetConversionFunction<ElectricCurrentGradient>(ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.MilliamperePerSecond, quantity => quantity.ToUnit(ElectricCurrentGradientUnit.MilliamperePerSecond));
         }
 
         /// <summary>
@@ -262,6 +286,16 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.AmperePerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricCurrentGradient FromAmperesPerMinute(QuantityValue amperesperminute)
+        {
+            double value = (double) amperesperminute;
+            return new ElectricCurrentGradient(value, ElectricCurrentGradientUnit.AmperePerMinute);
+        }
+
+        /// <summary>
         ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.AmperePerNanosecond"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
@@ -279,6 +313,26 @@ namespace UnitsNet
         {
             double value = (double) amperespersecond;
             return new ElectricCurrentGradient(value, ElectricCurrentGradientUnit.AmperePerSecond);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.MilliamperePerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricCurrentGradient FromMilliamperesPerMinute(QuantityValue milliamperesperminute)
+        {
+            double value = (double) milliamperesperminute;
+            return new ElectricCurrentGradient(value, ElectricCurrentGradientUnit.MilliamperePerMinute);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="ElectricCurrentGradient"/> from <see cref="ElectricCurrentGradientUnit.MilliamperePerSecond"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static ElectricCurrentGradient FromMilliamperesPerSecond(QuantityValue milliamperespersecond)
+        {
+            double value = (double) milliamperespersecond;
+            return new ElectricCurrentGradient(value, ElectricCurrentGradientUnit.MilliamperePerSecond);
         }
 
         /// <summary>
@@ -776,12 +830,18 @@ namespace UnitsNet
                 // ElectricCurrentGradientUnit -> BaseUnit
                 (ElectricCurrentGradientUnit.AmperePerMicrosecond, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient(_value * 1E6, ElectricCurrentGradientUnit.AmperePerSecond),
                 (ElectricCurrentGradientUnit.AmperePerMillisecond, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient(_value * 1E3, ElectricCurrentGradientUnit.AmperePerSecond),
+                (ElectricCurrentGradientUnit.AmperePerMinute, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient(_value / 60, ElectricCurrentGradientUnit.AmperePerSecond),
                 (ElectricCurrentGradientUnit.AmperePerNanosecond, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient(_value * 1E9, ElectricCurrentGradientUnit.AmperePerSecond),
+                (ElectricCurrentGradientUnit.MilliamperePerMinute, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient((_value / 60) * 1e-3d, ElectricCurrentGradientUnit.AmperePerSecond),
+                (ElectricCurrentGradientUnit.MilliamperePerSecond, ElectricCurrentGradientUnit.AmperePerSecond) => new ElectricCurrentGradient((_value) * 1e-3d, ElectricCurrentGradientUnit.AmperePerSecond),
 
                 // BaseUnit -> ElectricCurrentGradientUnit
                 (ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerMicrosecond) => new ElectricCurrentGradient(_value / 1E6, ElectricCurrentGradientUnit.AmperePerMicrosecond),
                 (ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerMillisecond) => new ElectricCurrentGradient(_value / 1E3, ElectricCurrentGradientUnit.AmperePerMillisecond),
+                (ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerMinute) => new ElectricCurrentGradient(_value * 60, ElectricCurrentGradientUnit.AmperePerMinute),
                 (ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.AmperePerNanosecond) => new ElectricCurrentGradient(_value / 1E9, ElectricCurrentGradientUnit.AmperePerNanosecond),
+                (ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.MilliamperePerMinute) => new ElectricCurrentGradient((_value * 60) / 1e-3d, ElectricCurrentGradientUnit.MilliamperePerMinute),
+                (ElectricCurrentGradientUnit.AmperePerSecond, ElectricCurrentGradientUnit.MilliamperePerSecond) => new ElectricCurrentGradient((_value) / 1e-3d, ElectricCurrentGradientUnit.MilliamperePerSecond),
 
                 _ => null
             };

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -33,7 +33,7 @@ namespace UnitsNet
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume. 
+    ///     Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume.
     /// </summary>
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Molar_concentration

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -33,7 +33,7 @@ namespace UnitsNet
 {
     /// <inheritdoc />
     /// <summary>
-    ///     Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume.
+    ///     Molar concentration, also called molarity, amount concentration or substance concentration, is a measure of the concentration of a solute in a solution, or of any chemical species, in terms of amount of substance in a given volume. 
     /// </summary>
     /// <remarks>
     ///     https://en.wikipedia.org/wiki/Molar_concentration

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -66,6 +66,8 @@ namespace UnitsNet
                 new UnitInfo<PressureChangeRateUnit>[]
                 {
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.AtmospherePerSecond, "AtmospheresPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
+                    new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.BarPerMinute, "BarsPerMinute", BaseUnits.Undefined, "PressureChangeRate"),
+                    new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.BarPerSecond, "BarsPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.KilopascalPerMinute, "KilopascalsPerMinute", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.KilopascalPerSecond, "KilopascalsPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute, "KilopoundsForcePerSquareInchPerMinute", BaseUnits.Undefined, "PressureChangeRate"),
@@ -74,6 +76,8 @@ namespace UnitsNet
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.MegapascalPerSecond, "MegapascalsPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute, "MegapoundsForcePerSquareInchPerMinute", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond, "MegapoundsForcePerSquareInchPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
+                    new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.MillibarPerMinute, "MillibarsPerMinute", BaseUnits.Undefined, "PressureChangeRate"),
+                    new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.MillibarPerSecond, "MillibarsPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, "MillimetersOfMercuryPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.PascalPerMinute, "PascalsPerMinute", BaseUnits.Undefined, "PressureChangeRate"),
                     new UnitInfo<PressureChangeRateUnit>(PressureChangeRateUnit.PascalPerSecond, "PascalsPerSecond", BaseUnits.Undefined, "PressureChangeRate"),
@@ -188,6 +192,16 @@ namespace UnitsNet
         public double AtmospheresPerSecond => As(PressureChangeRateUnit.AtmospherePerSecond);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.BarPerMinute"/>
+        /// </summary>
+        public double BarsPerMinute => As(PressureChangeRateUnit.BarPerMinute);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.BarPerSecond"/>
+        /// </summary>
+        public double BarsPerSecond => As(PressureChangeRateUnit.BarPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.KilopascalPerMinute"/>
         /// </summary>
         public double KilopascalsPerMinute => As(PressureChangeRateUnit.KilopascalPerMinute);
@@ -228,6 +242,16 @@ namespace UnitsNet
         public double MegapoundsForcePerSquareInchPerSecond => As(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.MillibarPerMinute"/>
+        /// </summary>
+        public double MillibarsPerMinute => As(PressureChangeRateUnit.MillibarPerMinute);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.MillibarPerSecond"/>
+        /// </summary>
+        public double MillibarsPerSecond => As(PressureChangeRateUnit.MillibarPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="PressureChangeRateUnit.MillimeterOfMercuryPerSecond"/>
         /// </summary>
         public double MillimetersOfMercuryPerSecond => As(PressureChangeRateUnit.MillimeterOfMercuryPerSecond);
@@ -264,6 +288,8 @@ namespace UnitsNet
         {
             // Register in unit converter: PressureChangeRateUnit -> BaseUnit
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.AtmospherePerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.BarPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.BarPerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.KilopascalPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.KilopascalPerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
@@ -272,6 +298,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.MegapascalPerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.MillibarPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.MillibarPerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.MillimeterOfMercuryPerSecond, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PoundForcePerSquareInchPerMinute, PressureChangeRateUnit.PascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerSecond));
@@ -282,6 +310,8 @@ namespace UnitsNet
 
             // Register in unit converter: BaseUnit -> PressureChangeRateUnit
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.AtmospherePerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.AtmospherePerSecond));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.BarPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.BarPerMinute));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.BarPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.BarPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.KilopascalPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.KilopascalPerMinute));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.KilopascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.KilopascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute));
@@ -290,6 +320,8 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MegapascalPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.MegapascalPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MillibarPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.MillibarPerMinute));
+            unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MillibarPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.MillibarPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MillimeterOfMercuryPerSecond, quantity => quantity.ToUnit(PressureChangeRateUnit.MillimeterOfMercuryPerSecond));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.PascalPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.PascalPerMinute));
             unitConverter.SetConversionFunction<PressureChangeRate>(PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.PoundForcePerSquareInchPerMinute, quantity => quantity.ToUnit(PressureChangeRateUnit.PoundForcePerSquareInchPerMinute));
@@ -329,6 +361,26 @@ namespace UnitsNet
         {
             double value = (double) atmospherespersecond;
             return new PressureChangeRate(value, PressureChangeRateUnit.AtmospherePerSecond);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.BarPerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromBarsPerMinute(QuantityValue barsperminute)
+        {
+            double value = (double) barsperminute;
+            return new PressureChangeRate(value, PressureChangeRateUnit.BarPerMinute);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.BarPerSecond"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromBarsPerSecond(QuantityValue barspersecond)
+        {
+            double value = (double) barspersecond;
+            return new PressureChangeRate(value, PressureChangeRateUnit.BarPerSecond);
         }
 
         /// <summary>
@@ -409,6 +461,26 @@ namespace UnitsNet
         {
             double value = (double) megapoundsforcepersquareinchpersecond;
             return new PressureChangeRate(value, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.MillibarPerMinute"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromMillibarsPerMinute(QuantityValue millibarsperminute)
+        {
+            double value = (double) millibarsperminute;
+            return new PressureChangeRate(value, PressureChangeRateUnit.MillibarPerMinute);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="PressureChangeRate"/> from <see cref="PressureChangeRateUnit.MillibarPerSecond"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static PressureChangeRate FromMillibarsPerSecond(QuantityValue millibarspersecond)
+        {
+            double value = (double) millibarspersecond;
+            return new PressureChangeRate(value, PressureChangeRateUnit.MillibarPerSecond);
         }
 
         /// <summary>
@@ -955,6 +1027,8 @@ namespace UnitsNet
             {
                 // PressureChangeRateUnit -> BaseUnit
                 (PressureChangeRateUnit.AtmospherePerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value * 1.01325 * 1e5, PressureChangeRateUnit.PascalPerSecond),
+                (PressureChangeRateUnit.BarPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value * 1e5 / 60, PressureChangeRateUnit.PascalPerSecond),
+                (PressureChangeRateUnit.BarPerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value * 1e5, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.KilopascalPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value / 60) * 1e3d, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.KilopascalPerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value) * 1e3d, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value * 6.894757293168361e3 / 60) * 1e3d, PressureChangeRateUnit.PascalPerSecond),
@@ -963,6 +1037,8 @@ namespace UnitsNet
                 (PressureChangeRateUnit.MegapascalPerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value) * 1e6d, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value * 6.894757293168361e3 / 60) * 1e6d, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value * 6.894757293168361e3) * 1e6d, PressureChangeRateUnit.PascalPerSecond),
+                (PressureChangeRateUnit.MillibarPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value * 1e5 / 60) * 1e-3d, PressureChangeRateUnit.PascalPerSecond),
+                (PressureChangeRateUnit.MillibarPerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate((_value * 1e5) * 1e-3d, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.MillimeterOfMercuryPerSecond, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value * 133.322, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.PascalPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value / 60, PressureChangeRateUnit.PascalPerSecond),
                 (PressureChangeRateUnit.PoundForcePerSquareInchPerMinute, PressureChangeRateUnit.PascalPerSecond) => new PressureChangeRate(_value * 6.894757293168361e3 / 60, PressureChangeRateUnit.PascalPerSecond),
@@ -970,6 +1046,8 @@ namespace UnitsNet
 
                 // BaseUnit -> PressureChangeRateUnit
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.AtmospherePerSecond) => new PressureChangeRate(_value / (1.01325 * 1e5), PressureChangeRateUnit.AtmospherePerSecond),
+                (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.BarPerMinute) => new PressureChangeRate(_value / 1e5 * 60, PressureChangeRateUnit.BarPerMinute),
+                (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.BarPerSecond) => new PressureChangeRate(_value / 1e5, PressureChangeRateUnit.BarPerSecond),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.KilopascalPerMinute) => new PressureChangeRate((_value * 60) / 1e3d, PressureChangeRateUnit.KilopascalPerMinute),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.KilopascalPerSecond) => new PressureChangeRate((_value) / 1e3d, PressureChangeRateUnit.KilopascalPerSecond),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute) => new PressureChangeRate((_value / 6.894757293168361e3 * 60) / 1e3d, PressureChangeRateUnit.KilopoundForcePerSquareInchPerMinute),
@@ -978,6 +1056,8 @@ namespace UnitsNet
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MegapascalPerSecond) => new PressureChangeRate((_value) / 1e6d, PressureChangeRateUnit.MegapascalPerSecond),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute) => new PressureChangeRate((_value / 6.894757293168361e3 * 60) / 1e6d, PressureChangeRateUnit.MegapoundForcePerSquareInchPerMinute),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond) => new PressureChangeRate((_value / 6.894757293168361e3) / 1e6d, PressureChangeRateUnit.MegapoundForcePerSquareInchPerSecond),
+                (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MillibarPerMinute) => new PressureChangeRate((_value / 1e5 * 60) / 1e-3d, PressureChangeRateUnit.MillibarPerMinute),
+                (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MillibarPerSecond) => new PressureChangeRate((_value / 1e5) / 1e-3d, PressureChangeRateUnit.MillibarPerSecond),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.MillimeterOfMercuryPerSecond) => new PressureChangeRate(_value / 133.322, PressureChangeRateUnit.MillimeterOfMercuryPerSecond),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.PascalPerMinute) => new PressureChangeRate(_value * 60, PressureChangeRateUnit.PascalPerMinute),
                 (PressureChangeRateUnit.PascalPerSecond, PressureChangeRateUnit.PoundForcePerSquareInchPerMinute) => new PressureChangeRate(_value / 6.894757293168361e3 * 60, PressureChangeRateUnit.PoundForcePerSquareInchPerMinute),

--- a/UnitsNet/GeneratedCode/Resources/ElectricCurrentGradient.restext
+++ b/UnitsNet/GeneratedCode/Resources/ElectricCurrentGradient.restext
@@ -1,4 +1,7 @@
 AmperesPerMicrosecond=A/μs
 AmperesPerMillisecond=A/ms
+AmperesPerMinute=A/min
 AmperesPerNanosecond=A/ns
 AmperesPerSecond=A/s
+MilliamperesPerMinute=mA/min
+MilliamperesPerSecond=mA/s

--- a/UnitsNet/GeneratedCode/Resources/PressureChangeRate.restext
+++ b/UnitsNet/GeneratedCode/Resources/PressureChangeRate.restext
@@ -1,4 +1,6 @@
 AtmospheresPerSecond=atm/s
+BarsPerMinute=bar/min
+BarsPerSecond=bar/s
 KilopascalsPerMinute=kPa/min
 KilopascalsPerSecond=kPa/s
 KilopoundsForcePerSquareInchPerMinute=ksi/min,kipf/in²/min
@@ -7,6 +9,8 @@ MegapascalsPerMinute=MPa/min
 MegapascalsPerSecond=MPa/s
 MegapoundsForcePerSquareInchPerMinute=Mpsi/min,Mlb/in²/min
 MegapoundsForcePerSquareInchPerSecond=Mpsi/s,Mlb/in²/s
+MillibarsPerMinute=mbar/min
+MillibarsPerSecond=mbar/s
 MillimetersOfMercuryPerSecond=mmHg/s
 PascalsPerMinute=Pa/min
 PascalsPerSecond=Pa/s

--- a/UnitsNet/GeneratedCode/Resources/PressureChangeRate.ru-RU.restext
+++ b/UnitsNet/GeneratedCode/Resources/PressureChangeRate.ru-RU.restext
@@ -1,4 +1,6 @@
 AtmospheresPerSecond=атм/с
+BarsPerMinute=бар/мин
+BarsPerSecond=бар/с
 KilopascalsPerMinute=кПа/мин
 KilopascalsPerSecond=кПа/с
 KilopoundsForcePerSquareInchPerMinute=ksi/мин,kipf/in²/мин
@@ -7,6 +9,8 @@ MegapascalsPerMinute=МПа/мин
 MegapascalsPerSecond=МПа/с
 MegapoundsForcePerSquareInchPerMinute=Мpsi/мин,Мlb/in²/мин
 MegapoundsForcePerSquareInchPerSecond=Мpsi/с,Мlb/in²/с
+MillibarsPerMinute=мбар/мин
+MillibarsPerSecond=мбар/с
 MillimetersOfMercuryPerSecond=mmHg/с
 PascalsPerMinute=Па/мин
 PascalsPerSecond=Па/с

--- a/UnitsNet/GeneratedCode/Units/ElectricCurrentGradientUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/ElectricCurrentGradientUnit.g.cs
@@ -27,8 +27,11 @@ namespace UnitsNet.Units
     {
         AmperePerMicrosecond = 1,
         AmperePerMillisecond = 2,
+        AmperePerMinute = 11,
         AmperePerNanosecond = 3,
         AmperePerSecond = 4,
+        MilliamperePerMinute = 6,
+        MilliamperePerSecond = 14,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet/GeneratedCode/Units/PressureChangeRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/PressureChangeRateUnit.g.cs
@@ -26,6 +26,8 @@ namespace UnitsNet.Units
     public enum PressureChangeRateUnit
     {
         AtmospherePerSecond = 1,
+        BarPerMinute = 16,
+        BarPerSecond = 23,
         KilopascalPerMinute = 2,
         KilopascalPerSecond = 3,
         KilopoundForcePerSquareInchPerMinute = 4,
@@ -34,6 +36,8 @@ namespace UnitsNet.Units
         MegapascalPerSecond = 7,
         MegapoundForcePerSquareInchPerMinute = 8,
         MegapoundForcePerSquareInchPerSecond = 9,
+        MillibarPerMinute = 24,
+        MillibarPerSecond = 20,
         MillimeterOfMercuryPerSecond = 10,
         PascalPerMinute = 11,
         PascalPerSecond = 12,


### PR DESCRIPTION
Hi
I added some units witch we missed in our hydraulic use cases ;) 
and did 2 small fixes? please look over these!

I hope I'm following all the guidelines correctly, if not please advice for changes ;)

### Added Units

__ElectricCurrentGradient__:
* AmperesPerMinute
* MilliAmperesPerMinute
* MilliAmperesPerSecond
> I don't know russian, but i copy pasted the unit abbreviation from the other units. Google says its ok.

__PressureChangeRate__:
* BarsPerSecond
* BarsPerMinute
* MillibarsPerSecond
* MillibarsPerMinute

### Added operators
* Multiplication of __ElectricCurrentGradient__ and __TimeSpan|Duration__ returns __ElectricCurrent__
* Multiplcation of __PressureChangeRate__ and __TimeSpan|Duration__ returns __Pressure__
* Division of __ElectricCurrent__ by __Time|Duration__ returns __ElectricCurrentGradient__
* Division of __Pressure__ by __TimeSpan|Duration__ returns __PressureChangeRate__

> found some operator only use `Duration` and some use both `TimeSpan` and `Duration`, thats what I went with.


### FIX

__All__ generated files in `UnitsNet/GeneratedCode/Quanities/` had a change of 1 spacechar.
That's the change in `QuantityGenerator.cs`.

I set `SupportsSIUnitSystem` to `true` in `ElectricCurrentGradientTests` and added the `BaseUnits` element on AmperesPerSecond in `ElectricCurrentGradient.json`.
I think thats correct?


Addidionaly added some generated files that had a change of spaces in the \<summary\> tag.