### PR TITLE
Add Duration.Sol (day on Mars)

### DIFF
--- a/Common/UnitDefinitions/Duration.json
+++ b/Common/UnitDefinitions/Duration.json
@@ -161,8 +161,8 @@
       "BaseUnits": {
         "T": "Sol"
       },
-      "FromUnitToBaseFunc": "{x} * 88775",
-      "FromBaseToUnitFunc": "{x} / 88775",
+      "FromUnitToBaseFunc": "{x} * 88775.244",
+      "FromBaseToUnitFunc": "{x} / 88775.244",
       "Localization": [
         {
           "Culture": "en-US",

--- a/Common/UnitDefinitions/Duration.json
+++ b/Common/UnitDefinitions/Duration.json
@@ -154,6 +154,21 @@
           "Abbreviations": [ "jyr", "jyear", "jyears" ]
         }
       ]
+    },
+    {
+      "SingularName": "Sol",
+      "PluralName": "Sols",
+      "BaseUnits": {
+        "T": "Sol"
+      },
+      "FromUnitToBaseFunc": "{x} * 88775",
+      "FromBaseToUnitFunc": "{x} / 88775",
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "sol" ]
+        }
+      ]
     }
   ]
 }

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -240,7 +240,8 @@
     "Nanosecond": 8,
     "Second": 9,
     "Week": 10,
-    "Year365": 11
+    "Year365": 11,
+    "Sol": 15
   },
   "DynamicViscosity": {
     "Centipoise": 1,

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/Duration.g.cs
@@ -125,6 +125,11 @@ namespace UnitsNet
         public double Seconds => As(DurationUnit.Second);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="DurationUnit.Sol"/>
+        /// </summary>
+        public double Sols => As(DurationUnit.Sol);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="DurationUnit.Week"/>
         /// </summary>
         public double Weeks => As(DurationUnit.Week);
@@ -193,6 +198,12 @@ namespace UnitsNet
         public static Duration FromSeconds(double seconds) => new Duration(seconds, DurationUnit.Second);
 
         /// <summary>
+        ///     Creates a <see cref="Duration"/> from <see cref="DurationUnit.Sol"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Duration FromSols(double sols) => new Duration(sols, DurationUnit.Sol);
+
+        /// <summary>
         ///     Creates a <see cref="Duration"/> from <see cref="DurationUnit.Week"/>.
         /// </summary>
         /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
@@ -253,6 +264,7 @@ namespace UnitsNet
                         DurationUnit.Month30 => _value * 30 * 24 * 3600,
                         DurationUnit.Nanosecond => (_value) * 1e-9d,
                         DurationUnit.Second => _value,
+                        DurationUnit.Sol => _value * 88775,
                         DurationUnit.Week => _value * 7 * 24 * 3600,
                         DurationUnit.Year365 => _value * 365 * 24 * 3600,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to base units.")
@@ -277,6 +289,7 @@ namespace UnitsNet
                         DurationUnit.Month30 => baseUnitValue / (30 * 24 * 3600),
                         DurationUnit.Nanosecond => (baseUnitValue) / 1e-9d,
                         DurationUnit.Second => baseUnitValue,
+                        DurationUnit.Sol => baseUnitValue / 88775,
                         DurationUnit.Week => baseUnitValue / (7 * 24 * 3600),
                         DurationUnit.Year365 => baseUnitValue / (365 * 24 * 3600),
                         _ => throw new NotImplementedException($"Can not convert {Unit} to {unit}.")

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/Duration.g.cs
@@ -264,7 +264,7 @@ namespace UnitsNet
                         DurationUnit.Month30 => _value * 30 * 24 * 3600,
                         DurationUnit.Nanosecond => (_value) * 1e-9d,
                         DurationUnit.Second => _value,
-                        DurationUnit.Sol => _value * 88775,
+                        DurationUnit.Sol => _value * 88775.244,
                         DurationUnit.Week => _value * 7 * 24 * 3600,
                         DurationUnit.Year365 => _value * 365 * 24 * 3600,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to base units.")
@@ -289,7 +289,7 @@ namespace UnitsNet
                         DurationUnit.Month30 => baseUnitValue / (30 * 24 * 3600),
                         DurationUnit.Nanosecond => (baseUnitValue) / 1e-9d,
                         DurationUnit.Second => baseUnitValue,
-                        DurationUnit.Sol => baseUnitValue / 88775,
+                        DurationUnit.Sol => baseUnitValue / 88775.244,
                         DurationUnit.Week => baseUnitValue / (7 * 24 * 3600),
                         DurationUnit.Year365 => baseUnitValue / (365 * 24 * 3600),
                         _ => throw new NotImplementedException($"Can not convert {Unit} to {unit}.")

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/DurationUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/DurationUnit.g.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Units
         Month30 = 7,
         Nanosecond = 8,
         Second = 9,
+        Sol = 15,
         Week = 10,
         Year365 = 11,
     }

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToDurationExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToDurationExtensionsTest.g.cs
@@ -61,6 +61,10 @@ namespace UnitsNet.Tests
             Assert.Equal(Duration.FromSeconds(2), 2.Seconds());
 
         [Fact]
