### PR TITLE
💥Change UnitAbbreviationsCache ctor to not load defaults

### DIFF
--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -325,10 +325,10 @@ namespace UnitsNet.Tests
             var culture = AmericanCulture;
             var unit = AreaUnit.SquareMeter;
 
-            var cache1 = new UnitAbbreviationsCache();
+            var cache1 = UnitAbbreviationsCache.CreateDefault();
             cache1.MapUnitToAbbreviation(unit, culture, "m^2");
 
-            var cache2 = new UnitAbbreviationsCache();
+            var cache2 = UnitAbbreviationsCache.CreateDefault();
             cache2.MapUnitToAbbreviation(unit, culture, "m2");
 
             Assert.Equal(new[] { "m²", "m^2" }, cache1.GetUnitAbbreviations(unit, culture));
@@ -340,7 +340,7 @@ namespace UnitsNet.Tests
         [Fact]
         public void MapUnitToAbbreviation_AddCustomUnit_DoesNotOverrideDefaultAbbreviationForAlreadyMappedUnits()
         {
-            var cache = new UnitAbbreviationsCache();
+            var cache = UnitAbbreviationsCache.CreateDefault();
             cache.MapUnitToAbbreviation(AreaUnit.SquareMeter, AmericanCulture, "m^2");
 
             Assert.Equal("m²", cache.GetDefaultAbbreviation(AreaUnit.SquareMeter, AmericanCulture));

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -39,12 +39,10 @@ namespace UnitsNet
         private ConcurrentDictionary<AbbreviationMapKey, IReadOnlyList<string>> AbbreviationsMap { get; } = new();
 
         /// <summary>
-        ///     Create an instance of the cache and load all the abbreviations defined in the library.
+        ///     Create an empty instance of the cache, with no default abbreviations loaded.
         /// </summary>
-        // TODO Change this to create an empty cache in v6: https://github.com/angularsen/UnitsNet/issues/1200
-        [Obsolete("Use CreateDefault() instead to create an instance that loads the built-in units. The default ctor will change to create an empty cache in UnitsNet v6.")]
         public UnitAbbreviationsCache()
-            : this(new QuantityInfoLookup(Quantity.ByName.Values))
+            : this(new QuantityInfoLookup([]))
         {
         }
 
@@ -58,16 +56,6 @@ namespace UnitsNet
         {
             QuantityInfoLookup = quantityInfoLookup;
         }
-
-        /// <summary>
-        ///     Create an instance with empty cache.
-        /// </summary>
-        /// <remarks>
-        ///     Workaround until v6 changes the default ctor to create an empty cache.<br/>
-        /// </remarks>
-        /// <returns>Instance with empty cache.</returns>
-        // TODO Remove in v6: https://github.com/angularsen/UnitsNet/issues/1200
-        public static UnitAbbreviationsCache CreateEmpty() => new(new QuantityInfoLookup(new List<QuantityInfo>()));
 
         /// <summary>
         ///     Create an instance of the cache and load all the built-in unit abbreviations defined in the library.


### PR DESCRIPTION
Ref #1200

- Remove UnitAbbreviationsCache.CreateEmpty()
- Change default ctor to NOT load default unit abbreviations, use `CreateDefault()` instead
- Fix 2 broken test cases