### PR TITLE
🔥Remove static Default getters, obsoleted by UnitsNetSetup

### DIFF
--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -35,12 +35,6 @@ namespace UnitsNet
         private readonly UnitParser _unitParser;
 
         /// <summary>
-        ///     The default instance of <see cref="QuantityParser"/>, which uses <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.UnitAbbreviations"/>.
-        /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.QuantityParser instead.")]
-        public static QuantityParser Default => UnitsNetSetup.Default.QuantityParser;
-
-        /// <summary>
         ///     Creates an instance of <see cref="QuantityParser"/>, optionally specifying an <see cref="UnitAbbreviationsCache"/>
         ///     with unit abbreviations to use when parsing.
         /// </summary>

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -31,12 +31,6 @@ namespace UnitsNet
         /// </example>
         internal static readonly CultureInfo FallbackCulture = CultureInfo.InvariantCulture;
 
-        /// <summary>
-        ///     The static instance used internally for ToString() and Parse() of quantities and units.
-        /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
-        public static UnitAbbreviationsCache Default => UnitsNetSetup.Default.UnitAbbreviations;
-
         private QuantityInfoLookup QuantityInfoLookup { get; }
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -13,19 +13,12 @@ namespace UnitsNet
 {
     /// <summary>
     ///     Parses units given a unit abbreviations cache.
-    ///     The static instance <see cref="Default"/> is used internally to parse quantities and units using the
-    ///     default abbreviations cache for all units and abbreviations defined in the library.
+    ///     A static instance <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.UnitParser"/> is used internally
+    ///     to parse quantities and units using the default abbreviations cache for all units and abbreviations defined in the library.
     /// </summary>
     public sealed class UnitParser
     {
         private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
-
-        /// <summary>
-        ///     The default static instance used internally to parse quantities and units using the
-        ///     default abbreviations cache for all units and abbreviations defined in the library.
-        /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.UnitParser instead.")]
-        public static UnitParser Default => UnitsNetSetup.Default.UnitParser;
 
         /// <summary>
         ///     Create a parser using the given unit abbreviations cache.
@@ -205,7 +198,7 @@ namespace UnitsNet
             {
                 return false;
             }
-        
+
             unit = matches[0].Unit;
             return true;
         }

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using System.Reflection;
 using System.Linq;
 using UnitsNet.InternalHelpers;
@@ -35,13 +34,6 @@ namespace UnitsNet
     /// </summary>
     public sealed class UnitConverter
     {
-        /// <summary>
-        /// The static instance used by Units.NET to convert between units. Modify this to add/remove conversion functions at runtime, such
-        /// as adding your own third-party units and quantities to convert between.
-        /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.UnitConverter instead.")]
-        public static UnitConverter Default => UnitsNetSetup.Default.UnitConverter;
-
         /// <summary>
         /// Creates a new <see cref="UnitConverter"/> instance.
         /// </summary>


### PR DESCRIPTION
Ref #1200 

Remove static `Default` getter property for `UnitConverter`, `UnitAbbreviationsCache`, `QuantityParser`, `UnitParser`. These just pointed to the singleton `UnitsNetSetup.Default` and were made obsolete in v5.