+        public void NumberToSolsTest() =>
+            Assert.Equal(Duration.FromSols(2), 2.Sols());
+
+        [Fact]
         public void NumberToWeeksTest() =>
             Assert.Equal(Duration.FromWeeks(2), 2.Weeks());
 

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToDurationExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToDurationExtensions.g.cs
@@ -104,6 +104,14 @@ namespace UnitsNet.NumberExtensions.NumberToDuration
 #endif
             => Duration.FromSeconds(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="Duration.FromSols(UnitsNet.QuantityValue)" />
+        public static Duration Sols<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => Duration.FromSols(Convert.ToDouble(value));
+
         /// <inheritdoc cref="Duration.FromWeeks(UnitsNet.QuantityValue)" />
         public static Duration Weeks<T>(this T value)
             where T : notnull

--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -33,7 +33,7 @@ namespace UnitsNet.Tests
 
         protected override double JulianYearsInOneSecond => 3.16880878140289e-08;
 
-        protected override double SolsInOneSecond => 1.1264432554210082e-5;
+        protected override double SolsInOneSecond => 1.126440159375963e-5;
 
         [Fact]
         public static void ToTimeSpanShouldThrowExceptionOnValuesLargerThanTimeSpanMax()

--- a/UnitsNet.Tests/CustomCode/DurationTests.cs
+++ b/UnitsNet.Tests/CustomCode/DurationTests.cs
@@ -33,6 +33,8 @@ namespace UnitsNet.Tests
 
         protected override double JulianYearsInOneSecond => 3.16880878140289e-08;
 
+        protected override double SolsInOneSecond => 1.1264432554210082e-5;
+
         [Fact]
         public static void ToTimeSpanShouldThrowExceptionOnValuesLargerThanTimeSpanMax()
         {

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
@@ -47,6 +47,7 @@ namespace UnitsNet.Tests
         protected abstract double Months30InOneSecond { get; }
         protected abstract double NanosecondsInOneSecond { get; }
         protected abstract double SecondsInOneSecond { get; }
+        protected abstract double SolsInOneSecond { get; }
         protected abstract double WeeksInOneSecond { get; }
         protected abstract double Years365InOneSecond { get; }
 
@@ -60,6 +61,7 @@ namespace UnitsNet.Tests
         protected virtual double Months30Tolerance { get { return 1e-5; } }
         protected virtual double NanosecondsTolerance { get { return 1e-5; } }
         protected virtual double SecondsTolerance { get { return 1e-5; } }
+        protected virtual double SolsTolerance { get { return 1e-5; } }
         protected virtual double WeeksTolerance { get { return 1e-5; } }
         protected virtual double Years365Tolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
@@ -77,6 +79,7 @@ namespace UnitsNet.Tests
                 DurationUnit.Month30 => (Months30InOneSecond, Months30Tolerance),
                 DurationUnit.Nanosecond => (NanosecondsInOneSecond, NanosecondsTolerance),
                 DurationUnit.Second => (SecondsInOneSecond, SecondsTolerance),
+                DurationUnit.Sol => (SolsInOneSecond, SolsTolerance),
                 DurationUnit.Week => (WeeksInOneSecond, WeeksTolerance),
                 DurationUnit.Year365 => (Years365InOneSecond, Years365Tolerance),
                 _ => throw new NotSupportedException()
@@ -94,6 +97,7 @@ namespace UnitsNet.Tests
             new object[] { DurationUnit.Month30 },
             new object[] { DurationUnit.Nanosecond },
             new object[] { DurationUnit.Second },
+            new object[] { DurationUnit.Sol },
             new object[] { DurationUnit.Week },
             new object[] { DurationUnit.Year365 },
         };
@@ -167,6 +171,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(Months30InOneSecond, second.Months30, Months30Tolerance);
             AssertEx.EqualTolerance(NanosecondsInOneSecond, second.Nanoseconds, NanosecondsTolerance);
             AssertEx.EqualTolerance(SecondsInOneSecond, second.Seconds, SecondsTolerance);
+            AssertEx.EqualTolerance(SolsInOneSecond, second.Sols, SolsTolerance);
             AssertEx.EqualTolerance(WeeksInOneSecond, second.Weeks, WeeksTolerance);
             AssertEx.EqualTolerance(Years365InOneSecond, second.Years365, Years365Tolerance);
         }
