### PR TITLE
json: 🐛Fix stack overflow deserializing empty JSON

### DIFF
--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetIComparableJsonConverterTest.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetIComparableJsonConverterTest.cs
@@ -13,7 +13,7 @@ namespace UnitsNet.Serialization.JsonNet.Tests
 {
     public sealed class UnitsNetIComparableJsonConverterTest
     {
-        private UnitsNetIComparableJsonConverter _sut;
+        private readonly UnitsNetIComparableJsonConverter _sut;
 
         public UnitsNetIComparableJsonConverterTest()
         {

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
@@ -99,10 +99,9 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         [Fact]
-        public void EmptyJsonValue_NullableType_ExpectNullReturned()
+        public void EmptyJsonValue_NullableType_ExpectJsonSerializationException()
         {
-            Mass? deserializedNullMass = DeserializeObject<Mass?>("{}");
-            Assert.Null(deserializedNullMass);
+            Assert.Throws<JsonSerializationException>(() => DeserializeObject<Mass?>("{}"));
         }
 
         [Fact]

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
@@ -99,12 +99,16 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         [Fact]
-        public void EmptyJsonValue_ExpectNullReturned()
+        public void EmptyJsonValue_NullableType_ExpectNullReturned()
         {
-            var json = "{}";
-            var deserializedNullMass = DeserializeObject<Mass?>(json);
-
+            Mass? deserializedNullMass = DeserializeObject<Mass?>("{}");
             Assert.Null(deserializedNullMass);
+        }
+
+        [Fact]
+        public void EmptyJsonValue_NonNullableType_ExpectJsonSerializationException()
+        {
+            Assert.Throws<JsonSerializationException>(() => DeserializeObject<Mass>("{}"));
         }
 
         [Fact]

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
@@ -101,13 +101,19 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         [Fact]
         public void EmptyJsonValue_NullableType_ExpectJsonSerializationException()
         {
-            Assert.Throws<JsonSerializationException>(() => DeserializeObject<Mass?>("{}"));
+            var ex = Assert.Throws<JsonSerializationException>(() => DeserializeObject<Mass?>("{}"));
+            Assert.Equal("Failed to deserialize IQuantity for target type System.Nullable`1[UnitsNet.Mass] from JSON '{}', expected properties Unit and Value.", ex.Message);
+            Assert.Equal("https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft", ex.HelpLink);
+            Assert.Equal("{}", ex.Data["JsonToken"]);
         }
 
         [Fact]
         public void EmptyJsonValue_NonNullableType_ExpectJsonSerializationException()
         {
-            Assert.Throws<JsonSerializationException>(() => DeserializeObject<Mass>("{}"));
+            var ex = Assert.Throws<JsonSerializationException>(() => DeserializeObject<Mass>("{}"));
+            Assert.Equal("Failed to deserialize IQuantity for target type UnitsNet.Mass from JSON '{}', expected properties Unit and Value.", ex.Message);
+            Assert.Equal("https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft", ex.HelpLink);
+            Assert.Equal("{}", ex.Data["JsonToken"]);
         }
 
         [Fact]

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNetJsonDeserializationTests.cs
@@ -99,6 +99,15 @@ namespace UnitsNet.Serialization.JsonNet.Tests
         }
 
         [Fact]
+        public void EmptyJsonValue_ExpectNullReturned()
+        {
+            var json = "{}";
+            var deserializedNullMass = DeserializeObject<Mass?>(json);
+
+            Assert.Null(deserializedNullMass);
+        }
+
+        [Fact]
         public void NullValueNestedInObject_ExpectValueDeserializedToNullCorrectly()
         {
             var testObj = new TestObject()

--- a/UnitsNet.Serialization.JsonNet/StringExtensions.cs
+++ b/UnitsNet.Serialization.JsonNet/StringExtensions.cs
@@ -1,0 +1,25 @@
+﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace UnitsNet.Serialization.JsonNet
+{
+    internal static class StringExtensions
+    {
+        /// <summary>
+        /// Truncates a string to the given length, with truncation suffix.
+        /// </summary>
+        /// <param name="value">The string.</param>
+        /// <param name="maxLength">The max length, including <paramref name="truncationSuffix"/>.</param>
+        /// <param name="truncationSuffix">Suffix to append if truncated, defaults to "…".</param>
+        /// <returns>The truncated string if longer, otherwise the original string.</returns>
+        [return: NotNullIfNotNull("value")]
+        public static string? Truncate(this string? value, int maxLength, string truncationSuffix = "…")
+        {
+            return value?.Length > maxLength
+                ? value.Substring(0, maxLength - truncationSuffix.Length) + truncationSuffix
+                : value;
+        }
+    }
+}

--- a/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
@@ -47,6 +47,7 @@ namespace UnitsNet.Serialization.JsonNet
         /// <returns>A <see cref="ValueUnit"/></returns>
         protected ValueUnit? ReadValueUnit(JToken jsonToken)
         {
+            // Empty JSON "{}"
             if (!jsonToken.HasValues)
             {
                 return null;

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIComparableJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIComparableJsonConverter.cs
@@ -53,19 +53,18 @@ namespace UnitsNet.Serialization.JsonNet
             if (reader == null) throw new ArgumentNullException(nameof(reader));
             if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
-            if (reader.TokenType is JsonToken.Null or JsonToken.None)
+            var token = JToken.Load(reader);
+
+            if (token.Type is JTokenType.Null)
             {
                 return existingValue;
             }
 
-            // Remove the current converter from the list of converters to avoid infinite recursion.
-            JsonSerializer localSerializer = CreateLocalSerializer(serializer, this);
-
-            var token = JToken.Load(reader);
-
             // If objectType is not IComparable but a type that implements IComparable, deserialize directly as this type instead.
             if (objectType != typeof(IComparable))
             {
+                // Remove the current converter from the list of converters to avoid infinite recursion.
+                JsonSerializer localSerializer = CreateLocalSerializer(serializer, this);
                 return (IComparable)token.ToObject(objectType, localSerializer)!;
             }
 
@@ -73,6 +72,8 @@ namespace UnitsNet.Serialization.JsonNet
 
             if (valueUnit == null)
             {
+                // Remove the current converter from the list of converters to avoid infinite recursion.
+                JsonSerializer localSerializer = CreateLocalSerializer(serializer, this);
                 return token.ToObject<IComparable>(localSerializer);
             }
 

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIComparableJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIComparableJsonConverter.cs
@@ -53,7 +53,7 @@ namespace UnitsNet.Serialization.JsonNet
             if (reader == null) throw new ArgumentNullException(nameof(reader));
             if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
-            if (reader.TokenType == JsonToken.Null)
+            if (reader.TokenType is JsonToken.Null or JsonToken.None)
             {
                 return existingValue;
             }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIComparableJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIComparableJsonConverter.cs
@@ -50,15 +50,16 @@ namespace UnitsNet.Serialization.JsonNet
         public override IComparable? ReadJson(JsonReader reader, Type objectType, IComparable? existingValue, bool hasExistingValue,
             JsonSerializer serializer)
         {
-            reader = reader ?? throw new ArgumentNullException(nameof(reader));
-            serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
             if (reader.TokenType == JsonToken.Null)
             {
                 return existingValue;
             }
 
-            var localSerializer = CreateLocalSerializer(serializer, this);
+            // Remove the current converter from the list of converters to avoid infinite recursion.
+            JsonSerializer localSerializer = CreateLocalSerializer(serializer, this);
 
             var token = JToken.Load(reader);
 
@@ -68,7 +69,7 @@ namespace UnitsNet.Serialization.JsonNet
                 return (IComparable)token.ToObject(objectType, localSerializer)!;
             }
 
-            var valueUnit = ReadValueUnit(token);
+            ValueUnit? valueUnit = ReadValueUnit(token);
 
             if (valueUnit == null)
             {

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -54,35 +54,21 @@ namespace UnitsNet.Serialization.JsonNet
         public override IQuantity? ReadJson(JsonReader reader, Type objectType, IQuantity? existingValue, bool hasExistingValue,
             JsonSerializer serializer)
         {
-            var ret = existingValue;
-
-            reader = reader ?? throw new ArgumentNullException(nameof(reader));
-            serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            if (reader == null) throw new ArgumentNullException(nameof(reader));
+            if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
             if (reader.TokenType == JsonToken.Null)
             {
-                return ret;
+                return existingValue;
             }
 
             var token = JToken.Load(reader);
 
-            var json = token.ToString();
-
-            if (!string.IsNullOrWhiteSpace(json) && !IsEmptyJson(json))
-            {
-                var valueUnit = ReadValueUnit(token);
-
-                if (valueUnit == null)
-                {
-                    ret = token.ToObject<IQuantity>(serializer);
-                }
-                else
-                {
-                    ret = ConvertValueUnit(valueUnit);
-                }
-            }
-
-            return ret;
+            // Try to read value and unit from JSON.
+            ValueUnit? valueUnit = ReadValueUnit(token);
+            return valueUnit != null
+                ? ConvertValueUnit(valueUnit)
+                : existingValue;
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -64,8 +64,9 @@ namespace UnitsNet.Serialization.JsonNet
 
             var token = JToken.Load(reader);
 
-            // Try to read value and unit from JSON.
+            // Try to read value and unit from JSON, otherwise return existing value.
             ValueUnit? valueUnit = ReadValueUnit(token);
+
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
                 : existingValue;

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -64,12 +64,12 @@ namespace UnitsNet.Serialization.JsonNet
                 return existingValue;
             }
 
-            // Try to read value and unit from JSON, otherwise return existing value.
+            // Try to read value and unit from JSON, otherwise throw.
             ValueUnit? valueUnit = ReadValueUnit(token);
 
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
-                : throw new JsonSerializationException("Failed to deserialize IQuantity, expected a numeric Value property and a string Unit property.");
+                : throw new JsonSerializationException("Failed to deserialize IQuantity, expected properties Unit and Value. See https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft.");
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -37,8 +37,6 @@ namespace UnitsNet.Serialization.JsonNet
             serializer.Serialize(writer, valueUnit);
         }
 
-        private static bool IsEmptyJson(string source) => Regex.IsMatch(source, @"^\s*{\s*}\s*", RegexOptions.IgnoreCase | RegexOptions.Compiled | RegexOptions.CultureInvariant);
-
         /// <summary>
         /// Reads the JSON representation of the object.
         /// </summary>

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -57,12 +57,12 @@ namespace UnitsNet.Serialization.JsonNet
             if (reader == null) throw new ArgumentNullException(nameof(reader));
             if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
-            if (reader.TokenType is JsonToken.Null or JsonToken.None)
+            var token = JToken.Load(reader);
+
+            if (token.Type is JTokenType.Null)
             {
                 return existingValue;
             }
-
-            var token = JToken.Load(reader);
 
             // Try to read value and unit from JSON, otherwise return existing value.
             ValueUnit? valueUnit = ReadValueUnit(token);

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -69,10 +69,7 @@ namespace UnitsNet.Serialization.JsonNet
 
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
-                : hasExistingValue
-                    ? existingValue
-                    : throw new JsonSerializationException(
-                        "Failed to deserialize IQuantity, expected a numeric Value property and a string Unit property.");
+                : throw new JsonSerializationException("Failed to deserialize IQuantity, expected a numeric Value property and a string Unit property.");
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -2,7 +2,6 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
-using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -32,7 +31,7 @@ namespace UnitsNet.Serialization.JsonNet
                 return;
             }
 
-            var valueUnit = ConvertIQuantity(value);
+            ValueUnit valueUnit = ConvertIQuantity(value);
 
             serializer.Serialize(writer, valueUnit);
         }
@@ -67,7 +66,13 @@ namespace UnitsNet.Serialization.JsonNet
 
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
-                : throw new JsonSerializationException($"Failed to deserialize IQuantity '{token.ToString().Truncate(50)}', expected properties Unit and Value. See https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft.");
+                : throw new JsonSerializationException(
+                    $"Failed to deserialize IQuantity for target type {objectType} from JSON '{token.ToString().Truncate(100)}', expected properties Unit and Value.")
+                {
+                    HelpLink =
+                        "https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft",
+                    Data = { { "JsonToken", token.ToString() }, }
+                };
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -57,7 +57,7 @@ namespace UnitsNet.Serialization.JsonNet
             if (reader == null) throw new ArgumentNullException(nameof(reader));
             if (serializer == null) throw new ArgumentNullException(nameof(serializer));
 
-            if (reader.TokenType == JsonToken.Null)
+            if (reader.TokenType is JsonToken.Null or JsonToken.None)
             {
                 return existingValue;
             }
@@ -69,7 +69,10 @@ namespace UnitsNet.Serialization.JsonNet
 
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
-                : existingValue;
+                : hasExistingValue
+                    ? existingValue
+                    : throw new JsonSerializationException(
+                        "Failed to deserialize IQuantity, expected a numeric Value property and a string Unit property.");
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -67,7 +67,7 @@ namespace UnitsNet.Serialization.JsonNet
 
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
-                : throw new JsonSerializationException($"Failed to deserialize IQuantity '{token}', expected properties Unit and Value. See https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft.");
+                : throw new JsonSerializationException($"Failed to deserialize IQuantity '{token.ToString().Truncate(50)}', expected properties Unit and Value. See https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft.");
         }
     }
 }

--- a/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetIQuantityJsonConverter.cs
@@ -69,7 +69,7 @@ namespace UnitsNet.Serialization.JsonNet
 
             return valueUnit != null
                 ? ConvertValueUnit(valueUnit)
-                : throw new JsonSerializationException("Failed to deserialize IQuantity, expected properties Unit and Value. See https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft.");
+                : throw new JsonSerializationException($"Failed to deserialize IQuantity '{token}', expected properties Unit and Value. See https://github.com/angularsen/UnitsNet/wiki/Serializing-to-JSON,-XML-and-more#unitsnetserializationjsonnet-with-jsonnet-newtonsoft.");
         }
     }
 }


### PR DESCRIPTION
Fixes #1292 

The call to "token.ToObject<IQuantity>(serializer)" with an empty or invalid json calls `JsonConvert.DeserializeObject` again and results in infinite recursion and stack overflow.

### Changes
- Throw `JsonSerializationException` on invalid JSON in `UnitsNetIQuantityJsonConverter`
	- Include helpful info in exception, link to wiki, truncated JSON token in message and full JSON token in `Data["JsonToken"]` property.
- Add tests for new behavior