### PR TITLE
Change RadiationEquivalentDoseRate base unit to Sv/s - v6

### DIFF
--- a/Common/UnitDefinitions/RadiationEquivalentDoseRate.json
+++ b/Common/UnitDefinitions/RadiationEquivalentDoseRate.json
@@ -1,6 +1,6 @@
 {
   "Name": "RadiationEquivalentDoseRate",
-  "BaseUnit": "SievertPerHour",
+  "BaseUnit": "SievertPerSecond",
   "XmlDocSummary": "A dose rate is quantity of radiation absorbed or delivered per unit time.",
   "XmlDocsRemarks": "https://en.wikipedia.org/wiki/Dose_rate",
   "BaseDimensions": {
@@ -11,8 +11,8 @@
     {
       "SingularName": "SievertPerHour",
       "PluralName": "SievertsPerHour",
-      "FromUnitToBaseFunc": "{x}",
-      "FromBaseToUnitFunc": "{x}",
+      "FromUnitToBaseFunc": "{x}/3600",
+      "FromBaseToUnitFunc": "{x}*3600",
       "Prefixes": [ "Nano", "Micro", "Milli" ],
       "Localization": [
         {
@@ -26,10 +26,27 @@
       ]
     },
     {
+      "SingularName": "SievertPerSecond",
+      "PluralName": "SievertsPerSecond",
+      "FromUnitToBaseFunc": "{x}",
+      "FromBaseToUnitFunc": "{x}",
+      "Prefixes": [ "Nano", "Micro", "Milli" ],
+      "Localization": [
+        {
+          "Culture": "en-US",
+          "Abbreviations": [ "Sv/s" ]
+        },
+        {
+          "Culture": "ru-RU",
+          "Abbreviations": [ "Зв/с" ]
+        }
+      ]
+    },
+    {
       "SingularName": "RoentgenEquivalentManPerHour",
       "PluralName": "RoentgensEquivalentManPerHour",
-      "FromUnitToBaseFunc": "{x} / 100",
-      "FromBaseToUnitFunc": "{x} * 100",
+      "FromUnitToBaseFunc": "{x} / 100 / 3600",
+      "FromBaseToUnitFunc": "{x} * 100 * 3600",
       "Prefixes": [ "Milli" ],
       "Localization": [
         {

--- a/Common/UnitEnumValues.g.json
+++ b/Common/UnitEnumValues.g.json
@@ -1869,7 +1869,11 @@
     "MillisievertPerHour": 3,
     "NanosievertPerHour": 2,
     "RoentgenEquivalentManPerHour": 5,
-    "SievertPerHour": 6
+    "SievertPerHour": 6,
+    "SievertPerSecond": 16,
+    "MicrosievertPerSecond": 17,
+    "MillisievertPerSecond": 14,
+    "NanosievertPerSecond": 9
   },
   "ThermalInsulance": {
     "HourSquareFeetDegreeFahrenheitPerBtu": 2,

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
@@ -60,7 +60,7 @@ namespace UnitsNet
         /// <summary>
         ///     The base unit of RadiationEquivalentDoseRate, which is Second. All conversions go via this value.
         /// </summary>
-        public static RadiationEquivalentDoseRateUnit BaseUnit { get; } = RadiationEquivalentDoseRateUnit.SievertPerHour;
+        public static RadiationEquivalentDoseRateUnit BaseUnit { get; } = RadiationEquivalentDoseRateUnit.SievertPerSecond;
 
         /// <summary>
         /// Represents the largest possible value of RadiationEquivalentDoseRate.
@@ -84,6 +84,11 @@ namespace UnitsNet
         public double MicrosievertsPerHour => As(RadiationEquivalentDoseRateUnit.MicrosievertPerHour);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.MicrosievertPerSecond"/>
+        /// </summary>
+        public double MicrosievertsPerSecond => As(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour"/>
         /// </summary>
         public double MilliroentgensEquivalentManPerHour => As(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour);
@@ -94,9 +99,19 @@ namespace UnitsNet
         public double MillisievertsPerHour => As(RadiationEquivalentDoseRateUnit.MillisievertPerHour);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.MillisievertPerSecond"/>
+        /// </summary>
+        public double MillisievertsPerSecond => As(RadiationEquivalentDoseRateUnit.MillisievertPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerHour"/>
         /// </summary>
         public double NanosievertsPerHour => As(RadiationEquivalentDoseRateUnit.NanosievertPerHour);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerSecond"/>
+        /// </summary>
+        public double NanosievertsPerSecond => As(RadiationEquivalentDoseRateUnit.NanosievertPerSecond);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour"/>
@@ -108,6 +123,11 @@ namespace UnitsNet
         /// </summary>
         public double SievertsPerHour => As(RadiationEquivalentDoseRateUnit.SievertPerHour);
 
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.SievertPerSecond"/>
+        /// </summary>
+        public double SievertsPerSecond => As(RadiationEquivalentDoseRateUnit.SievertPerSecond);
+
         #endregion
 
         #region Static Factory Methods
@@ -116,6 +136,11 @@ namespace UnitsNet
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MicrosievertPerHour"/>.
         /// </summary>
         public static RadiationEquivalentDoseRate FromMicrosievertsPerHour(double microsievertsperhour) => new RadiationEquivalentDoseRate(microsievertsperhour, RadiationEquivalentDoseRateUnit.MicrosievertPerHour);
+
+        /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MicrosievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromMicrosievertsPerSecond(double microsievertspersecond) => new RadiationEquivalentDoseRate(microsievertspersecond, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond);
 
         /// <summary>
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour"/>.
@@ -128,9 +153,19 @@ namespace UnitsNet
         public static RadiationEquivalentDoseRate FromMillisievertsPerHour(double millisievertsperhour) => new RadiationEquivalentDoseRate(millisievertsperhour, RadiationEquivalentDoseRateUnit.MillisievertPerHour);
 
         /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MillisievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromMillisievertsPerSecond(double millisievertspersecond) => new RadiationEquivalentDoseRate(millisievertspersecond, RadiationEquivalentDoseRateUnit.MillisievertPerSecond);
+
+        /// <summary>
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerHour"/>.
         /// </summary>
         public static RadiationEquivalentDoseRate FromNanosievertsPerHour(double nanosievertsperhour) => new RadiationEquivalentDoseRate(nanosievertsperhour, RadiationEquivalentDoseRateUnit.NanosievertPerHour);
+
+        /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromNanosievertsPerSecond(double nanosievertspersecond) => new RadiationEquivalentDoseRate(nanosievertspersecond, RadiationEquivalentDoseRateUnit.NanosievertPerSecond);
 
         /// <summary>
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour"/>.
@@ -141,6 +176,11 @@ namespace UnitsNet
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.SievertPerHour"/>.
         /// </summary>
         public static RadiationEquivalentDoseRate FromSievertsPerHour(double sievertsperhour) => new RadiationEquivalentDoseRate(sievertsperhour, RadiationEquivalentDoseRateUnit.SievertPerHour);
+
+        /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.SievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromSievertsPerSecond(double sievertspersecond) => new RadiationEquivalentDoseRate(sievertspersecond, RadiationEquivalentDoseRateUnit.SievertPerSecond);
 
         /// <summary>
         ///     Dynamically convert from value and unit enum <see cref="RadiationEquivalentDoseRateUnit" /> to <see cref="RadiationEquivalentDoseRate" />.
@@ -182,12 +222,16 @@ namespace UnitsNet
                 {
                     return Unit switch
                     {
-                        RadiationEquivalentDoseRateUnit.MicrosievertPerHour => (_value) * 1e-6d,
-                        RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour => (_value / 100) * 1e-3d,
-                        RadiationEquivalentDoseRateUnit.MillisievertPerHour => (_value) * 1e-3d,
-                        RadiationEquivalentDoseRateUnit.NanosievertPerHour => (_value) * 1e-9d,
-                        RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour => _value / 100,
-                        RadiationEquivalentDoseRateUnit.SievertPerHour => _value,
+                        RadiationEquivalentDoseRateUnit.MicrosievertPerHour => (_value/3600) * 1e-6d,
+                        RadiationEquivalentDoseRateUnit.MicrosievertPerSecond => (_value) * 1e-6d,
+                        RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour => (_value / 100 / 3600) * 1e-3d,
+                        RadiationEquivalentDoseRateUnit.MillisievertPerHour => (_value/3600) * 1e-3d,
+                        RadiationEquivalentDoseRateUnit.MillisievertPerSecond => (_value) * 1e-3d,
+                        RadiationEquivalentDoseRateUnit.NanosievertPerHour => (_value/3600) * 1e-9d,
+                        RadiationEquivalentDoseRateUnit.NanosievertPerSecond => (_value) * 1e-9d,
+                        RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour => _value / 100 / 3600,
+                        RadiationEquivalentDoseRateUnit.SievertPerHour => _value/3600,
+                        RadiationEquivalentDoseRateUnit.SievertPerSecond => _value,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to base units.")
                     };
                     }
@@ -201,12 +245,16 @@ namespace UnitsNet
 
                     return unit switch
                     {
-                        RadiationEquivalentDoseRateUnit.MicrosievertPerHour => (baseUnitValue) / 1e-6d,
-                        RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour => (baseUnitValue * 100) / 1e-3d,
-                        RadiationEquivalentDoseRateUnit.MillisievertPerHour => (baseUnitValue) / 1e-3d,
-                        RadiationEquivalentDoseRateUnit.NanosievertPerHour => (baseUnitValue) / 1e-9d,
-                        RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour => baseUnitValue * 100,
-                        RadiationEquivalentDoseRateUnit.SievertPerHour => baseUnitValue,
+                        RadiationEquivalentDoseRateUnit.MicrosievertPerHour => (baseUnitValue*3600) / 1e-6d,
+                        RadiationEquivalentDoseRateUnit.MicrosievertPerSecond => (baseUnitValue) / 1e-6d,
+                        RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour => (baseUnitValue * 100 * 3600) / 1e-3d,
+                        RadiationEquivalentDoseRateUnit.MillisievertPerHour => (baseUnitValue*3600) / 1e-3d,
+                        RadiationEquivalentDoseRateUnit.MillisievertPerSecond => (baseUnitValue) / 1e-3d,
+                        RadiationEquivalentDoseRateUnit.NanosievertPerHour => (baseUnitValue*3600) / 1e-9d,
+                        RadiationEquivalentDoseRateUnit.NanosievertPerSecond => (baseUnitValue) / 1e-9d,
+                        RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour => baseUnitValue * 100 * 3600,
+                        RadiationEquivalentDoseRateUnit.SievertPerHour => baseUnitValue*3600,
+                        RadiationEquivalentDoseRateUnit.SievertPerSecond => baseUnitValue,
                         _ => throw new NotImplementedException($"Can not convert {Unit} to {unit}.")
                     };
                     }

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/RadiationEquivalentDoseRateUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/RadiationEquivalentDoseRateUnit.g.cs
@@ -26,11 +26,15 @@ namespace UnitsNet.Units
     public enum RadiationEquivalentDoseRateUnit
     {
         MicrosievertPerHour = 1,
+        MicrosievertPerSecond = 17,
         MilliroentgenEquivalentManPerHour = 4,
         MillisievertPerHour = 3,
+        MillisievertPerSecond = 14,
         NanosievertPerHour = 2,
+        NanosievertPerSecond = 9,
         RoentgenEquivalentManPerHour = 5,
         SievertPerHour = 6,
+        SievertPerSecond = 16,
     }
 
     #pragma warning restore 1591

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToRadiationEquivalentDoseRateExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToRadiationEquivalentDoseRateExtensionsTest.g.cs
@@ -29,6 +29,10 @@ namespace UnitsNet.Tests
             Assert.Equal(RadiationEquivalentDoseRate.FromMicrosievertsPerHour(2), 2.MicrosievertsPerHour());
 
         [Fact]
+        public void NumberToMicrosievertsPerSecondTest() =>
+            Assert.Equal(RadiationEquivalentDoseRate.FromMicrosievertsPerSecond(2), 2.MicrosievertsPerSecond());
+
+        [Fact]
         public void NumberToMilliroentgensEquivalentManPerHourTest() =>
             Assert.Equal(RadiationEquivalentDoseRate.FromMilliroentgensEquivalentManPerHour(2), 2.MilliroentgensEquivalentManPerHour());
 
@@ -37,8 +41,16 @@ namespace UnitsNet.Tests
             Assert.Equal(RadiationEquivalentDoseRate.FromMillisievertsPerHour(2), 2.MillisievertsPerHour());
 
         [Fact]
+        public void NumberToMillisievertsPerSecondTest() =>
+            Assert.Equal(RadiationEquivalentDoseRate.FromMillisievertsPerSecond(2), 2.MillisievertsPerSecond());
+
+        [Fact]
         public void NumberToNanosievertsPerHourTest() =>
             Assert.Equal(RadiationEquivalentDoseRate.FromNanosievertsPerHour(2), 2.NanosievertsPerHour());
+
+        [Fact]
+        public void NumberToNanosievertsPerSecondTest() =>
+            Assert.Equal(RadiationEquivalentDoseRate.FromNanosievertsPerSecond(2), 2.NanosievertsPerSecond());
 
         [Fact]
         public void NumberToRoentgensEquivalentManPerHourTest() =>
@@ -47,6 +59,10 @@ namespace UnitsNet.Tests
         [Fact]
         public void NumberToSievertsPerHourTest() =>
             Assert.Equal(RadiationEquivalentDoseRate.FromSievertsPerHour(2), 2.SievertsPerHour());
+
+        [Fact]
+        public void NumberToSievertsPerSecondTest() =>
+            Assert.Equal(RadiationEquivalentDoseRate.FromSievertsPerSecond(2), 2.SievertsPerSecond());
 
     }
 }

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToRadiationEquivalentDoseRateExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToRadiationEquivalentDoseRateExtensions.g.cs
@@ -40,6 +40,14 @@ namespace UnitsNet.NumberExtensions.NumberToRadiationEquivalentDoseRate
 #endif
             => RadiationEquivalentDoseRate.FromMicrosievertsPerHour(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="RadiationEquivalentDoseRate.FromMicrosievertsPerSecond(double)" />
+        public static RadiationEquivalentDoseRate MicrosievertsPerSecond<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => RadiationEquivalentDoseRate.FromMicrosievertsPerSecond(Convert.ToDouble(value));
+
         /// <inheritdoc cref="RadiationEquivalentDoseRate.FromMilliroentgensEquivalentManPerHour(double)" />
         public static RadiationEquivalentDoseRate MilliroentgensEquivalentManPerHour<T>(this T value)
             where T : notnull
@@ -56,6 +64,14 @@ namespace UnitsNet.NumberExtensions.NumberToRadiationEquivalentDoseRate
 #endif
             => RadiationEquivalentDoseRate.FromMillisievertsPerHour(Convert.ToDouble(value));
 
+        /// <inheritdoc cref="RadiationEquivalentDoseRate.FromMillisievertsPerSecond(double)" />
+        public static RadiationEquivalentDoseRate MillisievertsPerSecond<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => RadiationEquivalentDoseRate.FromMillisievertsPerSecond(Convert.ToDouble(value));
+
         /// <inheritdoc cref="RadiationEquivalentDoseRate.FromNanosievertsPerHour(double)" />
         public static RadiationEquivalentDoseRate NanosievertsPerHour<T>(this T value)
             where T : notnull
@@ -63,6 +79,14 @@ namespace UnitsNet.NumberExtensions.NumberToRadiationEquivalentDoseRate
             , INumber<T>
 #endif
             => RadiationEquivalentDoseRate.FromNanosievertsPerHour(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="RadiationEquivalentDoseRate.FromNanosievertsPerSecond(double)" />
+        public static RadiationEquivalentDoseRate NanosievertsPerSecond<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => RadiationEquivalentDoseRate.FromNanosievertsPerSecond(Convert.ToDouble(value));
 
         /// <inheritdoc cref="RadiationEquivalentDoseRate.FromRoentgensEquivalentManPerHour(double)" />
         public static RadiationEquivalentDoseRate RoentgensEquivalentManPerHour<T>(this T value)
@@ -79,6 +103,14 @@ namespace UnitsNet.NumberExtensions.NumberToRadiationEquivalentDoseRate
             , INumber<T>
 #endif
             => RadiationEquivalentDoseRate.FromSievertsPerHour(Convert.ToDouble(value));
+
+        /// <inheritdoc cref="RadiationEquivalentDoseRate.FromSievertsPerSecond(double)" />
+        public static RadiationEquivalentDoseRate SievertsPerSecond<T>(this T value)
+            where T : notnull
+#if NET7_0_OR_GREATER
+            , INumber<T>
+#endif
+            => RadiationEquivalentDoseRate.FromSievertsPerSecond(Convert.ToDouble(value));
 
     }
 }

--- a/UnitsNet.Tests/CustomCode/RadiationEquivalentDoseRateTests.cs
+++ b/UnitsNet.Tests/CustomCode/RadiationEquivalentDoseRateTests.cs
@@ -10,12 +10,16 @@ namespace UnitsNet.Tests.CustomCode
     {
         // Override properties in base class here
         protected override bool SupportsSIUnitSystem => false;
-        protected override double SievertsPerHourInOneSievertPerHour => 1;
-        protected override double MillisievertsPerHourInOneSievertPerHour => 1e+3;
-        protected override double MicrosievertsPerHourInOneSievertPerHour => 1e+6;
-        protected override double NanosievertsPerHourInOneSievertPerHour => 1e+9;
-        protected override double RoentgensEquivalentManPerHourInOneSievertPerHour => 100;
-        protected override double MilliroentgensEquivalentManPerHourInOneSievertPerHour => 1e+5;
+        protected override double SievertsPerSecondInOneSievertPerSecond => 1;
+        protected override double MillisievertsPerSecondInOneSievertPerSecond => 1e+3;
+        protected override double MicrosievertsPerSecondInOneSievertPerSecond => 1e+6;
+        protected override double NanosievertsPerSecondInOneSievertPerSecond => 1e+9;
+        protected override double SievertsPerHourInOneSievertPerSecond => 3600;
+        protected override double MillisievertsPerHourInOneSievertPerSecond => 3.6e+6;
+        protected override double MicrosievertsPerHourInOneSievertPerSecond => 3.6e+9;
+        protected override double NanosievertsPerHourInOneSievertPerSecond => 3.6e+12;
+        protected override double RoentgensEquivalentManPerHourInOneSievertPerSecond => 3.6e+5;
+        protected override double MilliroentgensEquivalentManPerHourInOneSievertPerSecond => 3.6e+8;
 
         [Fact]
         public void RadiationEquivalentDoseRateTimesTimeSpanEqualsRadiationEquivalentDose()

--- a/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/IQuantityTests.g.cs
@@ -119,7 +119,7 @@ namespace UnitsNet.Tests
             Assertion(3, PressureUnit.Torr, Quantity.From(3, PressureUnit.Torr));
             Assertion(3, PressureChangeRateUnit.PoundForcePerSquareInchPerSecond, Quantity.From(3, PressureChangeRateUnit.PoundForcePerSquareInchPerSecond));
             Assertion(3, RadiationEquivalentDoseUnit.Sievert, Quantity.From(3, RadiationEquivalentDoseUnit.Sievert));
-            Assertion(3, RadiationEquivalentDoseRateUnit.SievertPerHour, Quantity.From(3, RadiationEquivalentDoseRateUnit.SievertPerHour));
+            Assertion(3, RadiationEquivalentDoseRateUnit.SievertPerSecond, Quantity.From(3, RadiationEquivalentDoseRateUnit.SievertPerSecond));
             Assertion(3, RadiationExposureUnit.Roentgen, Quantity.From(3, RadiationExposureUnit.Roentgen));
             Assertion(3, RadioactivityUnit.Terarutherford, Quantity.From(3, RadioactivityUnit.Terarutherford));
             Assertion(3, RatioUnit.Percent, Quantity.From(3, RatioUnit.Percent));

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseRateTestsBase.g.cs
@@ -38,32 +38,44 @@ namespace UnitsNet.Tests
 // ReSharper disable once PartialTypeWithSinglePart
     public abstract partial class RadiationEquivalentDoseRateTestsBase : QuantityTestsBase
     {
-        protected abstract double MicrosievertsPerHourInOneSievertPerHour { get; }
-        protected abstract double MilliroentgensEquivalentManPerHourInOneSievertPerHour { get; }
-        protected abstract double MillisievertsPerHourInOneSievertPerHour { get; }
-        protected abstract double NanosievertsPerHourInOneSievertPerHour { get; }
-        protected abstract double RoentgensEquivalentManPerHourInOneSievertPerHour { get; }
-        protected abstract double SievertsPerHourInOneSievertPerHour { get; }
+        protected abstract double MicrosievertsPerHourInOneSievertPerSecond { get; }
+        protected abstract double MicrosievertsPerSecondInOneSievertPerSecond { get; }
+        protected abstract double MilliroentgensEquivalentManPerHourInOneSievertPerSecond { get; }
+        protected abstract double MillisievertsPerHourInOneSievertPerSecond { get; }
+        protected abstract double MillisievertsPerSecondInOneSievertPerSecond { get; }
+        protected abstract double NanosievertsPerHourInOneSievertPerSecond { get; }
+        protected abstract double NanosievertsPerSecondInOneSievertPerSecond { get; }
+        protected abstract double RoentgensEquivalentManPerHourInOneSievertPerSecond { get; }
+        protected abstract double SievertsPerHourInOneSievertPerSecond { get; }
+        protected abstract double SievertsPerSecondInOneSievertPerSecond { get; }
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double MicrosievertsPerHourTolerance { get { return 1e-5; } }
+        protected virtual double MicrosievertsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double MilliroentgensEquivalentManPerHourTolerance { get { return 1e-5; } }
         protected virtual double MillisievertsPerHourTolerance { get { return 1e-5; } }
+        protected virtual double MillisievertsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double NanosievertsPerHourTolerance { get { return 1e-5; } }
+        protected virtual double NanosievertsPerSecondTolerance { get { return 1e-5; } }
         protected virtual double RoentgensEquivalentManPerHourTolerance { get { return 1e-5; } }
         protected virtual double SievertsPerHourTolerance { get { return 1e-5; } }
+        protected virtual double SievertsPerSecondTolerance { get { return 1e-5; } }
 // ReSharper restore VirtualMemberNeverOverriden.Global
 
         protected (double UnitsInBaseUnit, double Tolerence) GetConversionFactor(RadiationEquivalentDoseRateUnit unit)
         {
             return unit switch
             {
-                RadiationEquivalentDoseRateUnit.MicrosievertPerHour => (MicrosievertsPerHourInOneSievertPerHour, MicrosievertsPerHourTolerance),
-                RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour => (MilliroentgensEquivalentManPerHourInOneSievertPerHour, MilliroentgensEquivalentManPerHourTolerance),
-                RadiationEquivalentDoseRateUnit.MillisievertPerHour => (MillisievertsPerHourInOneSievertPerHour, MillisievertsPerHourTolerance),
-                RadiationEquivalentDoseRateUnit.NanosievertPerHour => (NanosievertsPerHourInOneSievertPerHour, NanosievertsPerHourTolerance),
-                RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour => (RoentgensEquivalentManPerHourInOneSievertPerHour, RoentgensEquivalentManPerHourTolerance),
-                RadiationEquivalentDoseRateUnit.SievertPerHour => (SievertsPerHourInOneSievertPerHour, SievertsPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.MicrosievertPerHour => (MicrosievertsPerHourInOneSievertPerSecond, MicrosievertsPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.MicrosievertPerSecond => (MicrosievertsPerSecondInOneSievertPerSecond, MicrosievertsPerSecondTolerance),
+                RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour => (MilliroentgensEquivalentManPerHourInOneSievertPerSecond, MilliroentgensEquivalentManPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.MillisievertPerHour => (MillisievertsPerHourInOneSievertPerSecond, MillisievertsPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.MillisievertPerSecond => (MillisievertsPerSecondInOneSievertPerSecond, MillisievertsPerSecondTolerance),
+                RadiationEquivalentDoseRateUnit.NanosievertPerHour => (NanosievertsPerHourInOneSievertPerSecond, NanosievertsPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.NanosievertPerSecond => (NanosievertsPerSecondInOneSievertPerSecond, NanosievertsPerSecondTolerance),
+                RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour => (RoentgensEquivalentManPerHourInOneSievertPerSecond, RoentgensEquivalentManPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.SievertPerHour => (SievertsPerHourInOneSievertPerSecond, SievertsPerHourTolerance),
+                RadiationEquivalentDoseRateUnit.SievertPerSecond => (SievertsPerSecondInOneSievertPerSecond, SievertsPerSecondTolerance),
                 _ => throw new NotSupportedException()
             };
         }
@@ -71,11 +83,15 @@ namespace UnitsNet.Tests
         public static IEnumerable<object[]> UnitTypes = new List<object[]>
         {
             new object[] { RadiationEquivalentDoseRateUnit.MicrosievertPerHour },
+            new object[] { RadiationEquivalentDoseRateUnit.MicrosievertPerSecond },
             new object[] { RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour },
             new object[] { RadiationEquivalentDoseRateUnit.MillisievertPerHour },
+            new object[] { RadiationEquivalentDoseRateUnit.MillisievertPerSecond },
             new object[] { RadiationEquivalentDoseRateUnit.NanosievertPerHour },
+            new object[] { RadiationEquivalentDoseRateUnit.NanosievertPerSecond },
             new object[] { RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour },
             new object[] { RadiationEquivalentDoseRateUnit.SievertPerHour },
+            new object[] { RadiationEquivalentDoseRateUnit.SievertPerSecond },
         };
 
         [Fact]
@@ -83,14 +99,14 @@ namespace UnitsNet.Tests
         {
             var quantity = new RadiationEquivalentDoseRate();
             Assert.Equal(0, quantity.Value);
-            Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, quantity.Unit);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity.Unit);
         }
 
         [Fact]
         public void Ctor_WithInfinityValue_DoNotThrowsArgumentException()
         {
-            var exception1 = Record.Exception(() => new RadiationEquivalentDoseRate(double.PositiveInfinity, RadiationEquivalentDoseRateUnit.SievertPerHour));
-            var exception2 = Record.Exception(() => new RadiationEquivalentDoseRate(double.NegativeInfinity, RadiationEquivalentDoseRateUnit.SievertPerHour));
+            var exception1 = Record.Exception(() => new RadiationEquivalentDoseRate(double.PositiveInfinity, RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            var exception2 = Record.Exception(() => new RadiationEquivalentDoseRate(double.NegativeInfinity, RadiationEquivalentDoseRateUnit.SievertPerSecond));
 
             Assert.Null(exception1);
             Assert.Null(exception2);
@@ -99,7 +115,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void Ctor_WithNaNValue_DoNotThrowsArgumentException()
         {
-            var exception = Record.Exception(() => new RadiationEquivalentDoseRate(double.NaN, RadiationEquivalentDoseRateUnit.SievertPerHour));
+            var exception = Record.Exception(() => new RadiationEquivalentDoseRate(double.NaN, RadiationEquivalentDoseRateUnit.SievertPerSecond));
 
             Assert.Null(exception);
         }
@@ -128,7 +144,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void RadiationEquivalentDoseRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
-            var quantity = new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerHour);
+            var quantity = new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerSecond);
 
             QuantityInfo<RadiationEquivalentDoseRateUnit> quantityInfo = quantity.QuantityInfo;
 
@@ -140,15 +156,19 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void SievertPerHourToRadiationEquivalentDoseRateUnits()
+        public void SievertPerSecondToRadiationEquivalentDoseRateUnits()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            AssertEx.EqualTolerance(MicrosievertsPerHourInOneSievertPerHour, sievertperhour.MicrosievertsPerHour, MicrosievertsPerHourTolerance);
-            AssertEx.EqualTolerance(MilliroentgensEquivalentManPerHourInOneSievertPerHour, sievertperhour.MilliroentgensEquivalentManPerHour, MilliroentgensEquivalentManPerHourTolerance);
-            AssertEx.EqualTolerance(MillisievertsPerHourInOneSievertPerHour, sievertperhour.MillisievertsPerHour, MillisievertsPerHourTolerance);
-            AssertEx.EqualTolerance(NanosievertsPerHourInOneSievertPerHour, sievertperhour.NanosievertsPerHour, NanosievertsPerHourTolerance);
-            AssertEx.EqualTolerance(RoentgensEquivalentManPerHourInOneSievertPerHour, sievertperhour.RoentgensEquivalentManPerHour, RoentgensEquivalentManPerHourTolerance);
-            AssertEx.EqualTolerance(SievertsPerHourInOneSievertPerHour, sievertperhour.SievertsPerHour, SievertsPerHourTolerance);
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            AssertEx.EqualTolerance(MicrosievertsPerHourInOneSievertPerSecond, sievertpersecond.MicrosievertsPerHour, MicrosievertsPerHourTolerance);
+            AssertEx.EqualTolerance(MicrosievertsPerSecondInOneSievertPerSecond, sievertpersecond.MicrosievertsPerSecond, MicrosievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(MilliroentgensEquivalentManPerHourInOneSievertPerSecond, sievertpersecond.MilliroentgensEquivalentManPerHour, MilliroentgensEquivalentManPerHourTolerance);
+            AssertEx.EqualTolerance(MillisievertsPerHourInOneSievertPerSecond, sievertpersecond.MillisievertsPerHour, MillisievertsPerHourTolerance);
+            AssertEx.EqualTolerance(MillisievertsPerSecondInOneSievertPerSecond, sievertpersecond.MillisievertsPerSecond, MillisievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(NanosievertsPerHourInOneSievertPerSecond, sievertpersecond.NanosievertsPerHour, NanosievertsPerHourTolerance);
+            AssertEx.EqualTolerance(NanosievertsPerSecondInOneSievertPerSecond, sievertpersecond.NanosievertsPerSecond, NanosievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(RoentgensEquivalentManPerHourInOneSievertPerSecond, sievertpersecond.RoentgensEquivalentManPerHour, RoentgensEquivalentManPerHourTolerance);
+            AssertEx.EqualTolerance(SievertsPerHourInOneSievertPerSecond, sievertpersecond.SievertsPerHour, SievertsPerHourTolerance);
+            AssertEx.EqualTolerance(SievertsPerSecondInOneSievertPerSecond, sievertpersecond.SievertsPerSecond, SievertsPerSecondTolerance);
         }
 
         [Fact]
@@ -158,42 +178,58 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity00.MicrosievertsPerHour, MicrosievertsPerHourTolerance);
             Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, quantity00.Unit);
 
-            var quantity01 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour);
-            AssertEx.EqualTolerance(1, quantity01.MilliroentgensEquivalentManPerHour, MilliroentgensEquivalentManPerHourTolerance);
-            Assert.Equal(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, quantity01.Unit);
+            var quantity01 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond);
+            AssertEx.EqualTolerance(1, quantity01.MicrosievertsPerSecond, MicrosievertsPerSecondTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, quantity01.Unit);
 
-            var quantity02 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.MillisievertPerHour);
-            AssertEx.EqualTolerance(1, quantity02.MillisievertsPerHour, MillisievertsPerHourTolerance);
-            Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerHour, quantity02.Unit);
+            var quantity02 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour);
+            AssertEx.EqualTolerance(1, quantity02.MilliroentgensEquivalentManPerHour, MilliroentgensEquivalentManPerHourTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, quantity02.Unit);
 
-            var quantity03 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.NanosievertPerHour);
-            AssertEx.EqualTolerance(1, quantity03.NanosievertsPerHour, NanosievertsPerHourTolerance);
-            Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, quantity03.Unit);
+            var quantity03 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.MillisievertPerHour);
+            AssertEx.EqualTolerance(1, quantity03.MillisievertsPerHour, MillisievertsPerHourTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerHour, quantity03.Unit);
 
-            var quantity04 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour);
-            AssertEx.EqualTolerance(1, quantity04.RoentgensEquivalentManPerHour, RoentgensEquivalentManPerHourTolerance);
-            Assert.Equal(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, quantity04.Unit);
+            var quantity04 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.MillisievertPerSecond);
+            AssertEx.EqualTolerance(1, quantity04.MillisievertsPerSecond, MillisievertsPerSecondTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, quantity04.Unit);
 
-            var quantity05 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.SievertPerHour);
-            AssertEx.EqualTolerance(1, quantity05.SievertsPerHour, SievertsPerHourTolerance);
-            Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, quantity05.Unit);
+            var quantity05 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.NanosievertPerHour);
+            AssertEx.EqualTolerance(1, quantity05.NanosievertsPerHour, NanosievertsPerHourTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, quantity05.Unit);
+
+            var quantity06 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.NanosievertPerSecond);
+            AssertEx.EqualTolerance(1, quantity06.NanosievertsPerSecond, NanosievertsPerSecondTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, quantity06.Unit);
+
+            var quantity07 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour);
+            AssertEx.EqualTolerance(1, quantity07.RoentgensEquivalentManPerHour, RoentgensEquivalentManPerHourTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, quantity07.Unit);
+
+            var quantity08 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.SievertPerHour);
+            AssertEx.EqualTolerance(1, quantity08.SievertsPerHour, SievertsPerHourTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, quantity08.Unit);
+
+            var quantity09 = RadiationEquivalentDoseRate.From(1, RadiationEquivalentDoseRateUnit.SievertPerSecond);
+            AssertEx.EqualTolerance(1, quantity09.SievertsPerSecond, SievertsPerSecondTolerance);
+            Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity09.Unit);
 
         }
 
         [Fact]
