### PR TITLE
🐛 Fix unit abbreviation lookup for unit value cast to Enum

### DIFF
--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -325,7 +325,7 @@ namespace UnitsNet.Tests
 
         /// <inheritdoc cref="MapAndLookup_WithSpecificEnumType"/>
         [Fact]
-        public void MapWithSpecificEnumType_LookupWithEnumType()
+        public void MapAndLookup_MapWithSpecificEnumType_LookupWithEnumType()
         {
             UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "sm");
             Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation((Enum)HowMuchUnit.Some));

--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -308,24 +308,24 @@ namespace UnitsNet.Tests
         /// which the Enum type satisfies, but trying to use typeof(TUnitEnum) no longer represent the actual enum type so unitEnumValue.GetType() should be used.
         /// </summary>
         [Fact]
-        public void MappingAndLookup_WithSpecificEnumType()
+        public void MapAndLookup_WithSpecificEnumType()
         {
             UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "sm");
             Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation(HowMuchUnit.Some));
         }
 
-        /// <inheritdoc cref="MappingAndLookup_WithSpecificEnumType"/>
+        /// <inheritdoc cref="MapAndLookup_WithSpecificEnumType"/>
         [Fact]
-        public void MappingAndLookup_WithEnumType()
+        public void MapAndLookup_WithEnumType()
         {
             Enum valueAsEnumType = HowMuchUnit.Some;
             UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(valueAsEnumType, "sm");
             Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation(valueAsEnumType));
         }
 
-        /// <inheritdoc cref="MappingAndLookup_WithSpecificEnumType"/>
+        /// <inheritdoc cref="MapAndLookup_WithSpecificEnumType"/>
         [Fact]
-        public void MappingWithSpecificEnumType_LookupWithEnumType()
+        public void MapWithSpecificEnumType_LookupWithEnumType()
         {
             UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "sm");
             Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation((Enum)HowMuchUnit.Some));

--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -280,13 +280,13 @@ namespace UnitsNet.Tests
         {
             var cache = new UnitAbbreviationsCache();
 
-            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "soome");
-            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "soome");
-            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "soome");
+            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "sm");
+            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "sm");
+            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "sm");
 
-            Assert.Equal("soome", cache.GetDefaultAbbreviation(HowMuchUnit.Some));
-            Assert.Equal(new[] { "soome" }, cache.GetUnitAbbreviations(HowMuchUnit.Some));
-            Assert.Equal(new[] { "soome" }, cache.GetAllUnitAbbreviationsForQuantity(typeof(HowMuchUnit)));
+            Assert.Equal("sm", cache.GetDefaultAbbreviation(HowMuchUnit.Some));
+            Assert.Equal(new[] { "sm" }, cache.GetUnitAbbreviations(HowMuchUnit.Some));
+            Assert.Equal(new[] { "sm" }, cache.GetAllUnitAbbreviationsForQuantity(typeof(HowMuchUnit)));
         }
 
         [Fact]
@@ -294,12 +294,41 @@ namespace UnitsNet.Tests
         {
             var cache = new UnitAbbreviationsCache();
 
-            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "soome");
+            cache.MapUnitToAbbreviation(HowMuchUnit.Some, "sm");
             cache.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "1st default");
             cache.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "2nd default");
 
             Assert.Equal("2nd default", cache.GetDefaultAbbreviation(HowMuchUnit.Some));
-            Assert.Equal(new[] { "2nd default", "1st default", "soome" }, cache.GetUnitAbbreviations(HowMuchUnit.Some));
+            Assert.Equal(new[] { "2nd default", "1st default", "sm" }, cache.GetUnitAbbreviations(HowMuchUnit.Some));
+        }
+
+        /// <summary>
+        /// Test that lookup works when specifying unit enum value both as cast to <see cref="Enum"/> and as specific enum value type.
+        /// We have had subtle bugs when <see cref="Enum"/> is passed to generic methods with constraint TUnitEnum : Enum,
+        /// which the Enum type satisfies, but trying to use typeof(TUnitEnum) no longer represent the actual enum type so unitEnumValue.GetType() should be used.
+        /// </summary>
+        [Fact]
+        public void MappingAndLookup_WithSpecificEnumType()
+        {
+            UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "sm");
+            Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation(HowMuchUnit.Some));
+        }
+
+        /// <inheritdoc cref="MappingAndLookup_WithSpecificEnumType"/>
+        [Fact]
+        public void MappingAndLookup_WithEnumType()
+        {
+            Enum valueAsEnumType = HowMuchUnit.Some;
+            UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(valueAsEnumType, "sm");
+            Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation(valueAsEnumType));
+        }
+
+        /// <inheritdoc cref="MappingAndLookup_WithSpecificEnumType"/>
+        [Fact]
+        public void MappingWithSpecificEnumType_LookupWithEnumType()
+        {
+            UnitAbbreviationsCache.Default.MapUnitToDefaultAbbreviation(HowMuchUnit.Some, "sm");
+            Assert.Equal("sm", UnitAbbreviationsCache.Default.GetDefaultAbbreviation((Enum)HowMuchUnit.Some));
         }
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -187,6 +187,10 @@ namespace UnitsNet
         public string GetDefaultAbbreviation<TUnitType>(TUnitType unit, IFormatProvider? formatProvider = null) where TUnitType : Enum
         {
             Type unitType = typeof(TUnitType);
+
+            // Edge-case: If the value was cast to Enum, it still satisfies the generic constraint so we must get the type from the value instead.
+            if (unitType == typeof(Enum)) unitType = unit.GetType();
+
             return GetDefaultAbbreviation(unitType, Convert.ToInt32(unit), formatProvider);
         }
 


### PR DESCRIPTION
Fixes #1301

When looking up unit abbreviation for a unit enum value that is cast to `Enum`, for example via variable or method parameter, the lookup failed due to using `typeof(TUnitEnum)` in the generic method. `Enum` satisfies the generic constraint, but the generic type no longer describes the original unit enum type. Instead, we must use `unitEnumValue.GetType()`.

```
System.ArgumentException: Type provided must be an Enum.
   at System.Enum.GetEnumInfo(RuntimeType enumType, Boolean getNames)
   at System.RuntimeType.GetEnumName(Object value)
   at UnitsNet.UnitAbbreviationsCache.TryGetUnitAbbreviations(Type unitType, Int32 unitValue, IFormatProvider formatProvider, String[]& abbreviations) in C:\dev\unitsnet\UnitsNet\CustomCode\UnitAbbreviationsCache.cs:line 246
```

### Changes
- Handle edge-case when `Enum` type is passed instead of an actual unit enum type