### PR TITLE
Update the ToString format of the BaseUnits/Dimensions

### DIFF
--- a/UnitsNet.Tests/BaseDimensionsTests.cs
+++ b/UnitsNet.Tests/BaseDimensionsTests.cs
@@ -74,7 +74,7 @@ namespace UnitsNet.Tests
         {
             Assert.False(Acceleration.BaseDimensions.IsBaseQuantity());
         }
-
+        
         [Theory]
         [InlineData(2, 0, 0, 0, 0, 0, 0)]
         [InlineData(0, 2, 0, 0, 0, 0, 0)]
@@ -733,13 +733,13 @@ namespace UnitsNet.Tests
         [Fact]
         public void CheckToStringUsingMolarEntropy()
         {
-            Assert.Equal("[Length]^2[Mass][Time]^-2[Temperature]^-1[Amount]^-1", MolarEntropy.BaseDimensions.ToString());
+            Assert.Equal("[Length^2][Mass][Time^-2][Temperature^-1][Amount^-1]", MolarEntropy.BaseDimensions.ToString());
         }
 
         [Fact]
         public void CheckToStringUsingSpeed()
         {
-            Assert.Equal("[Length][Time]^-1", Speed.BaseDimensions.ToString());
+            Assert.Equal("[Length][Time^-1]", Speed.BaseDimensions.ToString());
         }
 
         [Fact]
@@ -782,5 +782,6 @@ namespace UnitsNet.Tests
             // Example case
             Assert.True(Level.BaseDimensions.IsDimensionless());
         }
+
     }
 }

--- a/UnitsNet.Tests/BaseUnitsTests.cs
+++ b/UnitsNet.Tests/BaseUnitsTests.cs
@@ -139,16 +139,16 @@ namespace UnitsNet.Tests
                 TemperatureUnit.Kelvin,
                 AmountOfSubstanceUnit.Mole,
                 LuminousIntensityUnit.Candela);
-            
-            var m = LengthUnit.Meter;
-            var kg = MassUnit.Kilogram;
-            var s = DurationUnit.Second;
-            var A = ElectricCurrentUnit.Ampere;
-            var K = TemperatureUnit.Kelvin;
-            var mol = AmountOfSubstanceUnit.Mole;
-            var cd = LuminousIntensityUnit.Candela;
 
-            Assert.Equal($"[Length]: {m}, [Mass]: {kg}, [Time]: {s}, [Current]: {A}, [Temperature]: {K}, [Amount]: {mol}, [LuminousIntensity]: {cd}", siBaseUnits.ToString());
+            Assert.Equal("L=Meter, M=Kilogram, T=Second, I=Ampere, Θ=Kelvin, N=Mole, J=Candela", siBaseUnits.ToString());
+        }
+
+        [Fact]
+        public void ToString_WithFewerDimensions_ContainsOnlyTheSpecifiedDimensions()
+        {
+            var siBaseUnits = new BaseUnits(length:LengthUnit.Meter, mass:MassUnit.Gram, time:DurationUnit.Second, temperature:TemperatureUnit.DegreeCelsius);
+
+            Assert.Equal("L=Meter, M=Gram, T=Second, Θ=DegreeCelsius", siBaseUnits.ToString());
         }
 
         [Fact]

--- a/UnitsNet.Tests/BaseUnitsTests.cs
+++ b/UnitsNet.Tests/BaseUnitsTests.cs
@@ -139,17 +139,22 @@ namespace UnitsNet.Tests
                 TemperatureUnit.Kelvin,
                 AmountOfSubstanceUnit.Mole,
                 LuminousIntensityUnit.Candela);
-
-            UnitAbbreviationsCache cache = UnitsNetSetup.Default.UnitAbbreviations;
-            var m = cache.GetDefaultAbbreviation(LengthUnit.Meter);
-            var kg = cache.GetDefaultAbbreviation(MassUnit.Kilogram);
-            var s = cache.GetDefaultAbbreviation(DurationUnit.Second);
-            var A = cache.GetDefaultAbbreviation(ElectricCurrentUnit.Ampere);
-            var K = cache.GetDefaultAbbreviation(TemperatureUnit.Kelvin);
-            var mol = cache.GetDefaultAbbreviation(AmountOfSubstanceUnit.Mole);
-            var cd = cache.GetDefaultAbbreviation(LuminousIntensityUnit.Candela);
+            
+            var m = LengthUnit.Meter;
+            var kg = MassUnit.Kilogram;
+            var s = DurationUnit.Second;
+            var A = ElectricCurrentUnit.Ampere;
+            var K = TemperatureUnit.Kelvin;
+            var mol = AmountOfSubstanceUnit.Mole;
+            var cd = LuminousIntensityUnit.Candela;
 
             Assert.Equal($"[Length]: {m}, [Mass]: {kg}, [Time]: {s}, [Current]: {A}, [Temperature]: {K}, [Amount]: {mol}, [LuminousIntensity]: {cd}", siBaseUnits.ToString());
