### PR TITLE
Bump nanoFramework refs

### DIFF
--- a/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
@@ -27,7 +27,7 @@ namespace CodeGen.Generators.NanoFrameworkGen
     <id>UnitsNet.nanoFramework.{_quantity.Name}</id>
     <version>5.35.0</version>
     <title>Units.NET {_quantity.Name} - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type=""expression"">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>

--- a/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/AbsorbedDoseOfIonizingRadiation.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/AbsorbedDoseOfIonizingRadiation.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/UnitsNet.NanoFramework.AbsorbedDoseOfIonizingRadiation.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/UnitsNet.NanoFramework.AbsorbedDoseOfIonizingRadiation.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.AbsorbedDoseOfIonizingRadiation</id>
     <version>5.35.0</version>
     <title>Units.NET AbsorbedDoseOfIonizingRadiation - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework absorbeddoseofionizingradiation unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/Acceleration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/Acceleration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/UnitsNet.NanoFramework.Acceleration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/UnitsNet.NanoFramework.Acceleration.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Acceleration</id>
     <version>5.35.0</version>
     <title>Units.NET Acceleration - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework acceleration unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/AmountOfSubstance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/AmountOfSubstance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/UnitsNet.NanoFramework.AmountOfSubstance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/UnitsNet.NanoFramework.AmountOfSubstance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.AmountOfSubstance</id>
     <version>5.35.0</version>
     <title>Units.NET AmountOfSubstance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework amountofsubstance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/AmplitudeRatio.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/AmplitudeRatio.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/UnitsNet.NanoFramework.AmplitudeRatio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/UnitsNet.NanoFramework.AmplitudeRatio.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.AmplitudeRatio</id>
     <version>5.35.0</version>
     <title>Units.NET AmplitudeRatio - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework amplituderatio unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/Angle.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/Angle.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.5.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.5.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/UnitsNet.NanoFramework.Angle.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/UnitsNet.NanoFramework.Angle.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Angle</id>
     <version>5.35.0</version>
     <title>Units.NET Angle - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework angle unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.System.Math" version="1.5.29" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.System.Math" version="1.5.43" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/ApparentEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/ApparentEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/UnitsNet.NanoFramework.ApparentEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/UnitsNet.NanoFramework.ApparentEnergy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ApparentEnergy</id>
     <version>5.35.0</version>
     <title>Units.NET ApparentEnergy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework apparentenergy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/ApparentPower.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/ApparentPower.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/UnitsNet.NanoFramework.ApparentPower.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/UnitsNet.NanoFramework.ApparentPower.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ApparentPower</id>
     <version>5.35.0</version>
     <title>Units.NET ApparentPower - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework apparentpower unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/Area.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/Area.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/UnitsNet.NanoFramework.Area.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/UnitsNet.NanoFramework.Area.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Area</id>
     <version>5.35.0</version>
     <title>Units.NET Area - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework area unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/AreaDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/AreaDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/UnitsNet.NanoFramework.AreaDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/UnitsNet.NanoFramework.AreaDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.AreaDensity</id>
     <version>5.35.0</version>
     <title>Units.NET AreaDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework areadensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/AreaMomentOfInertia.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/AreaMomentOfInertia.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/UnitsNet.NanoFramework.AreaMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/UnitsNet.NanoFramework.AreaMomentOfInertia.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.AreaMomentOfInertia</id>
     <version>5.35.0</version>
     <title>Units.NET AreaMomentOfInertia - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework areamomentofinertia unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/BitRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/BitRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/UnitsNet.NanoFramework.BitRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/UnitsNet.NanoFramework.BitRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.BitRate</id>
     <version>5.35.0</version>
     <title>Units.NET BitRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework bitrate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumption.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/BrakeSpecificFuelConsumption.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/UnitsNet.NanoFramework.BrakeSpecificFuelConsumption.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/UnitsNet.NanoFramework.BrakeSpecificFuelConsumption.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.BrakeSpecificFuelConsumption</id>
     <version>5.35.0</version>
     <title>Units.NET BrakeSpecificFuelConsumption - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework brakespecificfuelconsumption unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/Capacitance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/Capacitance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/UnitsNet.NanoFramework.Capacitance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/UnitsNet.NanoFramework.Capacitance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Capacitance</id>
     <version>5.35.0</version>
     <title>Units.NET Capacitance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework capacitance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/CoefficientOfThermalExpansion.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/CoefficientOfThermalExpansion.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/UnitsNet.NanoFramework.CoefficientOfThermalExpansion.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/UnitsNet.NanoFramework.CoefficientOfThermalExpansion.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.CoefficientOfThermalExpansion</id>
     <version>5.35.0</version>
     <title>Units.NET CoefficientOfThermalExpansion - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework coefficientofthermalexpansion unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Compressibility/Compressibility.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Compressibility/Compressibility.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Compressibility/UnitsNet.NanoFramework.Compressibility.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Compressibility/UnitsNet.NanoFramework.Compressibility.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Compressibility</id>
     <version>5.35.0</version>
     <title>Units.NET Compressibility - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework compressibility unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Compressibility/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Compressibility/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/Density.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/Density.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/UnitsNet.NanoFramework.Density.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/UnitsNet.NanoFramework.Density.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Density</id>
     <version>5.35.0</version>
     <title>Units.NET Density - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework density unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/Duration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/Duration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/UnitsNet.NanoFramework.Duration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/UnitsNet.NanoFramework.Duration.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Duration</id>
     <version>5.35.0</version>
     <title>Units.NET Duration - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework duration unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/DynamicViscosity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/DynamicViscosity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/UnitsNet.NanoFramework.DynamicViscosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/UnitsNet.NanoFramework.DynamicViscosity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.DynamicViscosity</id>
     <version>5.35.0</version>
     <title>Units.NET DynamicViscosity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework dynamicviscosity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/ElectricAdmittance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/ElectricAdmittance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/UnitsNet.NanoFramework.ElectricAdmittance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/UnitsNet.NanoFramework.ElectricAdmittance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricAdmittance</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricAdmittance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricadmittance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/ElectricCharge.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/ElectricCharge.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/UnitsNet.NanoFramework.ElectricCharge.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/UnitsNet.NanoFramework.ElectricCharge.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricCharge</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricCharge - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electriccharge unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/ElectricChargeDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/ElectricChargeDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/UnitsNet.NanoFramework.ElectricChargeDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/UnitsNet.NanoFramework.ElectricChargeDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricChargeDensity</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricChargeDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricchargedensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/ElectricConductance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/ElectricConductance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/UnitsNet.NanoFramework.ElectricConductance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/UnitsNet.NanoFramework.ElectricConductance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricConductance</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricConductance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricconductance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/ElectricConductivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/ElectricConductivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/UnitsNet.NanoFramework.ElectricConductivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/UnitsNet.NanoFramework.ElectricConductivity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricConductivity</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricConductivity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricconductivity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/ElectricCurrent.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/ElectricCurrent.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/UnitsNet.NanoFramework.ElectricCurrent.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/UnitsNet.NanoFramework.ElectricCurrent.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricCurrent</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricCurrent - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electriccurrent unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/ElectricCurrentDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/ElectricCurrentDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/UnitsNet.NanoFramework.ElectricCurrentDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/UnitsNet.NanoFramework.ElectricCurrentDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricCurrentDensity</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricCurrentDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electriccurrentdensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/ElectricCurrentGradient.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/ElectricCurrentGradient.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/UnitsNet.NanoFramework.ElectricCurrentGradient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/UnitsNet.NanoFramework.ElectricCurrentGradient.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricCurrentGradient</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricCurrentGradient - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electriccurrentgradient unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/ElectricField.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/ElectricField.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/UnitsNet.NanoFramework.ElectricField.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/UnitsNet.NanoFramework.ElectricField.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricField</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricField - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricfield unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/ElectricInductance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/ElectricInductance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/UnitsNet.NanoFramework.ElectricInductance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/UnitsNet.NanoFramework.ElectricInductance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricInductance</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricInductance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricinductance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/ElectricPotential.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/ElectricPotential.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/UnitsNet.NanoFramework.ElectricPotential.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/UnitsNet.NanoFramework.ElectricPotential.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricPotential</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricPotential - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricpotential unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/ElectricPotentialAc.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/ElectricPotentialAc.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/UnitsNet.NanoFramework.ElectricPotentialAc.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/UnitsNet.NanoFramework.ElectricPotentialAc.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricPotentialAc</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricPotentialAc - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricpotentialac unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/ElectricPotentialChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/ElectricPotentialChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/UnitsNet.NanoFramework.ElectricPotentialChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/UnitsNet.NanoFramework.ElectricPotentialChangeRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricPotentialChangeRate</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricPotentialChangeRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricpotentialchangerate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/ElectricPotentialDc.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/ElectricPotentialDc.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/UnitsNet.NanoFramework.ElectricPotentialDc.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/UnitsNet.NanoFramework.ElectricPotentialDc.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricPotentialDc</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricPotentialDc - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricpotentialdc unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/ElectricResistance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/ElectricResistance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/UnitsNet.NanoFramework.ElectricResistance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/UnitsNet.NanoFramework.ElectricResistance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricResistance</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricResistance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricresistance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/ElectricResistivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/ElectricResistivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/UnitsNet.NanoFramework.ElectricResistivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/UnitsNet.NanoFramework.ElectricResistivity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricResistivity</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricResistivity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricresistivity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/ElectricSurfaceChargeDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/UnitsNet.NanoFramework.ElectricSurfaceChargeDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/UnitsNet.NanoFramework.ElectricSurfaceChargeDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ElectricSurfaceChargeDensity</id>
     <version>5.35.0</version>
     <title>Units.NET ElectricSurfaceChargeDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework electricsurfacechargedensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/Energy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/Energy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/UnitsNet.NanoFramework.Energy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/UnitsNet.NanoFramework.Energy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Energy</id>
     <version>5.35.0</version>
     <title>Units.NET Energy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework energy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/EnergyDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/EnergyDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/UnitsNet.NanoFramework.EnergyDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/UnitsNet.NanoFramework.EnergyDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.EnergyDensity</id>
     <version>5.35.0</version>
     <title>Units.NET EnergyDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework energydensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/Entropy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/Entropy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/UnitsNet.NanoFramework.Entropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/UnitsNet.NanoFramework.Entropy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Entropy</id>
     <version>5.35.0</version>
     <title>Units.NET Entropy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework entropy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/Force.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/Force.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/UnitsNet.NanoFramework.Force.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/UnitsNet.NanoFramework.Force.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Force</id>
     <version>5.35.0</version>
     <title>Units.NET Force - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework force unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/ForceChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/ForceChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/UnitsNet.NanoFramework.ForceChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/UnitsNet.NanoFramework.ForceChangeRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ForceChangeRate</id>
     <version>5.35.0</version>
     <title>Units.NET ForceChangeRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework forcechangerate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/ForcePerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/ForcePerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/UnitsNet.NanoFramework.ForcePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/UnitsNet.NanoFramework.ForcePerLength.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ForcePerLength</id>
     <version>5.35.0</version>
     <title>Units.NET ForcePerLength - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework forceperlength unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/Frequency.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/Frequency.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.5.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.5.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/UnitsNet.NanoFramework.Frequency.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/UnitsNet.NanoFramework.Frequency.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Frequency</id>
     <version>5.35.0</version>
     <title>Units.NET Frequency - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework frequency unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.System.Math" version="1.5.29" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.System.Math" version="1.5.43" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/FuelEfficiency.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/FuelEfficiency.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/UnitsNet.NanoFramework.FuelEfficiency.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/UnitsNet.NanoFramework.FuelEfficiency.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.FuelEfficiency</id>
     <version>5.35.0</version>
     <title>Units.NET FuelEfficiency - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework fuelefficiency unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/HeatFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/HeatFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/UnitsNet.NanoFramework.HeatFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/UnitsNet.NanoFramework.HeatFlux.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.HeatFlux</id>
     <version>5.35.0</version>
     <title>Units.NET HeatFlux - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework heatflux unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/HeatTransferCoefficient.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/HeatTransferCoefficient.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/UnitsNet.NanoFramework.HeatTransferCoefficient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/UnitsNet.NanoFramework.HeatTransferCoefficient.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.HeatTransferCoefficient</id>
     <version>5.35.0</version>
     <title>Units.NET HeatTransferCoefficient - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework heattransfercoefficient unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/Illuminance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/Illuminance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/UnitsNet.NanoFramework.Illuminance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/UnitsNet.NanoFramework.Illuminance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Illuminance</id>
     <version>5.35.0</version>
     <title>Units.NET Illuminance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework illuminance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Impulse/Impulse.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Impulse/Impulse.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Impulse/UnitsNet.NanoFramework.Impulse.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Impulse/UnitsNet.NanoFramework.Impulse.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Impulse</id>
     <version>5.35.0</version>
     <title>Units.NET Impulse - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework impulse unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Impulse/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Impulse/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/Information.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/Information.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/UnitsNet.NanoFramework.Information.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/UnitsNet.NanoFramework.Information.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Information</id>
     <version>5.35.0</version>
     <title>Units.NET Information - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework information unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/Irradiance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/Irradiance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/UnitsNet.NanoFramework.Irradiance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/UnitsNet.NanoFramework.Irradiance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Irradiance</id>
     <version>5.35.0</version>
     <title>Units.NET Irradiance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework irradiance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/Irradiation.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/Irradiation.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/UnitsNet.NanoFramework.Irradiation.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/UnitsNet.NanoFramework.Irradiation.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Irradiation</id>
     <version>5.35.0</version>
     <title>Units.NET Irradiation - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework irradiation unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Jerk/Jerk.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Jerk/Jerk.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Jerk/UnitsNet.NanoFramework.Jerk.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Jerk/UnitsNet.NanoFramework.Jerk.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Jerk</id>
     <version>5.35.0</version>
     <title>Units.NET Jerk - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework jerk unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Jerk/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Jerk/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/KinematicViscosity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/KinematicViscosity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/UnitsNet.NanoFramework.KinematicViscosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/UnitsNet.NanoFramework.KinematicViscosity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.KinematicViscosity</id>
     <version>5.35.0</version>
     <title>Units.NET KinematicViscosity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework kinematicviscosity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/LapseRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/LapseRate.nfproj
