### PR TITLE
💥Add CoefficientOfThermalExpansion units, change base unit

### DIFF
--- a/Common/UnitDefinitions/CoefficientOfThermalExpansion.json
+++ b/Common/UnitDefinitions/CoefficientOfThermalExpansion.json
@@ -18,7 +18,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": []
+          "Abbreviations": [ "1/K" ]
         }
       ]
     },
@@ -34,7 +34,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": []
+          "Abbreviations": [ "1/°C" ]
         }
       ]
     },
@@ -50,7 +50,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": []
+          "Abbreviations": [ "1/°F" ]
         }
       ]
     },
@@ -65,7 +65,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "K⁻¹", "1/K" ]
+          "Abbreviations": [ "K⁻¹" ]
         }
       ]
     },
@@ -80,7 +80,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "°C⁻¹", "1/°C" ]
+          "Abbreviations": [ "°C⁻¹" ]
         }
       ]
     },
@@ -95,7 +95,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "°F⁻¹", "1/°F" ]
+          "Abbreviations": [ "°F⁻¹" ]
         }
       ]
     },

--- a/Common/UnitDefinitions/CoefficientOfThermalExpansion.json
+++ b/Common/UnitDefinitions/CoefficientOfThermalExpansion.json
@@ -1,6 +1,6 @@
 {
   "Name": "CoefficientOfThermalExpansion",
-  "BaseUnit": "InverseKelvin",
+  "BaseUnit": "PerKelvin",
   "XmlDocSummary": "A unit that represents a fractional change in size in response to a change in temperature.",
   "BaseDimensions": {
     "Θ": -1
@@ -9,6 +9,54 @@
     {
       "SingularName": "InverseKelvin",
       "PluralName": "InverseKelvin",
+      "ObsoleteText": "Use PerKelvin instead.",
+      "BaseUnits": {
+        "Θ": "Kelvin"
+      },
+      "FromUnitToBaseFunc": "{x}",
+      "FromBaseToUnitFunc": "{x}",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": []
+        }
+      ]
+    },
+    {
+      "SingularName": "InverseDegreeCelsius",
+      "PluralName": "InverseDegreeCelsius",
+      "ObsoleteText": "Use PerDegreeCelsius instead.",
+      "BaseUnits": {
+        "Θ": "DegreeCelsius"
+      },
+      "FromUnitToBaseFunc": "{x}",
+      "FromBaseToUnitFunc": "{x}",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": []
+        }
+      ]
+    },
+    {
+      "SingularName": "InverseDegreeFahrenheit",
+      "PluralName": "InverseDegreeFahrenheit",
+      "ObsoleteText": "Use PerDegreeFahrenheit instead.",
+      "BaseUnits": {
+        "Θ": "DegreeFahrenheit"
+      },
+      "FromUnitToBaseFunc": "{x} * 9 / 5",
+      "FromBaseToUnitFunc": "{x} * 5 / 9",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": []
+        }
+      ]
+    },
+    {
+      "SingularName": "PerKelvin",
+      "PluralName": "PerKelvin",
       "BaseUnits": {
         "Θ": "Kelvin"
       },
@@ -22,8 +70,8 @@
       ]
     },
     {
-      "SingularName": "InverseDegreeCelsius",
-      "PluralName": "InverseDegreeCelsius",
+      "SingularName": "PerDegreeCelsius",
+      "PluralName": "PerDegreeCelsius",
       "BaseUnits": {
         "Θ": "DegreeCelsius"
       },
@@ -37,8 +85,8 @@
       ]
     },
     {
-      "SingularName": "InverseDegreeFahrenheit",
-      "PluralName": "InverseDegreeFahrenheit",
+      "SingularName": "PerDegreeFahrenheit",
+      "PluralName": "PerDegreeFahrenheit",
       "BaseUnits": {
         "Θ": "DegreeFahrenheit"
       },
@@ -52,8 +100,8 @@
       ]
     },
     {
-      "SingularName": "PartsPerMillionPerKelvin",
-      "PluralName": "PartsPerMillionPerKelvin",
+      "SingularName": "PpmPerKelvin",
+      "PluralName": "PpmPerKelvin",
       "BaseUnits": {
         "Θ": "Kelvin"
       },
@@ -67,8 +115,8 @@
       ]
     },
     {
-      "SingularName": "PartsPerMillionPerDegreeCelsius",
-      "PluralName": "PartsPerMillionPerDegreeCelsius",
+      "SingularName": "PpmPerDegreeCelsius",
+      "PluralName": "PpmPerDegreeCelsius",
       "BaseUnits": {
         "Θ": "DegreeCelsius"
       },
@@ -82,8 +130,8 @@
       ]
     },
     {
-      "SingularName": "PartsPerMillionPerDegreeFahrenheit",
-      "PluralName": "PartsPerMillionPerDegreeFahrenheit",
+      "SingularName": "PpmPerDegreeFahrenheit",
+      "PluralName": "PpmPerDegreeFahrenheit",
       "BaseUnits": {
         "Θ": "DegreeFahrenheit"
       },

--- a/Common/UnitDefinitions/CoefficientOfThermalExpansion.json
+++ b/Common/UnitDefinitions/CoefficientOfThermalExpansion.json
@@ -50,6 +50,51 @@
           "Abbreviations": [ "°F⁻¹", "1/°F" ]
         }
       ]
+    },
+    {
+      "SingularName": "PartsPerMillionPerKelvin",
+      "PluralName": "PartsPerMillionPerKelvin",
+      "BaseUnits": {
+        "Θ": "Kelvin"
+      },
+      "FromUnitToBaseFunc": "{x} / 1e6",
+      "FromBaseToUnitFunc": "{x} * 1e6",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "ppm/K" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "PartsPerMillionPerDegreeCelsius",
+      "PluralName": "PartsPerMillionPerDegreeCelsius",
+      "BaseUnits": {
+        "Θ": "DegreeCelsius"
+      },
+      "FromUnitToBaseFunc": "{x} / 1e6",
+      "FromBaseToUnitFunc": "{x} * 1e6",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "ppm/°C" ]
+        }
+      ]
+    },
+    {
+      "SingularName": "PartsPerMillionPerDegreeFahrenheit",
+      "PluralName": "PartsPerMillionPerDegreeFahrenheit",
+      "BaseUnits": {
+        "Θ": "DegreeFahrenheit"
+      },
+      "FromUnitToBaseFunc": "{x} * 9 / 5e6",
+      "FromBaseToUnitFunc": "{x} * 5e6 / 9",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "ppm/°F" ]
+        }
+      ]
     }
   ]
 }

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -153,9 +153,12 @@
     "InverseDegreeCelsius": 1,
     "InverseDegreeFahrenheit": 2,
     "InverseKelvin": 3,
-    "PartsPerMillionPerDegreeCelsius": 10,
-    "PartsPerMillionPerDegreeFahrenheit": 5,
-    "PartsPerMillionPerKelvin": 9
+    "PerDegreeCelsius": 9,
+    "PerDegreeFahrenheit": 11,
+    "PerKelvin": 13,
+    "PpmPerDegreeCelsius": 6,
+    "PpmPerDegreeFahrenheit": 4,
+    "PpmPerKelvin": 7
   },
   "Compressibility": {
     "InverseAtmosphere": 1,

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -152,7 +152,10 @@
   "CoefficientOfThermalExpansion": {
     "InverseDegreeCelsius": 1,
     "InverseDegreeFahrenheit": 2,
-    "InverseKelvin": 3
+    "InverseKelvin": 3,
+    "PartsPerMillionPerDegreeCelsius": 10,
+    "PartsPerMillionPerDegreeFahrenheit": 5,
+    "PartsPerMillionPerKelvin": 9
   },
   "Compressibility": {
     "InverseAtmosphere": 1,

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -94,6 +94,21 @@ namespace UnitsNet
         /// </summary>
         public double InverseKelvin => As(CoefficientOfThermalExpansionUnit.InverseKelvin);
 
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>
+        /// </summary>
+        public double PartsPerMillionPerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>
+        /// </summary>
+        public double PartsPerMillionPerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>
+        /// </summary>
+        public double PartsPerMillionPerKelvin => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+
         #endregion
 
         #region Static Factory Methods
@@ -115,6 +130,24 @@ namespace UnitsNet
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
         public static CoefficientOfThermalExpansion FromInverseKelvin(double inversekelvin) => new CoefficientOfThermalExpansion(inversekelvin, CoefficientOfThermalExpansionUnit.InverseKelvin);
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeCelsius(double partspermillionperdegreecelsius) => new CoefficientOfThermalExpansion(partspermillionperdegreecelsius, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeFahrenheit(double partspermillionperdegreefahrenheit) => new CoefficientOfThermalExpansion(partspermillionperdegreefahrenheit, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPartsPerMillionPerKelvin(double partspermillionperkelvin) => new CoefficientOfThermalExpansion(partspermillionperkelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
 
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="CoefficientOfThermalExpansionUnit" /> to <see cref="CoefficientOfThermalExpansion" />.
@@ -159,6 +192,9 @@ namespace UnitsNet
                         CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => _value,
                         CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => _value * 9 / 5,
                         CoefficientOfThermalExpansionUnit.InverseKelvin => _value,
+                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius => _value / 1e6,
+                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit => _value * 9 / 5e6,
+                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin => _value / 1e6,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to base units.")
                     };
                     }
@@ -175,6 +211,9 @@ namespace UnitsNet
                         CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => baseUnitValue,
                         CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => baseUnitValue * 5 / 9,
                         CoefficientOfThermalExpansionUnit.InverseKelvin => baseUnitValue,
+                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius => baseUnitValue * 1e6,
+                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit => baseUnitValue * 5e6 / 9,
+                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin => baseUnitValue * 1e6,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to {unit}.")
                     };
                     }

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -61,7 +61,7 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of Duration, which is Second. All conversions go via this value.
         /// </summary>
-        public static CoefficientOfThermalExpansionUnit BaseUnit { get; } = CoefficientOfThermalExpansionUnit.InverseKelvin;
+        public static CoefficientOfThermalExpansionUnit BaseUnit { get; } = CoefficientOfThermalExpansionUnit.PerKelvin;
 
         /// <summary>
         /// Represents the largest possible value of Duration
@@ -82,32 +82,50 @@ namespace UnitsNet
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeCelsius"/>
         /// </summary>
+        [Obsolete("Use PerDegreeCelsius instead.")]
         public double InverseDegreeCelsius => As(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit"/>
         /// </summary>
+        [Obsolete("Use PerDegreeFahrenheit instead.")]
         public double InverseDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.InverseKelvin"/>
         /// </summary>
+        [Obsolete("Use PerKelvin instead.")]
         public double InverseKelvin => As(CoefficientOfThermalExpansionUnit.InverseKelvin);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PerDegreeCelsius"/>
         /// </summary>
-        public double PartsPerMillionPerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+        public double PerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PerDegreeCelsius);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit"/>
         /// </summary>
-        public double PartsPerMillionPerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+        public double PerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PerKelvin"/>
         /// </summary>
-        public double PartsPerMillionPerKelvin => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+        public double PerKelvin => As(CoefficientOfThermalExpansionUnit.PerKelvin);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius"/>
+        /// </summary>
+        public double PpmPerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit"/>
+        /// </summary>
+        public double PpmPerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PpmPerKelvin"/>
+        /// </summary>
+        public double PpmPerKelvin => As(CoefficientOfThermalExpansionUnit.PpmPerKelvin);
 
         #endregion
 
@@ -117,37 +135,58 @@ namespace UnitsNet
         ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeCelsius"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Obsolete("Use PerDegreeCelsius instead.")]
         public static CoefficientOfThermalExpansion FromInverseDegreeCelsius(double inversedegreecelsius) => new CoefficientOfThermalExpansion(inversedegreecelsius, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius);
 
         /// <summary>
         ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Obsolete("Use PerDegreeFahrenheit instead.")]
         public static CoefficientOfThermalExpansion FromInverseDegreeFahrenheit(double inversedegreefahrenheit) => new CoefficientOfThermalExpansion(inversedegreefahrenheit, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit);
 
         /// <summary>
         ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.InverseKelvin"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Obsolete("Use PerKelvin instead.")]
         public static CoefficientOfThermalExpansion FromInverseKelvin(double inversekelvin) => new CoefficientOfThermalExpansion(inversekelvin, CoefficientOfThermalExpansionUnit.InverseKelvin);
 
         /// <summary>
