### PR TITLE
Fix a bug in BaseDimensions.ToString()

### DIFF
--- a/UnitsNet.Tests/BaseDimensionsTests.cs
+++ b/UnitsNet.Tests/BaseDimensionsTests.cs
@@ -695,7 +695,13 @@ namespace UnitsNet.Tests
         [Fact]
         public void CheckToStringUsingMolarEntropy()
         {
-            Assert.Equal("[Length]^2[Mass][Time]^-2[Temperature][Amount]", MolarEntropy.BaseDimensions.ToString());
+            Assert.Equal("[Length]^2[Mass][Time]^-2[Temperature]^-1[Amount]^-1", MolarEntropy.BaseDimensions.ToString());
+        }
+
+        [Fact]
+        public void CheckToStringUsingSpeed()
+        {
+            Assert.Equal("[Length][Time]^-1", Speed.BaseDimensions.ToString());
         }
 
         [Fact]

--- a/UnitsNet/BaseDimensions.cs
+++ b/UnitsNet/BaseDimensions.cs
@@ -182,13 +182,11 @@ namespace UnitsNet
 
         private static void AppendDimensionString(StringBuilder sb, string name, int value)
         {
-            var absoluteValue = Math.Abs(value);
-
-            if(absoluteValue > 0)
+            if (0 != value)
             {
                 sb.AppendFormat("[{0}]", name);
 
-                if(absoluteValue > 1)
+                if (1 != value)
                     sb.AppendFormat("^{0}", value);
             }
         }


### PR DESCRIPTION
Current implementation of `AppendDimensionString` ignores value `-1`.
This PR fixes the bug.