### PR TITLE
👔Change nuget license from MIT to MIT-0

### DIFF
--- a/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
@@ -29,7 +29,7 @@ namespace CodeGen.Generators.NanoFrameworkGen
     <title>Units.NET {_quantity.Name} - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type=""expression"">MIT</license>
+    <license type=""expression"">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds {_quantity.Name} units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/UnitsNet.NanoFramework.AbsorbedDoseOfIonizingRadiation.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AbsorbedDoseOfIonizingRadiation/UnitsNet.NanoFramework.AbsorbedDoseOfIonizingRadiation.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET AbsorbedDoseOfIonizingRadiation - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds AbsorbedDoseOfIonizingRadiation units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Acceleration/UnitsNet.NanoFramework.Acceleration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Acceleration/UnitsNet.NanoFramework.Acceleration.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Acceleration - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Acceleration units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/UnitsNet.NanoFramework.AmountOfSubstance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmountOfSubstance/UnitsNet.NanoFramework.AmountOfSubstance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET AmountOfSubstance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds AmountOfSubstance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/UnitsNet.NanoFramework.AmplitudeRatio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AmplitudeRatio/UnitsNet.NanoFramework.AmplitudeRatio.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET AmplitudeRatio - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds AmplitudeRatio units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Angle/UnitsNet.NanoFramework.Angle.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Angle/UnitsNet.NanoFramework.Angle.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Angle - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Angle units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/UnitsNet.NanoFramework.ApparentEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentEnergy/UnitsNet.NanoFramework.ApparentEnergy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ApparentEnergy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ApparentEnergy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/UnitsNet.NanoFramework.ApparentPower.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ApparentPower/UnitsNet.NanoFramework.ApparentPower.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ApparentPower - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ApparentPower units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Area/UnitsNet.NanoFramework.Area.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Area/UnitsNet.NanoFramework.Area.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Area - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Area units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/UnitsNet.NanoFramework.AreaDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaDensity/UnitsNet.NanoFramework.AreaDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET AreaDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds AreaDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/UnitsNet.NanoFramework.AreaMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/AreaMomentOfInertia/UnitsNet.NanoFramework.AreaMomentOfInertia.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET AreaMomentOfInertia - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds AreaMomentOfInertia units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/BitRate/UnitsNet.NanoFramework.BitRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/BitRate/UnitsNet.NanoFramework.BitRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET BitRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds BitRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/UnitsNet.NanoFramework.BrakeSpecificFuelConsumption.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/BrakeSpecificFuelConsumption/UnitsNet.NanoFramework.BrakeSpecificFuelConsumption.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET BrakeSpecificFuelConsumption - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds BrakeSpecificFuelConsumption units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Capacitance/UnitsNet.NanoFramework.Capacitance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Capacitance/UnitsNet.NanoFramework.Capacitance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Capacitance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Capacitance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/UnitsNet.NanoFramework.CoefficientOfThermalExpansion.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/CoefficientOfThermalExpansion/UnitsNet.NanoFramework.CoefficientOfThermalExpansion.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET CoefficientOfThermalExpansion - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds CoefficientOfThermalExpansion units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Compressibility/UnitsNet.NanoFramework.Compressibility.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Compressibility/UnitsNet.NanoFramework.Compressibility.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Compressibility - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Compressibility units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Density/UnitsNet.NanoFramework.Density.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Density/UnitsNet.NanoFramework.Density.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Density - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Density units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Duration/UnitsNet.NanoFramework.Duration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Duration/UnitsNet.NanoFramework.Duration.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Duration - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Duration units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/UnitsNet.NanoFramework.DynamicViscosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/DynamicViscosity/UnitsNet.NanoFramework.DynamicViscosity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET DynamicViscosity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds DynamicViscosity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/UnitsNet.NanoFramework.ElectricAdmittance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricAdmittance/UnitsNet.NanoFramework.ElectricAdmittance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricAdmittance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricAdmittance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/UnitsNet.NanoFramework.ElectricCharge.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCharge/UnitsNet.NanoFramework.ElectricCharge.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricCharge - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricCharge units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/UnitsNet.NanoFramework.ElectricChargeDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricChargeDensity/UnitsNet.NanoFramework.ElectricChargeDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricChargeDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricChargeDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/UnitsNet.NanoFramework.ElectricConductance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductance/UnitsNet.NanoFramework.ElectricConductance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricConductance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricConductance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/UnitsNet.NanoFramework.ElectricConductivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricConductivity/UnitsNet.NanoFramework.ElectricConductivity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricConductivity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricConductivity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/UnitsNet.NanoFramework.ElectricCurrent.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrent/UnitsNet.NanoFramework.ElectricCurrent.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricCurrent - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricCurrent units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/UnitsNet.NanoFramework.ElectricCurrentDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentDensity/UnitsNet.NanoFramework.ElectricCurrentDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricCurrentDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricCurrentDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/UnitsNet.NanoFramework.ElectricCurrentGradient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricCurrentGradient/UnitsNet.NanoFramework.ElectricCurrentGradient.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricCurrentGradient - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricCurrentGradient units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricField/UnitsNet.NanoFramework.ElectricField.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricField/UnitsNet.NanoFramework.ElectricField.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricField - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricField units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/UnitsNet.NanoFramework.ElectricInductance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricInductance/UnitsNet.NanoFramework.ElectricInductance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricInductance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricInductance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/UnitsNet.NanoFramework.ElectricPotential.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotential/UnitsNet.NanoFramework.ElectricPotential.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricPotential - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricPotential units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/UnitsNet.NanoFramework.ElectricPotentialAc.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialAc/UnitsNet.NanoFramework.ElectricPotentialAc.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricPotentialAc - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricPotentialAc units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/UnitsNet.NanoFramework.ElectricPotentialChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialChangeRate/UnitsNet.NanoFramework.ElectricPotentialChangeRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricPotentialChangeRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricPotentialChangeRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/UnitsNet.NanoFramework.ElectricPotentialDc.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricPotentialDc/UnitsNet.NanoFramework.ElectricPotentialDc.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricPotentialDc - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricPotentialDc units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/UnitsNet.NanoFramework.ElectricResistance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistance/UnitsNet.NanoFramework.ElectricResistance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricResistance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricResistance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/UnitsNet.NanoFramework.ElectricResistivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricResistivity/UnitsNet.NanoFramework.ElectricResistivity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricResistivity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricResistivity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/UnitsNet.NanoFramework.ElectricSurfaceChargeDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ElectricSurfaceChargeDensity/UnitsNet.NanoFramework.ElectricSurfaceChargeDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ElectricSurfaceChargeDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ElectricSurfaceChargeDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Energy/UnitsNet.NanoFramework.Energy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Energy/UnitsNet.NanoFramework.Energy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Energy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Energy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/UnitsNet.NanoFramework.EnergyDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/EnergyDensity/UnitsNet.NanoFramework.EnergyDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET EnergyDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds EnergyDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Entropy/UnitsNet.NanoFramework.Entropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Entropy/UnitsNet.NanoFramework.Entropy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Entropy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Entropy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Force/UnitsNet.NanoFramework.Force.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Force/UnitsNet.NanoFramework.Force.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Force - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Force units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/UnitsNet.NanoFramework.ForceChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForceChangeRate/UnitsNet.NanoFramework.ForceChangeRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ForceChangeRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ForceChangeRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/UnitsNet.NanoFramework.ForcePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ForcePerLength/UnitsNet.NanoFramework.ForcePerLength.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ForcePerLength - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ForcePerLength units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Frequency/UnitsNet.NanoFramework.Frequency.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Frequency/UnitsNet.NanoFramework.Frequency.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Frequency - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Frequency units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/UnitsNet.NanoFramework.FuelEfficiency.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/FuelEfficiency/UnitsNet.NanoFramework.FuelEfficiency.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET FuelEfficiency - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds FuelEfficiency units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/UnitsNet.NanoFramework.HeatFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatFlux/UnitsNet.NanoFramework.HeatFlux.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET HeatFlux - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds HeatFlux units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/UnitsNet.NanoFramework.HeatTransferCoefficient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/HeatTransferCoefficient/UnitsNet.NanoFramework.HeatTransferCoefficient.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET HeatTransferCoefficient - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds HeatTransferCoefficient units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Illuminance/UnitsNet.NanoFramework.Illuminance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Illuminance/UnitsNet.NanoFramework.Illuminance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Illuminance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Illuminance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Impulse/UnitsNet.NanoFramework.Impulse.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Impulse/UnitsNet.NanoFramework.Impulse.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Impulse - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Impulse units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Information/UnitsNet.NanoFramework.Information.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Information/UnitsNet.NanoFramework.Information.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Information - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Information units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiance/UnitsNet.NanoFramework.Irradiance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiance/UnitsNet.NanoFramework.Irradiance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Irradiance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Irradiance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Irradiation/UnitsNet.NanoFramework.Irradiation.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Irradiation/UnitsNet.NanoFramework.Irradiation.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Irradiation - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Irradiation units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Jerk/UnitsNet.NanoFramework.Jerk.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Jerk/UnitsNet.NanoFramework.Jerk.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Jerk - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Jerk units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/UnitsNet.NanoFramework.KinematicViscosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/KinematicViscosity/UnitsNet.NanoFramework.KinematicViscosity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET KinematicViscosity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds KinematicViscosity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/LapseRate/UnitsNet.NanoFramework.LapseRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LapseRate/UnitsNet.NanoFramework.LapseRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET LapseRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds LapseRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/LeakRate/UnitsNet.NanoFramework.LeakRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LeakRate/UnitsNet.NanoFramework.LeakRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET LeakRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds LeakRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Length/UnitsNet.NanoFramework.Length.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Length/UnitsNet.NanoFramework.Length.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Length - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Length units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Level/UnitsNet.NanoFramework.Level.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Level/UnitsNet.NanoFramework.Level.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Level - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Level units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/UnitsNet.NanoFramework.LinearDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearDensity/UnitsNet.NanoFramework.LinearDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET LinearDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds LinearDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/UnitsNet.NanoFramework.LinearPowerDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LinearPowerDensity/UnitsNet.NanoFramework.LinearPowerDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET LinearPowerDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds LinearPowerDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminance/UnitsNet.NanoFramework.Luminance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminance/UnitsNet.NanoFramework.Luminance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Luminance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Luminance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Luminosity/UnitsNet.NanoFramework.Luminosity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Luminosity/UnitsNet.NanoFramework.Luminosity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Luminosity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Luminosity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/UnitsNet.NanoFramework.LuminousFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousFlux/UnitsNet.NanoFramework.LuminousFlux.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET LuminousFlux - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds LuminousFlux units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/UnitsNet.NanoFramework.LuminousIntensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/LuminousIntensity/UnitsNet.NanoFramework.LuminousIntensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET LuminousIntensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds LuminousIntensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticField/UnitsNet.NanoFramework.MagneticField.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticField/UnitsNet.NanoFramework.MagneticField.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MagneticField - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MagneticField units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/UnitsNet.NanoFramework.MagneticFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MagneticFlux/UnitsNet.NanoFramework.MagneticFlux.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MagneticFlux - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MagneticFlux units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Magnetization/UnitsNet.NanoFramework.Magnetization.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Magnetization/UnitsNet.NanoFramework.Magnetization.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Magnetization - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Magnetization units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Mass/UnitsNet.NanoFramework.Mass.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Mass/UnitsNet.NanoFramework.Mass.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Mass - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Mass units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/UnitsNet.NanoFramework.MassConcentration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassConcentration/UnitsNet.NanoFramework.MassConcentration.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MassConcentration - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MassConcentration units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlow/UnitsNet.NanoFramework.MassFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlow/UnitsNet.NanoFramework.MassFlow.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MassFlow - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MassFlow units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFlux/UnitsNet.NanoFramework.MassFlux.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFlux/UnitsNet.NanoFramework.MassFlux.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MassFlux - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MassFlux units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassFraction/UnitsNet.NanoFramework.MassFraction.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassFraction/UnitsNet.NanoFramework.MassFraction.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MassFraction - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MassFraction units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/UnitsNet.NanoFramework.MassMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MassMomentOfInertia/UnitsNet.NanoFramework.MassMomentOfInertia.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MassMomentOfInertia - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MassMomentOfInertia units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molality/UnitsNet.NanoFramework.Molality.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molality/UnitsNet.NanoFramework.Molality.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Molality - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Molality units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/UnitsNet.NanoFramework.MolarEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEnergy/UnitsNet.NanoFramework.MolarEnergy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MolarEnergy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MolarEnergy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/UnitsNet.NanoFramework.MolarEntropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarEntropy/UnitsNet.NanoFramework.MolarEntropy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MolarEntropy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MolarEntropy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/UnitsNet.NanoFramework.MolarFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarFlow/UnitsNet.NanoFramework.MolarFlow.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MolarFlow - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MolarFlow units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/MolarMass/UnitsNet.NanoFramework.MolarMass.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/MolarMass/UnitsNet.NanoFramework.MolarMass.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET MolarMass - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds MolarMass units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Molarity/UnitsNet.NanoFramework.Molarity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Molarity/UnitsNet.NanoFramework.Molarity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Molarity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Molarity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permeability/UnitsNet.NanoFramework.Permeability.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permeability/UnitsNet.NanoFramework.Permeability.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Permeability - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Permeability units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Permittivity/UnitsNet.NanoFramework.Permittivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Permittivity/UnitsNet.NanoFramework.Permittivity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Permittivity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Permittivity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/UnitsNet.NanoFramework.PorousMediumPermeability.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PorousMediumPermeability/UnitsNet.NanoFramework.PorousMediumPermeability.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET PorousMediumPermeability - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds PorousMediumPermeability units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Power/UnitsNet.NanoFramework.Power.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Power/UnitsNet.NanoFramework.Power.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Power - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Power units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/UnitsNet.NanoFramework.PowerDensity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerDensity/UnitsNet.NanoFramework.PowerDensity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET PowerDensity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds PowerDensity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/UnitsNet.NanoFramework.PowerRatio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PowerRatio/UnitsNet.NanoFramework.PowerRatio.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET PowerRatio - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds PowerRatio units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Pressure/UnitsNet.NanoFramework.Pressure.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Pressure/UnitsNet.NanoFramework.Pressure.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Pressure - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Pressure units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/UnitsNet.NanoFramework.PressureChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/PressureChangeRate/UnitsNet.NanoFramework.PressureChangeRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET PressureChangeRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds PressureChangeRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RadiationEquivalentDose/UnitsNet.NanoFramework.RadiationEquivalentDose.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RadiationEquivalentDose/UnitsNet.NanoFramework.RadiationEquivalentDose.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RadiationEquivalentDose - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RadiationEquivalentDose units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RadiationExposure/UnitsNet.NanoFramework.RadiationExposure.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RadiationExposure/UnitsNet.NanoFramework.RadiationExposure.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RadiationExposure - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RadiationExposure units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Radioactivity/UnitsNet.NanoFramework.Radioactivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Radioactivity/UnitsNet.NanoFramework.Radioactivity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Radioactivity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Radioactivity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Ratio/UnitsNet.NanoFramework.Ratio.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Ratio/UnitsNet.NanoFramework.Ratio.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Ratio - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Ratio units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/UnitsNet.NanoFramework.RatioChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RatioChangeRate/UnitsNet.NanoFramework.RatioChangeRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RatioChangeRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RatioChangeRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/UnitsNet.NanoFramework.ReactiveEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactiveEnergy/UnitsNet.NanoFramework.ReactiveEnergy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ReactiveEnergy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ReactiveEnergy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/UnitsNet.NanoFramework.ReactivePower.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReactivePower/UnitsNet.NanoFramework.ReactivePower.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ReactivePower - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ReactivePower units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/UnitsNet.NanoFramework.ReciprocalArea.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalArea/UnitsNet.NanoFramework.ReciprocalArea.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ReciprocalArea - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ReciprocalArea units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/UnitsNet.NanoFramework.ReciprocalLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ReciprocalLength/UnitsNet.NanoFramework.ReciprocalLength.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ReciprocalLength - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ReciprocalLength units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/UnitsNet.NanoFramework.RelativeHumidity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RelativeHumidity/UnitsNet.NanoFramework.RelativeHumidity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RelativeHumidity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RelativeHumidity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/UnitsNet.NanoFramework.RotationalAcceleration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalAcceleration/UnitsNet.NanoFramework.RotationalAcceleration.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RotationalAcceleration - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RotationalAcceleration units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/UnitsNet.NanoFramework.RotationalSpeed.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalSpeed/UnitsNet.NanoFramework.RotationalSpeed.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RotationalSpeed - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RotationalSpeed units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/UnitsNet.NanoFramework.RotationalStiffness.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffness/UnitsNet.NanoFramework.RotationalStiffness.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RotationalStiffness - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RotationalStiffness units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/UnitsNet.NanoFramework.RotationalStiffnessPerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/RotationalStiffnessPerLength/UnitsNet.NanoFramework.RotationalStiffnessPerLength.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET RotationalStiffnessPerLength - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds RotationalStiffnessPerLength units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Scalar/UnitsNet.NanoFramework.Scalar.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Scalar/UnitsNet.NanoFramework.Scalar.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Scalar - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Scalar units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/UnitsNet.NanoFramework.SolidAngle.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SolidAngle/UnitsNet.NanoFramework.SolidAngle.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET SolidAngle - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds SolidAngle units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/UnitsNet.NanoFramework.SpecificEnergy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEnergy/UnitsNet.NanoFramework.SpecificEnergy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET SpecificEnergy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds SpecificEnergy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/UnitsNet.NanoFramework.SpecificEntropy.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificEntropy/UnitsNet.NanoFramework.SpecificEntropy.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET SpecificEntropy - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds SpecificEntropy units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/UnitsNet.NanoFramework.SpecificFuelConsumption.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificFuelConsumption/UnitsNet.NanoFramework.SpecificFuelConsumption.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET SpecificFuelConsumption - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds SpecificFuelConsumption units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/UnitsNet.NanoFramework.SpecificVolume.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificVolume/UnitsNet.NanoFramework.SpecificVolume.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET SpecificVolume - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds SpecificVolume units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/UnitsNet.NanoFramework.SpecificWeight.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/SpecificWeight/UnitsNet.NanoFramework.SpecificWeight.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET SpecificWeight - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds SpecificWeight units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Speed/UnitsNet.NanoFramework.Speed.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Speed/UnitsNet.NanoFramework.Speed.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Speed - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Speed units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/UnitsNet.NanoFramework.StandardVolumeFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/StandardVolumeFlow/UnitsNet.NanoFramework.StandardVolumeFlow.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET StandardVolumeFlow - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds StandardVolumeFlow units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Temperature/UnitsNet.NanoFramework.Temperature.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Temperature/UnitsNet.NanoFramework.Temperature.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Temperature - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Temperature units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/UnitsNet.NanoFramework.TemperatureChangeRate.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureChangeRate/UnitsNet.NanoFramework.TemperatureChangeRate.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET TemperatureChangeRate - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds TemperatureChangeRate units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/UnitsNet.NanoFramework.TemperatureDelta.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureDelta/UnitsNet.NanoFramework.TemperatureDelta.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET TemperatureDelta - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds TemperatureDelta units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/UnitsNet.NanoFramework.TemperatureGradient.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TemperatureGradient/UnitsNet.NanoFramework.TemperatureGradient.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET TemperatureGradient - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds TemperatureGradient units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/UnitsNet.NanoFramework.ThermalConductivity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalConductivity/UnitsNet.NanoFramework.ThermalConductivity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ThermalConductivity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ThermalConductivity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/UnitsNet.NanoFramework.ThermalResistance.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/ThermalResistance/UnitsNet.NanoFramework.ThermalResistance.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET ThermalResistance - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds ThermalResistance units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Torque/UnitsNet.NanoFramework.Torque.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Torque/UnitsNet.NanoFramework.Torque.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Torque - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Torque units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/UnitsNet.NanoFramework.TorquePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/TorquePerLength/UnitsNet.NanoFramework.TorquePerLength.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET TorquePerLength - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds TorquePerLength units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Turbidity/UnitsNet.NanoFramework.Turbidity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Turbidity/UnitsNet.NanoFramework.Turbidity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Turbidity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Turbidity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/VitaminA/UnitsNet.NanoFramework.VitaminA.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VitaminA/UnitsNet.NanoFramework.VitaminA.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET VitaminA - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds VitaminA units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/Volume/UnitsNet.NanoFramework.Volume.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/Volume/UnitsNet.NanoFramework.Volume.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET Volume - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds Volume units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/UnitsNet.NanoFramework.VolumeConcentration.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeConcentration/UnitsNet.NanoFramework.VolumeConcentration.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET VolumeConcentration - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds VolumeConcentration units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/UnitsNet.NanoFramework.VolumeFlow.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlow/UnitsNet.NanoFramework.VolumeFlow.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET VolumeFlow - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds VolumeFlow units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/UnitsNet.NanoFramework.VolumeFlowPerArea.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumeFlowPerArea/UnitsNet.NanoFramework.VolumeFlowPerArea.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET VolumeFlowPerArea - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds VolumeFlowPerArea units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/UnitsNet.NanoFramework.VolumePerLength.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumePerLength/UnitsNet.NanoFramework.VolumePerLength.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET VolumePerLength - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds VolumePerLength units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/UnitsNet.NanoFramework.VolumetricHeatCapacity.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/VolumetricHeatCapacity/UnitsNet.NanoFramework.VolumetricHeatCapacity.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET VolumetricHeatCapacity - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds VolumetricHeatCapacity units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/UnitsNet.NanoFramework.WarpingMomentOfInertia.nuspec
+++ b/UnitsNet.NanoFramework/GeneratedCode/WarpingMomentOfInertia/UnitsNet.NanoFramework.WarpingMomentOfInertia.nuspec
@@ -6,7 +6,7 @@
     <title>Units.NET WarpingMomentOfInertia - nanoFramework</title>
     <authors>Andreas Gullberg Larsen,nanoframework</authors>
     <owners>UnitsNet</owners>