-        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>.
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PerDegreeCelsius"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeCelsius(double partspermillionperdegreecelsius) => new CoefficientOfThermalExpansion(partspermillionperdegreecelsius, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+        public static CoefficientOfThermalExpansion FromPerDegreeCelsius(double perdegreecelsius) => new CoefficientOfThermalExpansion(perdegreecelsius, CoefficientOfThermalExpansionUnit.PerDegreeCelsius);
 
         /// <summary>
-        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>.
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeFahrenheit(double partspermillionperdegreefahrenheit) => new CoefficientOfThermalExpansion(partspermillionperdegreefahrenheit, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+        public static CoefficientOfThermalExpansion FromPerDegreeFahrenheit(double perdegreefahrenheit) => new CoefficientOfThermalExpansion(perdegreefahrenheit, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit);
 
         /// <summary>
-        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>.
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PerKelvin"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static CoefficientOfThermalExpansion FromPartsPerMillionPerKelvin(double partspermillionperkelvin) => new CoefficientOfThermalExpansion(partspermillionperkelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+        public static CoefficientOfThermalExpansion FromPerKelvin(double perkelvin) => new CoefficientOfThermalExpansion(perkelvin, CoefficientOfThermalExpansionUnit.PerKelvin);
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPpmPerDegreeCelsius(double ppmperdegreecelsius) => new CoefficientOfThermalExpansion(ppmperdegreecelsius, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius);
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPpmPerDegreeFahrenheit(double ppmperdegreefahrenheit) => new CoefficientOfThermalExpansion(ppmperdegreefahrenheit, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit);
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PpmPerKelvin"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPpmPerKelvin(double ppmperkelvin) => new CoefficientOfThermalExpansion(ppmperkelvin, CoefficientOfThermalExpansionUnit.PpmPerKelvin);
 
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="CoefficientOfThermalExpansionUnit" /> to <see cref="CoefficientOfThermalExpansion" />.
@@ -192,9 +231,12 @@ namespace UnitsNet
                         CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => _value,
                         CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => _value * 9 / 5,
                         CoefficientOfThermalExpansionUnit.InverseKelvin => _value,
-                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius => _value / 1e6,
-                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit => _value * 9 / 5e6,
-                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin => _value / 1e6,
+                        CoefficientOfThermalExpansionUnit.PerDegreeCelsius => _value,
+                        CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit => _value * 9 / 5,
+                        CoefficientOfThermalExpansionUnit.PerKelvin => _value,
+                        CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius => _value / 1e6,
+                        CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit => _value * 9 / 5e6,
+                        CoefficientOfThermalExpansionUnit.PpmPerKelvin => _value / 1e6,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to base units.")
                     };
                     }
@@ -211,9 +253,12 @@ namespace UnitsNet
                         CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => baseUnitValue,
                         CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => baseUnitValue * 5 / 9,
                         CoefficientOfThermalExpansionUnit.InverseKelvin => baseUnitValue,
-                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius => baseUnitValue * 1e6,
-                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit => baseUnitValue * 5e6 / 9,
-                        CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin => baseUnitValue * 1e6,
+                        CoefficientOfThermalExpansionUnit.PerDegreeCelsius => baseUnitValue,
+                        CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit => baseUnitValue * 5 / 9,
+                        CoefficientOfThermalExpansionUnit.PerKelvin => baseUnitValue,
+                        CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius => baseUnitValue * 1e6,
+                        CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit => baseUnitValue * 5e6 / 9,
+                        CoefficientOfThermalExpansionUnit.PpmPerKelvin => baseUnitValue * 1e6,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to {unit}.")
                     };
                     }

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
@@ -28,6 +28,9 @@ namespace UnitsNet.Units
         InverseDegreeCelsius = 1,
         InverseDegreeFahrenheit = 2,
         InverseKelvin = 3,
+        PartsPerMillionPerDegreeCelsius = 10,
+        PartsPerMillionPerDegreeFahrenheit = 5,
+        PartsPerMillionPerKelvin = 9,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
@@ -25,12 +25,18 @@ namespace UnitsNet.Units
 
     public enum CoefficientOfThermalExpansionUnit
     {
+        [System.Obsolete("Use PerDegreeCelsius instead.")]
         InverseDegreeCelsius = 1,
+        [System.Obsolete("Use PerDegreeFahrenheit instead.")]
         InverseDegreeFahrenheit = 2,
+        [System.Obsolete("Use PerKelvin instead.")]
         InverseKelvin = 3,
-        PartsPerMillionPerDegreeCelsius = 10,
-        PartsPerMillionPerDegreeFahrenheit = 5,
-        PartsPerMillionPerKelvin = 9,
+        PerDegreeCelsius = 9,
+        PerDegreeFahrenheit = 11,
+        PerKelvin = 13,
+        PpmPerDegreeCelsius = 6,
+        PpmPerDegreeFahrenheit = 4,
+        PpmPerKelvin = 7,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensionsTest.g.cs
@@ -37,16 +37,28 @@ namespace UnitsNet.Tests
             Assert.Equal(CoefficientOfThermalExpansion.FromInverseKelvin(2), 2.InverseKelvin());
 
         [Fact]
-        public void NumberToPartsPerMillionPerDegreeCelsiusTest() =>
-            Assert.Equal(CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(2), 2.PartsPerMillionPerDegreeCelsius());
+        public void NumberToPerDegreeCelsiusTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPerDegreeCelsius(2), 2.PerDegreeCelsius());
 
         [Fact]
-        public void NumberToPartsPerMillionPerDegreeFahrenheitTest() =>
-            Assert.Equal(CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(2), 2.PartsPerMillionPerDegreeFahrenheit());
+        public void NumberToPerDegreeFahrenheitTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPerDegreeFahrenheit(2), 2.PerDegreeFahrenheit());
 
         [Fact]
-        public void NumberToPartsPerMillionPerKelvinTest() =>
-            Assert.Equal(CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(2), 2.PartsPerMillionPerKelvin());
+        public void NumberToPerKelvinTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPerKelvin(2), 2.PerKelvin());
+
+        [Fact]
+        public void NumberToPpmPerDegreeCelsiusTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPpmPerDegreeCelsius(2), 2.PpmPerDegreeCelsius());
+
+        [Fact]
+        public void NumberToPpmPerDegreeFahrenheitTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPpmPerDegreeFahrenheit(2), 2.PpmPerDegreeFahrenheit());
+
+        [Fact]
+        public void NumberToPpmPerKelvinTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPpmPerKelvin(2), 2.PpmPerKelvin());
 
     }
 }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensionsTest.g.cs
@@ -36,5 +36,17 @@ namespace UnitsNet.Tests
         public void NumberToInverseKelvinTest() =>
             Assert.Equal(CoefficientOfThermalExpansion.FromInverseKelvin(2), 2.InverseKelvin());
 
