### PR TITLE
Add type safety and improve type inference

### DIFF
--- a/UnitsNet.Tests/UnitMathTests.cs
+++ b/UnitsNet.Tests/UnitMathTests.cs
@@ -46,27 +46,11 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void AverageOfDifferentUnitsThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
-
-            Assert.Throws<ArgumentException>(() => units.Average(LengthUnit.Centimeter));
-        }
-
-        [Fact]
         public void AverageOfEmptySourceThrowsException()
         {
             var units = new Length[] { };
 
             Assert.Throws<InvalidOperationException>(() => units.Average(LengthUnit.Centimeter));
-        }
-
-        [Fact]
-        public void AverageOfLengthsWithNullValueThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), null!};
-
-            Assert.Throws<NullReferenceException>(() => units.Average(LengthUnit.Centimeter));
         }
 
         [Fact]
@@ -117,22 +101,6 @@ namespace UnitsNet.Tests
 
             Assert.Equal(1, max.Value);
             Assert.Equal(LengthUnit.Meter, max.Unit);
-        }
-
-        [Fact]
-        public void MaxOfDifferentUnitsThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
-
-            Assert.Throws<ArgumentException>(() => units.Max(LengthUnit.Centimeter));
-        }
-
-        [Fact]
-        public void MaxOfLengthsWithNullValueThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), null!};
-
-            Assert.Throws<NullReferenceException>(() => units.Max(LengthUnit.Centimeter));
         }
 
         [Fact]
@@ -194,22 +162,6 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void MinOfDifferentUnitsThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
-
-            Assert.Throws<ArgumentException>(() => units.Min(LengthUnit.Centimeter));
-        }
-
-        [Fact]
-        public void MinOfLengthsWithNullValueThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), null!};
-
-            Assert.Throws<NullReferenceException>(() => units.Min(LengthUnit.Centimeter));
-        }
-
-        [Fact]
         public void MinOfEmptySourceThrowsException()
         {
             var units = new Length[] { };
@@ -253,22 +205,6 @@ namespace UnitsNet.Tests
 
             Assert.Equal(50, min.Value);
             Assert.Equal(LengthUnit.Centimeter, min.Unit);
-        }
-
-        [Fact]
-        public void SumOfDifferentUnitsThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), Volume.FromLiters(50)};
-
-            Assert.Throws<ArgumentException>(() => units.Sum(LengthUnit.Centimeter));
-        }
-
-        [Fact]
-        public void SumOfLengthsWithNullValueThrowsException()
-        {
-            var units = new IQuantity[] {Length.FromMeters(1), null!};
-
-            Assert.Throws<NullReferenceException>(() => units.Sum(LengthUnit.Centimeter));
         }
 
         [Fact]

--- a/UnitsNet/UnitMath.cs
+++ b/UnitsNet/UnitMath.cs
@@ -30,8 +30,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Sum<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Sum<TQuantity, TUnitType>(this IEnumerable<TQuantity> source, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return (TQuantity) Quantity.From(source.Sum(x => x.As(unitType)), unitType);
         }
@@ -44,7 +45,8 @@ namespace UnitsNet
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <param name="unitType">The desired unit type for the resulting quantity</param>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>
-        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation.</typeparam>
+        /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         /// <returns>The sum of the projected values, represented in the specified unit type.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
@@ -52,8 +54,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Sum<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Sum<TSource, TQuantity, TUnitType>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return source.Select(selector).Sum(unitType);
         }
@@ -79,8 +82,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Min<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Min<TQuantity, TUnitType>(this IEnumerable<TQuantity> source, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return (TQuantity) Quantity.From(source.Min(x => x.As(unitType)), unitType);
         }
@@ -93,7 +97,8 @@ namespace UnitsNet
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <param name="unitType">The desired unit type for the resulting quantity</param>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>
-        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation.</typeparam>
+        /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         /// <returns>The min of the projected values, represented in the specified unit type.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
@@ -102,8 +107,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Min<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Min<TSource, TQuantity, TUnitType>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return source.Select(selector).Min(unitType);
         }
@@ -129,8 +135,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Max<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Max<TQuantity, TUnitType>(this IEnumerable<TQuantity> source, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return (TQuantity) Quantity.From(source.Max(x => x.As(unitType)), unitType);
         }
@@ -143,7 +150,8 @@ namespace UnitsNet
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <param name="unitType">The desired unit type for the resulting quantity</param>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>
-        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation.</typeparam>
+        /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         /// <returns>The max of the projected values, represented in the specified unit type.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
@@ -152,8 +160,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Max<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Max<TSource, TQuantity, TUnitType>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return source.Select(selector).Max(unitType);
         }
@@ -169,8 +178,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Average<TQuantity>(this IEnumerable<TQuantity> source, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Average<TQuantity, TUnitType>(this IEnumerable<TQuantity> source, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return (TQuantity) Quantity.From(source.Average(x => x.As(unitType)), unitType);
         }
@@ -183,7 +193,8 @@ namespace UnitsNet
         /// <param name="selector">A transform function to apply to each element.</param>
         /// <param name="unitType">The desired unit type for the resulting quantity</param>
         /// <typeparam name="TSource">The type of the elements of source.</typeparam>
-        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation</typeparam>
+        /// <typeparam name="TQuantity">The type of quantity that is produced by this operation.</typeparam>
+        /// <typeparam name="TUnitType">The type of unit enum.</typeparam>
         /// <returns>The average of the projected values, represented in the specified unit type.</returns>
         /// <exception cref="T:System.ArgumentNullException">
         ///     <paramref name="source">source</paramref> or <paramref name="selector">selector</paramref> is null.
@@ -192,8 +203,9 @@ namespace UnitsNet
         /// <exception cref="ArgumentException">
         ///     <paramref name="source">source</paramref> contains quantity types different from <paramref name="unitType" />.
         /// </exception>
-        public static TQuantity Average<TSource, TQuantity>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, Enum unitType)
-            where TQuantity : IQuantity
+        public static TQuantity Average<TSource, TQuantity, TUnitType>(this IEnumerable<TSource> source, Func<TSource, TQuantity> selector, TUnitType unitType)
+            where TUnitType : Enum
+            where TQuantity : IQuantity<TUnitType>
         {
             return source.Select(selector).Average(unitType);
         }


### PR DESCRIPTION
Some of the extension methods in `UnitMath.cs` (e.g. Average) take an `Enum unitType` argument.
The compiler should be able to detect when the units type doesn't match the quantity type.

* This will break backwards compatibility, but only for:
  * People doing really weird things.
  * People using the explicit generic type instead of inference (e.g. `Average<Length>(LengthUnit.Inch)`), in which case they can fix the code by changing it to e.g. `Average<Length, LengthUnit>(LengthUnit.Inch)`
* This change might be warranted in `UnitConverter.cs` as well, but can't be implemented as a straight-forward refactor since it breaks compatibility in generated code (e.g. `unitConverter.SetConversionFunction<ElectricPotential>` in `ElectricPotential` should be `SetConversionFunction<ElectricPotential, ElectricPotentialUnit>`

In addition, had to remove a few unit tests that were asserting type safety.
All tests that were removed:
* Were only testing that an incorrect behavior throws an exception (`Assert.Throws`)
* Don't compile after the changes in `UnitMath.cs`