@@ -27,8 +27,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/UnitsNet.NanoFramework.LapseRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/UnitsNet.NanoFramework.LapseRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.LapseRate</id>
     <version>5.35.0</version>
     <title>Units.NET LapseRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnano1.0" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LeakRate/LeakRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LeakRate/LeakRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LeakRate/UnitsNet.NanoFramework.LeakRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LeakRate/UnitsNet.NanoFramework.LeakRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.LeakRate</id>
     <version>5.35.0</version>
     <title>Units.NET LeakRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework leakrate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LeakRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LeakRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/Length.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/Length.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/UnitsNet.NanoFramework.Length.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/UnitsNet.NanoFramework.Length.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Length</id>
     <version>5.35.0</version>
     <title>Units.NET Length - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework length unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/Level.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/Level.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/UnitsNet.NanoFramework.Level.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/UnitsNet.NanoFramework.Level.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Level</id>
     <version>5.35.0</version>
     <title>Units.NET Level - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework level unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/LinearDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/LinearDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/UnitsNet.NanoFramework.LinearDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/UnitsNet.NanoFramework.LinearDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.LinearDensity</id>
     <version>5.35.0</version>
     <title>Units.NET LinearDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework lineardensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/LinearPowerDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/LinearPowerDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/UnitsNet.NanoFramework.LinearPowerDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/UnitsNet.NanoFramework.LinearPowerDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.LinearPowerDensity</id>
     <version>5.35.0</version>
     <title>Units.NET LinearPowerDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework linearpowerdensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminance/Luminance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminance/Luminance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminance/UnitsNet.NanoFramework.Luminance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminance/UnitsNet.NanoFramework.Luminance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Luminance</id>
     <version>5.35.0</version>
     <title>Units.NET Luminance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework luminance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/Luminosity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/Luminosity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/UnitsNet.NanoFramework.Luminosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/UnitsNet.NanoFramework.Luminosity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Luminosity</id>
     <version>5.35.0</version>
     <title>Units.NET Luminosity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework luminosity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/LuminousFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/LuminousFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/UnitsNet.NanoFramework.LuminousFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/UnitsNet.NanoFramework.LuminousFlux.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.LuminousFlux</id>
     <version>5.35.0</version>
     <title>Units.NET LuminousFlux - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework luminousflux unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/LuminousIntensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/LuminousIntensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/UnitsNet.NanoFramework.LuminousIntensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/UnitsNet.NanoFramework.LuminousIntensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.LuminousIntensity</id>
     <version>5.35.0</version>
     <title>Units.NET LuminousIntensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework luminousintensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/MagneticField.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/MagneticField.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/UnitsNet.NanoFramework.MagneticField.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/UnitsNet.NanoFramework.MagneticField.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MagneticField</id>
     <version>5.35.0</version>
     <title>Units.NET MagneticField - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework magneticfield unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/MagneticFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/MagneticFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/UnitsNet.NanoFramework.MagneticFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/UnitsNet.NanoFramework.MagneticFlux.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MagneticFlux</id>
     <version>5.35.0</version>
     <title>Units.NET MagneticFlux - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework magneticflux unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/Magnetization.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/Magnetization.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/UnitsNet.NanoFramework.Magnetization.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/UnitsNet.NanoFramework.Magnetization.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Magnetization</id>
     <version>5.35.0</version>
     <title>Units.NET Magnetization - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework magnetization unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/Mass.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/Mass.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/UnitsNet.NanoFramework.Mass.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/UnitsNet.NanoFramework.Mass.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Mass</id>
     <version>5.35.0</version>
     <title>Units.NET Mass - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework mass unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/MassConcentration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/MassConcentration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/UnitsNet.NanoFramework.MassConcentration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/UnitsNet.NanoFramework.MassConcentration.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MassConcentration</id>
     <version>5.35.0</version>
     <title>Units.NET MassConcentration - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework massconcentration unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/MassFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/MassFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/UnitsNet.NanoFramework.MassFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/UnitsNet.NanoFramework.MassFlow.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MassFlow</id>
     <version>5.35.0</version>
     <title>Units.NET MassFlow - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework massflow unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/MassFlux.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/MassFlux.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/UnitsNet.NanoFramework.MassFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/UnitsNet.NanoFramework.MassFlux.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MassFlux</id>
     <version>5.35.0</version>
     <title>Units.NET MassFlux - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework massflux unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/MassFraction.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/MassFraction.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/UnitsNet.NanoFramework.MassFraction.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/UnitsNet.NanoFramework.MassFraction.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MassFraction</id>
     <version>5.35.0</version>
     <title>Units.NET MassFraction - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework massfraction unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/MassMomentOfInertia.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/MassMomentOfInertia.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/UnitsNet.NanoFramework.MassMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/UnitsNet.NanoFramework.MassMomentOfInertia.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MassMomentOfInertia</id>
     <version>5.35.0</version>
     <title>Units.NET MassMomentOfInertia - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework massmomentofinertia unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/MolarEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/MolarEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/UnitsNet.NanoFramework.MolarEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/UnitsNet.NanoFramework.MolarEnergy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MolarEnergy</id>
     <version>5.35.0</version>
     <title>Units.NET MolarEnergy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework molarenergy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/MolarEntropy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/MolarEntropy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/UnitsNet.NanoFramework.MolarEntropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/UnitsNet.NanoFramework.MolarEntropy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MolarEntropy</id>
     <version>5.35.0</version>
     <title>Units.NET MolarEntropy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework molarentropy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/MolarFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/MolarFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/UnitsNet.NanoFramework.MolarFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/UnitsNet.NanoFramework.MolarFlow.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MolarFlow</id>
     <version>5.35.0</version>
     <title>Units.NET MolarFlow - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework molarflow unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/MolarMass.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/MolarMass.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/UnitsNet.NanoFramework.MolarMass.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/UnitsNet.NanoFramework.MolarMass.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.MolarMass</id>
     <version>5.35.0</version>
     <title>Units.NET MolarMass - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework molarmass unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/Molarity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/Molarity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/UnitsNet.NanoFramework.Molarity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/UnitsNet.NanoFramework.Molarity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Molarity</id>
     <version>5.35.0</version>
     <title>Units.NET Molarity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework molarity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/Permeability.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/Permeability.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/UnitsNet.NanoFramework.Permeability.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/UnitsNet.NanoFramework.Permeability.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Permeability</id>
     <version>5.35.0</version>
     <title>Units.NET Permeability - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework permeability unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/Permittivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/Permittivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/UnitsNet.NanoFramework.Permittivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/UnitsNet.NanoFramework.Permittivity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Permittivity</id>
     <version>5.35.0</version>
     <title>Units.NET Permittivity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework permittivity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/PorousMediumPermeability.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/PorousMediumPermeability.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/UnitsNet.NanoFramework.PorousMediumPermeability.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/UnitsNet.NanoFramework.PorousMediumPermeability.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.PorousMediumPermeability</id>
     <version>5.35.0</version>
     <title>Units.NET PorousMediumPermeability - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework porousmediumpermeability unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/Power.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/Power.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/UnitsNet.NanoFramework.Power.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/UnitsNet.NanoFramework.Power.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Power</id>
     <version>5.35.0</version>
     <title>Units.NET Power - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework power unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/PowerDensity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/PowerDensity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/UnitsNet.NanoFramework.PowerDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/UnitsNet.NanoFramework.PowerDensity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.PowerDensity</id>
     <version>5.35.0</version>
     <title>Units.NET PowerDensity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework powerdensity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/PowerRatio.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/PowerRatio.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/UnitsNet.NanoFramework.PowerRatio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/UnitsNet.NanoFramework.PowerRatio.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.PowerRatio</id>
     <version>5.35.0</version>
     <title>Units.NET PowerRatio - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework powerratio unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/Pressure.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/Pressure.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.5.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.5.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/UnitsNet.NanoFramework.Pressure.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/UnitsNet.NanoFramework.Pressure.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Pressure</id>
     <version>5.35.0</version>
     <title>Units.NET Pressure - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework pressure unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.System.Math" version="1.5.29" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.System.Math" version="1.5.43" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/PressureChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/PressureChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/UnitsNet.NanoFramework.PressureChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/UnitsNet.NanoFramework.PressureChangeRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.PressureChangeRate</id>
     <version>5.35.0</version>
     <title>Units.NET PressureChangeRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework pressurechangerate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/Ratio.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/Ratio.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/UnitsNet.NanoFramework.Ratio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/UnitsNet.NanoFramework.Ratio.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Ratio</id>
     <version>5.35.0</version>
     <title>Units.NET Ratio - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework ratio unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/RatioChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/RatioChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/UnitsNet.NanoFramework.RatioChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/UnitsNet.NanoFramework.RatioChangeRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.RatioChangeRate</id>
     <version>5.35.0</version>
     <title>Units.NET RatioChangeRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework ratiochangerate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/ReactiveEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/ReactiveEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/UnitsNet.NanoFramework.ReactiveEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/UnitsNet.NanoFramework.ReactiveEnergy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ReactiveEnergy</id>
     <version>5.35.0</version>
     <title>Units.NET ReactiveEnergy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework reactiveenergy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/ReactivePower.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/ReactivePower.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/UnitsNet.NanoFramework.ReactivePower.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/UnitsNet.NanoFramework.ReactivePower.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ReactivePower</id>
     <version>5.35.0</version>
     <title>Units.NET ReactivePower - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework reactivepower unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/ReciprocalArea.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/ReciprocalArea.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/UnitsNet.NanoFramework.ReciprocalArea.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/UnitsNet.NanoFramework.ReciprocalArea.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ReciprocalArea</id>
     <version>5.35.0</version>
     <title>Units.NET ReciprocalArea - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework reciprocalarea unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/ReciprocalLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/ReciprocalLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/UnitsNet.NanoFramework.ReciprocalLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/UnitsNet.NanoFramework.ReciprocalLength.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ReciprocalLength</id>
     <version>5.35.0</version>
     <title>Units.NET ReciprocalLength - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework reciprocallength unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/RelativeHumidity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/RelativeHumidity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/UnitsNet.NanoFramework.RelativeHumidity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/UnitsNet.NanoFramework.RelativeHumidity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.RelativeHumidity</id>
     <version>5.35.0</version>
     <title>Units.NET RelativeHumidity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework relativehumidity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/RotationalAcceleration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/RotationalAcceleration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/UnitsNet.NanoFramework.RotationalAcceleration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/UnitsNet.NanoFramework.RotationalAcceleration.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.RotationalAcceleration</id>
     <version>5.35.0</version>
     <title>Units.NET RotationalAcceleration - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework rotationalacceleration unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/RotationalSpeed.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/RotationalSpeed.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/UnitsNet.NanoFramework.RotationalSpeed.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/UnitsNet.NanoFramework.RotationalSpeed.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.RotationalSpeed</id>
     <version>5.35.0</version>
     <title>Units.NET RotationalSpeed - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework rotationalspeed unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/RotationalStiffness.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/RotationalStiffness.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/UnitsNet.NanoFramework.RotationalStiffness.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/UnitsNet.NanoFramework.RotationalStiffness.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.RotationalStiffness</id>
     <version>5.35.0</version>
     <title>Units.NET RotationalStiffness - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework rotationalstiffness unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/RotationalStiffnessPerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/RotationalStiffnessPerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/UnitsNet.NanoFramework.RotationalStiffnessPerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/UnitsNet.NanoFramework.RotationalStiffnessPerLength.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.RotationalStiffnessPerLength</id>
     <version>5.35.0</version>
     <title>Units.NET RotationalStiffnessPerLength - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework rotationalstiffnessperlength unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/Scalar.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/Scalar.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/UnitsNet.NanoFramework.Scalar.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/UnitsNet.NanoFramework.Scalar.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Scalar</id>
     <version>5.35.0</version>
     <title>Units.NET Scalar - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework scalar unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/SolidAngle.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/SolidAngle.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/UnitsNet.NanoFramework.SolidAngle.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/UnitsNet.NanoFramework.SolidAngle.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.SolidAngle</id>
     <version>5.35.0</version>
     <title>Units.NET SolidAngle - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework solidangle unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/SpecificEnergy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/SpecificEnergy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/UnitsNet.NanoFramework.SpecificEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/UnitsNet.NanoFramework.SpecificEnergy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.SpecificEnergy</id>
     <version>5.35.0</version>
     <title>Units.NET SpecificEnergy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework specificenergy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/SpecificEntropy.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/SpecificEntropy.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/UnitsNet.NanoFramework.SpecificEntropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/UnitsNet.NanoFramework.SpecificEntropy.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.SpecificEntropy</id>
     <version>5.35.0</version>
     <title>Units.NET SpecificEntropy - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework specificentropy unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/SpecificFuelConsumption.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/SpecificFuelConsumption.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/UnitsNet.NanoFramework.SpecificFuelConsumption.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/UnitsNet.NanoFramework.SpecificFuelConsumption.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.SpecificFuelConsumption</id>
     <version>5.35.0</version>
     <title>Units.NET SpecificFuelConsumption - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework specificfuelconsumption unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/SpecificVolume.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/SpecificVolume.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/UnitsNet.NanoFramework.SpecificVolume.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/UnitsNet.NanoFramework.SpecificVolume.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.SpecificVolume</id>
     <version>5.35.0</version>
     <title>Units.NET SpecificVolume - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework specificvolume unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/SpecificWeight.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/SpecificWeight.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/UnitsNet.NanoFramework.SpecificWeight.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/UnitsNet.NanoFramework.SpecificWeight.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.SpecificWeight</id>
     <version>5.35.0</version>
     <title>Units.NET SpecificWeight - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework specificweight unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/Speed.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/Speed.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/UnitsNet.NanoFramework.Speed.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/UnitsNet.NanoFramework.Speed.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Speed</id>
     <version>5.35.0</version>
     <title>Units.NET Speed - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework speed unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/StandardVolumeFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/StandardVolumeFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/UnitsNet.NanoFramework.StandardVolumeFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/UnitsNet.NanoFramework.StandardVolumeFlow.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.StandardVolumeFlow</id>
     <version>5.35.0</version>
     <title>Units.NET StandardVolumeFlow - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework standardvolumeflow unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/Temperature.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/Temperature.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/UnitsNet.NanoFramework.Temperature.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/UnitsNet.NanoFramework.Temperature.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Temperature</id>
     <version>5.35.0</version>
     <title>Units.NET Temperature - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework temperature unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/TemperatureChangeRate.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/TemperatureChangeRate.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/UnitsNet.NanoFramework.TemperatureChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/UnitsNet.NanoFramework.TemperatureChangeRate.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.TemperatureChangeRate</id>
     <version>5.35.0</version>
     <title>Units.NET TemperatureChangeRate - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework temperaturechangerate unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/TemperatureDelta.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/TemperatureDelta.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/UnitsNet.NanoFramework.TemperatureDelta.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/UnitsNet.NanoFramework.TemperatureDelta.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.TemperatureDelta</id>
     <version>5.35.0</version>
     <title>Units.NET TemperatureDelta - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework temperaturedelta unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/TemperatureGradient.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/TemperatureGradient.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/UnitsNet.NanoFramework.TemperatureGradient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/UnitsNet.NanoFramework.TemperatureGradient.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.TemperatureGradient</id>
     <version>5.35.0</version>
     <title>Units.NET TemperatureGradient - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework temperaturegradient unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/ThermalConductivity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/ThermalConductivity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/UnitsNet.NanoFramework.ThermalConductivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/UnitsNet.NanoFramework.ThermalConductivity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ThermalConductivity</id>
     <version>5.35.0</version>
     <title>Units.NET ThermalConductivity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework thermalconductivity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/ThermalResistance.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/ThermalResistance.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/UnitsNet.NanoFramework.ThermalResistance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/UnitsNet.NanoFramework.ThermalResistance.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.ThermalResistance</id>
     <version>5.35.0</version>
     <title>Units.NET ThermalResistance - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework thermalresistance unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/Torque.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/Torque.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/UnitsNet.NanoFramework.Torque.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/UnitsNet.NanoFramework.Torque.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Torque</id>
     <version>5.35.0</version>
     <title>Units.NET Torque - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework torque unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/TorquePerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/TorquePerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/UnitsNet.NanoFramework.TorquePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/UnitsNet.NanoFramework.TorquePerLength.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.TorquePerLength</id>
     <version>5.35.0</version>
     <title>Units.NET TorquePerLength - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework torqueperlength unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/Turbidity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/Turbidity.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.5.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.5.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/UnitsNet.NanoFramework.Turbidity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/UnitsNet.NanoFramework.Turbidity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Turbidity</id>
     <version>5.35.0</version>
     <title>Units.NET Turbidity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework turbidity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.System.Math" version="1.5.29" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.System.Math" version="1.5.43" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/UnitsNet.NanoFramework.VitaminA.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/UnitsNet.NanoFramework.VitaminA.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.VitaminA</id>
     <version>5.35.0</version>
     <title>Units.NET VitaminA - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework vitamina unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/VitaminA.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/VitaminA.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/UnitsNet.NanoFramework.Volume.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/UnitsNet.NanoFramework.Volume.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.Volume</id>
     <version>5.35.0</version>
     <title>Units.NET Volume - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework volume unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/Volume.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/Volume.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/UnitsNet.NanoFramework.VolumeConcentration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/UnitsNet.NanoFramework.VolumeConcentration.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.VolumeConcentration</id>
     <version>5.35.0</version>
     <title>Units.NET VolumeConcentration - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework volumeconcentration unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/VolumeConcentration.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/VolumeConcentration.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/UnitsNet.NanoFramework.VolumeFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/UnitsNet.NanoFramework.VolumeFlow.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.VolumeFlow</id>
     <version>5.35.0</version>
     <title>Units.NET VolumeFlow - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework volumeflow unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/VolumeFlow.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/VolumeFlow.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/UnitsNet.NanoFramework.VolumeFlowPerArea.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/UnitsNet.NanoFramework.VolumeFlowPerArea.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.VolumeFlowPerArea</id>
     <version>5.35.0</version>
     <title>Units.NET VolumeFlowPerArea - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework volumeflowperarea unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/VolumeFlowPerArea.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/VolumeFlowPerArea.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/UnitsNet.NanoFramework.VolumePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/UnitsNet.NanoFramework.VolumePerLength.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.VolumePerLength</id>
     <version>5.35.0</version>
     <title>Units.NET VolumePerLength - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework volumeperlength unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/VolumePerLength.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/VolumePerLength.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/UnitsNet.NanoFramework.VolumetricHeatCapacity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/UnitsNet.NanoFramework.VolumetricHeatCapacity.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.VolumetricHeatCapacity</id>
     <version>5.35.0</version>
     <title>Units.NET VolumetricHeatCapacity - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,7 +17,7 @@
     <language>en-US</language>
     <tags>nanoframework volumetricheatcapacity unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/VolumetricHeatCapacity.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/VolumetricHeatCapacity.nfproj
