### PR TITLE
🔧Increase stale bot limit to 100 issues/prs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -36,4 +36,4 @@ jobs:
         exempt-draft-pr: false
         exempt-milestones: true
         exempt-all-milestones: true
-        operations-per-run: 1000 # TODO TEMPORARY FOR INITIAL RUN
+        operations-per-run: 100 # Default 30, a bit small as we have many stale/pinned issues to re-process

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -36,3 +36,4 @@ jobs:
         exempt-draft-pr: false
         exempt-milestones: true
         exempt-all-milestones: true
+        operations-per-run: 1000 # TODO TEMPORARY FOR INITIAL RUN


### PR DESCRIPTION
Currently have 46 issues/PRs to process, so the default of 30 was too small.
The idea with a limit is to avoid hitting github throttling.