### PR TITLE
💥🐛Change DataMember ordering to 1-indexed (#1360)

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -82,13 +82,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = ""Value"", Order = 0)]
+        [DataMember(Name = ""Value"", Order = 1)]
         private readonly {_quantity.ValueType} _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = ""Unit"", Order = 1)]
+        [DataMember(Name = ""Unit"", Order = 2)]
         private readonly {_unitEnumName}? _unit;
 ");
             GenerateStaticConstructor();

--- a/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AbsorbedDoseOfIonizingRadiationUnit? _unit;
 
         static AbsorbedDoseOfIonizingRadiation()

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AccelerationUnit? _unit;
 
         static Acceleration()

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AmountOfSubstanceUnit? _unit;
 
         static AmountOfSubstance()

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AmplitudeRatioUnit? _unit;
 
         static AmplitudeRatio()

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AngleUnit? _unit;
 
         static Angle()

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ApparentEnergyUnit? _unit;
 
         static ApparentEnergy()

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ApparentPowerUnit? _unit;
 
         static ApparentPower()

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AreaUnit? _unit;
 
         static Area()

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AreaDensityUnit? _unit;
 
         static AreaDensity()

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly AreaMomentOfInertiaUnit? _unit;
 
         static AreaMomentOfInertia()

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -51,13 +51,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly decimal _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly BitRateUnit? _unit;
 
         static BitRate()

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly BrakeSpecificFuelConsumptionUnit? _unit;
 
         static BrakeSpecificFuelConsumption()

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly CapacitanceUnit? _unit;
 
         static Capacitance()

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly CoefficientOfThermalExpansionUnit? _unit;
 
         static CoefficientOfThermalExpansion()

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly CompressibilityUnit? _unit;
 
         static Compressibility()

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly DensityUnit? _unit;
 
         static Density()

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly DurationUnit? _unit;
 
         static Duration()

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly DynamicViscosityUnit? _unit;
 
         static DynamicViscosity()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricAdmittanceUnit? _unit;
 
         static ElectricAdmittance()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricChargeUnit? _unit;
 
         static ElectricCharge()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricChargeDensityUnit? _unit;
 
         static ElectricChargeDensity()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricConductanceUnit? _unit;
 
         static ElectricConductance()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricConductivityUnit? _unit;
 
         static ElectricConductivity()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricCurrentUnit? _unit;
 
         static ElectricCurrent()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricCurrentDensityUnit? _unit;
 
         static ElectricCurrentDensity()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricCurrentGradientUnit? _unit;
 
         static ElectricCurrentGradient()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricFieldUnit? _unit;
 
         static ElectricField()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricInductanceUnit? _unit;
 
         static ElectricInductance()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricPotentialUnit? _unit;
 
         static ElectricPotential()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricPotentialAcUnit? _unit;
 
         static ElectricPotentialAc()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricPotentialChangeRateUnit? _unit;
 
         static ElectricPotentialChangeRate()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricPotentialDcUnit? _unit;
 
         static ElectricPotentialDc()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricResistanceUnit? _unit;
 
         static ElectricResistance()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricResistivityUnit? _unit;
 
         static ElectricResistivity()

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ElectricSurfaceChargeDensityUnit? _unit;
 
         static ElectricSurfaceChargeDensity()

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly EnergyUnit? _unit;
 
         static Energy()

--- a/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly EnergyDensityUnit? _unit;
 
         static EnergyDensity()

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly EntropyUnit? _unit;
 
         static Entropy()

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ForceUnit? _unit;
 
         static Force()

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ForceChangeRateUnit? _unit;
 
         static ForceChangeRate()

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ForcePerLengthUnit? _unit;
 
         static ForcePerLength()

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly FrequencyUnit? _unit;
 
         static Frequency()

--- a/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly FuelEfficiencyUnit? _unit;
 
         static FuelEfficiency()

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly HeatFluxUnit? _unit;
 
         static HeatFlux()

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly HeatTransferCoefficientUnit? _unit;
 
         static HeatTransferCoefficient()

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly IlluminanceUnit? _unit;
 
         static Illuminance()

--- a/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ImpulseUnit? _unit;
 
         static Impulse()

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -48,13 +48,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly decimal _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly InformationUnit? _unit;
 
         static Information()

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly IrradianceUnit? _unit;
 
         static Irradiance()

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly IrradiationUnit? _unit;
 
         static Irradiation()

--- a/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly JerkUnit? _unit;
 
         static Jerk()

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly KinematicViscosityUnit? _unit;
 
         static KinematicViscosity()

--- a/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LeakRateUnit? _unit;
 
         static LeakRate()

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LengthUnit? _unit;
 
         static Length()

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LevelUnit? _unit;
 
         static Level()

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LinearDensityUnit? _unit;
 
         static LinearDensity()

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LinearPowerDensityUnit? _unit;
 
         static LinearPowerDensity()

--- a/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LuminanceUnit? _unit;
 
         static Luminance()

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LuminosityUnit? _unit;
 
         static Luminosity()

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LuminousFluxUnit? _unit;
 
         static LuminousFlux()

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly LuminousIntensityUnit? _unit;
 
         static LuminousIntensity()

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MagneticFieldUnit? _unit;
 
         static MagneticField()

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MagneticFluxUnit? _unit;
 
         static MagneticFlux()

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MagnetizationUnit? _unit;
 
         static Magnetization()

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MassUnit? _unit;
 
         static Mass()

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MassConcentrationUnit? _unit;
 
         static MassConcentration()

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MassFlowUnit? _unit;
 
         static MassFlow()

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MassFluxUnit? _unit;
 
         static MassFlux()

