### PR TITLE
🚸UnitParser.Parse should throw AmbiguousUnitParseException before any UnitNotFoundException (#1484)

### DIFF
--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -178,7 +178,7 @@ namespace UnitsNet.Serialization.JsonNet
         }
 
         /// <summary>
-        ///     Attempt to find an a unique (non-ambiguous) unit matching the provided abbreviation.
+        ///     Attempt to find a unique (non-ambiguous) unit matching the provided abbreviation.
         ///     <remarks>
         ///         An exhaustive search using all quantities is very likely to fail with an
         ///         <exception cref="AmbiguousUnitParseException" />, so make sure you're using the minimum set of supported quantities.

--- a/UnitsNet.Tests/QuantityParserTests.cs
+++ b/UnitsNet.Tests/QuantityParserTests.cs
@@ -42,7 +42,7 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void Parse_WithMultipleCaseInsensitiveMatchesButNoExactMatches_ThrowsUnitNotFoundException()
+        public void Parse_WithMultipleCaseInsensitiveMatchesButNoExactMatches_ThrowsAmbiguousUnitParseException()
         {
             var unitAbbreviationsCache = new UnitAbbreviationsCache();
             unitAbbreviationsCache.MapUnitToAbbreviation(HowMuchUnit.Some, "foo");
@@ -54,7 +54,8 @@ namespace UnitsNet.Tests
                 quantityParser.Parse<HowMuch, HowMuchUnit>("1 Foo", null, (value, unit) => new HowMuch((double) value, unit));
             }
 
-            Assert.Throws<UnitNotFoundException>(Act);
+            var ex = Assert.Throws<AmbiguousUnitParseException>(Act);
+            Assert.Equal("""Cannot parse "Foo" since it matches multiple units: ATon ("FOO"), Some ("foo").""", ex.Message);
         }
 
         [Fact]

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -115,8 +115,8 @@ namespace UnitsNet.Tests
             var exception2 = Assert.Throws<AmbiguousUnitParseException>(() => Length.Parse("1 pt", CultureInfo.InvariantCulture));
 
             // Assert
-            Assert.Equal("Cannot parse \"pt\" since it could be either of these: DtpPoint, PrinterPoint", exception1.Message);
-            Assert.Equal("Cannot parse \"pt\" since it could be either of these: DtpPoint, PrinterPoint", exception2.Message);
+            Assert.Equal("""Cannot parse "pt" since it matches multiple units: DtpPoint ("pt"), PrinterPoint ("pt").""", exception1.Message);
+            Assert.Equal("""Cannot parse "pt" since it matches multiple units: DtpPoint ("pt"), PrinterPoint ("pt").""", exception2.Message);
         }
 
         [Theory]
@@ -142,6 +142,13 @@ namespace UnitsNet.Tests
             var parsedUnit = unitParser.Parse<HowMuchUnit>("fooh");
 
             Assert.Equal(HowMuchUnit.Some, parsedUnit);
+        }
+        
+        [Fact]
+        public void Parse_LengthUnit_MM_ThrowsExceptionDescribingTheAmbiguity()
+        {
+            var ex = Assert.Throws<AmbiguousUnitParseException>(() => UnitsNetSetup.Default.UnitParser.Parse<LengthUnit>("MM"));
+            Assert.Equal("""Cannot parse "MM" since it matches multiple units: Megameter ("Mm"), Millimeter ("mm").""", ex.Message);
         }
         
         [Fact]


### PR DESCRIPTION
Fixes #1423 for `release-v6`
Carry over from #1484

`UnitParser.Parse<LengthUnit>("MM")` fails due to matching both `Megameter` and `Millimeter` in case-insensitive matching, but matches neither of them in the case-sensitive fallback. It was confusing to get `UnitsNotFoundException` in this case, since case-insensitive usually works for most units.

### Changes
- Handle this case and throw `AmbiguousUnitParseException` instead of `UnitNotFoundException`
- Describe the case-insensitive units that matched
- Fix existing test `Parse_WithMultipleCaseInsensitiveMatchesButNoExactMatches_ThrowsUnitNotFoundException`
- Skip retrying with fallback culture if no specific `formatProvider` was given
- Avoid some of the unnecessary array allocations