-        public void FromSievertsPerHour_WithInfinityValue_DoNotThrowsArgumentException()
+        public void FromSievertsPerSecond_WithInfinityValue_DoNotThrowsArgumentException()
         {
-            var exception1 = Record.Exception(() => RadiationEquivalentDoseRate.FromSievertsPerHour(double.PositiveInfinity));
-            var exception2 = Record.Exception(() => RadiationEquivalentDoseRate.FromSievertsPerHour(double.NegativeInfinity));
+            var exception1 = Record.Exception(() => RadiationEquivalentDoseRate.FromSievertsPerSecond(double.PositiveInfinity));
+            var exception2 = Record.Exception(() => RadiationEquivalentDoseRate.FromSievertsPerSecond(double.NegativeInfinity));
 
             Assert.Null(exception1);
             Assert.Null(exception2);
         }
 
         [Fact]
-        public void FromSievertsPerHour_WithNanValue_DoNotThrowsArgumentException()
+        public void FromSievertsPerSecond_WithNanValue_DoNotThrowsArgumentException()
         {
-            var exception = Record.Exception(() => RadiationEquivalentDoseRate.FromSievertsPerHour(double.NaN));
+            var exception = Record.Exception(() => RadiationEquivalentDoseRate.FromSievertsPerSecond(double.NaN));
 
             Assert.Null(exception);
         }