@@ -210,13 +215,17 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity08.Seconds, SecondsTolerance);
             Assert.Equal(DurationUnit.Second, quantity08.Unit);
 
-            var quantity09 = Duration.From(1, DurationUnit.Week);
-            AssertEx.EqualTolerance(1, quantity09.Weeks, WeeksTolerance);
-            Assert.Equal(DurationUnit.Week, quantity09.Unit);
+            var quantity09 = Duration.From(1, DurationUnit.Sol);
+            AssertEx.EqualTolerance(1, quantity09.Sols, SolsTolerance);
+            Assert.Equal(DurationUnit.Sol, quantity09.Unit);
 
-            var quantity10 = Duration.From(1, DurationUnit.Year365);
-            AssertEx.EqualTolerance(1, quantity10.Years365, Years365Tolerance);
-            Assert.Equal(DurationUnit.Year365, quantity10.Unit);
+            var quantity10 = Duration.From(1, DurationUnit.Week);
+            AssertEx.EqualTolerance(1, quantity10.Weeks, WeeksTolerance);
+            Assert.Equal(DurationUnit.Week, quantity10.Unit);
+
+            var quantity11 = Duration.From(1, DurationUnit.Year365);
+            AssertEx.EqualTolerance(1, quantity11.Years365, Years365Tolerance);
+            Assert.Equal(DurationUnit.Year365, quantity11.Unit);
 
         }
 
@@ -246,6 +255,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(Months30InOneSecond, second.As(DurationUnit.Month30), Months30Tolerance);
             AssertEx.EqualTolerance(NanosecondsInOneSecond, second.As(DurationUnit.Nanosecond), NanosecondsTolerance);
             AssertEx.EqualTolerance(SecondsInOneSecond, second.As(DurationUnit.Second), SecondsTolerance);
+            AssertEx.EqualTolerance(SolsInOneSecond, second.As(DurationUnit.Sol), SolsTolerance);
             AssertEx.EqualTolerance(WeeksInOneSecond, second.As(DurationUnit.Week), WeeksTolerance);
             AssertEx.EqualTolerance(Years365InOneSecond, second.As(DurationUnit.Year365), Years365Tolerance);
         }
