### PR TITLE
✨Update Length.SolarRadius definition per IAU Res. B3

### DIFF
--- a/Common/UnitDefinitions/Length.json
+++ b/Common/UnitDefinitions/Length.json
@@ -381,8 +381,8 @@
     {
       "SingularName": "SolarRadius",
       "PluralName": "SolarRadiuses",
-      "FromUnitToBaseFunc": "{x} * 6.95510000E+08",
-      "FromBaseToUnitFunc": "{x} / 6.95510000E+08",
+      "FromUnitToBaseFunc": "{x} * 6.95700e8",
+      "FromBaseToUnitFunc": "{x} / 6.95700e8",
       "XmlDocSummary": "Solar radius is a ratio unit to the radius of the solar system star, the sun.",
       "XmlDocRemarks": "https://en.wikipedia.org/wiki/Stellar_classification",
       "Localization": [

--- a/UnitsNet.Tests/CustomCode/LengthTests.cs
+++ b/UnitsNet.Tests/CustomCode/LengthTests.cs
@@ -77,7 +77,7 @@ namespace UnitsNet.Tests
 
         protected override double ParsecsInOneMeter => 3.2407790389471100000000000E-17;
 
-        protected override double SolarRadiusesInOneMeter => 1.43779384911791000E-09;
+        protected override double SolarRadiusesInOneMeter => 1.4374011786689664E-09;
 
         protected override double ChainsInOneMeter => 0.0497096953789867;
 


### PR DESCRIPTION
Fixes https://github.com/angularsen/UnitsNet/issues/1425

The current value of `6.95510e8` differs from the standardized nominal solar radius value `6.95700e8` defined in [IAU Resolution B3 (2015)](https://www.iau.org/static/resolutions/IAU2015_English.pdf), [also on Wikipedia](https://en.wikipedia.org/wiki/Solar_radius#:~:text=Nominal%20solar%20radius%5B,700%C2%A0km)