@@ -201,13 +237,17 @@ namespace UnitsNet.Tests
         [Fact]
         public void As()
         {
-            var sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            AssertEx.EqualTolerance(MicrosievertsPerHourInOneSievertPerHour, sievertperhour.As(RadiationEquivalentDoseRateUnit.MicrosievertPerHour), MicrosievertsPerHourTolerance);
-            AssertEx.EqualTolerance(MilliroentgensEquivalentManPerHourInOneSievertPerHour, sievertperhour.As(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour), MilliroentgensEquivalentManPerHourTolerance);
-            AssertEx.EqualTolerance(MillisievertsPerHourInOneSievertPerHour, sievertperhour.As(RadiationEquivalentDoseRateUnit.MillisievertPerHour), MillisievertsPerHourTolerance);
-            AssertEx.EqualTolerance(NanosievertsPerHourInOneSievertPerHour, sievertperhour.As(RadiationEquivalentDoseRateUnit.NanosievertPerHour), NanosievertsPerHourTolerance);
-            AssertEx.EqualTolerance(RoentgensEquivalentManPerHourInOneSievertPerHour, sievertperhour.As(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour), RoentgensEquivalentManPerHourTolerance);
-            AssertEx.EqualTolerance(SievertsPerHourInOneSievertPerHour, sievertperhour.As(RadiationEquivalentDoseRateUnit.SievertPerHour), SievertsPerHourTolerance);
+            var sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            AssertEx.EqualTolerance(MicrosievertsPerHourInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.MicrosievertPerHour), MicrosievertsPerHourTolerance);
+            AssertEx.EqualTolerance(MicrosievertsPerSecondInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond), MicrosievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(MilliroentgensEquivalentManPerHourInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour), MilliroentgensEquivalentManPerHourTolerance);
+            AssertEx.EqualTolerance(MillisievertsPerHourInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.MillisievertPerHour), MillisievertsPerHourTolerance);
+            AssertEx.EqualTolerance(MillisievertsPerSecondInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.MillisievertPerSecond), MillisievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(NanosievertsPerHourInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.NanosievertPerHour), NanosievertsPerHourTolerance);
+            AssertEx.EqualTolerance(NanosievertsPerSecondInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.NanosievertPerSecond), NanosievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(RoentgensEquivalentManPerHourInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour), RoentgensEquivalentManPerHourTolerance);
+            AssertEx.EqualTolerance(SievertsPerHourInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.SievertPerHour), SievertsPerHourTolerance);
+            AssertEx.EqualTolerance(SievertsPerSecondInOneSievertPerSecond, sievertpersecond.As(RadiationEquivalentDoseRateUnit.SievertPerSecond), SievertsPerSecondTolerance);
         }
 
         [Fact]