@@ -24,8 +24,8 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
 </packages>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/UnitsNet.NanoFramework.WarpingMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/UnitsNet.NanoFramework.WarpingMomentOfInertia.nuspec
@@ -4,7 +4,7 @@
     <id>UnitsNet.nanoFramework.WarpingMomentOfInertia</id>
     <version>5.35.0</version>
     <title>Units.NET WarpingMomentOfInertia - nanoFramework</title>
-    <authors>Andreas Gullberg Larsen,nanoFramework project contributors</authors>
+    <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
     <license type="expression">MIT</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
@@ -17,8 +17,8 @@
     <language>en-US</language>
     <tags>nanoframework warpingmomentofinertia unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.14.2" />
-      <dependency id="nanoFramework.System.Math" version="1.5.29" />
+      <dependency id="nanoFramework.CoreLibrary" version="1.15.5" />
+      <dependency id="nanoFramework.System.Math" version="1.5.43" />
     </dependencies>
   </metadata>
   <files>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/WarpingMomentOfInertia.nfproj
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/WarpingMomentOfInertia.nfproj
@@ -24,13 +24,13 @@
     <Compile Include="..\Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib, Version=1.14.3.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.CoreLibrary.1.14.2\lib\mscorlib.dll</HintPath>
+    <Reference Include="mscorlib, Version=1.15.6.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.CoreLibrary.1.15.5\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>
-    <Reference Include="System.Math, Version=1.5.29.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\packages\nanoFramework.System.Math.1.5.29\lib\System.Math.dll</HintPath>
+    <Reference Include="System.Math, Version=1.5.43.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\packages\nanoFramework.System.Math.1.5.43\lib\System.Math.dll</HintPath>
       <Private>True</Private>
       <SpecificVersion>True</SpecificVersion>
     </Reference>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/packages.config
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="nanoFramework.CoreLibrary" version="1.14.2" targetFramework="netnanoframework10" />
-  <package id="nanoFramework.System.Math" version="1.5.29" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.CoreLibrary" version="1.15.5" targetFramework="netnanoframework10" />
+  <package id="nanoFramework.System.Math" version="1.5.43" targetFramework="netnanoframework10" />
 </packages>


### PR DESCRIPTION
- Bump mscorlib and Math versions, following new release of mscorlib.
- Update authors un nuspecs (and template) to use project reserved nuget.org name.