@@ -636,6 +646,13 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsed = Duration.Parse("1 sol", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.Sols, SolsTolerance);
+                Assert.Equal(DurationUnit.Sol, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = Duration.Parse("1 wk", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.Weeks, WeeksTolerance);
                 Assert.Equal(DurationUnit.Week, parsed.Unit);
@@ -1008,6 +1025,12 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(Duration.TryParse("1 sol", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.Sols, SolsTolerance);
+                Assert.Equal(DurationUnit.Sol, parsed.Unit);
+            }
+
+            {
                 Assert.True(Duration.TryParse("1 wk", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.Weeks, WeeksTolerance);
                 Assert.Equal(DurationUnit.Week, parsed.Unit);
@@ -1374,6 +1397,12 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsedUnit = Duration.ParseUnit("sol", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(DurationUnit.Sol, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsedUnit = Duration.ParseUnit("wk", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(DurationUnit.Week, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -1686,6 +1715,11 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(Duration.TryParseUnit("sol", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(DurationUnit.Sol, parsedUnit);
+            }
+
+            {
                 Assert.True(Duration.TryParseUnit("wk", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(DurationUnit.Week, parsedUnit);
             }
@@ -1782,6 +1816,7 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, Duration.FromMonths30(second.Months30).Seconds, Months30Tolerance);
             AssertEx.EqualTolerance(1, Duration.FromNanoseconds(second.Nanoseconds).Seconds, NanosecondsTolerance);
             AssertEx.EqualTolerance(1, Duration.FromSeconds(second.Seconds).Seconds, SecondsTolerance);
+            AssertEx.EqualTolerance(1, Duration.FromSols(second.Sols).Seconds, SolsTolerance);
             AssertEx.EqualTolerance(1, Duration.FromWeeks(second.Weeks).Seconds, WeeksTolerance);
             AssertEx.EqualTolerance(1, Duration.FromYears365(second.Years365).Seconds, Years365Tolerance);
         }
@@ -1942,6 +1977,7 @@ namespace UnitsNet.Tests
                 Assert.Equal("1 mo", new Duration(1, DurationUnit.Month30).ToString());
                 Assert.Equal("1 ns", new Duration(1, DurationUnit.Nanosecond).ToString());
                 Assert.Equal("1 s", new Duration(1, DurationUnit.Second).ToString());
+                Assert.Equal("1 sol", new Duration(1, DurationUnit.Sol).ToString());
                 Assert.Equal("1 wk", new Duration(1, DurationUnit.Week).ToString());
                 Assert.Equal("1 yr", new Duration(1, DurationUnit.Year365).ToString());
             }
@@ -1966,6 +2002,7 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mo", new Duration(1, DurationUnit.Month30).ToString(swedishCulture));
             Assert.Equal("1 ns", new Duration(1, DurationUnit.Nanosecond).ToString(swedishCulture));
             Assert.Equal("1 s", new Duration(1, DurationUnit.Second).ToString(swedishCulture));
+            Assert.Equal("1 sol", new Duration(1, DurationUnit.Sol).ToString(swedishCulture));
             Assert.Equal("1 wk", new Duration(1, DurationUnit.Week).ToString(swedishCulture));
             Assert.Equal("1 yr", new Duration(1, DurationUnit.Year365).ToString(swedishCulture));
         }

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -928,7 +928,7 @@ namespace UnitsNet
                 (DurationUnit.Minute, DurationUnit.Second) => new Duration(_value * 60, DurationUnit.Second),
                 (DurationUnit.Month30, DurationUnit.Second) => new Duration(_value * 30 * 24 * 3600, DurationUnit.Second),
                 (DurationUnit.Nanosecond, DurationUnit.Second) => new Duration((_value) * 1e-9d, DurationUnit.Second),
-                (DurationUnit.Sol, DurationUnit.Second) => new Duration(_value * 88775, DurationUnit.Second),
+                (DurationUnit.Sol, DurationUnit.Second) => new Duration(_value * 88775.244, DurationUnit.Second),
                 (DurationUnit.Week, DurationUnit.Second) => new Duration(_value * 7 * 24 * 3600, DurationUnit.Second),
                 (DurationUnit.Year365, DurationUnit.Second) => new Duration(_value * 365 * 24 * 3600, DurationUnit.Second),
 
@@ -941,7 +941,7 @@ namespace UnitsNet
                 (DurationUnit.Second, DurationUnit.Minute) => new Duration(_value / 60, DurationUnit.Minute),
                 (DurationUnit.Second, DurationUnit.Month30) => new Duration(_value / (30 * 24 * 3600), DurationUnit.Month30),
                 (DurationUnit.Second, DurationUnit.Nanosecond) => new Duration((_value) / 1e-9d, DurationUnit.Nanosecond),
-                (DurationUnit.Second, DurationUnit.Sol) => new Duration(_value / 88775, DurationUnit.Sol),
+                (DurationUnit.Second, DurationUnit.Sol) => new Duration(_value / 88775.244, DurationUnit.Sol),
                 (DurationUnit.Second, DurationUnit.Week) => new Duration(_value / (7 * 24 * 3600), DurationUnit.Week),
                 (DurationUnit.Second, DurationUnit.Year365) => new Duration(_value / (365 * 24 * 3600), DurationUnit.Year365),
 

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -76,6 +76,7 @@ namespace UnitsNet
                     new UnitInfo<DurationUnit>(DurationUnit.Month30, "Months30", new BaseUnits(time: DurationUnit.Month30), "Duration"),
                     new UnitInfo<DurationUnit>(DurationUnit.Nanosecond, "Nanoseconds", BaseUnits.Undefined, "Duration"),
                     new UnitInfo<DurationUnit>(DurationUnit.Second, "Seconds", new BaseUnits(time: DurationUnit.Second), "Duration"),
+                    new UnitInfo<DurationUnit>(DurationUnit.Sol, "Sols", new BaseUnits(time: DurationUnit.Sol), "Duration"),
                     new UnitInfo<DurationUnit>(DurationUnit.Week, "Weeks", new BaseUnits(time: DurationUnit.Week), "Duration"),
                     new UnitInfo<DurationUnit>(DurationUnit.Year365, "Years365", new BaseUnits(time: DurationUnit.Year365), "Duration"),
                 },
@@ -227,6 +228,11 @@ namespace UnitsNet
         public double Seconds => As(DurationUnit.Second);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="DurationUnit.Sol"/>
+        /// </summary>
+        public double Sols => As(DurationUnit.Sol);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="DurationUnit.Week"/>
         /// </summary>
         public double Weeks => As(DurationUnit.Week);
@@ -255,6 +261,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Minute, DurationUnit.Second, quantity => quantity.ToUnit(DurationUnit.Second));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Month30, DurationUnit.Second, quantity => quantity.ToUnit(DurationUnit.Second));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Nanosecond, DurationUnit.Second, quantity => quantity.ToUnit(DurationUnit.Second));
+            unitConverter.SetConversionFunction<Duration>(DurationUnit.Sol, DurationUnit.Second, quantity => quantity.ToUnit(DurationUnit.Second));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Week, DurationUnit.Second, quantity => quantity.ToUnit(DurationUnit.Second));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Year365, DurationUnit.Second, quantity => quantity.ToUnit(DurationUnit.Second));
 