@@ -246,6 +286,20 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 µSv/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MicrosievertsPerSecond, MicrosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 мкЗв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.MicrosievertsPerSecond, MicrosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = RadiationEquivalentDoseRate.Parse("1 mrem/h", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.MilliroentgensEquivalentManPerHour, MilliroentgensEquivalentManPerHourTolerance);
                 Assert.Equal(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, parsed.Unit);
@@ -267,6 +321,20 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 mSv/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.MillisievertsPerSecond, MillisievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 мЗв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.MillisievertsPerSecond, MillisievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsed = RadiationEquivalentDoseRate.Parse("1 nSv/h", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.NanosievertsPerHour, NanosievertsPerHourTolerance);
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsed.Unit);
@@ -277,6 +345,20 @@ namespace UnitsNet.Tests
                 var parsed = RadiationEquivalentDoseRate.Parse("1 нЗв/ч", CultureInfo.GetCultureInfo("ru-RU"));
                 AssertEx.EqualTolerance(1, parsed.NanosievertsPerHour, NanosievertsPerHourTolerance);
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 nSv/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.NanosievertsPerSecond, NanosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 нЗв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.NanosievertsPerSecond, NanosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -300,6 +382,20 @@ namespace UnitsNet.Tests
                 Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
+            try
+            {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 Sv/s", CultureInfo.GetCultureInfo("en-US"));
+                AssertEx.EqualTolerance(1, parsed.SievertsPerSecond, SievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsed = RadiationEquivalentDoseRate.Parse("1 Зв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                AssertEx.EqualTolerance(1, parsed.SievertsPerSecond, SievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsed.Unit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
         }
 
         [Fact]
@@ -315,6 +411,18 @@ namespace UnitsNet.Tests
                 Assert.True(RadiationEquivalentDoseRate.TryParse("1 мкЗв/ч", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.MicrosievertsPerHour, MicrosievertsPerHourTolerance);
                 Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, parsed.Unit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 µSv/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MicrosievertsPerSecond, MicrosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 мкЗв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MicrosievertsPerSecond, MicrosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsed.Unit);
             }
 
             {
@@ -336,6 +444,18 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 mSv/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillisievertsPerSecond, MillisievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 мЗв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.MillisievertsPerSecond, MillisievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsed.Unit);
+            }
+
+            {
                 Assert.True(RadiationEquivalentDoseRate.TryParse("1 nSv/h", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.NanosievertsPerHour, NanosievertsPerHourTolerance);
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsed.Unit);
@@ -345,6 +465,18 @@ namespace UnitsNet.Tests
                 Assert.True(RadiationEquivalentDoseRate.TryParse("1 нЗв/ч", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.NanosievertsPerHour, NanosievertsPerHourTolerance);
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsed.Unit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 nSv/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.NanosievertsPerSecond, NanosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 нЗв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.NanosievertsPerSecond, NanosievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsed.Unit);
             }
 
             {
@@ -365,6 +497,18 @@ namespace UnitsNet.Tests
                 Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, parsed.Unit);
             }
 
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 Sv/s", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.SievertsPerSecond, SievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsed.Unit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParse("1 Зв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsed));
+                AssertEx.EqualTolerance(1, parsed.SievertsPerSecond, SievertsPerSecondTolerance);
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsed.Unit);
+            }
+
         }
 
         [Fact]