--- a/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MassFractionUnit? _unit;
 
         static MassFraction()

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MassMomentOfInertiaUnit? _unit;
 
         static MassMomentOfInertia()

--- a/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MolalityUnit? _unit;
 
         static Molality()

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MolarEnergyUnit? _unit;
 
         static MolarEnergy()

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MolarEntropyUnit? _unit;
 
         static MolarEntropy()

--- a/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MolarFlowUnit? _unit;
 
         static MolarFlow()

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MolarMassUnit? _unit;
 
         static MolarMass()

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly MolarityUnit? _unit;
 
         static Molarity()

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PermeabilityUnit? _unit;
 
         static Permeability()

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PermittivityUnit? _unit;
 
         static Permittivity()

--- a/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PorousMediumPermeabilityUnit? _unit;
 
         static PorousMediumPermeability()

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -48,13 +48,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly decimal _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PowerUnit? _unit;
 
         static Power()

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PowerDensityUnit? _unit;
 
         static PowerDensity()

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PowerRatioUnit? _unit;
 
         static PowerRatio()

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PressureUnit? _unit;
 
         static Pressure()

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly PressureChangeRateUnit? _unit;
 
         static PressureChangeRate()

--- a/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RadiationExposureUnit? _unit;
 
         static RadiationExposure()

--- a/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RadioactivityUnit? _unit;
 
         static Radioactivity()

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RatioUnit? _unit;
 
         static Ratio()

--- a/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RatioChangeRateUnit? _unit;
 
         static RatioChangeRate()

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ReactiveEnergyUnit? _unit;
 
         static ReactiveEnergy()

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ReactivePowerUnit? _unit;
 
         static ReactivePower()

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ReciprocalAreaUnit? _unit;
 
         static ReciprocalArea()

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ReciprocalLengthUnit? _unit;
 
         static ReciprocalLength()

--- a/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RelativeHumidityUnit? _unit;
 
         static RelativeHumidity()

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RotationalAccelerationUnit? _unit;
 
         static RotationalAcceleration()

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RotationalSpeedUnit? _unit;
 
         static RotationalSpeed()

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RotationalStiffnessUnit? _unit;
 
         static RotationalStiffness()

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly RotationalStiffnessPerLengthUnit? _unit;
 
         static RotationalStiffnessPerLength()

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ScalarUnit? _unit;
 
         static Scalar()

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SolidAngleUnit? _unit;
 
         static SolidAngle()

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SpecificEnergyUnit? _unit;
 
         static SpecificEnergy()

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SpecificEntropyUnit? _unit;
 
         static SpecificEntropy()

--- a/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SpecificFuelConsumptionUnit? _unit;
 
         static SpecificFuelConsumption()

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SpecificVolumeUnit? _unit;
 
         static SpecificVolume()

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SpecificWeightUnit? _unit;
 
         static SpecificWeight()

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly SpeedUnit? _unit;
 
         static Speed()

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly StandardVolumeFlowUnit? _unit;
 
         static StandardVolumeFlow()

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TemperatureUnit? _unit;
 
         static Temperature()

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TemperatureChangeRateUnit? _unit;
 
         static TemperatureChangeRate()

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TemperatureDeltaUnit? _unit;
 
         static TemperatureDelta()

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TemperatureGradientUnit? _unit;
 
         static TemperatureGradient()

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ThermalConductivityUnit? _unit;
 
         static ThermalConductivity()

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly ThermalResistanceUnit? _unit;
 
         static ThermalResistance()

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TorqueUnit? _unit;
 
         static Torque()

--- a/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TorquePerLengthUnit? _unit;
 
         static TorquePerLength()

--- a/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly TurbidityUnit? _unit;
 
         static Turbidity()

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VitaminAUnit? _unit;
 
         static VitaminA()

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VolumeUnit? _unit;
 
         static Volume()

--- a/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VolumeConcentrationUnit? _unit;
 
         static VolumeConcentration()

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VolumeFlowUnit? _unit;
 
         static VolumeFlow()

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VolumeFlowPerAreaUnit? _unit;
 
         static VolumeFlowPerArea()

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VolumePerLengthUnit? _unit;
 
         static VolumePerLength()

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -50,13 +50,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly VolumetricHeatCapacityUnit? _unit;
 
         static VolumetricHeatCapacity()

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -47,13 +47,13 @@ namespace UnitsNet
         /// <summary>
         ///     The numeric value this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Value", Order = 0)]
+        [DataMember(Name = "Value", Order = 1)]
         private readonly double _value;
 
         /// <summary>
         ///     The unit this quantity was constructed with.
         /// </summary>
-        [DataMember(Name = "Unit", Order = 1)]
+        [DataMember(Name = "Unit", Order = 2)]
         private readonly WarpingMomentOfInertiaUnit? _unit;
 
         static WarpingMomentOfInertia()


### PR DESCRIPTION
Backport of #1360 to v5 (master).

Related #1200
Fixes #1356

Apparently, protobuf-net does not support 0-indexed order values.

- Change `DataMember` explicit order from 0-indexed to 1-indexed

Some investigation indicates that the actual order value is not important, only the relative ordering: https://github.com/angularsen/UnitsNet/issues/1356#issuecomment-1900278438

- WCF should tolerate this, according to its docs. https://github.com/angularsen/UnitsNet/issues/1356#issuecomment-1900278438
- Binary formatters hopefully only care about relative ordering and thus still compatible?
	- Protobuf-net, it never worked and should be OK
	- [BinaryFormatter](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.serialization.formatters.binary.binaryformatter?view=net-8.0) is obsolete and generally not recommended for years, so hopefully no users are affected
	- A bunch of others exist too, haven't looked into how they handle this
- XML/JSON serializers should tolerate any order, can't imagine it breaking these?