+        [Fact]
+        public void NumberToPartsPerMillionPerDegreeCelsiusTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(2), 2.PartsPerMillionPerDegreeCelsius());
+
+        [Fact]
+        public void NumberToPartsPerMillionPerDegreeFahrenheitTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(2), 2.PartsPerMillionPerDegreeFahrenheit());
+
+        [Fact]
+        public void NumberToPartsPerMillionPerKelvinTest() =>
+            Assert.Equal(CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(2), 2.PartsPerMillionPerKelvin());
+
     }
 }

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensions.g.cs
@@ -33,6 +33,7 @@ namespace UnitsNet.NumberExtensions.NumberToCoefficientOfThermalExpansion
     public static class NumberToCoefficientOfThermalExpansionExtensions
     {
         /// <inheritdoc cref="CoefficientOfThermalExpansion.FromInverseDegreeCelsius(UnitsNet.QuantityValue)" />
+        [Obsolete("Use PerDegreeCelsius instead.")]
         public static CoefficientOfThermalExpansion InverseDegreeCelsius<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
@@ -41,6 +42,7 @@ namespace UnitsNet.NumberExtensions.NumberToCoefficientOfThermalExpansion
             => CoefficientOfThermalExpansion.FromInverseDegreeCelsius(Convert.ToDouble(value));
 
         /// <inheritdoc cref="CoefficientOfThermalExpansion.FromInverseDegreeFahrenheit(UnitsNet.QuantityValue)" />
+        [Obsolete("Use PerDegreeFahrenheit instead.")]
         public static CoefficientOfThermalExpansion InverseDegreeFahrenheit<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
@@ -49,6 +51,7 @@ namespace UnitsNet.NumberExtensions.NumberToCoefficientOfThermalExpansion
             => CoefficientOfThermalExpansion.FromInverseDegreeFahrenheit(Convert.ToDouble(value));
 
         /// <inheritdoc cref="CoefficientOfThermalExpansion.FromInverseKelvin(UnitsNet.QuantityValue)" />
+        [Obsolete("Use PerKelvin instead.")]
         public static CoefficientOfThermalExpansion InverseKelvin<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
@@ -56,29 +59,53 @@ namespace UnitsNet.NumberExtensions.NumberToCoefficientOfThermalExpansion
 #endif
             => CoefficientOfThermalExpansion.FromInverseKelvin(Convert.ToDouble(value));
 
-        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(UnitsNet.QuantityValue)" />
-        public static CoefficientOfThermalExpansion PartsPerMillionPerDegreeCelsius<T>(this T value)
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPerDegreeCelsius(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PerDegreeCelsius<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
             , INumber<T>
 #endif
-            => CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(Convert.ToDouble(value));
+            => CoefficientOfThermalExpansion.FromPerDegreeCelsius(Convert.ToDouble(value));
 
-        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(UnitsNet.QuantityValue)" />
-        public static CoefficientOfThermalExpansion PartsPerMillionPerDegreeFahrenheit<T>(this T value)
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPerDegreeFahrenheit(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PerDegreeFahrenheit<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
             , INumber<T>
 #endif
-            => CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(Convert.ToDouble(value));
+            => CoefficientOfThermalExpansion.FromPerDegreeFahrenheit(Convert.ToDouble(value));
 
-        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(UnitsNet.QuantityValue)" />
-        public static CoefficientOfThermalExpansion PartsPerMillionPerKelvin<T>(this T value)
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPerKelvin(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PerKelvin<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
             , INumber<T>
 #endif
-            => CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(Convert.ToDouble(value));
+            => CoefficientOfThermalExpansion.FromPerKelvin(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPpmPerDegreeCelsius(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PpmPerDegreeCelsius<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => CoefficientOfThermalExpansion.FromPpmPerDegreeCelsius(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPpmPerDegreeFahrenheit(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PpmPerDegreeFahrenheit<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => CoefficientOfThermalExpansion.FromPpmPerDegreeFahrenheit(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPpmPerKelvin(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PpmPerKelvin<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => CoefficientOfThermalExpansion.FromPpmPerKelvin(Convert.ToDouble(value));
 
     }
 }

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToCoefficientOfThermalExpansionExtensions.g.cs
@@ -56,5 +56,29 @@ namespace UnitsNet.NumberExtensions.NumberToCoefficientOfThermalExpansion
 #endif
             => CoefficientOfThermalExpansion.FromInverseKelvin(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PartsPerMillionPerDegreeCelsius<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PartsPerMillionPerDegreeFahrenheit<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(UnitsNet.QuantityValue)" />
+        public static CoefficientOfThermalExpansion PartsPerMillionPerKelvin<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(Convert.ToDouble(value));
+
     }
 }

--- a/UnitsNet.Tests/CustomCode/CoefficientOfThermalExpansionTests.cs
+++ b/UnitsNet.Tests/CustomCode/CoefficientOfThermalExpansionTests.cs
@@ -29,17 +29,23 @@ namespace UnitsNet.Tests.CustomCode
     {
         protected override bool SupportsSIUnitSystem => true;
 
-        protected override double InverseDegreeCelsiusInOneInverseKelvin => 1.0;
+        protected override double InverseDegreeCelsiusInOnePerKelvin => 1.0;
 
-        protected override double InverseDegreeFahrenheitInOneInverseKelvin => 0.5555555555555556;
+        protected override double InverseDegreeFahrenheitInOnePerKelvin => 0.5555555555555556;
 
-        protected override double InverseKelvinInOneInverseKelvin => 1.0;
+        protected override double InverseKelvinInOnePerKelvin => 1.0;
 
-        protected override double PartsPerMillionPerDegreeCelsiusInOneInverseKelvin => 1e6;
+        protected override double PerDegreeCelsiusInOnePerKelvin => 1.0;
 
-        protected override double PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin => 5.5555555555555556e5;
+        protected override double PerDegreeFahrenheitInOnePerKelvin => 0.5555555555555556;
 
-        protected override double PartsPerMillionPerKelvinInOneInverseKelvin => 1e6;
+        protected override double PerKelvinInOnePerKelvin => 1.0;
+
+        protected override double PpmPerDegreeCelsiusInOnePerKelvin => 1e6;
+
+        protected override double PpmPerDegreeFahrenheitInOnePerKelvin => 5.5555555555555556e5;
+
+        protected override double PpmPerKelvinInOnePerKelvin => 1e6;
 
         [Fact]
         public void CoefficientOfThermalExpansionTimesTemperatureDelta()

--- a/UnitsNet.Tests/CustomCode/CoefficientOfThermalExpansionTests.cs
+++ b/UnitsNet.Tests/CustomCode/CoefficientOfThermalExpansionTests.cs
@@ -35,6 +35,12 @@ namespace UnitsNet.Tests.CustomCode
 
         protected override double InverseKelvinInOneInverseKelvin => 1.0;
 
+        protected override double PartsPerMillionPerDegreeCelsiusInOneInverseKelvin => 1e6;
+
+        protected override double PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin => 5.5555555555555556e5;
+
+        protected override double PartsPerMillionPerKelvinInOneInverseKelvin => 1e6;
+
         [Fact]
         public void CoefficientOfThermalExpansionTimesTemperatureDelta()
         {

--- a/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
@@ -47,7 +47,7 @@ namespace UnitsNet.Tests
             Assertion(3, BitRateUnit.TerabytePerSecond, Quantity.From(3, BitRateUnit.TerabytePerSecond));
             Assertion(3, BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour, Quantity.From(3, BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour));
             Assertion(3, CapacitanceUnit.Picofarad, Quantity.From(3, CapacitanceUnit.Picofarad));
-            Assertion(3, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, Quantity.From(3, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin));
+            Assertion(3, CoefficientOfThermalExpansionUnit.PpmPerKelvin, Quantity.From(3, CoefficientOfThermalExpansionUnit.PpmPerKelvin));
             Assertion(3, CompressibilityUnit.InversePoundForcePerSquareInch, Quantity.From(3, CompressibilityUnit.InversePoundForcePerSquareInch));
             Assertion(3, DensityUnit.TonnePerCubicMillimeter, Quantity.From(3, DensityUnit.TonnePerCubicMillimeter));
             Assertion(3, DurationUnit.Year365, Quantity.From(3, DurationUnit.Year365));

--- a/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
@@ -47,7 +47,7 @@ namespace UnitsNet.Tests
             Assertion(3, BitRateUnit.TerabytePerSecond, Quantity.From(3, BitRateUnit.TerabytePerSecond));
             Assertion(3, BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour, Quantity.From(3, BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour));
             Assertion(3, CapacitanceUnit.Picofarad, Quantity.From(3, CapacitanceUnit.Picofarad));
-            Assertion(3, CoefficientOfThermalExpansionUnit.InverseKelvin, Quantity.From(3, CoefficientOfThermalExpansionUnit.InverseKelvin));
+            Assertion(3, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, Quantity.From(3, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin));
             Assertion(3, CompressibilityUnit.InversePoundForcePerSquareInch, Quantity.From(3, CompressibilityUnit.InversePoundForcePerSquareInch));
             Assertion(3, DensityUnit.TonnePerCubicMillimeter, Quantity.From(3, DensityUnit.TonnePerCubicMillimeter));
             Assertion(3, DurationUnit.Year365, Quantity.From(3, DurationUnit.Year365));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
@@ -259,13 +259,6 @@ namespace UnitsNet.Tests
 
             try
             {
-                var parsed = CoefficientOfThermalExpansion.Parse("1 1/°C", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.PerDegreeCelsius, PerDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsed.Unit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 °F⁻¹", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
@@ -273,21 +266,7 @@ namespace UnitsNet.Tests
 
             try
             {
-                var parsed = CoefficientOfThermalExpansion.Parse("1 1/°F", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 K⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
-                var parsed = CoefficientOfThermalExpansion.Parse("1 1/K", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -325,31 +304,13 @@ namespace UnitsNet.Tests
             }
 
             {
-                Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/°C", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.PerDegreeCelsius, PerDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsed.Unit);
-            }
-
-            {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 °F⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
             }
 
             {
-                Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/°F", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
-            }
-
-            {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 K⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
-            }
-
-            {
-                Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/K", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
             }
@@ -385,31 +346,13 @@ namespace UnitsNet.Tests
 
             try
             {
-                var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("1/°C", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsedUnit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("°F⁻¹", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
-                var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("1/°F", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("K⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
-                var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("1/K", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
@@ -442,27 +385,12 @@ namespace UnitsNet.Tests
             }
 
             {
-                Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/°C", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsedUnit);
-            }
-
-            {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("°F⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
             }
 
             {
-                Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/°F", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
-            }
-
-            {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("K⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
-            }
-
-            {
-                Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/K", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
             }
 
@@ -685,9 +613,9 @@ namespace UnitsNet.Tests
             var prevCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             try {
-                Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString());
-                Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString());
-                Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString());
+                Assert.Equal("1 1/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString());
+                Assert.Equal("1 1/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString());
+                Assert.Equal("1 1/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString());
                 Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeCelsius).ToString());
                 Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit).ToString());
                 Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerKelvin).ToString());
@@ -707,9 +635,9 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
-            Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString(swedishCulture));
-            Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString(swedishCulture));
-            Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString(swedishCulture));
+            Assert.Equal("1 1/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString(swedishCulture));
+            Assert.Equal("1 1/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString(swedishCulture));
+            Assert.Equal("1 1/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString(swedishCulture));
             Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeCelsius).ToString(swedishCulture));
             Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit).ToString(swedishCulture));
             Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerKelvin).ToString(swedishCulture));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
@@ -38,32 +38,41 @@ namespace UnitsNet.Tests
 // ReSharper disable once PartialTypeWithSinglePart
     public abstract partial class CoefficientOfThermalExpansionTestsBase : QuantityTestsBase
     {
-        protected abstract double InverseDegreeCelsiusInOneInverseKelvin { get; }
-        protected abstract double InverseDegreeFahrenheitInOneInverseKelvin { get; }
-        protected abstract double InverseKelvinInOneInverseKelvin { get; }
-        protected abstract double PartsPerMillionPerDegreeCelsiusInOneInverseKelvin { get; }
-        protected abstract double PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin { get; }
-        protected abstract double PartsPerMillionPerKelvinInOneInverseKelvin { get; }
+        protected abstract double InverseDegreeCelsiusInOnePerKelvin { get; }
+        protected abstract double InverseDegreeFahrenheitInOnePerKelvin { get; }
+        protected abstract double InverseKelvinInOnePerKelvin { get; }
+        protected abstract double PerDegreeCelsiusInOnePerKelvin { get; }
+        protected abstract double PerDegreeFahrenheitInOnePerKelvin { get; }
+        protected abstract double PerKelvinInOnePerKelvin { get; }
+        protected abstract double PpmPerDegreeCelsiusInOnePerKelvin { get; }
+        protected abstract double PpmPerDegreeFahrenheitInOnePerKelvin { get; }
+        protected abstract double PpmPerKelvinInOnePerKelvin { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double InverseDegreeCelsiusTolerance { get { return 1e-5; } }
         protected virtual double InverseDegreeFahrenheitTolerance { get { return 1e-5; } }
         protected virtual double InverseKelvinTolerance { get { return 1e-5; } }
-        protected virtual double PartsPerMillionPerDegreeCelsiusTolerance { get { return 1e-5; } }
-        protected virtual double PartsPerMillionPerDegreeFahrenheitTolerance { get { return 1e-5; } }
-        protected virtual double PartsPerMillionPerKelvinTolerance { get { return 1e-5; } }
+        protected virtual double PerDegreeCelsiusTolerance { get { return 1e-5; } }
+        protected virtual double PerDegreeFahrenheitTolerance { get { return 1e-5; } }
+        protected virtual double PerKelvinTolerance { get { return 1e-5; } }
+        protected virtual double PpmPerDegreeCelsiusTolerance { get { return 1e-5; } }
+        protected virtual double PpmPerDegreeFahrenheitTolerance { get { return 1e-5; } }
+        protected virtual double PpmPerKelvinTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         protected (double UnitsInBaseUnit, double Tolerence) GetConversionFactor(CoefficientOfThermalExpansionUnit unit)
         {
             return unit switch
             {
-                CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => (InverseDegreeCelsiusInOneInverseKelvin, InverseDegreeCelsiusTolerance),
-                CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => (InverseDegreeFahrenheitInOneInverseKelvin, InverseDegreeFahrenheitTolerance),
-                CoefficientOfThermalExpansionUnit.InverseKelvin => (InverseKelvinInOneInverseKelvin, InverseKelvinTolerance),
-                CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius => (PartsPerMillionPerDegreeCelsiusInOneInverseKelvin, PartsPerMillionPerDegreeCelsiusTolerance),
-                CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit => (PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin, PartsPerMillionPerDegreeFahrenheitTolerance),
-                CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin => (PartsPerMillionPerKelvinInOneInverseKelvin, PartsPerMillionPerKelvinTolerance),
+                CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => (InverseDegreeCelsiusInOnePerKelvin, InverseDegreeCelsiusTolerance),
+                CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => (InverseDegreeFahrenheitInOnePerKelvin, InverseDegreeFahrenheitTolerance),
+                CoefficientOfThermalExpansionUnit.InverseKelvin => (InverseKelvinInOnePerKelvin, InverseKelvinTolerance),
+                CoefficientOfThermalExpansionUnit.PerDegreeCelsius => (PerDegreeCelsiusInOnePerKelvin, PerDegreeCelsiusTolerance),
+                CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit => (PerDegreeFahrenheitInOnePerKelvin, PerDegreeFahrenheitTolerance),
+                CoefficientOfThermalExpansionUnit.PerKelvin => (PerKelvinInOnePerKelvin, PerKelvinTolerance),
+                CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius => (PpmPerDegreeCelsiusInOnePerKelvin, PpmPerDegreeCelsiusTolerance),
+                CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit => (PpmPerDegreeFahrenheitInOnePerKelvin, PpmPerDegreeFahrenheitTolerance),
+                CoefficientOfThermalExpansionUnit.PpmPerKelvin => (PpmPerKelvinInOnePerKelvin, PpmPerKelvinTolerance),
                 _ => throw new NotSupportedException()
             };
         }
@@ -73,9 +82,12 @@ namespace UnitsNet.Tests
             new object[] { CoefficientOfThermalExpansionUnit.InverseDegreeCelsius },
             new object[] { CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit },
             new object[] { CoefficientOfThermalExpansionUnit.InverseKelvin },
-            new object[] { CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius },
-            new object[] { CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit },
-            new object[] { CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin },
+            new object[] { CoefficientOfThermalExpansionUnit.PerDegreeCelsius },
+            new object[] { CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit },
+            new object[] { CoefficientOfThermalExpansionUnit.PerKelvin },
+            new object[] { CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius },
+            new object[] { CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit },
+            new object[] { CoefficientOfThermalExpansionUnit.PpmPerKelvin },
         };
 
         [Fact]
@@ -83,20 +95,20 @@ namespace UnitsNet.Tests
         {
             var quantity = new CoefficientOfThermalExpansion();
             Assert.Equal(0, quantity.Value);
-            Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, quantity.Unit);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, quantity.Unit);
         }
 
         [Fact]
         public void Ctor_WithInfinityValue_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(() => new CoefficientOfThermalExpansion(double.PositiveInfinity, CoefficientOfThermalExpansionUnit.InverseKelvin));
-            Assert.Throws<ArgumentException>(() => new CoefficientOfThermalExpansion(double.NegativeInfinity, CoefficientOfThermalExpansionUnit.InverseKelvin));
+            Assert.Throws<ArgumentException>(() => new CoefficientOfThermalExpansion(double.PositiveInfinity, CoefficientOfThermalExpansionUnit.PerKelvin));
+            Assert.Throws<ArgumentException>(() => new CoefficientOfThermalExpansion(double.NegativeInfinity, CoefficientOfThermalExpansionUnit.PerKelvin));
         }
 
         [Fact]
         public void Ctor_WithNaNValue_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(() => new CoefficientOfThermalExpansion(double.NaN, CoefficientOfThermalExpansionUnit.InverseKelvin));
+            Assert.Throws<ArgumentException>(() => new CoefficientOfThermalExpansion(double.NaN, CoefficientOfThermalExpansionUnit.PerKelvin));
         }
 
         [Fact]
@@ -123,7 +135,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void CoefficientOfThermalExpansion_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
-            var quantity = new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin);
+            var quantity = new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerKelvin);
 
             QuantityInfo<CoefficientOfThermalExpansionUnit> quantityInfo = quantity.QuantityInfo;
 
@@ -135,15 +147,18 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void InverseKelvinToCoefficientOfThermalExpansionUnits()
+        public void PerKelvinToCoefficientOfThermalExpansionUnits()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            AssertEx.EqualTolerance(InverseDegreeCelsiusInOneInverseKelvin, inversekelvin.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
-            AssertEx.EqualTolerance(InverseDegreeFahrenheitInOneInverseKelvin, inversekelvin.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
-            AssertEx.EqualTolerance(InverseKelvinInOneInverseKelvin, inversekelvin.InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(PartsPerMillionPerDegreeCelsiusInOneInverseKelvin, inversekelvin.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
-            AssertEx.EqualTolerance(PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin, inversekelvin.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
-            AssertEx.EqualTolerance(PartsPerMillionPerKelvinInOneInverseKelvin, inversekelvin.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            AssertEx.EqualTolerance(InverseDegreeCelsiusInOnePerKelvin, perkelvin.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(InverseDegreeFahrenheitInOnePerKelvin, perkelvin.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(InverseKelvinInOnePerKelvin, perkelvin.InverseKelvin, InverseKelvinTolerance);
+            AssertEx.EqualTolerance(PerDegreeCelsiusInOnePerKelvin, perkelvin.PerDegreeCelsius, PerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(PerDegreeFahrenheitInOnePerKelvin, perkelvin.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(PerKelvinInOnePerKelvin, perkelvin.PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(PpmPerDegreeCelsiusInOnePerKelvin, perkelvin.PpmPerDegreeCelsius, PpmPerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(PpmPerDegreeFahrenheitInOnePerKelvin, perkelvin.PpmPerDegreeFahrenheit, PpmPerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(PpmPerKelvinInOnePerKelvin, perkelvin.PpmPerKelvin, PpmPerKelvinTolerance);
         }
 
         [Fact]
@@ -161,43 +176,58 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity02.InverseKelvin, InverseKelvinTolerance);
             Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, quantity02.Unit);
 
-            var quantity03 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
-            AssertEx.EqualTolerance(1, quantity03.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
-            Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, quantity03.Unit);
+            var quantity03 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PerDegreeCelsius);
+            AssertEx.EqualTolerance(1, quantity03.PerDegreeCelsius, PerDegreeCelsiusTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, quantity03.Unit);
 
-            var quantity04 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
-            AssertEx.EqualTolerance(1, quantity04.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
-            Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, quantity04.Unit);
+            var quantity04 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit);
+            AssertEx.EqualTolerance(1, quantity04.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, quantity04.Unit);
 
-            var quantity05 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
-            AssertEx.EqualTolerance(1, quantity05.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
-            Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, quantity05.Unit);
+            var quantity05 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PerKelvin);
+            AssertEx.EqualTolerance(1, quantity05.PerKelvin, PerKelvinTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, quantity05.Unit);
+
+            var quantity06 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius);
+            AssertEx.EqualTolerance(1, quantity06.PpmPerDegreeCelsius, PpmPerDegreeCelsiusTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, quantity06.Unit);
+
+            var quantity07 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit);
+            AssertEx.EqualTolerance(1, quantity07.PpmPerDegreeFahrenheit, PpmPerDegreeFahrenheitTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, quantity07.Unit);
+
+            var quantity08 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PpmPerKelvin);
+            AssertEx.EqualTolerance(1, quantity08.PpmPerKelvin, PpmPerKelvinTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerKelvin, quantity08.Unit);
 
         }
 
         [Fact]
-        public void FromInverseKelvin_WithInfinityValue_ThrowsArgumentException()
+        public void FromPerKelvin_WithInfinityValue_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(() => CoefficientOfThermalExpansion.FromInverseKelvin(double.PositiveInfinity));
-            Assert.Throws<ArgumentException>(() => CoefficientOfThermalExpansion.FromInverseKelvin(double.NegativeInfinity));
+            Assert.Throws<ArgumentException>(() => CoefficientOfThermalExpansion.FromPerKelvin(double.PositiveInfinity));
+            Assert.Throws<ArgumentException>(() => CoefficientOfThermalExpansion.FromPerKelvin(double.NegativeInfinity));
         }
 
         [Fact]
-        public void FromInverseKelvin_WithNanValue_ThrowsArgumentException()
+        public void FromPerKelvin_WithNanValue_ThrowsArgumentException()
         {
-            Assert.Throws<ArgumentException>(() => CoefficientOfThermalExpansion.FromInverseKelvin(double.NaN));
+            Assert.Throws<ArgumentException>(() => CoefficientOfThermalExpansion.FromPerKelvin(double.NaN));
         }
 
         [Fact]
         public void As()
         {
-            var inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            AssertEx.EqualTolerance(InverseDegreeCelsiusInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius), InverseDegreeCelsiusTolerance);
-            AssertEx.EqualTolerance(InverseDegreeFahrenheitInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit), InverseDegreeFahrenheitTolerance);
-            AssertEx.EqualTolerance(InverseKelvinInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.InverseKelvin), InverseKelvinTolerance);
-            AssertEx.EqualTolerance(PartsPerMillionPerDegreeCelsiusInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius), PartsPerMillionPerDegreeCelsiusTolerance);
-            AssertEx.EqualTolerance(PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit), PartsPerMillionPerDegreeFahrenheitTolerance);
-            AssertEx.EqualTolerance(PartsPerMillionPerKelvinInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin), PartsPerMillionPerKelvinTolerance);
+            var perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            AssertEx.EqualTolerance(InverseDegreeCelsiusInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius), InverseDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(InverseDegreeFahrenheitInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit), InverseDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(InverseKelvinInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.InverseKelvin), InverseKelvinTolerance);
+            AssertEx.EqualTolerance(PerDegreeCelsiusInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.PerDegreeCelsius), PerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(PerDegreeFahrenheitInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit), PerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(PerKelvinInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.PerKelvin), PerKelvinTolerance);
+            AssertEx.EqualTolerance(PpmPerDegreeCelsiusInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius), PpmPerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(PpmPerDegreeFahrenheitInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit), PpmPerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(PpmPerKelvinInOnePerKelvin, perkelvin.As(CoefficientOfThermalExpansionUnit.PpmPerKelvin), PpmPerKelvinTolerance);
         }
 
         [Fact]