@@ -380,6 +524,18 @@ namespace UnitsNet.Tests
             {
                 var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("мкЗв/ч", CultureInfo.GetCultureInfo("ru-RU"));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("µSv/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("мкЗв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -402,6 +558,18 @@ namespace UnitsNet.Tests
 
             try
             {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("mSv/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("мЗв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
                 var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("nSv/h", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -410,6 +578,18 @@ namespace UnitsNet.Tests
             {
                 var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("нЗв/ч", CultureInfo.GetCultureInfo("ru-RU"));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("nSv/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("нЗв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -430,6 +610,18 @@ namespace UnitsNet.Tests
                 Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("Sv/s", CultureInfo.GetCultureInfo("en-US"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
+            try
+            {
+                var parsedUnit = RadiationEquivalentDoseRate.ParseUnit("Зв/с", CultureInfo.GetCultureInfo("ru-RU"));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsedUnit);
+            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
+
         }
 
         [Fact]
@@ -443,6 +635,16 @@ namespace UnitsNet.Tests
             {
                 Assert.True(RadiationEquivalentDoseRate.TryParseUnit("мкЗв/ч", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("µSv/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("мкЗв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, parsedUnit);
             }
 
             {
@@ -461,6 +663,16 @@ namespace UnitsNet.Tests
             }
 
             {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("mSv/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("мЗв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, parsedUnit);
+            }
+
+            {
                 Assert.True(RadiationEquivalentDoseRate.TryParseUnit("nSv/h", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsedUnit);
             }
@@ -468,6 +680,16 @@ namespace UnitsNet.Tests
             {
                 Assert.True(RadiationEquivalentDoseRate.TryParseUnit("нЗв/ч", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerHour, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("nSv/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("нЗв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, parsedUnit);
             }
 
             {
@@ -483,6 +705,16 @@ namespace UnitsNet.Tests
             {
                 Assert.True(RadiationEquivalentDoseRate.TryParseUnit("Зв/ч", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
                 Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerHour, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("Sv/s", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsedUnit);
+            }
+
+            {
+                Assert.True(RadiationEquivalentDoseRate.TryParseUnit("Зв/с", CultureInfo.GetCultureInfo("ru-RU"), out var parsedUnit));
+                Assert.Equal(RadiationEquivalentDoseRateUnit.SievertPerSecond, parsedUnit);
             }
 
         }
@@ -532,73 +764,77 @@ namespace UnitsNet.Tests
         [Fact]
         public void ConversionRoundTrip()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMicrosievertsPerHour(sievertperhour.MicrosievertsPerHour).SievertsPerHour, MicrosievertsPerHourTolerance);
-            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMilliroentgensEquivalentManPerHour(sievertperhour.MilliroentgensEquivalentManPerHour).SievertsPerHour, MilliroentgensEquivalentManPerHourTolerance);
-            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMillisievertsPerHour(sievertperhour.MillisievertsPerHour).SievertsPerHour, MillisievertsPerHourTolerance);
-            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromNanosievertsPerHour(sievertperhour.NanosievertsPerHour).SievertsPerHour, NanosievertsPerHourTolerance);
-            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromRoentgensEquivalentManPerHour(sievertperhour.RoentgensEquivalentManPerHour).SievertsPerHour, RoentgensEquivalentManPerHourTolerance);
-            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromSievertsPerHour(sievertperhour.SievertsPerHour).SievertsPerHour, SievertsPerHourTolerance);
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMicrosievertsPerHour(sievertpersecond.MicrosievertsPerHour).SievertsPerSecond, MicrosievertsPerHourTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMicrosievertsPerSecond(sievertpersecond.MicrosievertsPerSecond).SievertsPerSecond, MicrosievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMilliroentgensEquivalentManPerHour(sievertpersecond.MilliroentgensEquivalentManPerHour).SievertsPerSecond, MilliroentgensEquivalentManPerHourTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMillisievertsPerHour(sievertpersecond.MillisievertsPerHour).SievertsPerSecond, MillisievertsPerHourTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromMillisievertsPerSecond(sievertpersecond.MillisievertsPerSecond).SievertsPerSecond, MillisievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromNanosievertsPerHour(sievertpersecond.NanosievertsPerHour).SievertsPerSecond, NanosievertsPerHourTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromNanosievertsPerSecond(sievertpersecond.NanosievertsPerSecond).SievertsPerSecond, NanosievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromRoentgensEquivalentManPerHour(sievertpersecond.RoentgensEquivalentManPerHour).SievertsPerSecond, RoentgensEquivalentManPerHourTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromSievertsPerHour(sievertpersecond.SievertsPerHour).SievertsPerSecond, SievertsPerHourTolerance);
+            AssertEx.EqualTolerance(1, RadiationEquivalentDoseRate.FromSievertsPerSecond(sievertpersecond.SievertsPerSecond).SievertsPerSecond, SievertsPerSecondTolerance);
         }
 
         [Fact]
         public void ArithmeticOperators()
         {
-            RadiationEquivalentDoseRate v = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            AssertEx.EqualTolerance(-1, -v.SievertsPerHour, SievertsPerHourTolerance);
-            AssertEx.EqualTolerance(2, (RadiationEquivalentDoseRate.FromSievertsPerHour(3)-v).SievertsPerHour, SievertsPerHourTolerance);
-            AssertEx.EqualTolerance(2, (v + v).SievertsPerHour, SievertsPerHourTolerance);
-            AssertEx.EqualTolerance(10, (v*10).SievertsPerHour, SievertsPerHourTolerance);
-            AssertEx.EqualTolerance(10, (10*v).SievertsPerHour, SievertsPerHourTolerance);
-            AssertEx.EqualTolerance(2, (RadiationEquivalentDoseRate.FromSievertsPerHour(10)/5).SievertsPerHour, SievertsPerHourTolerance);
-            AssertEx.EqualTolerance(2, RadiationEquivalentDoseRate.FromSievertsPerHour(10)/RadiationEquivalentDoseRate.FromSievertsPerHour(5), SievertsPerHourTolerance);
+            RadiationEquivalentDoseRate v = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            AssertEx.EqualTolerance(-1, -v.SievertsPerSecond, SievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(2, (RadiationEquivalentDoseRate.FromSievertsPerSecond(3)-v).SievertsPerSecond, SievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(2, (v + v).SievertsPerSecond, SievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(10, (v*10).SievertsPerSecond, SievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(10, (10*v).SievertsPerSecond, SievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(2, (RadiationEquivalentDoseRate.FromSievertsPerSecond(10)/5).SievertsPerSecond, SievertsPerSecondTolerance);
+            AssertEx.EqualTolerance(2, RadiationEquivalentDoseRate.FromSievertsPerSecond(10)/RadiationEquivalentDoseRate.FromSievertsPerSecond(5), SievertsPerSecondTolerance);
         }
 
         [Fact]
         public void ComparisonOperators()
         {
-            RadiationEquivalentDoseRate oneSievertPerHour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            RadiationEquivalentDoseRate twoSievertsPerHour = RadiationEquivalentDoseRate.FromSievertsPerHour(2);
+            RadiationEquivalentDoseRate oneSievertPerSecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            RadiationEquivalentDoseRate twoSievertsPerSecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(2);
 
-            Assert.True(oneSievertPerHour < twoSievertsPerHour);
-            Assert.True(oneSievertPerHour <= twoSievertsPerHour);
-            Assert.True(twoSievertsPerHour > oneSievertPerHour);
-            Assert.True(twoSievertsPerHour >= oneSievertPerHour);
+            Assert.True(oneSievertPerSecond < twoSievertsPerSecond);
+            Assert.True(oneSievertPerSecond <= twoSievertsPerSecond);
+            Assert.True(twoSievertsPerSecond > oneSievertPerSecond);
+            Assert.True(twoSievertsPerSecond >= oneSievertPerSecond);
 
-            Assert.False(oneSievertPerHour > twoSievertsPerHour);
-            Assert.False(oneSievertPerHour >= twoSievertsPerHour);
-            Assert.False(twoSievertsPerHour < oneSievertPerHour);
-            Assert.False(twoSievertsPerHour <= oneSievertPerHour);
+            Assert.False(oneSievertPerSecond > twoSievertsPerSecond);
+            Assert.False(oneSievertPerSecond >= twoSievertsPerSecond);
+            Assert.False(twoSievertsPerSecond < oneSievertPerSecond);
+            Assert.False(twoSievertsPerSecond <= oneSievertPerSecond);
         }
 
         [Fact]
         public void CompareToIsImplemented()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.Equal(0, sievertperhour.CompareTo(sievertperhour));
-            Assert.True(sievertperhour.CompareTo(RadiationEquivalentDoseRate.Zero) > 0);
-            Assert.True(RadiationEquivalentDoseRate.Zero.CompareTo(sievertperhour) < 0);
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.Equal(0, sievertpersecond.CompareTo(sievertpersecond));
+            Assert.True(sievertpersecond.CompareTo(RadiationEquivalentDoseRate.Zero) > 0);
+            Assert.True(RadiationEquivalentDoseRate.Zero.CompareTo(sievertpersecond) < 0);
         }
 
         [Fact]
         public void CompareToThrowsOnTypeMismatch()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.Throws<ArgumentException>(() => sievertperhour.CompareTo(new object()));
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.Throws<ArgumentException>(() => sievertpersecond.CompareTo(new object()));
         }
 
         [Fact]
         public void CompareToThrowsOnNull()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.Throws<ArgumentNullException>(() => sievertperhour.CompareTo(null));
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.Throws<ArgumentNullException>(() => sievertpersecond.CompareTo(null));
         }
 
         [Theory]
-        [InlineData(1, RadiationEquivalentDoseRateUnit.SievertPerHour, 1, RadiationEquivalentDoseRateUnit.SievertPerHour, true)]  // Same value and unit.
-        [InlineData(1, RadiationEquivalentDoseRateUnit.SievertPerHour, 2, RadiationEquivalentDoseRateUnit.SievertPerHour, false)] // Different value.
-        [InlineData(2, RadiationEquivalentDoseRateUnit.SievertPerHour, 1, RadiationEquivalentDoseRateUnit.MicrosievertPerHour, false)] // Different value and unit.
-        [InlineData(1, RadiationEquivalentDoseRateUnit.SievertPerHour, 1, RadiationEquivalentDoseRateUnit.MicrosievertPerHour, false)] // Different unit.
+        [InlineData(1, RadiationEquivalentDoseRateUnit.SievertPerSecond, 1, RadiationEquivalentDoseRateUnit.SievertPerSecond, true)]  // Same value and unit.
+        [InlineData(1, RadiationEquivalentDoseRateUnit.SievertPerSecond, 2, RadiationEquivalentDoseRateUnit.SievertPerSecond, false)] // Different value.
+        [InlineData(2, RadiationEquivalentDoseRateUnit.SievertPerSecond, 1, RadiationEquivalentDoseRateUnit.MicrosievertPerHour, false)] // Different value and unit.
+        [InlineData(1, RadiationEquivalentDoseRateUnit.SievertPerSecond, 1, RadiationEquivalentDoseRateUnit.MicrosievertPerHour, false)] // Different unit.
         public void Equals_ReturnsTrue_IfValueAndUnitAreEqual(double valueA, RadiationEquivalentDoseRateUnit unitA, double valueB, RadiationEquivalentDoseRateUnit unitB, bool expectEqual)
         {
             var a = new RadiationEquivalentDoseRate(valueA, unitA);
@@ -638,32 +874,32 @@ namespace UnitsNet.Tests
         [Fact]
         public void Equals_RelativeTolerance_IsImplemented()
         {
-            var v = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.True(v.Equals(RadiationEquivalentDoseRate.FromSievertsPerHour(1), SievertsPerHourTolerance, ComparisonType.Relative));
-            Assert.False(v.Equals(RadiationEquivalentDoseRate.Zero, SievertsPerHourTolerance, ComparisonType.Relative));
-            Assert.True(RadiationEquivalentDoseRate.FromSievertsPerHour(100).Equals(RadiationEquivalentDoseRate.FromSievertsPerHour(120), 0.3, ComparisonType.Relative));
-            Assert.False(RadiationEquivalentDoseRate.FromSievertsPerHour(100).Equals(RadiationEquivalentDoseRate.FromSievertsPerHour(120), 0.1, ComparisonType.Relative));
+            var v = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.True(v.Equals(RadiationEquivalentDoseRate.FromSievertsPerSecond(1), SievertsPerSecondTolerance, ComparisonType.Relative));
+            Assert.False(v.Equals(RadiationEquivalentDoseRate.Zero, SievertsPerSecondTolerance, ComparisonType.Relative));
+            Assert.True(RadiationEquivalentDoseRate.FromSievertsPerSecond(100).Equals(RadiationEquivalentDoseRate.FromSievertsPerSecond(120), 0.3, ComparisonType.Relative));
+            Assert.False(RadiationEquivalentDoseRate.FromSievertsPerSecond(100).Equals(RadiationEquivalentDoseRate.FromSievertsPerSecond(120), 0.1, ComparisonType.Relative));
         }
 
         [Fact]
         public void Equals_NegativeRelativeTolerance_ThrowsArgumentOutOfRangeException()
         {
-            var v = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.Throws<ArgumentOutOfRangeException>(() => v.Equals(RadiationEquivalentDoseRate.FromSievertsPerHour(1), -1, ComparisonType.Relative));
+            var v = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => v.Equals(RadiationEquivalentDoseRate.FromSievertsPerSecond(1), -1, ComparisonType.Relative));
         }
 
         [Fact]
         public void EqualsReturnsFalseOnTypeMismatch()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.False(sievertperhour.Equals(new object()));
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.False(sievertpersecond.Equals(new object()));
         }
 
         [Fact]
         public void EqualsReturnsFalseOnNull()
         {
-            RadiationEquivalentDoseRate sievertperhour = RadiationEquivalentDoseRate.FromSievertsPerHour(1);
-            Assert.False(sievertperhour.Equals(null));
+            RadiationEquivalentDoseRate sievertpersecond = RadiationEquivalentDoseRate.FromSievertsPerSecond(1);
+            Assert.False(sievertpersecond.Equals(null));
         }
 
         [Fact]
@@ -689,11 +925,15 @@ namespace UnitsNet.Tests
             Thread.CurrentThread.CurrentCulture = CultureInfo.GetCultureInfo("en-US");
             try {
                 Assert.Equal("1 µSv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MicrosievertPerHour).ToString());
+                Assert.Equal("1 µSv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond).ToString());
                 Assert.Equal("1 mrem/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour).ToString());
                 Assert.Equal("1 mSv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MillisievertPerHour).ToString());
+                Assert.Equal("1 mSv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MillisievertPerSecond).ToString());
                 Assert.Equal("1 nSv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.NanosievertPerHour).ToString());
+                Assert.Equal("1 nSv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.NanosievertPerSecond).ToString());
                 Assert.Equal("1 rem/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour).ToString());
                 Assert.Equal("1 Sv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString());
+                Assert.Equal("1 Sv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString());
             }
             finally
             {
@@ -708,11 +948,15 @@ namespace UnitsNet.Tests
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
             Assert.Equal("1 µSv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MicrosievertPerHour).ToString(swedishCulture));
+            Assert.Equal("1 µSv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond).ToString(swedishCulture));
             Assert.Equal("1 mrem/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour).ToString(swedishCulture));
             Assert.Equal("1 mSv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MillisievertPerHour).ToString(swedishCulture));
+            Assert.Equal("1 mSv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.MillisievertPerSecond).ToString(swedishCulture));
             Assert.Equal("1 nSv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.NanosievertPerHour).ToString(swedishCulture));
+            Assert.Equal("1 nSv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.NanosievertPerSecond).ToString(swedishCulture));
             Assert.Equal("1 rem/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour).ToString(swedishCulture));
             Assert.Equal("1 Sv/h", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString(swedishCulture));
+            Assert.Equal("1 Sv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString(swedishCulture));
         }
 
         [Fact]
@@ -722,10 +966,10 @@ namespace UnitsNet.Tests
             try
             {
                 CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
-                Assert.Equal("0.1 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s1"));
-                Assert.Equal("0.12 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s2"));
-                Assert.Equal("0.123 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s3"));
-                Assert.Equal("0.1235 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s4"));
+                Assert.Equal("0.1 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s1"));
+                Assert.Equal("0.12 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s2"));
+                Assert.Equal("0.123 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s3"));
+                Assert.Equal("0.1235 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s4"));
             }
             finally
             {
@@ -737,10 +981,10 @@ namespace UnitsNet.Tests
         public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
         {
             var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s1", culture));
-            Assert.Equal("0.12 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s2", culture));
-            Assert.Equal("0.123 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s3", culture));
-            Assert.Equal("0.1235 Sv/h", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerHour).ToString("s4", culture));
+            Assert.Equal("0.1 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s1", culture));
+            Assert.Equal("0.12 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s2", culture));
+            Assert.Equal("0.123 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s3", culture));
+            Assert.Equal("0.1235 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s4", culture));
         }
 
         [Theory]
@@ -748,7 +992,7 @@ namespace UnitsNet.Tests
         [InlineData("en-US")]
         public void ToString_NullFormat_DefaultsToGeneralFormat(string cultureName)
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             CultureInfo formatProvider = cultureName == null
                 ? null
                 : CultureInfo.GetCultureInfo(cultureName);
@@ -761,154 +1005,154 @@ namespace UnitsNet.Tests
         [InlineData("g")]
         public void ToString_NullProvider_EqualsCurrentCulture(string format)
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(quantity.ToString(format, CultureInfo.CurrentCulture), quantity.ToString(format, null));
         }
 
         [Fact]
         public void Convert_ToBool_ThrowsInvalidCastException()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ToBoolean(quantity));
         }
 
         [Fact]
         public void Convert_ToByte_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
            Assert.Equal((byte)quantity.Value, Convert.ToByte(quantity));
         }
 
         [Fact]
         public void Convert_ToChar_ThrowsInvalidCastException()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ToChar(quantity));
         }
 
         [Fact]
         public void Convert_ToDateTime_ThrowsInvalidCastException()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ToDateTime(quantity));
         }
 
         [Fact]
         public void Convert_ToDecimal_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((decimal)quantity.Value, Convert.ToDecimal(quantity));
         }
 
         [Fact]
         public void Convert_ToDouble_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((double)quantity.Value, Convert.ToDouble(quantity));
         }
 
         [Fact]
         public void Convert_ToInt16_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((short)quantity.Value, Convert.ToInt16(quantity));
         }
 
         [Fact]
         public void Convert_ToInt32_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((int)quantity.Value, Convert.ToInt32(quantity));
         }
 
         [Fact]
         public void Convert_ToInt64_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((long)quantity.Value, Convert.ToInt64(quantity));
         }
 
         [Fact]
         public void Convert_ToSByte_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((sbyte)quantity.Value, Convert.ToSByte(quantity));
         }
 
         [Fact]
         public void Convert_ToSingle_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((float)quantity.Value, Convert.ToSingle(quantity));
         }
 
         [Fact]
         public void Convert_ToString_EqualsToString()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(quantity.ToString(), Convert.ToString(quantity));
         }
 
         [Fact]
         public void Convert_ToUInt16_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((ushort)quantity.Value, Convert.ToUInt16(quantity));
         }
 
         [Fact]
         public void Convert_ToUInt32_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((uint)quantity.Value, Convert.ToUInt32(quantity));
         }
 
         [Fact]
         public void Convert_ToUInt64_EqualsValueAsSameType()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal((ulong)quantity.Value, Convert.ToUInt64(quantity));
         }
 
         [Fact]
         public void Convert_ChangeType_SelfType_EqualsSelf()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(quantity, Convert.ChangeType(quantity, typeof(RadiationEquivalentDoseRate)));
         }
 
         [Fact]
         public void Convert_ChangeType_UnitType_EqualsUnit()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(quantity.Unit, Convert.ChangeType(quantity, typeof(RadiationEquivalentDoseRateUnit)));
         }
 
         [Fact]
         public void Convert_ChangeType_QuantityInfo_EqualsQuantityInfo()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(RadiationEquivalentDoseRate.Info, Convert.ChangeType(quantity, typeof(QuantityInfo)));
         }
 
         [Fact]
         public void Convert_ChangeType_BaseDimensions_EqualsBaseDimensions()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(RadiationEquivalentDoseRate.BaseDimensions, Convert.ChangeType(quantity, typeof(BaseDimensions)));
         }
 
         [Fact]
         public void Convert_ChangeType_InvalidType_ThrowsInvalidCastException()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Throws<InvalidCastException>(() => Convert.ChangeType(quantity, typeof(QuantityFormatter)));
         }
 
         [Fact]
         public void GetHashCode_Equals()
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(1.0);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(1.0);
             Assert.Equal(new {RadiationEquivalentDoseRate.Info.Name, quantity.Value, quantity.Unit}.GetHashCode(), quantity.GetHashCode());
         }
 
