### PR TITLE
Fix typo: Celcius -> Celsius

### DIFF
--- a/Common/UnitDefinitions/TemperatureGradient.json
+++ b/Common/UnitDefinitions/TemperatureGradient.json
@@ -25,7 +25,7 @@
     },
     {
       "SingularName": "DegreeCelsiusPerMeter",
-      "PluralName": "DegreesCelciusPerMeter",
+      "PluralName": "DegreesCelsiusPerMeter",
       "BaseUnits": {
         "L": "Meter",
         "Θ": "DegreeCelsius"
@@ -57,7 +57,7 @@
     },
     {
       "SingularName": "DegreeCelsiusPerKilometer",
-      "PluralName": "DegreesCelciusPerKilometer",
+      "PluralName": "DegreesCelsiusPerKilometer",
       "BaseUnits": {
         "L": "Kilometer",
         "Θ": "DegreeCelsius"

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -82,12 +82,12 @@ namespace UnitsNet
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="TemperatureGradientUnit.DegreeCelsiusPerKilometer"/>
         /// </summary>
-        public double DegreesCelciusPerKilometer => As(TemperatureGradientUnit.DegreeCelsiusPerKilometer);
+        public double DegreesCelsiusPerKilometer => As(TemperatureGradientUnit.DegreeCelsiusPerKilometer);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="TemperatureGradientUnit.DegreeCelsiusPerMeter"/>
         /// </summary>
-        public double DegreesCelciusPerMeter => As(TemperatureGradientUnit.DegreeCelsiusPerMeter);
+        public double DegreesCelsiusPerMeter => As(TemperatureGradientUnit.DegreeCelsiusPerMeter);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="TemperatureGradientUnit.DegreeFahrenheitPerFoot"/>
@@ -107,13 +107,13 @@ namespace UnitsNet
         ///     Creates a <see cref="TemperatureGradient"/> from <see cref="TemperatureGradientUnit.DegreeCelsiusPerKilometer"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static TemperatureGradient FromDegreesCelciusPerKilometer(double degreescelciusperkilometer) => new TemperatureGradient(degreescelciusperkilometer, TemperatureGradientUnit.DegreeCelsiusPerKilometer);
+        public static TemperatureGradient FromDegreesCelsiusPerKilometer(double degreescelsiusperkilometer) => new TemperatureGradient(degreescelsiusperkilometer, TemperatureGradientUnit.DegreeCelsiusPerKilometer);
 
         /// <summary>
         ///     Creates a <see cref="TemperatureGradient"/> from <see cref="TemperatureGradientUnit.DegreeCelsiusPerMeter"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static TemperatureGradient FromDegreesCelciusPerMeter(double degreescelciuspermeter) => new TemperatureGradient(degreescelciuspermeter, TemperatureGradientUnit.DegreeCelsiusPerMeter);
+        public static TemperatureGradient FromDegreesCelsiusPerMeter(double degreescelsiuspermeter) => new TemperatureGradient(degreescelsiuspermeter, TemperatureGradientUnit.DegreeCelsiusPerMeter);
 
         /// <summary>
         ///     Creates a <see cref="TemperatureGradient"/> from <see cref="TemperatureGradientUnit.DegreeFahrenheitPerFoot"/>.

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToTemperatureGradientExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToTemperatureGradientExtensionsTest.g.cs
@@ -25,12 +25,12 @@ namespace UnitsNet.Tests
     public class NumberToTemperatureGradientExtensionsTests
     {
         [Fact]
-        public void NumberToDegreesCelciusPerKilometerTest() =>
-            Assert.Equal(TemperatureGradient.FromDegreesCelciusPerKilometer(2), 2.DegreesCelciusPerKilometer());
+        public void NumberToDegreesCelsiusPerKilometerTest() =>
+            Assert.Equal(TemperatureGradient.FromDegreesCelsiusPerKilometer(2), 2.DegreesCelsiusPerKilometer());
 
         [Fact]
-        public void NumberToDegreesCelciusPerMeterTest() =>
-            Assert.Equal(TemperatureGradient.FromDegreesCelciusPerMeter(2), 2.DegreesCelciusPerMeter());
+        public void NumberToDegreesCelsiusPerMeterTest() =>
+            Assert.Equal(TemperatureGradient.FromDegreesCelsiusPerMeter(2), 2.DegreesCelsiusPerMeter());
 
         [Fact]
         public void NumberToDegreesFahrenheitPerFootTest() =>

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToTemperatureGradientExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToTemperatureGradientExtensions.g.cs
@@ -32,21 +32,21 @@ namespace UnitsNet.NumberExtensions.NumberToTemperatureGradient
     /// </summary>
     public static class NumberToTemperatureGradientExtensions
     {
-        /// <inheritdoc cref="TemperatureGradient.FromDegreesCelciusPerKilometer(UnitsNet.QuantityValue)" />
-        public static TemperatureGradient DegreesCelciusPerKilometer<T>(this T value)
+        /// <inheritdoc cref="TemperatureGradient.FromDegreesCelsiusPerKilometer(UnitsNet.QuantityValue)" />
+        public static TemperatureGradient DegreesCelsiusPerKilometer<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
             , INumber<T>
 #endif
-            => TemperatureGradient.FromDegreesCelciusPerKilometer(Convert.ToDouble(value));
+            => TemperatureGradient.FromDegreesCelsiusPerKilometer(Convert.ToDouble(value));
 
-        /// <inheritdoc cref="TemperatureGradient.FromDegreesCelciusPerMeter(UnitsNet.QuantityValue)" />
-        public static TemperatureGradient DegreesCelciusPerMeter<T>(this T value)
+        /// <inheritdoc cref="TemperatureGradient.FromDegreesCelsiusPerMeter(UnitsNet.QuantityValue)" />
+        public static TemperatureGradient DegreesCelsiusPerMeter<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER
             , INumber<T>
 #endif
-            => TemperatureGradient.FromDegreesCelciusPerMeter(Convert.ToDouble(value));
+            => TemperatureGradient.FromDegreesCelsiusPerMeter(Convert.ToDouble(value));
 
         /// <inheritdoc cref="TemperatureGradient.FromDegreesFahrenheitPerFoot(UnitsNet.QuantityValue)" />
         public static TemperatureGradient DegreesFahrenheitPerFoot<T>(this T value)

--- a/UnitsNet.Tests/CustomCode/TemperatureGradientTests.cs
+++ b/UnitsNet.Tests/CustomCode/TemperatureGradientTests.cs
@@ -26,9 +26,9 @@ namespace UnitsNet.Tests.CustomCode
     {
         protected override bool SupportsSIUnitSystem => true;
 
-        protected override double DegreesCelciusPerKilometerInOneKelvinPerMeter => 1000;
+        protected override double DegreesCelsiusPerKilometerInOneKelvinPerMeter => 1000;
 
-        protected override double DegreesCelciusPerMeterInOneKelvinPerMeter => 1;
+        protected override double DegreesCelsiusPerMeterInOneKelvinPerMeter => 1;
 
         protected override double DegreesFahrenheitPerFootInOneKelvinPerMeter => 0.54864;
 
@@ -37,7 +37,7 @@ namespace UnitsNet.Tests.CustomCode
         [Fact]
         public void TemperatureDeltaDividedByTemperatureGradientEqualsLength()
         {
-            Length length = TemperatureDelta.FromDegreesCelsius(50) / TemperatureGradient.FromDegreesCelciusPerKilometer(5);
+            Length length = TemperatureDelta.FromDegreesCelsius(50) / TemperatureGradient.FromDegreesCelsiusPerKilometer(5);
             Assert.Equal(length, Length.FromKilometers(10));
         }
 
@@ -45,20 +45,20 @@ namespace UnitsNet.Tests.CustomCode
         public void TemperatureDeltaDividedByLengthEqualsTemperatureGradient()
         {
             TemperatureGradient temperatureGradient = TemperatureDelta.FromDegreesCelsius(50) / Length.FromKilometers(10);
-            Assert.Equal(5, temperatureGradient.DegreesCelciusPerKilometer);
+            Assert.Equal(5, temperatureGradient.DegreesCelsiusPerKilometer);
         }
 
         [Fact]
         public void LengthMultipliedByTemperatureGradientEqualsTemperatureDelta()
         {
-            TemperatureDelta temperatureDelta = Length.FromKilometers(10) * TemperatureGradient.FromDegreesCelciusPerKilometer(5);
+            TemperatureDelta temperatureDelta = Length.FromKilometers(10) * TemperatureGradient.FromDegreesCelsiusPerKilometer(5);
             Assert.Equal(temperatureDelta, TemperatureDelta.FromDegreesCelsius(50));
         }
 
         [Fact]
         public void TemperatureGradientMultipliedByLengthEqualsTemperatureDelta()
         {
-            TemperatureDelta temperatureDelta = TemperatureGradient.FromDegreesCelciusPerKilometer(5) * Length.FromKilometers(10);
+            TemperatureDelta temperatureDelta = TemperatureGradient.FromDegreesCelsiusPerKilometer(5) * Length.FromKilometers(10);
             Assert.Equal(temperatureDelta, TemperatureDelta.FromDegreesCelsius(50));
         }
     }

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
@@ -38,14 +38,14 @@ namespace UnitsNet.Tests
 // ReSharper disable once PartialTypeWithSinglePart
     public abstract partial class TemperatureGradientTestsBase : QuantityTestsBase
     {
-        protected abstract double DegreesCelciusPerKilometerInOneKelvinPerMeter { get; }
-        protected abstract double DegreesCelciusPerMeterInOneKelvinPerMeter { get; }
+        protected abstract double DegreesCelsiusPerKilometerInOneKelvinPerMeter { get; }
+        protected abstract double DegreesCelsiusPerMeterInOneKelvinPerMeter { get; }
         protected abstract double DegreesFahrenheitPerFootInOneKelvinPerMeter { get; }
         protected abstract double KelvinsPerMeterInOneKelvinPerMeter { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
-        protected virtual double DegreesCelciusPerKilometerTolerance { get { return 1e-5; } }
-        protected virtual double DegreesCelciusPerMeterTolerance { get { return 1e-5; } }
+        protected virtual double DegreesCelsiusPerKilometerTolerance { get { return 1e-5; } }
+        protected virtual double DegreesCelsiusPerMeterTolerance { get { return 1e-5; } }
         protected virtual double DegreesFahrenheitPerFootTolerance { get { return 1e-5; } }
         protected virtual double KelvinsPerMeterTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
@@ -54,8 +54,8 @@ namespace UnitsNet.Tests
         {
             return unit switch
             {
-                TemperatureGradientUnit.DegreeCelsiusPerKilometer => (DegreesCelciusPerKilometerInOneKelvinPerMeter, DegreesCelciusPerKilometerTolerance),
-                TemperatureGradientUnit.DegreeCelsiusPerMeter => (DegreesCelciusPerMeterInOneKelvinPerMeter, DegreesCelciusPerMeterTolerance),
+                TemperatureGradientUnit.DegreeCelsiusPerKilometer => (DegreesCelsiusPerKilometerInOneKelvinPerMeter, DegreesCelsiusPerKilometerTolerance),
+                TemperatureGradientUnit.DegreeCelsiusPerMeter => (DegreesCelsiusPerMeterInOneKelvinPerMeter, DegreesCelsiusPerMeterTolerance),
                 TemperatureGradientUnit.DegreeFahrenheitPerFoot => (DegreesFahrenheitPerFootInOneKelvinPerMeter, DegreesFahrenheitPerFootTolerance),
                 TemperatureGradientUnit.KelvinPerMeter => (KelvinsPerMeterInOneKelvinPerMeter, KelvinsPerMeterTolerance),
                 _ => throw new NotSupportedException()
@@ -135,8 +135,8 @@ namespace UnitsNet.Tests
         public void KelvinPerMeterToTemperatureGradientUnits()
         {
             TemperatureGradient kelvinpermeter = TemperatureGradient.FromKelvinsPerMeter(1);
-            AssertEx.EqualTolerance(DegreesCelciusPerKilometerInOneKelvinPerMeter, kelvinpermeter.DegreesCelciusPerKilometer, DegreesCelciusPerKilometerTolerance);
-            AssertEx.EqualTolerance(DegreesCelciusPerMeterInOneKelvinPerMeter, kelvinpermeter.DegreesCelciusPerMeter, DegreesCelciusPerMeterTolerance);
+            AssertEx.EqualTolerance(DegreesCelsiusPerKilometerInOneKelvinPerMeter, kelvinpermeter.DegreesCelsiusPerKilometer, DegreesCelsiusPerKilometerTolerance);
+            AssertEx.EqualTolerance(DegreesCelsiusPerMeterInOneKelvinPerMeter, kelvinpermeter.DegreesCelsiusPerMeter, DegreesCelsiusPerMeterTolerance);
             AssertEx.EqualTolerance(DegreesFahrenheitPerFootInOneKelvinPerMeter, kelvinpermeter.DegreesFahrenheitPerFoot, DegreesFahrenheitPerFootTolerance);
             AssertEx.EqualTolerance(KelvinsPerMeterInOneKelvinPerMeter, kelvinpermeter.KelvinsPerMeter, KelvinsPerMeterTolerance);
         }
@@ -145,11 +145,11 @@ namespace UnitsNet.Tests
         public void From_ValueAndUnit_ReturnsQuantityWithSameValueAndUnit()
         {
             var quantity00 = TemperatureGradient.From(1, TemperatureGradientUnit.DegreeCelsiusPerKilometer);
-            AssertEx.EqualTolerance(1, quantity00.DegreesCelciusPerKilometer, DegreesCelciusPerKilometerTolerance);
+            AssertEx.EqualTolerance(1, quantity00.DegreesCelsiusPerKilometer, DegreesCelsiusPerKilometerTolerance);
             Assert.Equal(TemperatureGradientUnit.DegreeCelsiusPerKilometer, quantity00.Unit);
 
             var quantity01 = TemperatureGradient.From(1, TemperatureGradientUnit.DegreeCelsiusPerMeter);
-            AssertEx.EqualTolerance(1, quantity01.DegreesCelciusPerMeter, DegreesCelciusPerMeterTolerance);
+            AssertEx.EqualTolerance(1, quantity01.DegreesCelsiusPerMeter, DegreesCelsiusPerMeterTolerance);
             Assert.Equal(TemperatureGradientUnit.DegreeCelsiusPerMeter, quantity01.Unit);
 
             var quantity02 = TemperatureGradient.From(1, TemperatureGradientUnit.DegreeFahrenheitPerFoot);
@@ -184,8 +184,8 @@ namespace UnitsNet.Tests
         public void As()
         {
             var kelvinpermeter = TemperatureGradient.FromKelvinsPerMeter(1);
-            AssertEx.EqualTolerance(DegreesCelciusPerKilometerInOneKelvinPerMeter, kelvinpermeter.As(TemperatureGradientUnit.DegreeCelsiusPerKilometer), DegreesCelciusPerKilometerTolerance);
-            AssertEx.EqualTolerance(DegreesCelciusPerMeterInOneKelvinPerMeter, kelvinpermeter.As(TemperatureGradientUnit.DegreeCelsiusPerMeter), DegreesCelciusPerMeterTolerance);
+            AssertEx.EqualTolerance(DegreesCelsiusPerKilometerInOneKelvinPerMeter, kelvinpermeter.As(TemperatureGradientUnit.DegreeCelsiusPerKilometer), DegreesCelsiusPerKilometerTolerance);
+            AssertEx.EqualTolerance(DegreesCelsiusPerMeterInOneKelvinPerMeter, kelvinpermeter.As(TemperatureGradientUnit.DegreeCelsiusPerMeter), DegreesCelsiusPerMeterTolerance);
             AssertEx.EqualTolerance(DegreesFahrenheitPerFootInOneKelvinPerMeter, kelvinpermeter.As(TemperatureGradientUnit.DegreeFahrenheitPerFoot), DegreesFahrenheitPerFootTolerance);
             AssertEx.EqualTolerance(KelvinsPerMeterInOneKelvinPerMeter, kelvinpermeter.As(TemperatureGradientUnit.KelvinPerMeter), KelvinsPerMeterTolerance);
         }
@@ -213,14 +213,14 @@ namespace UnitsNet.Tests
             try
             {
                 var parsed = TemperatureGradient.Parse("1 ∆°C/km", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.DegreesCelciusPerKilometer, DegreesCelciusPerKilometerTolerance);
+                AssertEx.EqualTolerance(1, parsed.DegreesCelsiusPerKilometer, DegreesCelsiusPerKilometerTolerance);
                 Assert.Equal(TemperatureGradientUnit.DegreeCelsiusPerKilometer, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
             {
                 var parsed = TemperatureGradient.Parse("1 ∆°C/m", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.DegreesCelciusPerMeter, DegreesCelciusPerMeterTolerance);
+                AssertEx.EqualTolerance(1, parsed.DegreesCelsiusPerMeter, DegreesCelsiusPerMeterTolerance);
                 Assert.Equal(TemperatureGradientUnit.DegreeCelsiusPerMeter, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
@@ -245,13 +245,13 @@ namespace UnitsNet.Tests
         {
             {
                 Assert.True(TemperatureGradient.TryParse("1 ∆°C/km", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.DegreesCelciusPerKilometer, DegreesCelciusPerKilometerTolerance);
+                AssertEx.EqualTolerance(1, parsed.DegreesCelsiusPerKilometer, DegreesCelsiusPerKilometerTolerance);
                 Assert.Equal(TemperatureGradientUnit.DegreeCelsiusPerKilometer, parsed.Unit);
             }
 
             {
                 Assert.True(TemperatureGradient.TryParse("1 ∆°C/m", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.DegreesCelciusPerMeter, DegreesCelciusPerMeterTolerance);
+                AssertEx.EqualTolerance(1, parsed.DegreesCelsiusPerMeter, DegreesCelsiusPerMeterTolerance);
                 Assert.Equal(TemperatureGradientUnit.DegreeCelsiusPerMeter, parsed.Unit);
             }
 
@@ -369,8 +369,8 @@ namespace UnitsNet.Tests
         public void ConversionRoundTrip()
         {
             TemperatureGradient kelvinpermeter = TemperatureGradient.FromKelvinsPerMeter(1);
-            AssertEx.EqualTolerance(1, TemperatureGradient.FromDegreesCelciusPerKilometer(kelvinpermeter.DegreesCelciusPerKilometer).KelvinsPerMeter, DegreesCelciusPerKilometerTolerance);
-            AssertEx.EqualTolerance(1, TemperatureGradient.FromDegreesCelciusPerMeter(kelvinpermeter.DegreesCelciusPerMeter).KelvinsPerMeter, DegreesCelciusPerMeterTolerance);
+            AssertEx.EqualTolerance(1, TemperatureGradient.FromDegreesCelsiusPerKilometer(kelvinpermeter.DegreesCelsiusPerKilometer).KelvinsPerMeter, DegreesCelsiusPerKilometerTolerance);
+            AssertEx.EqualTolerance(1, TemperatureGradient.FromDegreesCelsiusPerMeter(kelvinpermeter.DegreesCelsiusPerMeter).KelvinsPerMeter, DegreesCelsiusPerMeterTolerance);
             AssertEx.EqualTolerance(1, TemperatureGradient.FromDegreesFahrenheitPerFoot(kelvinpermeter.DegreesFahrenheitPerFoot).KelvinsPerMeter, DegreesFahrenheitPerFootTolerance);
             AssertEx.EqualTolerance(1, TemperatureGradient.FromKelvinsPerMeter(kelvinpermeter.KelvinsPerMeter).KelvinsPerMeter, KelvinsPerMeterTolerance);
         }

--- a/UnitsNet/CustomCode/Quantities/TemperatureGradient.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/TemperatureGradient.extra.cs
@@ -8,7 +8,7 @@ namespace UnitsNet
         /// <summary>Get <see cref="Length"/> from <see cref="TemperatureDelta"/> divided by <see cref="TemperatureGradient"/>.</summary>
         public static Length operator /(TemperatureDelta left, TemperatureGradient right)
         {
-            return Length.FromKilometers(left.Kelvins / right.DegreesCelciusPerKilometer);
+            return Length.FromKilometers(left.Kelvins / right.DegreesCelsiusPerKilometer);
         }
 
         /// <summary>Get <see cref="TemperatureDelta"/> from <see cref="Length"/> times <see cref="TemperatureGradient"/>.</summary>
@@ -17,7 +17,7 @@ namespace UnitsNet
         /// <summary>Get <see cref="TemperatureDelta"/> from <see cref="TemperatureGradient"/> times <see cref="Length"/>.</summary>
         public static TemperatureDelta operator *(TemperatureGradient left, Length right)
         {
-            return TemperatureDelta.FromDegreesCelsius(left.DegreesCelciusPerKilometer * right.Kilometers);
+            return TemperatureDelta.FromDegreesCelsius(left.DegreesCelsiusPerKilometer * right.Kilometers);
         }
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -65,8 +65,8 @@ namespace UnitsNet
             Info = new QuantityInfo<TemperatureGradientUnit>("TemperatureGradient",
                 new UnitInfo<TemperatureGradientUnit>[]
                 {
-                    new UnitInfo<TemperatureGradientUnit>(TemperatureGradientUnit.DegreeCelsiusPerKilometer, "DegreesCelciusPerKilometer", new BaseUnits(length: LengthUnit.Kilometer, temperature: TemperatureUnit.DegreeCelsius), "TemperatureGradient"),
-                    new UnitInfo<TemperatureGradientUnit>(TemperatureGradientUnit.DegreeCelsiusPerMeter, "DegreesCelciusPerMeter", new BaseUnits(length: LengthUnit.Meter, temperature: TemperatureUnit.DegreeCelsius), "TemperatureGradient"),
+                    new UnitInfo<TemperatureGradientUnit>(TemperatureGradientUnit.DegreeCelsiusPerKilometer, "DegreesCelsiusPerKilometer", new BaseUnits(length: LengthUnit.Kilometer, temperature: TemperatureUnit.DegreeCelsius), "TemperatureGradient"),
+                    new UnitInfo<TemperatureGradientUnit>(TemperatureGradientUnit.DegreeCelsiusPerMeter, "DegreesCelsiusPerMeter", new BaseUnits(length: LengthUnit.Meter, temperature: TemperatureUnit.DegreeCelsius), "TemperatureGradient"),
                     new UnitInfo<TemperatureGradientUnit>(TemperatureGradientUnit.DegreeFahrenheitPerFoot, "DegreesFahrenheitPerFoot", new BaseUnits(length: LengthUnit.Foot, temperature: TemperatureUnit.DegreeFahrenheit), "TemperatureGradient"),
                     new UnitInfo<TemperatureGradientUnit>(TemperatureGradientUnit.KelvinPerMeter, "KelvinsPerMeter", new BaseUnits(length: LengthUnit.Meter, temperature: TemperatureUnit.Kelvin), "TemperatureGradient"),
                 },
@@ -175,12 +175,12 @@ namespace UnitsNet
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="TemperatureGradientUnit.DegreeCelsiusPerKilometer"/>
         /// </summary>
-        public double DegreesCelciusPerKilometer => As(TemperatureGradientUnit.DegreeCelsiusPerKilometer);
+        public double DegreesCelsiusPerKilometer => As(TemperatureGradientUnit.DegreeCelsiusPerKilometer);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="TemperatureGradientUnit.DegreeCelsiusPerMeter"/>
         /// </summary>
-        public double DegreesCelciusPerMeter => As(TemperatureGradientUnit.DegreeCelsiusPerMeter);
+        public double DegreesCelsiusPerMeter => As(TemperatureGradientUnit.DegreeCelsiusPerMeter);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="TemperatureGradientUnit.DegreeFahrenheitPerFoot"/>
@@ -245,9 +245,9 @@ namespace UnitsNet
         ///     Creates a <see cref="TemperatureGradient"/> from <see cref="TemperatureGradientUnit.DegreeCelsiusPerKilometer"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static TemperatureGradient FromDegreesCelciusPerKilometer(QuantityValue degreescelciusperkilometer)
+        public static TemperatureGradient FromDegreesCelsiusPerKilometer(QuantityValue degreescelsiusperkilometer)
         {
-            double value = (double) degreescelciusperkilometer;
+            double value = (double) degreescelsiusperkilometer;
             return new TemperatureGradient(value, TemperatureGradientUnit.DegreeCelsiusPerKilometer);
         }
 
@@ -255,9 +255,9 @@ namespace UnitsNet
         ///     Creates a <see cref="TemperatureGradient"/> from <see cref="TemperatureGradientUnit.DegreeCelsiusPerMeter"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
-        public static TemperatureGradient FromDegreesCelciusPerMeter(QuantityValue degreescelciuspermeter)
+        public static TemperatureGradient FromDegreesCelsiusPerMeter(QuantityValue degreescelsiuspermeter)
         {
-            double value = (double) degreescelciuspermeter;
+            double value = (double) degreescelsiuspermeter;
             return new TemperatureGradient(value, TemperatureGradientUnit.DegreeCelsiusPerMeter);
         }
 

--- a/UnitsNet/GeneratedCode/Resources/TemperatureGradient.restext
+++ b/UnitsNet/GeneratedCode/Resources/TemperatureGradient.restext
@@ -1,4 +1,4 @@
-DegreesCelciusPerKilometer=∆°C/km
-DegreesCelciusPerMeter=∆°C/m
+DegreesCelsiusPerKilometer=∆°C/km
+DegreesCelsiusPerMeter=∆°C/m
 DegreesFahrenheitPerFoot=∆°F/ft
 KelvinsPerMeter=∆°K/m


### PR DESCRIPTION
Came across this while working on #1329. I'm afraid it's an API-breaking change, so maybe it should wait for v6?