### PR TITLE
🐛Fix concurrency issue getting abbreviations

### DIFF
--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -2,6 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
@@ -35,14 +36,12 @@ namespace UnitsNet
         [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
         public static UnitAbbreviationsCache Default => UnitsNetSetup.Default.UnitAbbreviations;
 
-        private readonly object _syncRoot = new();
-
         private QuantityInfoLookup QuantityInfoLookup { get; }
 
         /// <summary>
         /// Culture name to abbreviations. To add a custom default abbreviation, add to the beginning of the list.
         /// </summary>
-        private IDictionary<AbbreviationMapKey, IReadOnlyList<string>> AbbreviationsMap { get; } = new Dictionary<AbbreviationMapKey, IReadOnlyList<string>>();
+        private ConcurrentDictionary<AbbreviationMapKey, IReadOnlyList<string>> AbbreviationsMap { get; } = new();
 
         /// <summary>
         ///     Create an instance of the cache and load all the abbreviations defined in the library.
@@ -295,14 +294,15 @@ namespace UnitsNet
         }
 
         /// <summary>
-        ///
+        ///    Get all abbreviations for the given unit and culture.
         /// </summary>
-        /// <param name="unitInfo"></param>
-        /// <param name="formatProvider"></param>
-        /// <returns></returns>
-        /// <exception cref="ArgumentNullException"></exception>
+        /// <param name="unitInfo">The unit.</param>
+        /// <param name="formatProvider">The culture to get localized abbreviations for. Defaults to <see cref="CultureInfo.CurrentCulture"/>.</param>
+        /// <returns>The list of abbreviations mapped for this unit. The first in the list is the primary abbreviation used by ToString().</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="unitInfo"/> was null.</exception>
         public IReadOnlyList<string> GetAbbreviations(UnitInfo unitInfo, IFormatProvider? formatProvider = null)
         {
+            if (unitInfo == null) throw new ArgumentNullException(nameof(unitInfo));
             if (formatProvider is not CultureInfo)
                 formatProvider = CultureInfo.CurrentCulture;
 
@@ -310,8 +310,9 @@ namespace UnitsNet
             var cultureName = GetCultureNameOrEnglish(culture);
 
             AbbreviationMapKey key = GetAbbreviationMapKey(unitInfo, cultureName);
-            if (!AbbreviationsMap.TryGetValue(key, out IReadOnlyList<string>? abbreviations))
-                AbbreviationsMap[key] = abbreviations = ReadAbbreviationsFromResourceFile(unitInfo.QuantityName, unitInfo.PluralName, culture);
+
+            IReadOnlyList<string> abbreviations = AbbreviationsMap.GetOrAdd(key,
+                valueFactory: _ => ReadAbbreviationsFromResourceFile(unitInfo.QuantityName, unitInfo.PluralName, culture));
 
             return abbreviations.Count == 0 && !culture.Equals(FallbackCulture)
                 ? GetAbbreviations(unitInfo, FallbackCulture)
@@ -324,9 +325,9 @@ namespace UnitsNet
         /// <param name="unitInfo">The unit to add for.</param>
         /// <param name="formatProvider">The culture this abbreviation is for, defaults to <see cref="CultureInfo.CurrentCulture"/>.</param>
         /// <param name="setAsDefault">Whether to set as the primary/default unit abbreviation used by ToString().</param>
-        /// <param name="abbreviations">One or more abbreviations to add.</param>
+        /// <param name="newAbbreviations">One or more abbreviations to add.</param>
         private void AddAbbreviation(UnitInfo unitInfo, IFormatProvider? formatProvider, bool setAsDefault,
-            params string[] abbreviations)
+            params string[] newAbbreviations)
         {
             if (formatProvider is not CultureInfo)
                 formatProvider = CultureInfo.CurrentCulture;
@@ -334,26 +335,35 @@ namespace UnitsNet
             var culture = (CultureInfo)formatProvider;
             var cultureName = GetCultureNameOrEnglish(culture);
 
-            // Restrict concurrency on writes.
-            // By using ConcurrencyDictionary and immutable IReadOnlyList instances, we don't need to lock on reads.
-            lock(_syncRoot)
-            {
-                var currentAbbreviationsList = new List<string>(GetAbbreviations(unitInfo, culture));
+            AbbreviationMapKey key = GetAbbreviationMapKey(unitInfo, cultureName);
 
-                foreach (var abbreviation in abbreviations)
+            AbbreviationsMap.AddOrUpdate(key,
+                addValueFactory: _ =>
                 {
-                    if (!currentAbbreviationsList.Contains(abbreviation))
-                    {
-                        if (setAsDefault)
-                            currentAbbreviationsList.Insert(0, abbreviation);
-                        else
-                            currentAbbreviationsList.Add(abbreviation);
-                    }
-                }
+                    List<string> bundledAbbreviations = ReadAbbreviationsFromResourceFile(unitInfo.QuantityName, unitInfo.PluralName, culture).ToList();
+                    return AddAbbreviationsToList(setAsDefault, bundledAbbreviations, newAbbreviations);
+                },
+                updateValueFactory: (_, existingReadOnlyList) => AddAbbreviationsToList(setAsDefault, existingReadOnlyList.ToList(), newAbbreviations));
+        }
 
-                AbbreviationMapKey key = GetAbbreviationMapKey(unitInfo, cultureName);
-                AbbreviationsMap[key] = currentAbbreviationsList.AsReadOnly();
+        private static IReadOnlyList<string> AddAbbreviationsToList(bool setAsDefault, List<string> list, IEnumerable<string> abbreviations)
+        {
+            foreach (var newAbbrev in abbreviations)
+            {
+                if (setAsDefault)
+                {
+                    // Remove if it already exists, then insert at beginning.
+                    // Normally only called with a single abbreviation.
+                    list.Remove(newAbbrev);
+                    list.Insert(0, newAbbrev);
+                }
+                else if (!list.Contains(newAbbrev))
+                {
+                    list.Add(newAbbrev);
+                }
             }
+
+            return list.AsReadOnly();
         }
 
         private static AbbreviationMapKey GetAbbreviationMapKey(UnitInfo unitInfo, string cultureName)


### PR DESCRIPTION
Fixes #1303

Change back to `ConcurrencyDictionary`, there was a subtle write-on-read when loading the initial values that could throw in `UnitAbbreviationsCache.GetAbbreviations()`:

```cs

if (!AbbreviationsMap.TryGetValue(key, out IReadOnlyList<string>? abbreviations))
    AbbreviationsMap[key] = abbreviations = ReadAbbreviationsFromResourceFile(unitInfo.QuantityName, unitInfo.PluralName, culture);
```

```
System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
    at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
    at System.Collections.Generic.Dictionary`2.TryGetValue(TKey key, TValue& value)
    at UnitsNet.UnitAbbreviationsCache.GetAbbreviations(UnitInfo unitInfo, IFormatProvider formatProvider)
    at UnitsNet.UnitAbbreviationsCache.TryGetUnitAbbreviations(Type unitType, Int32 unitValue, IFormatProvider formatProvider, String[]& abbreviations)
    at UnitsNet.UnitAbbreviationsCache.GetUnitAbbreviations(Type unitType, Int32 unitValue, IFormatProvider formatProvider)
```