@@ -223,64 +253,64 @@ namespace UnitsNet.Tests
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 °C⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeCelsius, PerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 1/°C", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeCelsius, PerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 °F⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 1/°F", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 K⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.InverseKelvin, InverseKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 1/K", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.InverseKelvin, InverseKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 ppm/°C", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PpmPerDegreeCelsius, PpmPerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 ppm/°F", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PpmPerDegreeFahrenheit, PpmPerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = CoefficientOfThermalExpansion.Parse("1 ppm/K", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PpmPerKelvin, PpmPerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerKelvin, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
         }
@@ -290,56 +320,56 @@ namespace UnitsNet.Tests
         {
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 °C⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeCelsius, PerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/°C", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeCelsius, PerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 °F⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/°F", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerDegreeFahrenheit, PerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 K⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.InverseKelvin, InverseKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/K", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.InverseKelvin, InverseKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PerKelvin, PerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 ppm/°C", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PpmPerDegreeCelsius, PpmPerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 ppm/°F", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PpmPerDegreeFahrenheit, PpmPerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, parsed.Unit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 ppm/K", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsed.Unit);
+                AssertEx.EqualTolerance(1, parsed.PpmPerKelvin, PpmPerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerKelvin, parsed.Unit);
             }
 
         }
@@ -350,55 +380,55 @@ namespace UnitsNet.Tests
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("°C⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("1/°C", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("°F⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("1/°F", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("K⁻¹", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("1/K", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("ppm/°C", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("ppm/°F", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("ppm/K", CultureInfo.GetCultureInfo("en-US"));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerKelvin, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
         }
@@ -408,47 +438,47 @@ namespace UnitsNet.Tests
         {
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("°C⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/°C", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("°F⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/°F", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("K⁻¹", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/K", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PerKelvin, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("ppm/°C", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("ppm/°F", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, parsedUnit);
             }
 
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("ppm/K", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
-                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsedUnit);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PpmPerKelvin, parsedUnit);
             }
 
         }
@@ -498,73 +528,76 @@ namespace UnitsNet.Tests
         [Fact]
         public void ConversionRoundTrip()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseDegreeCelsius(inversekelvin.InverseDegreeCelsius).InverseKelvin, InverseDegreeCelsiusTolerance);
-            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseDegreeFahrenheit(inversekelvin.InverseDegreeFahrenheit).InverseKelvin, InverseDegreeFahrenheitTolerance);
-            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseKelvin(inversekelvin.InverseKelvin).InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(inversekelvin.PartsPerMillionPerDegreeCelsius).InverseKelvin, PartsPerMillionPerDegreeCelsiusTolerance);
-            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(inversekelvin.PartsPerMillionPerDegreeFahrenheit).InverseKelvin, PartsPerMillionPerDegreeFahrenheitTolerance);
-            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(inversekelvin.PartsPerMillionPerKelvin).InverseKelvin, PartsPerMillionPerKelvinTolerance);
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseDegreeCelsius(perkelvin.InverseDegreeCelsius).PerKelvin, InverseDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseDegreeFahrenheit(perkelvin.InverseDegreeFahrenheit).PerKelvin, InverseDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseKelvin(perkelvin.InverseKelvin).PerKelvin, InverseKelvinTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPerDegreeCelsius(perkelvin.PerDegreeCelsius).PerKelvin, PerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPerDegreeFahrenheit(perkelvin.PerDegreeFahrenheit).PerKelvin, PerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPerKelvin(perkelvin.PerKelvin).PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPpmPerDegreeCelsius(perkelvin.PpmPerDegreeCelsius).PerKelvin, PpmPerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPpmPerDegreeFahrenheit(perkelvin.PpmPerDegreeFahrenheit).PerKelvin, PpmPerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPpmPerKelvin(perkelvin.PpmPerKelvin).PerKelvin, PpmPerKelvinTolerance);
         }
 
         [Fact]
         public void ArithmeticOperators()
         {
-            CoefficientOfThermalExpansion v = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            AssertEx.EqualTolerance(-1, -v.InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(2, (CoefficientOfThermalExpansion.FromInverseKelvin(3)-v).InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(2, (v + v).InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(10, (v*10).InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(10, (10*v).InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(2, (CoefficientOfThermalExpansion.FromInverseKelvin(10)/5).InverseKelvin, InverseKelvinTolerance);
-            AssertEx.EqualTolerance(2, CoefficientOfThermalExpansion.FromInverseKelvin(10)/CoefficientOfThermalExpansion.FromInverseKelvin(5), InverseKelvinTolerance);
+            CoefficientOfThermalExpansion v = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            AssertEx.EqualTolerance(-1, -v.PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(2, (CoefficientOfThermalExpansion.FromPerKelvin(3)-v).PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(2, (v + v).PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(10, (v*10).PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(10, (10*v).PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(2, (CoefficientOfThermalExpansion.FromPerKelvin(10)/5).PerKelvin, PerKelvinTolerance);
+            AssertEx.EqualTolerance(2, CoefficientOfThermalExpansion.FromPerKelvin(10)/CoefficientOfThermalExpansion.FromPerKelvin(5), PerKelvinTolerance);
         }
 
         [Fact]
         public void ComparisonOperators()
         {
-            CoefficientOfThermalExpansion oneInverseKelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            CoefficientOfThermalExpansion twoInverseKelvin = CoefficientOfThermalExpansion.FromInverseKelvin(2);
+            CoefficientOfThermalExpansion onePerKelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            CoefficientOfThermalExpansion twoPerKelvin = CoefficientOfThermalExpansion.FromPerKelvin(2);
 
-            Assert.True(oneInverseKelvin < twoInverseKelvin);
-            Assert.True(oneInverseKelvin <= twoInverseKelvin);
-            Assert.True(twoInverseKelvin > oneInverseKelvin);
-            Assert.True(twoInverseKelvin >= oneInverseKelvin);
+            Assert.True(onePerKelvin < twoPerKelvin);
+            Assert.True(onePerKelvin <= twoPerKelvin);
+            Assert.True(twoPerKelvin > onePerKelvin);
+            Assert.True(twoPerKelvin >= onePerKelvin);
 
-            Assert.False(oneInverseKelvin > twoInverseKelvin);
-            Assert.False(oneInverseKelvin >= twoInverseKelvin);
-            Assert.False(twoInverseKelvin < oneInverseKelvin);
-            Assert.False(twoInverseKelvin <= oneInverseKelvin);
+            Assert.False(onePerKelvin > twoPerKelvin);
+            Assert.False(onePerKelvin >= twoPerKelvin);
+            Assert.False(twoPerKelvin < onePerKelvin);
+            Assert.False(twoPerKelvin <= onePerKelvin);
         }
 
         [Fact]
         public void CompareToIsImplemented()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.Equal(0, inversekelvin.CompareTo(inversekelvin));
-            Assert.True(inversekelvin.CompareTo(CoefficientOfThermalExpansion.Zero) > 0);
-            Assert.True(CoefficientOfThermalExpansion.Zero.CompareTo(inversekelvin) < 0);
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.Equal(0, perkelvin.CompareTo(perkelvin));
+            Assert.True(perkelvin.CompareTo(CoefficientOfThermalExpansion.Zero) > 0);
+            Assert.True(CoefficientOfThermalExpansion.Zero.CompareTo(perkelvin) < 0);
         }
 
         [Fact]
         public void CompareToThrowsOnTypeMismatch()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.Throws<ArgumentException>(() => inversekelvin.CompareTo(new object()));
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.Throws<ArgumentException>(() => perkelvin.CompareTo(new object()));
         }
 
         [Fact]
         public void CompareToThrowsOnNull()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.Throws<ArgumentNullException>(() => inversekelvin.CompareTo(null));
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.Throws<ArgumentNullException>(() => perkelvin.CompareTo(null));
         }
 
         [Theory]
-        [InlineData(1, CoefficientOfThermalExpansionUnit.InverseKelvin, 1, CoefficientOfThermalExpansionUnit.InverseKelvin, true)]  // Same value and unit.
-        [InlineData(1, CoefficientOfThermalExpansionUnit.InverseKelvin, 2, CoefficientOfThermalExpansionUnit.InverseKelvin, false)] // Different value.
-        [InlineData(2, CoefficientOfThermalExpansionUnit.InverseKelvin, 1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, false)] // Different value and unit.
-        [InlineData(1, CoefficientOfThermalExpansionUnit.InverseKelvin, 1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, false)] // Different unit.
+        [InlineData(1, CoefficientOfThermalExpansionUnit.PerKelvin, 1, CoefficientOfThermalExpansionUnit.PerKelvin, true)]  // Same value and unit.
+        [InlineData(1, CoefficientOfThermalExpansionUnit.PerKelvin, 2, CoefficientOfThermalExpansionUnit.PerKelvin, false)] // Different value.
+        [InlineData(2, CoefficientOfThermalExpansionUnit.PerKelvin, 1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, false)] // Different value and unit.
+        [InlineData(1, CoefficientOfThermalExpansionUnit.PerKelvin, 1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, false)] // Different unit.
         public void Equals_ReturnsTrue_IfValueAndUnitAreEqual(double valueA, CoefficientOfThermalExpansionUnit unitA, double valueB, CoefficientOfThermalExpansionUnit unitB, bool expectEqual)
         {
             var a = new CoefficientOfThermalExpansion(valueA, unitA);
@@ -604,30 +637,30 @@ namespace UnitsNet.Tests
         [Fact]
         public void Equals_RelativeTolerance_IsImplemented()
         {
-            var v = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.True(v.Equals(CoefficientOfThermalExpansion.FromInverseKelvin(1), InverseKelvinTolerance, ComparisonType.Relative));
-            Assert.False(v.Equals(CoefficientOfThermalExpansion.Zero, InverseKelvinTolerance, ComparisonType.Relative));
+            var v = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.True(v.Equals(CoefficientOfThermalExpansion.FromPerKelvin(1), PerKelvinTolerance, ComparisonType.Relative));
+            Assert.False(v.Equals(CoefficientOfThermalExpansion.Zero, PerKelvinTolerance, ComparisonType.Relative));
         }
 
         [Fact]
         public void Equals_NegativeRelativeTolerance_ThrowsArgumentOutOfRangeException()
         {
-            var v = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => v.Equals(CoefficientOfThermalExpansion.FromInverseKelvin(1), -1, ComparisonType.Relative));
+            var v = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => v.Equals(CoefficientOfThermalExpansion.FromPerKelvin(1), -1, ComparisonType.Relative));
         }
 
         [Fact]
         public void EqualsReturnsFalseOnTypeMismatch()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.False(inversekelvin.Equals(new object()));
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.False(perkelvin.Equals(new object()));
         }
 
         [Fact]
         public void EqualsReturnsFalseOnNull()
         {
-            CoefficientOfThermalExpansion inversekelvin = CoefficientOfThermalExpansion.FromInverseKelvin(1);
-            Assert.False(inversekelvin.Equals(null));
+            CoefficientOfThermalExpansion perkelvin = CoefficientOfThermalExpansion.FromPerKelvin(1);
+            Assert.False(perkelvin.Equals(null));
         }
 
         [Fact]
@@ -652,12 +685,15 @@ namespace UnitsNet.Tests
             var prevCulture = Thread.CurrentThread.CurrentCulture;
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             try {
-                Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString());
-                Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString());
-                Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString());
-                Assert.Equal("1 ppm/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius).ToString());
-                Assert.Equal("1 ppm/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit).ToString());
-                Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin).ToString());
+                Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString());
+                Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString());
+                Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString());
+                Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeCelsius).ToString());
+                Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit).ToString());
+                Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerKelvin).ToString());
+                Assert.Equal("1 ppm/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius).ToString());
+                Assert.Equal("1 ppm/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit).ToString());
+                Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerKelvin).ToString());
             }
             finally
             {
@@ -671,12 +707,15 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
-            Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString(swedishCulture));
-            Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString(swedishCulture));
-            Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString(swedishCulture));
-            Assert.Equal("1 ppm/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius).ToString(swedishCulture));
-            Assert.Equal("1 ppm/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit).ToString(swedishCulture));
-            Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin).ToString(swedishCulture));
+            Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString(swedishCulture));
+            Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString(swedishCulture));
+            Assert.Equal("1", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString(swedishCulture));
+            Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeCelsius).ToString(swedishCulture));
+            Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit).ToString(swedishCulture));
+            Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerKelvin).ToString(swedishCulture));
+            Assert.Equal("1 ppm/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius).ToString(swedishCulture));
+            Assert.Equal("1 ppm/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit).ToString(swedishCulture));
+            Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerKelvin).ToString(swedishCulture));
         }
 
         [Fact]