+        }
+
+        [Fact]
+        public void ToString_WithUndefinedUnits_ReturnsUndefined()
+        {
+            Assert.Equal("Undefined", BaseUnits.Undefined.ToString());
         }
 
         [Fact]

--- a/UnitsNet/BaseDimensions.cs
+++ b/UnitsNet/BaseDimensions.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Text;
-using System.Linq;
 
 namespace UnitsNet
 {
@@ -30,9 +29,13 @@ namespace UnitsNet
         /// <returns>True if the dimensions represent a base quantity, otherwise false.</returns>
         public bool IsBaseQuantity()
         {
-            var dimensionsArray = new[] { Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity };
-            bool onlyOneEqualsOne = dimensionsArray.Select(dimension => dimension is 0 or 1 ? dimension : 2).Sum() == 1;
-            return onlyOneEqualsOne;
+            return (Length == 1 && Mass == 0 && Time == 0 && Current == 0 && Temperature == 0 && Amount == 0 && LuminousIntensity == 0) ||
+                   (Length == 0 && Mass == 1 && Time == 0 && Current == 0 && Temperature == 0 && Amount == 0 && LuminousIntensity == 0) ||
+                   (Length == 0 && Mass == 0 && Time == 1 && Current == 0 && Temperature == 0 && Amount == 0 && LuminousIntensity == 0) ||
+                   (Length == 0 && Mass == 0 && Time == 0 && Current == 1 && Temperature == 0 && Amount == 0 && LuminousIntensity == 0) ||
+                   (Length == 0 && Mass == 0 && Time == 0 && Current == 0 && Temperature == 1 && Amount == 0 && LuminousIntensity == 0) ||
+                   (Length == 0 && Mass == 0 && Time == 0 && Current == 0 && Temperature == 0 && Amount == 1 && LuminousIntensity == 0) ||
+                   (Length == 0 && Mass == 0 && Time == 0 && Current == 0 && Temperature == 0 && Amount == 0 && LuminousIntensity == 1);
         }
 
         /// <summary>
@@ -71,7 +74,11 @@ namespace UnitsNet
         /// <inheritdoc />
         public override int GetHashCode()
         {
-            return new {Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity}.GetHashCode();
+#if NET
+            return HashCode.Combine(Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity);
+#else
+            return new { Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity }.GetHashCode();
+#endif
         }
 
         /// <summary>
@@ -182,12 +189,16 @@ namespace UnitsNet
 
         private static void AppendDimensionString(StringBuilder sb, string name, int value)
         {
-            if (0 != value)
+            switch (value)
             {
-                sb.AppendFormat("[{0}]", name);
-
-                if (1 != value)
-                    sb.AppendFormat("^{0}", value);
+                case 0:
+                    return;
+                case 1:
+                    sb.AppendFormat("[{0}]", name);
+                    break;
+                default:
+                    sb.AppendFormat("[{0}^{1}]", name, value);
+                    break;
             }
         }
 

--- a/UnitsNet/BaseUnits.cs
+++ b/UnitsNet/BaseUnits.cs
@@ -2,7 +2,7 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
-using System.Text;
+using System.Collections.Generic;
 using UnitsNet.Units;
 
 namespace UnitsNet
@@ -103,11 +103,11 @@ namespace UnitsNet
         /// <inheritdoc />
         public override int GetHashCode()
         {
-#if NET
+            #if NET 
             return HashCode.Combine(Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity);
-#else
+            #else
             return new {Length, Mass, Time, Current, Temperature, Amount, LuminousIntensity}.GetHashCode();
-#endif
+            #endif
         }
 
         /// <summary>
@@ -133,31 +133,47 @@ namespace UnitsNet
         {
             return !(left == right);
         }
-
+        
         /// <inheritdoc />
         public override string ToString()
         {
-            if(!Equals(Undefined))
-            {
-                var sb = new StringBuilder();
-
-                string GetDefaultAbbreviation<TUnitType>(TUnitType? unitOrNull) where TUnitType : struct, Enum => unitOrNull is { } unit
-                    ? UnitsNetSetup.Default.UnitAbbreviations.GetDefaultAbbreviation(unit)
-                    : "N/A";
-
-                sb.AppendFormat("[Length]: {0}, ", GetDefaultAbbreviation(Length));
-                sb.AppendFormat("[Mass]: {0}, ", GetDefaultAbbreviation(Mass));
-                sb.AppendFormat("[Time]: {0}, ", GetDefaultAbbreviation(Time));
-                sb.AppendFormat("[Current]: {0}, ", GetDefaultAbbreviation(Current));
-                sb.AppendFormat("[Temperature]: {0}, ", GetDefaultAbbreviation(Temperature));
-                sb.AppendFormat("[Amount]: {0}, ", GetDefaultAbbreviation(Amount));
-                sb.AppendFormat("[LuminousIntensity]: {0}", GetDefaultAbbreviation(LuminousIntensity));
-
-                return sb.ToString();
-            }
-            else
+            if (Equals(Undefined))
             {
                 return "Undefined";
+            }
+
+            return string.Join(", ", GetUnitsDefined());
+
+            IEnumerable<string> GetUnitsDefined()
+            {
+                if (Length is not null)
+                {
+                    yield return $"[Length]: {Length}";
+                }
+                if (Mass is not null)
+                {
+                    yield return $"[Mass]: {Mass}";
+                }
+                if (Time is not null)
+                {
+                    yield return $"[Time]: {Time}";
+                }
+                if (Current is not null)
+                {
+                    yield return $"[Current]: {Current}";
+                }
+                if (Temperature is not null)
+                {
+                    yield return $"[Temperature]: {Temperature}";
+                }
+                if (Amount is not null)
+                {
+                    yield return $"[Amount]: {Amount}";
+                }
+                if (LuminousIntensity is not null)
+                {
+                    yield return $"[LuminousIntensity]: {LuminousIntensity}";
+                }
             }
         }
 
@@ -200,8 +216,8 @@ namespace UnitsNet
         ///     Gets a value indicating whether all base units are defined.
         /// </summary>
         /// <remarks>
-        ///     This property returns <c>true</c> if all seven base units
-        ///     (Length, Mass, Time, Current, Temperature, Amount, and LuminousIntensity)
+        ///     This property returns <c>true</c> if all seven base units 
+        ///     (Length, Mass, Time, Current, Temperature, Amount, and LuminousIntensity) 
         ///     are non-null; otherwise, it returns <c>false</c>.
         /// </remarks>
         public bool IsFullyDefined => Length is not null &&

--- a/UnitsNet/BaseUnits.cs
+++ b/UnitsNet/BaseUnits.cs
@@ -148,31 +148,31 @@ namespace UnitsNet
             {
                 if (Length is not null)
                 {
-                    yield return $"[Length]: {Length}";
+                    yield return $"L={Length}";
                 }
                 if (Mass is not null)
                 {
-                    yield return $"[Mass]: {Mass}";
+                    yield return $"M={Mass}";
                 }
                 if (Time is not null)
                 {
-                    yield return $"[Time]: {Time}";
+                    yield return $"T={Time}";
                 }
                 if (Current is not null)
                 {
-                    yield return $"[Current]: {Current}";
+                    yield return $"I={Current}";
                 }
                 if (Temperature is not null)
                 {
-                    yield return $"[Temperature]: {Temperature}";
+                    yield return $"Θ={Temperature}";
                 }
                 if (Amount is not null)
                 {
-                    yield return $"[Amount]: {Amount}";
+                    yield return $"N={Amount}";
                 }
                 if (LuminousIntensity is not null)
                 {
-                    yield return $"[LuminousIntensity]: {LuminousIntensity}";
+                    yield return $"J={LuminousIntensity}";
                 }
             }
         }


### PR DESCRIPTION
- `BaseUnits`: no longer using the `AbbeviationsCache`, the new format is `L=Meter, M=Kilogram, T=Second` 
- `BaseDimensions`: the exponent moved inside the dimension-brackets: `[Length][Time^-1]`
- `BaseDimensions`: minor performance improvements

As mentioned in #1452, the main motivation here is the removal of the potential side effects of accessing/loading the unit abbreviations (e.g. during the `QuantityInfo` construction)