@@ -270,6 +277,7 @@ namespace UnitsNet
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Second, DurationUnit.Minute, quantity => quantity.ToUnit(DurationUnit.Minute));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Second, DurationUnit.Month30, quantity => quantity.ToUnit(DurationUnit.Month30));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Second, DurationUnit.Nanosecond, quantity => quantity.ToUnit(DurationUnit.Nanosecond));
+            unitConverter.SetConversionFunction<Duration>(DurationUnit.Second, DurationUnit.Sol, quantity => quantity.ToUnit(DurationUnit.Sol));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Second, DurationUnit.Week, quantity => quantity.ToUnit(DurationUnit.Week));
             unitConverter.SetConversionFunction<Duration>(DurationUnit.Second, DurationUnit.Year365, quantity => quantity.ToUnit(DurationUnit.Year365));
         }
@@ -387,6 +395,16 @@ namespace UnitsNet
         {
             double value = (double) seconds;
             return new Duration(value, DurationUnit.Second);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="Duration"/> from <see cref="DurationUnit.Sol"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">If value is NaN or Infinity.</exception>
+        public static Duration FromSols(QuantityValue sols)
+        {
+            double value = (double) sols;
+            return new Duration(value, DurationUnit.Sol);
         }
 
         /// <summary>
@@ -910,6 +928,7 @@ namespace UnitsNet
                 (DurationUnit.Minute, DurationUnit.Second) => new Duration(_value * 60, DurationUnit.Second),
                 (DurationUnit.Month30, DurationUnit.Second) => new Duration(_value * 30 * 24 * 3600, DurationUnit.Second),
                 (DurationUnit.Nanosecond, DurationUnit.Second) => new Duration((_value) * 1e-9d, DurationUnit.Second),
+                (DurationUnit.Sol, DurationUnit.Second) => new Duration(_value * 88775, DurationUnit.Second),
                 (DurationUnit.Week, DurationUnit.Second) => new Duration(_value * 7 * 24 * 3600, DurationUnit.Second),
                 (DurationUnit.Year365, DurationUnit.Second) => new Duration(_value * 365 * 24 * 3600, DurationUnit.Second),
 
@@ -922,6 +941,7 @@ namespace UnitsNet
                 (DurationUnit.Second, DurationUnit.Minute) => new Duration(_value / 60, DurationUnit.Minute),
                 (DurationUnit.Second, DurationUnit.Month30) => new Duration(_value / (30 * 24 * 3600), DurationUnit.Month30),
                 (DurationUnit.Second, DurationUnit.Nanosecond) => new Duration((_value) / 1e-9d, DurationUnit.Nanosecond),
+                (DurationUnit.Second, DurationUnit.Sol) => new Duration(_value / 88775, DurationUnit.Sol),
                 (DurationUnit.Second, DurationUnit.Week) => new Duration(_value / (7 * 24 * 3600), DurationUnit.Week),
                 (DurationUnit.Second, DurationUnit.Year365) => new Duration(_value / (365 * 24 * 3600), DurationUnit.Year365),
 

--- a/UnitsNet/GeneratedCode/Resources/Duration.restext
+++ b/UnitsNet/GeneratedCode/Resources/Duration.restext
@@ -7,5 +7,6 @@ Minutes=m,min,minute,minutes
 Months30=mo,month,months
 Nanoseconds=ns,nsec,nsecs,nsecond,nseconds
 Seconds=s,sec,secs,second,seconds
+Sols=sol
 Weeks=wk,week,weeks
 Years365=yr,year,years

--- a/UnitsNet/GeneratedCode/Units/DurationUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/DurationUnit.g.cs
@@ -34,6 +34,7 @@ namespace UnitsNet.Units
         Month30 = 7,
         Nanosecond = 8,
         Second = 9,
+        Sol = 15,
         Week = 10,
         Year365 = 11,
     }


### PR DESCRIPTION
Closes issue #1346 by adding sol, a Mars day, which lasts 88775 seconds.