@@ -686,10 +725,10 @@ namespace UnitsNet.Tests
             try
             {
                 CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-                Assert.Equal("0.1 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s1"));
-                Assert.Equal("0.12 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s2"));
-                Assert.Equal("0.123 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s3"));
-                Assert.Equal("0.1235 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s4"));
+                Assert.Equal("0.1 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s1"));
+                Assert.Equal("0.12 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s2"));
+                Assert.Equal("0.123 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s3"));
+                Assert.Equal("0.1235 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s4"));
             }
             finally
             {
@@ -701,10 +740,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString("s4", culture));
+            Assert.Equal("0.1 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s1", culture));
+            Assert.Equal("0.12 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s2", culture));
+            Assert.Equal("0.123 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s3", culture));
+            Assert.Equal("0.1235 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s4", culture));
         }
 
         [Theory]
@@ -712,7 +751,7 @@ namespace UnitsNet.Tests
         [InlineData("en-US")]
         public void ToString_NullFormat_DefaultsToGeneralFormat(string cultureName)
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             CultureInfo formatProvider = cultureName == null
                 ? null
                 : CultureInfo.GetCultureInfo(cultureName);
@@ -725,154 +764,154 @@ namespace UnitsNet.Tests
         [InlineData("g")]
         public void ToString_NullProvider_EqualsCurrentCulture(string format)
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(quantity.ToString(format, CultureInfo.CurrentCulture), quantity.ToString(format, null));
         }
 
         [Fact]
         public void Convert_ToBool_ThrowsInvalidCastException()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ToBoolean(quantity));
         }
 
         [Fact]
         public void Convert_ToByte_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
            Assert.Equal((byte)quantity.Value, Convert.ToByte(quantity));
         }
 
         [Fact]
         public void Convert_ToChar_ThrowsInvalidCastException()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ToChar(quantity));
         }
 
         [Fact]
         public void Convert_ToDateTime_ThrowsInvalidCastException()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(quantity));
         }
 
         [Fact]
         public void Convert_ToDecimal_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((decimal)quantity.Value, Convert.ToDecimal(quantity));
         }
 
         [Fact]
         public void Convert_ToDouble_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((double)quantity.Value, Convert.ToDouble(quantity));
         }
 
         [Fact]
         public void Convert_ToInt16_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((short)quantity.Value, Convert.ToInt16(quantity));
         }
 
         [Fact]
         public void Convert_ToInt32_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((int)quantity.Value, Convert.ToInt32(quantity));
         }
 
         [Fact]
         public void Convert_ToInt64_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((long)quantity.Value, Convert.ToInt64(quantity));
         }
 
         [Fact]
         public void Convert_ToSByte_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((sbyte)quantity.Value, Convert.ToSByte(quantity));
         }
 
         [Fact]
         public void Convert_ToSingle_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((float)quantity.Value, Convert.ToSingle(quantity));
         }
 
         [Fact]
         public void Convert_ToString_EqualsToString()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(quantity.ToString(), Convert.ToString(quantity));
         }
 
         [Fact]
         public void Convert_ToUInt16_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((ushort)quantity.Value, Convert.ToUInt16(quantity));
         }
 
         [Fact]
         public void Convert_ToUInt32_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((uint)quantity.Value, Convert.ToUInt32(quantity));
         }
 
         [Fact]
         public void Convert_ToUInt64_EqualsValueAsSameType()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal((ulong)quantity.Value, Convert.ToUInt64(quantity));
         }
 
         [Fact]
         public void Convert_ChangeType_SelfType_EqualsSelf()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(quantity, Convert.ChangeType(quantity, typeof(CoefficientOfThermalExpansion)));
         }
 
         [Fact]
         public void Convert_ChangeType_UnitType_EqualsUnit()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(quantity.Unit, Convert.ChangeType(quantity, typeof(CoefficientOfThermalExpansionUnit)));
         }
 
         [Fact]
         public void Convert_ChangeType_QuantityInfo_EqualsQuantityInfo()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(CoefficientOfThermalExpansion.Info, Convert.ChangeType(quantity, typeof(QuantityInfo)));
         }
 
         [Fact]
         public void Convert_ChangeType_BaseDimensions_EqualsBaseDimensions()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(CoefficientOfThermalExpansion.BaseDimensions, Convert.ChangeType(quantity, typeof(BaseDimensions)));
         }
 
         [Fact]
         public void Convert_ChangeType_InvalidType_ThrowsInvalidCastException()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ChangeType(quantity, typeof(QuantityFormatter)));
         }
 
         [Fact]
         public void GetHashCode_Equals()
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(1.0);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(1.0);
             Assert.Equal(new {CoefficientOfThermalExpansion.Info.Name, quantity.Value, quantity.Unit}.GetHashCode(), quantity.GetHashCode());
         }
 