-    <license type="expression">MIT</license>
+    <license type="expression">MIT-0</license>
     <projectUrl>https://github.com/angularsen/UnitsNet</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Adds WarpingMomentOfInertia units for Units.NET on .NET nanoFramework. For .NET or .NET Core, use UnitsNet instead.</description>

--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>UnitsNet Extensions NumberToExtensions NumberToUnitsExtensions NumberExtensions NumberToUnits convert conversion parse</PackageTags>
   </PropertyGroup>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>unit units measurement json Json.NET Newtonsoft serialize deserialize serialization deserialization</PackageTags>
     <PackageReleaseNotes>Upgrade JSON.NET to 12.0.3. Support arrays.</PackageReleaseNotes>

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -12,7 +12,7 @@
     <PackageIcon>logo-32.png</PackageIcon>
     <PackageIconUrl>https://raw.githubusercontent.com/angularsen/UnitsNet/ce85185429be345d77eb2ce09c99d59cc9ab8aed/Docs/Images/logo-32.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/angularsen/UnitsNet</PackageProjectUrl>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageLicenseExpression>MIT-0</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>unit units quantity quantities measurement si metric imperial abbreviation abbreviations convert conversion parse immutable</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>


### PR DESCRIPTION
Fixes #1379
Backport from v6: #1380

Change the license expression in the nugets to match the LICENSE file. Previously, nuget.org did not accept MIT-0 expression.