### PR TITLE
Un-obsolete static Default getters

### DIFF
--- a/UnitsNet/CustomCode/QuantityParser.cs
+++ b/UnitsNet/CustomCode/QuantityParser.cs
@@ -35,9 +35,11 @@ namespace UnitsNet
         private readonly UnitParser _unitParser;
 
         /// <summary>
-        ///     The default instance of <see cref="QuantityParser"/>, which uses <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.UnitAbbreviations"/>.
+        ///     The default singleton instance for parsing quantities.
         /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.QuantityParser instead.")]
+        /// <remarks>
+        ///     Convenience shortcut for <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.QuantityParser"/>.
+        /// </remarks>
         public static QuantityParser Default => UnitsNetSetup.Default.QuantityParser;
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -32,9 +32,12 @@ namespace UnitsNet
         internal static readonly CultureInfo FallbackCulture = CultureInfo.InvariantCulture;
 
         /// <summary>
-        ///     The static instance used internally for ToString() and Parse() of quantities and units.
+        ///     The default singleton instance with the default configured unit abbreviations, used for ToString() and parsing of quantities and units.
         /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.UnitAbbreviations instead.")]
+        /// <remarks>
+        ///     Convenience shortcut for <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.UnitAbbreviations"/>.<br />
+        ///     You can add custom unit abbreviations at runtime, and this will affect all usages globally in the application.
+        /// </remarks>
         public static UnitAbbreviationsCache Default => UnitsNetSetup.Default.UnitAbbreviations;
 
         private QuantityInfoLookup QuantityInfoLookup { get; }

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -20,10 +20,11 @@ namespace UnitsNet
         private readonly UnitAbbreviationsCache _unitAbbreviationsCache;
 
         /// <summary>
-        ///     The default static instance used internally to parse quantities and units using the
-        ///     default abbreviations cache for all units and abbreviations defined in the library.
+        ///     The default singleton instance for parsing units from the default configured unit abbreviations.
         /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.UnitParser instead.")]
+        /// <remarks>
+        ///     Convenience shortcut for <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.UnitParser"/>.
+        /// </remarks>
         public static UnitParser Default => UnitsNetSetup.Default.UnitParser;
 
         /// <summary>

--- a/UnitsNet/UnitConverter.cs
+++ b/UnitsNet/UnitConverter.cs
@@ -36,10 +36,12 @@ namespace UnitsNet
     public sealed class UnitConverter
     {
         /// <summary>
-        /// The static instance used by Units.NET to convert between units. Modify this to add/remove conversion functions at runtime, such
-        /// as adding your own third-party units and quantities to convert between.
+        ///     The default singleton instance for converting values from one unit to another.<br />
+        ///     Modify this to add/remove conversion functions at runtime, such as adding your own third-party units and quantities to convert between.
         /// </summary>
-        [Obsolete("Use UnitsNetSetup.Default.UnitConverter instead.")]
+        /// <remarks>
+        ///     Convenience shortcut for <see cref="UnitsNetSetup"/>.<see cref="UnitsNetSetup.Default"/>.<see cref="UnitsNetSetup.UnitConverter"/>.
+        /// </remarks>
         public static UnitConverter Default => UnitsNetSetup.Default.UnitConverter;
 
         /// <summary>


### PR DESCRIPTION
Per [discussion ](https://github.com/angularsen/UnitsNet/pull/1475#issuecomment-2564377424) in v6, we no longer want to remove these.

Already reverted in v6 with #1480