@@ -881,8 +920,8 @@ namespace UnitsNet.Tests
         [InlineData(-1.0)]
         public void NegationOperator_ReturnsQuantity_WithNegatedValue(double value)
         {
-            var quantity = CoefficientOfThermalExpansion.FromInverseKelvin(value);
-            Assert.Equal(CoefficientOfThermalExpansion.FromInverseKelvin(-value), -quantity);
+            var quantity = CoefficientOfThermalExpansion.FromPerKelvin(value);
+            Assert.Equal(CoefficientOfThermalExpansion.FromPerKelvin(-value), -quantity);
         }
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
@@ -41,11 +41,17 @@ namespace UnitsNet.Tests
         protected abstract double InverseDegreeCelsiusInOneInverseKelvin { get; }
         protected abstract double InverseDegreeFahrenheitInOneInverseKelvin { get; }
         protected abstract double InverseKelvinInOneInverseKelvin { get; }
+        protected abstract double PartsPerMillionPerDegreeCelsiusInOneInverseKelvin { get; }
+        protected abstract double PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin { get; }
+        protected abstract double PartsPerMillionPerKelvinInOneInverseKelvin { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double InverseDegreeCelsiusTolerance { get { return 1e-5; } }
         protected virtual double InverseDegreeFahrenheitTolerance { get { return 1e-5; } }
         protected virtual double InverseKelvinTolerance { get { return 1e-5; } }
+        protected virtual double PartsPerMillionPerDegreeCelsiusTolerance { get { return 1e-5; } }
+        protected virtual double PartsPerMillionPerDegreeFahrenheitTolerance { get { return 1e-5; } }
+        protected virtual double PartsPerMillionPerKelvinTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         protected (double UnitsInBaseUnit, double Tolerence) GetConversionFactor(CoefficientOfThermalExpansionUnit unit)
@@ -55,6 +61,9 @@ namespace UnitsNet.Tests
                 CoefficientOfThermalExpansionUnit.InverseDegreeCelsius => (InverseDegreeCelsiusInOneInverseKelvin, InverseDegreeCelsiusTolerance),
                 CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit => (InverseDegreeFahrenheitInOneInverseKelvin, InverseDegreeFahrenheitTolerance),
                 CoefficientOfThermalExpansionUnit.InverseKelvin => (InverseKelvinInOneInverseKelvin, InverseKelvinTolerance),
+                CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius => (PartsPerMillionPerDegreeCelsiusInOneInverseKelvin, PartsPerMillionPerDegreeCelsiusTolerance),
+                CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit => (PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin, PartsPerMillionPerDegreeFahrenheitTolerance),
+                CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin => (PartsPerMillionPerKelvinInOneInverseKelvin, PartsPerMillionPerKelvinTolerance),
                 _ => throw new NotSupportedException()
             };
         }
@@ -64,6 +73,9 @@ namespace UnitsNet.Tests
             new object[] { CoefficientOfThermalExpansionUnit.InverseDegreeCelsius },
             new object[] { CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit },
             new object[] { CoefficientOfThermalExpansionUnit.InverseKelvin },
+            new object[] { CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius },
+            new object[] { CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit },
+            new object[] { CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin },
         };
 
         [Fact]
@@ -129,6 +141,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(InverseDegreeCelsiusInOneInverseKelvin, inversekelvin.InverseDegreeCelsius, InverseDegreeCelsiusTolerance);
             AssertEx.EqualTolerance(InverseDegreeFahrenheitInOneInverseKelvin, inversekelvin.InverseDegreeFahrenheit, InverseDegreeFahrenheitTolerance);
             AssertEx.EqualTolerance(InverseKelvinInOneInverseKelvin, inversekelvin.InverseKelvin, InverseKelvinTolerance);
+            AssertEx.EqualTolerance(PartsPerMillionPerDegreeCelsiusInOneInverseKelvin, inversekelvin.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin, inversekelvin.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(PartsPerMillionPerKelvinInOneInverseKelvin, inversekelvin.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
         }
 
         [Fact]
@@ -145,6 +160,18 @@ namespace UnitsNet.Tests
             var quantity02 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.InverseKelvin);
             AssertEx.EqualTolerance(1, quantity02.InverseKelvin, InverseKelvinTolerance);
             Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, quantity02.Unit);
+
+            var quantity03 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+            AssertEx.EqualTolerance(1, quantity03.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, quantity03.Unit);
+
+            var quantity04 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+            AssertEx.EqualTolerance(1, quantity04.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, quantity04.Unit);
+
+            var quantity05 = CoefficientOfThermalExpansion.From(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+            AssertEx.EqualTolerance(1, quantity05.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
+            Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, quantity05.Unit);
 
         }
 
@@ -168,6 +195,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(InverseDegreeCelsiusInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius), InverseDegreeCelsiusTolerance);
             AssertEx.EqualTolerance(InverseDegreeFahrenheitInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit), InverseDegreeFahrenheitTolerance);
             AssertEx.EqualTolerance(InverseKelvinInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.InverseKelvin), InverseKelvinTolerance);
+            AssertEx.EqualTolerance(PartsPerMillionPerDegreeCelsiusInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius), PartsPerMillionPerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(PartsPerMillionPerDegreeFahrenheitInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit), PartsPerMillionPerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(PartsPerMillionPerKelvinInOneInverseKelvin, inversekelvin.As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin), PartsPerMillionPerKelvinTolerance);
         }
 
         [Fact]
@@ -232,6 +262,27 @@ namespace UnitsNet.Tests
                 Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