@@ -917,8 +1161,8 @@ namespace UnitsNet.Tests
         [InlineData(-1.0)]
         public void NegationOperator_ReturnsQuantity_WithNegatedValue(double value)
         {
-            var quantity = RadiationEquivalentDoseRate.FromSievertsPerHour(value);
-            Assert.Equal(RadiationEquivalentDoseRate.FromSievertsPerHour(-value), -quantity);
+            var quantity = RadiationEquivalentDoseRate.FromSievertsPerSecond(value);
+            Assert.Equal(RadiationEquivalentDoseRate.FromSievertsPerSecond(-value), -quantity);
         }
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
@@ -70,18 +70,22 @@ namespace UnitsNet
         static RadiationEquivalentDoseRate()
         {
             BaseDimensions = new BaseDimensions(2, 0, -3, 0, 0, 0, 0);
-            BaseUnit = RadiationEquivalentDoseRateUnit.SievertPerHour;
+            BaseUnit = RadiationEquivalentDoseRateUnit.SievertPerSecond;
             Units = Enum.GetValues(typeof(RadiationEquivalentDoseRateUnit)).Cast<RadiationEquivalentDoseRateUnit>().ToArray();
             Zero = new RadiationEquivalentDoseRate(0, BaseUnit);
             Info = new QuantityInfo<RadiationEquivalentDoseRateUnit>("RadiationEquivalentDoseRate",
                 new UnitInfo<RadiationEquivalentDoseRateUnit>[]
                 {
                     new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, "MicrosievertsPerHour", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
+                    new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, "MicrosievertsPerSecond", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
                     new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, "MilliroentgensEquivalentManPerHour", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
                     new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.MillisievertPerHour, "MillisievertsPerHour", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
+                    new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, "MillisievertsPerSecond", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
                     new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.NanosievertPerHour, "NanosievertsPerHour", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
+                    new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, "NanosievertsPerSecond", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
                     new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, "RoentgensEquivalentManPerHour", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
                     new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.SievertPerHour, "SievertsPerHour", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
+                    new UnitInfo<RadiationEquivalentDoseRateUnit>(RadiationEquivalentDoseRateUnit.SievertPerSecond, "SievertsPerSecond", BaseUnits.Undefined, "RadiationEquivalentDoseRate"),
                 },
                 BaseUnit, Zero, BaseDimensions);
 
@@ -135,7 +139,7 @@ namespace UnitsNet
         public static BaseDimensions BaseDimensions { get; }
 
         /// <summary>
-        ///     The base unit of RadiationEquivalentDoseRate, which is SievertPerHour. All conversions go via this value.
+        ///     The base unit of RadiationEquivalentDoseRate, which is SievertPerSecond. All conversions go via this value.
         /// </summary>
         public static RadiationEquivalentDoseRateUnit BaseUnit { get; }
 
@@ -145,7 +149,7 @@ namespace UnitsNet
         public static RadiationEquivalentDoseRateUnit[] Units { get; }
 
         /// <summary>
-        ///     Gets an instance of this quantity with a value of 0 in the base unit SievertPerHour.
+        ///     Gets an instance of this quantity with a value of 0 in the base unit SievertPerSecond.
         /// </summary>
         public static RadiationEquivalentDoseRate Zero { get; }
 
@@ -190,6 +194,11 @@ namespace UnitsNet
         public double MicrosievertsPerHour => As(RadiationEquivalentDoseRateUnit.MicrosievertPerHour);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.MicrosievertPerSecond"/>
+        /// </summary>
+        public double MicrosievertsPerSecond => As(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour"/>
         /// </summary>
         public double MilliroentgensEquivalentManPerHour => As(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour);
@@ -200,9 +209,19 @@ namespace UnitsNet
         public double MillisievertsPerHour => As(RadiationEquivalentDoseRateUnit.MillisievertPerHour);
 
         /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.MillisievertPerSecond"/>
+        /// </summary>
+        public double MillisievertsPerSecond => As(RadiationEquivalentDoseRateUnit.MillisievertPerSecond);
+
+        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerHour"/>
         /// </summary>
         public double NanosievertsPerHour => As(RadiationEquivalentDoseRateUnit.NanosievertPerHour);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerSecond"/>
+        /// </summary>
+        public double NanosievertsPerSecond => As(RadiationEquivalentDoseRateUnit.NanosievertPerSecond);
 
         /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour"/>
@@ -213,6 +232,11 @@ namespace UnitsNet
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.SievertPerHour"/>
         /// </summary>
         public double SievertsPerHour => As(RadiationEquivalentDoseRateUnit.SievertPerHour);
+
+        /// <summary>
+        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="RadiationEquivalentDoseRateUnit.SievertPerSecond"/>
+        /// </summary>
+        public double SievertsPerSecond => As(RadiationEquivalentDoseRateUnit.SievertPerSecond);
 
         #endregion
 
@@ -225,21 +249,29 @@ namespace UnitsNet
         internal static void RegisterDefaultConversions(UnitConverter unitConverter)
         {
             // Register in unit converter: RadiationEquivalentDoseRateUnit -> BaseUnit
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MillisievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.NanosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MicrosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MillisievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.MillisievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.NanosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.NanosievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerSecond));
 
             // Register in unit converter: BaseUnit <-> BaseUnit
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity);
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond, quantity => quantity);
 
             // Register in unit converter: BaseUnit -> RadiationEquivalentDoseRateUnit
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.MicrosievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MicrosievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.MillisievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MillisievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.NanosievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.NanosievertPerHour));
-            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MicrosievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MicrosievertPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MicrosievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MillisievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MillisievertPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MillisievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.MillisievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.NanosievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.NanosievertPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.NanosievertPerSecond, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.NanosievertPerSecond));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour));
+            unitConverter.SetConversionFunction<RadiationEquivalentDoseRate>(RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerHour, quantity => quantity.ToUnit(RadiationEquivalentDoseRateUnit.SievertPerHour));
         }
 
         /// <summary>
