### PR TITLE
Fixing the nullability attribute of the AbbreviatedUnitsConverter (build failure)

### DIFF
--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -263,7 +263,7 @@ namespace UnitsNet.Serialization.JsonNet
         /// <returns>Unit enum value, such as <see cref="MassUnit.Kilogram" />.</returns>
         /// <exception cref="UnitNotFoundException">No units match the abbreviation.</exception>
         /// <exception cref="AmbiguousUnitParseException">More than one unit matches the abbreviation.</exception>
-        protected Enum Parse(string? unitAbbreviation, QuantityInfo quantityInfo)
+        protected Enum Parse(string unitAbbreviation, QuantityInfo quantityInfo)
         {
             return _unitParser.Parse(unitAbbreviation, quantityInfo.UnitType, CultureInfo.InvariantCulture);
         }


### PR DESCRIPTION
fixing the nullability of the `unitAbbreviation` in the Parse method (following the build failure from #1446 )

BTW, note that this method isn't even used anywhere. I'm not sure if we've ever used it and then stopped or if it was meant to serve another purpose (having _extended_ the converter)..