+            try
+            {
+                var parsed = CoefficientOfThermalExpansion.Parse("1 ppm/°C", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = CoefficientOfThermalExpansion.Parse("1 ppm/°F", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = CoefficientOfThermalExpansion.Parse("1 ppm/K", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
         }
 
         [Fact]
@@ -271,6 +322,24 @@ namespace UnitsNet.Tests
                 Assert.True(CoefficientOfThermalExpansion.TryParse("1 1/K", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.InverseKelvin, InverseKelvinTolerance);
                 Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsed.Unit);
+            }
+
+            {
+                Assert.True(CoefficientOfThermalExpansion.TryParse("1 ppm/°C", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeCelsius, PartsPerMillionPerDegreeCelsiusTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsed.Unit);
+            }
+
+            {
+                Assert.True(CoefficientOfThermalExpansion.TryParse("1 ppm/°F", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerDegreeFahrenheit, PartsPerMillionPerDegreeFahrenheitTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsed.Unit);
+            }
+
+            {
+                Assert.True(CoefficientOfThermalExpansion.TryParse("1 ppm/K", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.PartsPerMillionPerKelvin, PartsPerMillionPerKelvinTolerance);
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsed.Unit);
             }
 
         }
@@ -314,6 +383,24 @@ namespace UnitsNet.Tests
                 Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
+            try
+            {
+                var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("ppm/°C", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("ppm/°F", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = CoefficientOfThermalExpansion.ParseUnit("ppm/K", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
         }
 
         [Fact]
@@ -347,6 +434,21 @@ namespace UnitsNet.Tests
             {
                 Assert.True(CoefficientOfThermalExpansion.TryParseUnit("1/K", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(CoefficientOfThermalExpansionUnit.InverseKelvin, parsedUnit);
+            }
+
+            {
+                Assert.True(CoefficientOfThermalExpansion.TryParseUnit("ppm/°C", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, parsedUnit);
+            }
+
+            {
+                Assert.True(CoefficientOfThermalExpansion.TryParseUnit("ppm/°F", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, parsedUnit);
+            }
+
+            {
+                Assert.True(CoefficientOfThermalExpansion.TryParseUnit("ppm/K", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, parsedUnit);
             }
 
         }
@@ -400,6 +502,9 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseDegreeCelsius(inversekelvin.InverseDegreeCelsius).InverseKelvin, InverseDegreeCelsiusTolerance);
             AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseDegreeFahrenheit(inversekelvin.InverseDegreeFahrenheit).InverseKelvin, InverseDegreeFahrenheitTolerance);
             AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromInverseKelvin(inversekelvin.InverseKelvin).InverseKelvin, InverseKelvinTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeCelsius(inversekelvin.PartsPerMillionPerDegreeCelsius).InverseKelvin, PartsPerMillionPerDegreeCelsiusTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPartsPerMillionPerDegreeFahrenheit(inversekelvin.PartsPerMillionPerDegreeFahrenheit).InverseKelvin, PartsPerMillionPerDegreeFahrenheitTolerance);
+            AssertEx.EqualTolerance(1, CoefficientOfThermalExpansion.FromPartsPerMillionPerKelvin(inversekelvin.PartsPerMillionPerKelvin).InverseKelvin, PartsPerMillionPerKelvinTolerance);
         }
 
         [Fact]
@@ -550,6 +655,9 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString());
                 Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString());
                 Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString());
+                Assert.Equal("1 ppm/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius).ToString());
+                Assert.Equal("1 ppm/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit).ToString());
+                Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin).ToString());
             }
             finally
             {
@@ -566,6 +674,9 @@ namespace UnitsNet.Tests
             Assert.Equal("1 °C⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius).ToString(swedishCulture));
             Assert.Equal("1 °F⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit).ToString(swedishCulture));
             Assert.Equal("1 K⁻¹", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.InverseKelvin).ToString(swedishCulture));
+            Assert.Equal("1 ppm/°C", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius).ToString(swedishCulture));
+            Assert.Equal("1 ppm/°F", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit).ToString(swedishCulture));
+            Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin).ToString(swedishCulture));
         }
 
         [Fact]

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -72,8 +72,8 @@ namespace UnitsNet.Tests
         [InlineData("m^3", typeof(VolumeUnit), VolumeUnit.CubicMeter)]
         [InlineData("m⁴", typeof(AreaMomentOfInertiaUnit), AreaMomentOfInertiaUnit.MeterToTheFourth)]
         [InlineData("m^4", typeof(AreaMomentOfInertiaUnit), AreaMomentOfInertiaUnit.MeterToTheFourth)]
-        [InlineData("K⁻¹", typeof(CoefficientOfThermalExpansionUnit), CoefficientOfThermalExpansionUnit.InverseKelvin)]
-        [InlineData("K^-1", typeof(CoefficientOfThermalExpansionUnit), CoefficientOfThermalExpansionUnit.InverseKelvin)]
+        [InlineData("K⁻¹", typeof(CoefficientOfThermalExpansionUnit), CoefficientOfThermalExpansionUnit.PerKelvin)]
+        [InlineData("K^-1", typeof(CoefficientOfThermalExpansionUnit), CoefficientOfThermalExpansionUnit.PerKelvin)]
         [InlineData("kg·s⁻¹·m⁻²", typeof(MassFluxUnit), MassFluxUnit.KilogramPerSecondPerSquareMeter)]
         [InlineData("kg·s^-1·m^-2", typeof(MassFluxUnit), MassFluxUnit.KilogramPerSecondPerSquareMeter)]
         public void Parse_CanParseUnitsWithPowers(string unitAbbreviation, Type unitType, Enum resultUnitType)

--- a/UnitsNet/CustomCode/Quantities/CoefficientOfThermalExpansion.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/CoefficientOfThermalExpansion.extra.cs
@@ -6,6 +6,6 @@ namespace UnitsNet
     public partial struct CoefficientOfThermalExpansion
     {
         /// <summary>Get a scalar from a <see cref="CoefficientOfThermalExpansion"/> multiplied by a <see cref="TemperatureDelta"/>.</summary>
-        public static double operator *(CoefficientOfThermalExpansion cte, TemperatureDelta temperatureDelta) => cte.InverseKelvin * temperatureDelta.Kelvins;
+        public static double operator *(CoefficientOfThermalExpansion cte, TemperatureDelta temperatureDelta) => cte.PerKelvin * temperatureDelta.Kelvins;
     }
 }

--- a/UnitsNet/CustomCode/Quantities/TemperatureDelta.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/TemperatureDelta.extra.cs
@@ -38,7 +38,7 @@ namespace UnitsNet
         /// <summary>Get a scalar from a <see cref="TemperatureDelta"/> multiplied by a <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static double operator *(TemperatureDelta temperatureDelta, CoefficientOfThermalExpansion cte)
         {
-            return temperatureDelta.Kelvins * cte.InverseKelvin;
+            return temperatureDelta.Kelvins * cte.PerKelvin;
         }
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -59,7 +59,7 @@ namespace UnitsNet
         static CoefficientOfThermalExpansion()
         {
             BaseDimensions = new BaseDimensions(0, 0, 0, 0, -1, 0, 0);
-            BaseUnit = CoefficientOfThermalExpansionUnit.InverseKelvin;
+            BaseUnit = CoefficientOfThermalExpansionUnit.PerKelvin;
             Units = Enum.GetValues(typeof(CoefficientOfThermalExpansionUnit)).Cast<CoefficientOfThermalExpansionUnit>().ToArray();
             Zero = new CoefficientOfThermalExpansion(0, BaseUnit);
             Info = new QuantityInfo<CoefficientOfThermalExpansionUnit>("CoefficientOfThermalExpansion",
@@ -68,9 +68,12 @@ namespace UnitsNet
                     new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, "InverseDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius), "CoefficientOfThermalExpansion"),
                     new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, "InverseDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit), "CoefficientOfThermalExpansion"),
                     new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.InverseKelvin, "InverseKelvin", new BaseUnits(temperature: TemperatureUnit.Kelvin), "CoefficientOfThermalExpansion"),
-                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, "PartsPerMillionPerDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius), "CoefficientOfThermalExpansion"),
-                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, "PartsPerMillionPerDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit), "CoefficientOfThermalExpansion"),
-                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, "PartsPerMillionPerKelvin", new BaseUnits(temperature: TemperatureUnit.Kelvin), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, "PerDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, "PerDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PerKelvin, "PerKelvin", new BaseUnits(temperature: TemperatureUnit.Kelvin), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, "PpmPerDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, "PpmPerDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PpmPerKelvin, "PpmPerKelvin", new BaseUnits(temperature: TemperatureUnit.Kelvin), "CoefficientOfThermalExpansion"),
                 },
                 BaseUnit, Zero, BaseDimensions);
 
@@ -125,7 +128,7 @@ namespace UnitsNet
         public static BaseDimensions BaseDimensions { get; }
 
         /// <summary>
-        ///     The base unit of CoefficientOfThermalExpansion, which is InverseKelvin. All conversions go via this value.
+        ///     The base unit of CoefficientOfThermalExpansion, which is PerKelvin. All conversions go via this value.
         /// </summary>
         public static CoefficientOfThermalExpansionUnit BaseUnit { get; }
 
@@ -135,7 +138,7 @@ namespace UnitsNet
         public static CoefficientOfThermalExpansionUnit[] Units { get; }
 
         /// <summary>
-        ///     Gets an instance of this quantity with a value of 0 in the base unit InverseKelvin.
+        ///     Gets an instance of this quantity with a value of 0 in the base unit PerKelvin.
         /// </summary>
         public static CoefficientOfThermalExpansion Zero { get; }
 
@@ -177,32 +180,50 @@ namespace UnitsNet
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeCelsius"/>
         /// </summary>
+        [Obsolete("Use PerDegreeCelsius instead.")]
         public double InverseDegreeCelsius => As(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit"/>
         /// </summary>
+        [Obsolete("Use PerDegreeFahrenheit instead.")]
         public double InverseDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.InverseKelvin"/>
         /// </summary>
+        [Obsolete("Use PerKelvin instead.")]
         public double InverseKelvin => As(CoefficientOfThermalExpansionUnit.InverseKelvin);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PerDegreeCelsius"/>
         /// </summary>
-        public double PartsPerMillionPerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+        public double PerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PerDegreeCelsius);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit"/>
         /// </summary>
-        public double PartsPerMillionPerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+        public double PerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PerKelvin"/>
         /// </summary>
-        public double PartsPerMillionPerKelvin => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+        public double PerKelvin => As(CoefficientOfThermalExpansionUnit.PerKelvin);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius"/>
+        /// </summary>
+        public double PpmPerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit"/>
+        /// </summary>
+        public double PpmPerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PpmPerKelvin"/>
+        /// </summary>
+        public double PpmPerKelvin => As(CoefficientOfThermalExpansionUnit.PpmPerKelvin);
 
         #endregion
 
@@ -215,21 +236,27 @@ namespace UnitsNet
         internal static void RegisterDefaultConversions(UnitConverter unitConverter)
         {
             // Register in unit converter: CoefficientOfThermalExpansionUnit -> BaseUnit
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerDegreeCelsius, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PpmPerKelvin, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerKelvin));
 
             // Register in unit converter: BaseUnit <-> BaseUnit
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity);
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PerKelvin, quantity => quantity);
 
             // Register in unit converter: BaseUnit -> CoefficientOfThermalExpansionUnit
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit));
-            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PerDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerDegreeCelsius));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PpmPerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PpmPerKelvin));
         }
 
         /// <summary>
@@ -261,6 +288,7 @@ namespace UnitsNet
         ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeCelsius"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Obsolete("Use PerDegreeCelsius instead.")]
         public static CoefficientOfThermalExpansion FromInverseDegreeCelsius(QuantityValue inversedegreecelsius)
         {
             double value = (double) inversedegreecelsius;
@@ -271,6 +299,7 @@ namespace UnitsNet
         ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Obsolete("Use PerDegreeFahrenheit instead.")]
         public static CoefficientOfThermalExpansion FromInverseDegreeFahrenheit(QuantityValue inversedegreefahrenheit)
         {
             double value = (double) inversedegreefahrenheit;
@@ -281,6 +310,7 @@ namespace UnitsNet
         ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.InverseKelvin"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        [Obsolete("Use PerKelvin instead.")]
         public static CoefficientOfThermalExpansion FromInverseKelvin(QuantityValue inversekelvin)
         {
             double value = (double) inversekelvin;
@@ -288,33 +318,63 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>.
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PerDegreeCelsius"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeCelsius(QuantityValue partspermillionperdegreecelsius)
+        public static CoefficientOfThermalExpansion FromPerDegreeCelsius(QuantityValue perdegreecelsius)
         {
-            double value = (double) partspermillionperdegreecelsius;
-            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+            double value = (double) perdegreecelsius;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PerDegreeCelsius);
         }
 
         /// <summary>
-        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>.
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeFahrenheit(QuantityValue partspermillionperdegreefahrenheit)
+        public static CoefficientOfThermalExpansion FromPerDegreeFahrenheit(QuantityValue perdegreefahrenheit)
         {
-            double value = (double) partspermillionperdegreefahrenheit;
-            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+            double value = (double) perdegreefahrenheit;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit);
         }
 
         /// <summary>