@@ -276,6 +308,14 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MicrosievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromMicrosievertsPerSecond(double value)
+        {
+            return new RadiationEquivalentDoseRate(value, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond);
+        }
+
+        /// <summary>
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour"/>.
         /// </summary>
         public static RadiationEquivalentDoseRate FromMilliroentgensEquivalentManPerHour(double value)
@@ -292,11 +332,27 @@ namespace UnitsNet
         }
 
         /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.MillisievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromMillisievertsPerSecond(double value)
+        {
+            return new RadiationEquivalentDoseRate(value, RadiationEquivalentDoseRateUnit.MillisievertPerSecond);
+        }
+
+        /// <summary>
         ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerHour"/>.
         /// </summary>
         public static RadiationEquivalentDoseRate FromNanosievertsPerHour(double value)
         {
             return new RadiationEquivalentDoseRate(value, RadiationEquivalentDoseRateUnit.NanosievertPerHour);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.NanosievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromNanosievertsPerSecond(double value)
+        {
+            return new RadiationEquivalentDoseRate(value, RadiationEquivalentDoseRateUnit.NanosievertPerSecond);
         }
 
         /// <summary>
@@ -313,6 +369,14 @@ namespace UnitsNet
         public static RadiationEquivalentDoseRate FromSievertsPerHour(double value)
         {
             return new RadiationEquivalentDoseRate(value, RadiationEquivalentDoseRateUnit.SievertPerHour);
+        }
+
+        /// <summary>
+        ///     Creates a <see cref="RadiationEquivalentDoseRate"/> from <see cref="RadiationEquivalentDoseRateUnit.SievertPerSecond"/>.
+        /// </summary>
+        public static RadiationEquivalentDoseRate FromSievertsPerSecond(double value)
+        {
+            return new RadiationEquivalentDoseRate(value, RadiationEquivalentDoseRateUnit.SievertPerSecond);
         }
 
         /// <summary>
@@ -513,7 +577,7 @@ namespace UnitsNet
         /// <summary>Get ratio value from dividing <see cref="RadiationEquivalentDoseRate"/> by <see cref="RadiationEquivalentDoseRate"/>.</summary>
         public static double operator /(RadiationEquivalentDoseRate left, RadiationEquivalentDoseRate right)
         {
-            return left.SievertsPerHour / right.SievertsPerHour;
+            return left.SievertsPerSecond / right.SievertsPerSecond;
         }
 
         #endregion
@@ -809,18 +873,26 @@ namespace UnitsNet
             RadiationEquivalentDoseRate? convertedOrNull = (Unit, unit) switch
             {
                 // RadiationEquivalentDoseRateUnit -> BaseUnit
-                (RadiationEquivalentDoseRateUnit.MicrosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour) => new RadiationEquivalentDoseRate((_value) * 1e-6d, RadiationEquivalentDoseRateUnit.SievertPerHour),
-                (RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour) => new RadiationEquivalentDoseRate((_value / 100) * 1e-3d, RadiationEquivalentDoseRateUnit.SievertPerHour),
-                (RadiationEquivalentDoseRateUnit.MillisievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour) => new RadiationEquivalentDoseRate((_value) * 1e-3d, RadiationEquivalentDoseRateUnit.SievertPerHour),
-                (RadiationEquivalentDoseRateUnit.NanosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour) => new RadiationEquivalentDoseRate((_value) * 1e-9d, RadiationEquivalentDoseRateUnit.SievertPerHour),
-                (RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerHour) => new RadiationEquivalentDoseRate(_value / 100, RadiationEquivalentDoseRateUnit.SievertPerHour),
+                (RadiationEquivalentDoseRateUnit.MicrosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value/3600) * 1e-6d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value) * 1e-6d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value / 100 / 3600) * 1e-3d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.MillisievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value/3600) * 1e-3d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.MillisievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value) * 1e-3d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.NanosievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value/3600) * 1e-9d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.NanosievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate((_value) * 1e-9d, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate(_value / 100 / 3600, RadiationEquivalentDoseRateUnit.SievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.SievertPerSecond) => new RadiationEquivalentDoseRate(_value/3600, RadiationEquivalentDoseRateUnit.SievertPerSecond),
 
                 // BaseUnit -> RadiationEquivalentDoseRateUnit
-                (RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.MicrosievertPerHour) => new RadiationEquivalentDoseRate((_value) / 1e-6d, RadiationEquivalentDoseRateUnit.MicrosievertPerHour),
-                (RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour) => new RadiationEquivalentDoseRate((_value * 100) / 1e-3d, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour),
-                (RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.MillisievertPerHour) => new RadiationEquivalentDoseRate((_value) / 1e-3d, RadiationEquivalentDoseRateUnit.MillisievertPerHour),
-                (RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.NanosievertPerHour) => new RadiationEquivalentDoseRate((_value) / 1e-9d, RadiationEquivalentDoseRateUnit.NanosievertPerHour),
-                (RadiationEquivalentDoseRateUnit.SievertPerHour, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour) => new RadiationEquivalentDoseRate(_value * 100, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MicrosievertPerHour) => new RadiationEquivalentDoseRate((_value*3600) / 1e-6d, RadiationEquivalentDoseRateUnit.MicrosievertPerHour),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond) => new RadiationEquivalentDoseRate((_value) / 1e-6d, RadiationEquivalentDoseRateUnit.MicrosievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour) => new RadiationEquivalentDoseRate((_value * 100 * 3600) / 1e-3d, RadiationEquivalentDoseRateUnit.MilliroentgenEquivalentManPerHour),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MillisievertPerHour) => new RadiationEquivalentDoseRate((_value*3600) / 1e-3d, RadiationEquivalentDoseRateUnit.MillisievertPerHour),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.MillisievertPerSecond) => new RadiationEquivalentDoseRate((_value) / 1e-3d, RadiationEquivalentDoseRateUnit.MillisievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.NanosievertPerHour) => new RadiationEquivalentDoseRate((_value*3600) / 1e-9d, RadiationEquivalentDoseRateUnit.NanosievertPerHour),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.NanosievertPerSecond) => new RadiationEquivalentDoseRate((_value) / 1e-9d, RadiationEquivalentDoseRateUnit.NanosievertPerSecond),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour) => new RadiationEquivalentDoseRate(_value * 100 * 3600, RadiationEquivalentDoseRateUnit.RoentgenEquivalentManPerHour),
+                (RadiationEquivalentDoseRateUnit.SievertPerSecond, RadiationEquivalentDoseRateUnit.SievertPerHour) => new RadiationEquivalentDoseRate(_value*3600, RadiationEquivalentDoseRateUnit.SievertPerHour),
 
                 _ => null
             };

