### PR TITLE
Fix a bug in BaseDimensions.IsBaseQuantity()

### DIFF
--- a/UnitsNet.Tests/BaseDimensionsTests.cs
+++ b/UnitsNet.Tests/BaseDimensionsTests.cs
@@ -37,6 +37,12 @@ namespace UnitsNet.Tests
             Assert.False(derivedDimensions.IsBaseQuantity());
         }
 
+        [Fact]
+        public void IsBaseQuantityImplementedReallyProperly()
+        {
+            Assert.False(Acceleration.BaseDimensions.IsBaseQuantity());
+        }
+
         [Theory]
         [InlineData(2, 0, 0, 0, 0, 0, 0)]
         [InlineData(0, 2, 0, 0, 0, 0, 0)]

--- a/UnitsNet.Tests/BaseDimensionsTests.cs
+++ b/UnitsNet.Tests/BaseDimensionsTests.cs
@@ -28,17 +28,49 @@ namespace UnitsNet.Tests
         [InlineData(0, 0, 0, 0, 1, 0, 0)]
         [InlineData(0, 0, 0, 0, 0, 1, 0)]
         [InlineData(0, 0, 0, 0, 0, 0, 1)]
-        public void IsBaseQuantityImplementedProperly(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
+        public void IsBaseQuantity_ForBaseQuantity_ReturnsTrue(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
         {
             var baseDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity);
-            var derivedDimensions = new BaseDimensions(length * 2, mass * 2, time * 2, current * 2, temperature * 2, amount * 2, luminousIntensity * 2);
-
             Assert.True(baseDimensions.IsBaseQuantity());
+        }
+
+        [Theory]
+        [InlineData(2, 0, 0, 0, 0, 0, 0)]
+        [InlineData(0, 2, 0, 0, 0, 0, 0)]
+        [InlineData(0, 0, 2, 0, 0, 0, 0)]
+        [InlineData(0, 0, 0, 2, 0, 0, 0)]
+        [InlineData(0, 0, 0, 0, 2, 0, 0)]
+        [InlineData(0, 0, 0, 0, 0, 2, 0)]
+        [InlineData(0, 0, 0, 0, 0, 0, 2)]
+        public void IsBaseQuantity_ForDerivedQuantity_ReturnsFalse(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
+        {
+            var derivedDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity);
+            Assert.False(derivedDimensions.IsBaseQuantity());
+        }
+
+        [Theory]
+        [InlineData(1, 1, 0, 0, 0, 0, 0)]
+        [InlineData(0, 2, 1, 0, 0, 0, 0)]
+        [InlineData(0, 2, 1, 1, 0, 0, 0)]
+        [InlineData(1, 2, 1, 1, 1, 1, 1)]
+        [InlineData(0, 0, 1, 2,-2, 0, 0)]
+        [InlineData(0, 0, 2,-1, 0, 0, 0)]
+        [InlineData(0, 0, 0,-3, 1, 0, 0)]
+        [InlineData(0, 0, 0, 0,-4,-4, 0)]
+        public void IsBaseQuantity_ForMultipleDimensions_ReturnsFalse(int length, int mass, int time, int current, int temperature, int amount, int luminousIntensity)
+        {
+            var derivedDimensions = new BaseDimensions(length, mass, time, current, temperature, amount, luminousIntensity);
             Assert.False(derivedDimensions.IsBaseQuantity());
         }
 
         [Fact]
-        public void IsBaseQuantityImplementedReallyProperly()
+        public void IsBaseQuantity_ForDimensionless_ReturnsFalse()
+        {
+            Assert.False(BaseDimensions.Dimensionless.IsBaseQuantity());
+        }
+
+        [Fact]
+        public void IsBaseQuantity_ForAcceleration_ReturnsFalse()
         {
             Assert.False(Acceleration.BaseDimensions.IsBaseQuantity());
         }

--- a/UnitsNet/BaseDimensions.cs
+++ b/UnitsNet/BaseDimensions.cs
@@ -31,22 +31,7 @@ namespace UnitsNet
         public bool IsBaseQuantity()
         {
             var dimensionsArray = new[] { Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity };
-            bool onlyOneEqualsOne = false;
-            foreach (var dimension in dimensionsArray)
-            {
-                if (1 == dimension)
-                {
-                    if (onlyOneEqualsOne)
-                    {
-                        return false;
-                    }
-                    onlyOneEqualsOne = true;
-                }
-                else if (0 != dimension)
-                {
-                    return false;
-                }
-            }
+            bool onlyOneEqualsOne = dimensionsArray.Select(dimension => dimension is 0 or 1 ? dimension : 2).Sum() == 1;
             return onlyOneEqualsOne;
         }
 

--- a/UnitsNet/BaseDimensions.cs
+++ b/UnitsNet/BaseDimensions.cs
@@ -31,7 +31,22 @@ namespace UnitsNet
         public bool IsBaseQuantity()
         {
             var dimensionsArray = new[] { Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity };
-            bool onlyOneEqualsOne = dimensionsArray.Where(dimension => dimension == 1).Take(2).Count() == 1;
+            bool onlyOneEqualsOne = false;
+            foreach (var dimension in dimensionsArray)
+            {
+                if (1 == dimension)
+                {
+                    if (onlyOneEqualsOne)
+                    {
+                        return false;
+                    }
+                    onlyOneEqualsOne = true;
+                }
+                else if (0 != dimension)
+                {
+                    return false;
+                }
+            }
             return onlyOneEqualsOne;
         }
 


### PR DESCRIPTION
Current implementation of `BaseDimensions.IsBaseQuantity()` ignores any dimension which power is not `1`.
So it treats derived quantities (like _Acceleration_ shown in unit test) as base ones.
This PR fixes a bug