-        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>.
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PerKelvin"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static CoefficientOfThermalExpansion FromPartsPerMillionPerKelvin(QuantityValue partspermillionperkelvin)
+        public static CoefficientOfThermalExpansion FromPerKelvin(QuantityValue perkelvin)
         {
-            double value = (double) partspermillionperkelvin;
-            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+            double value = (double) perkelvin;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PerKelvin);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPpmPerDegreeCelsius(QuantityValue ppmperdegreecelsius)
+        {
+            double value = (double) ppmperdegreecelsius;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPpmPerDegreeFahrenheit(QuantityValue ppmperdegreefahrenheit)
+        {
+            double value = (double) ppmperdegreefahrenheit;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PpmPerKelvin"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPpmPerKelvin(QuantityValue ppmperkelvin)
+        {
+            double value = (double) ppmperkelvin;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PpmPerKelvin);
         }
 
         /// <summary>
@@ -515,7 +575,7 @@ namespace UnitsNet
         /// <summary>Get ratio value from dividing <see cref="CoefficientOfThermalExpansion"/> by <see cref="CoefficientOfThermalExpansion"/>.</summary>
         public static double operator /(CoefficientOfThermalExpansion left, CoefficientOfThermalExpansion right)
         {
-            return left.InverseKelvin / right.InverseKelvin;
+            return left.PerKelvin / right.PerKelvin;
         }
 
         #endregion
@@ -810,18 +870,24 @@ namespace UnitsNet
             CoefficientOfThermalExpansion? convertedOrNull = (Unit, unit) switch
             {
                 // CoefficientOfThermalExpansionUnit -> BaseUnit
-                (CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseKelvin),
-                (CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5, CoefficientOfThermalExpansionUnit.InverseKelvin),
-                (CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value / 1e6, CoefficientOfThermalExpansionUnit.InverseKelvin),
-                (CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5e6, CoefficientOfThermalExpansionUnit.InverseKelvin),
-                (CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value / 1e6, CoefficientOfThermalExpansionUnit.InverseKelvin),
+                (CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.PerDegreeCelsius, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value / 1e6, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5e6, CoefficientOfThermalExpansionUnit.PerKelvin),
+                (CoefficientOfThermalExpansionUnit.PpmPerKelvin, CoefficientOfThermalExpansionUnit.PerKelvin) => new CoefficientOfThermalExpansion(_value / 1e6, CoefficientOfThermalExpansionUnit.PerKelvin),
 
                 // BaseUnit -> CoefficientOfThermalExpansionUnit
-                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius),
-                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5 / 9, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit),
-                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius) => new CoefficientOfThermalExpansion(_value * 1e6, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius),
-                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5e6 / 9, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit),
-                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin) => new CoefficientOfThermalExpansion(_value * 1e6, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5 / 9, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseKelvin),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PerDegreeCelsius) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.PerDegreeCelsius),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5 / 9, CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius) => new CoefficientOfThermalExpansion(_value * 1e6, CoefficientOfThermalExpansionUnit.PpmPerDegreeCelsius),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5e6 / 9, CoefficientOfThermalExpansionUnit.PpmPerDegreeFahrenheit),
+                (CoefficientOfThermalExpansionUnit.PerKelvin, CoefficientOfThermalExpansionUnit.PpmPerKelvin) => new CoefficientOfThermalExpansion(_value * 1e6, CoefficientOfThermalExpansionUnit.PpmPerKelvin),
 
                 _ => null
             };

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -68,6 +68,9 @@ namespace UnitsNet
                     new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, "InverseDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius), "CoefficientOfThermalExpansion"),
                     new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, "InverseDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit), "CoefficientOfThermalExpansion"),
                     new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.InverseKelvin, "InverseKelvin", new BaseUnits(temperature: TemperatureUnit.Kelvin), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, "PartsPerMillionPerDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, "PartsPerMillionPerDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit), "CoefficientOfThermalExpansion"),
+                    new UnitInfo<CoefficientOfThermalExpansionUnit>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, "PartsPerMillionPerKelvin", new BaseUnits(temperature: TemperatureUnit.Kelvin), "CoefficientOfThermalExpansion"),
                 },
                 BaseUnit, Zero, BaseDimensions);
 
@@ -186,6 +189,21 @@ namespace UnitsNet
         /// </summary>
         public double InverseKelvin => As(CoefficientOfThermalExpansionUnit.InverseKelvin);
 
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>
+        /// </summary>
+        public double PartsPerMillionPerDegreeCelsius => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>
+        /// </summary>
+        public double PartsPerMillionPerDegreeFahrenheit => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>
+        /// </summary>
+        public double PartsPerMillionPerKelvin => As(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
+
         #endregion
 
         #region Static Methods
@@ -199,6 +217,9 @@ namespace UnitsNet
             // Register in unit converter: CoefficientOfThermalExpansionUnit -> BaseUnit
             unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
             unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseKelvin));
 
             // Register in unit converter: BaseUnit <-> BaseUnit
             unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin, quantity => quantity);
@@ -206,6 +227,9 @@ namespace UnitsNet
             // Register in unit converter: BaseUnit -> CoefficientOfThermalExpansionUnit
             unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseDegreeCelsius));
             unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit));
+            unitConverter.SetConversionFunction<CoefficientOfThermalExpansion>(CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, quantity => quantity.ToUnit(CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin));
         }
 
         /// <summary>
@@ -261,6 +285,36 @@ namespace UnitsNet
         {
             double value = (double) inversekelvin;
             return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.InverseKelvin);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeCelsius(QuantityValue partspermillionperdegreecelsius)
+        {
+            double value = (double) partspermillionperdegreecelsius;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPartsPerMillionPerDegreeFahrenheit(QuantityValue partspermillionperdegreefahrenheit)
+        {
+            double value = (double) partspermillionperdegreefahrenheit;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="CoefficientOfThermalExpansion"/> from <see cref="CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static CoefficientOfThermalExpansion FromPartsPerMillionPerKelvin(QuantityValue partspermillionperkelvin)
+        {
+            double value = (double) partspermillionperkelvin;
+            return new CoefficientOfThermalExpansion(value, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin);
         }
 
         /// <summary>
@@ -758,10 +812,16 @@ namespace UnitsNet
                 // CoefficientOfThermalExpansionUnit -> BaseUnit
                 (CoefficientOfThermalExpansionUnit.InverseDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseKelvin),
                 (CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5, CoefficientOfThermalExpansionUnit.InverseKelvin),
+                (CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value / 1e6, CoefficientOfThermalExpansionUnit.InverseKelvin),
+                (CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value * 9 / 5e6, CoefficientOfThermalExpansionUnit.InverseKelvin),
+                (CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin, CoefficientOfThermalExpansionUnit.InverseKelvin) => new CoefficientOfThermalExpansion(_value / 1e6, CoefficientOfThermalExpansionUnit.InverseKelvin),
 
                 // BaseUnit -> CoefficientOfThermalExpansionUnit
                 (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius) => new CoefficientOfThermalExpansion(_value, CoefficientOfThermalExpansionUnit.InverseDegreeCelsius),
                 (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5 / 9, CoefficientOfThermalExpansionUnit.InverseDegreeFahrenheit),
+                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius) => new CoefficientOfThermalExpansion(_value * 1e6, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeCelsius),
+                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit) => new CoefficientOfThermalExpansion(_value * 5e6 / 9, CoefficientOfThermalExpansionUnit.PartsPerMillionPerDegreeFahrenheit),
+                (CoefficientOfThermalExpansionUnit.InverseKelvin, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin) => new CoefficientOfThermalExpansion(_value * 1e6, CoefficientOfThermalExpansionUnit.PartsPerMillionPerKelvin),
 
                 _ => null
             };

--- a/UnitsNet/GeneratedCode/Resources/CoefficientOfThermalExpansion.restext
+++ b/UnitsNet/GeneratedCode/Resources/CoefficientOfThermalExpansion.restext
@@ -1,3 +1,6 @@
 InverseDegreeCelsius=°C⁻¹,1/°C
 InverseDegreeFahrenheit=°F⁻¹,1/°F
 InverseKelvin=K⁻¹,1/K
+PartsPerMillionPerDegreeCelsius=ppm/°C
+PartsPerMillionPerDegreeFahrenheit=ppm/°F
+PartsPerMillionPerKelvin=ppm/K

--- a/UnitsNet/GeneratedCode/Resources/CoefficientOfThermalExpansion.restext
+++ b/UnitsNet/GeneratedCode/Resources/CoefficientOfThermalExpansion.restext
@@ -1,6 +1,6 @@
-InverseDegreeCelsius=°C⁻¹,1/°C
-InverseDegreeFahrenheit=°F⁻¹,1/°F
-InverseKelvin=K⁻¹,1/K
-PartsPerMillionPerDegreeCelsius=ppm/°C
-PartsPerMillionPerDegreeFahrenheit=ppm/°F
-PartsPerMillionPerKelvin=ppm/K
+PerDegreeCelsius=°C⁻¹,1/°C
+PerDegreeFahrenheit=°F⁻¹,1/°F
+PerKelvin=K⁻¹,1/K
+PpmPerDegreeCelsius=ppm/°C
+PpmPerDegreeFahrenheit=ppm/°F
+PpmPerKelvin=ppm/K

--- a/UnitsNet/GeneratedCode/Resources/CoefficientOfThermalExpansion.restext
+++ b/UnitsNet/GeneratedCode/Resources/CoefficientOfThermalExpansion.restext
@@ -1,6 +1,9 @@
-PerDegreeCelsius=°C⁻¹,1/°C
-PerDegreeFahrenheit=°F⁻¹,1/°F
-PerKelvin=K⁻¹,1/K
+InverseDegreeCelsius=1/°C
+InverseDegreeFahrenheit=1/°F
+InverseKelvin=1/K
+PerDegreeCelsius=°C⁻¹
+PerDegreeFahrenheit=°F⁻¹
+PerKelvin=K⁻¹
 PpmPerDegreeCelsius=ppm/°C
 PpmPerDegreeFahrenheit=ppm/°F
 PpmPerKelvin=ppm/K

--- a/UnitsNet/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
@@ -28,6 +28,9 @@ namespace UnitsNet.Units
         InverseDegreeCelsius = 1,
         InverseDegreeFahrenheit = 2,
         InverseKelvin = 3,
+        PartsPerMillionPerDegreeCelsius = 10,
+        PartsPerMillionPerDegreeFahrenheit = 5,
+        PartsPerMillionPerKelvin = 9,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/CoefficientOfThermalExpansionUnit.g.cs
@@ -25,12 +25,18 @@ namespace UnitsNet.Units
 
     public enum CoefficientOfThermalExpansionUnit
     {
+        [System.Obsolete("Use PerDegreeCelsius instead.")]
         InverseDegreeCelsius = 1,
+        [System.Obsolete("Use PerDegreeFahrenheit instead.")]
         InverseDegreeFahrenheit = 2,
+        [System.Obsolete("Use PerKelvin instead.")]
         InverseKelvin = 3,
-        PartsPerMillionPerDegreeCelsius = 10,
-        PartsPerMillionPerDegreeFahrenheit = 5,
-        PartsPerMillionPerKelvin = 9,
+        PerDegreeCelsius = 9,
+        PerDegreeFahrenheit = 11,
+        PerKelvin = 13,
+        PpmPerDegreeCelsius = 6,
+        PpmPerDegreeFahrenheit = 4,
+        PpmPerKelvin = 7,
     }
 
     #pragma warning restore 1591


### PR DESCRIPTION
Fixes #1259 

### Add units
PerKelvin
PerDegreeCelsius
PerDegreeFahrenheit
PpmPerKelvin
PpmPerDegreeCelsius
PpmPerDegreeFahrenheit

### 💥Change base unit
From `InverseKelvin` to `PerKelvin`.

### Obsolete units (renamed)
InverseKelvin
InverseDegreeCelsius
InverseDegreeFahrenheit