--- a/UnitsNet/GeneratedCode/Resources/RadiationEquivalentDoseRate.restext
+++ b/UnitsNet/GeneratedCode/Resources/RadiationEquivalentDoseRate.restext
@@ -1,6 +1,10 @@
 MicrosievertsPerHour=µSv/h
+MicrosievertsPerSecond=µSv/s
 MilliroentgensEquivalentManPerHour=mrem/h
 MillisievertsPerHour=mSv/h
+MillisievertsPerSecond=mSv/s
 NanosievertsPerHour=nSv/h
+NanosievertsPerSecond=nSv/s
 RoentgensEquivalentManPerHour=rem/h
 SievertsPerHour=Sv/h
+SievertsPerSecond=Sv/s

--- a/UnitsNet/GeneratedCode/Resources/RadiationEquivalentDoseRate.ru-RU.restext
+++ b/UnitsNet/GeneratedCode/Resources/RadiationEquivalentDoseRate.ru-RU.restext
@@ -1,4 +1,8 @@
 MicrosievertsPerHour=мкЗв/ч
+MicrosievertsPerSecond=мкЗв/с
 MillisievertsPerHour=мЗв/ч
+MillisievertsPerSecond=мЗв/с
 NanosievertsPerHour=нЗв/ч
+NanosievertsPerSecond=нЗв/с
 SievertsPerHour=Зв/ч
+SievertsPerSecond=Зв/с

--- a/UnitsNet/GeneratedCode/Units/RadiationEquivalentDoseRateUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/RadiationEquivalentDoseRateUnit.g.cs
@@ -26,11 +26,15 @@ namespace UnitsNet.Units
     public enum RadiationEquivalentDoseRateUnit
     {
         MicrosievertPerHour = 1,
+        MicrosievertPerSecond = 17,
         MilliroentgenEquivalentManPerHour = 4,
         MillisievertPerHour = 3,
+        MillisievertPerSecond = 14,
         NanosievertPerHour = 2,
+        NanosievertPerSecond = 9,
         RoentgenEquivalentManPerHour = 5,
         SievertPerHour = 6,
+        SievertPerSecond = 16,
     }
 
     #pragma warning restore 1591


### PR DESCRIPTION
Fixup of #1468
Port to v6 from https://github.com/angularsen/UnitsNet/pull/1469

- Add unit `SievertPerSecond`, for SI compatibility, with prefixes Nano, Micro, Milli
- Change `RadiationEquivalentDoseRate` base unit from `SievertPerHour` to `SievertPerSecond`
- Update conversion functions.