### PR TITLE
1505 - Extend the density definition with an additional abbreviation for pounds

### DIFF
--- a/Common/UnitDefinitions/Density.json
+++ b/Common/UnitDefinitions/Density.json
@@ -76,7 +76,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/in³" ],
+          "Abbreviations": [ "lb/in³", "lbm/in³" ],
           "AbbreviationsForPrefixes": { "Kilo": "kip/in³" }
         }
       ]
@@ -94,7 +94,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/ft³" ],
+          "Abbreviations": [ "lb/ft³", "lbm/ft³" ],
           "AbbreviationsForPrefixes": { "Kilo": "kip/ft³" }
         }
       ]
@@ -113,7 +113,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/yd³" ],
+          "Abbreviations": [ "lb/yd³", "lbm/yd³" ],
           "AbbreviationsForPrefixes": { "Kilo": "kip/yd³" }
         }
       ]
@@ -337,7 +337,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/m³" ]
+          "Abbreviations": [ "lb/m³", "lbm/m³" ]
         }
       ]
     },
@@ -353,7 +353,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/cm³" ]
+          "Abbreviations": [ "lb/cm³", "lbm/cm³" ]
         }
       ]
     },
@@ -369,7 +369,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "lb/mm³" ]
+          "Abbreviations": [ "lb/mm³", "lbm/mm³" ]
         }
       ]
     },


### PR DESCRIPTION
This is the solution for #1505, which introduces the missing `lbm` abbreviation for pounds in composed units of measurement.