### PR TITLE
Add `Mass / MassFlow => TimeSpan` operator.

### DIFF
--- a/UnitsNet.Tests/CustomCode/MassTests.cs
+++ b/UnitsNet.Tests/CustomCode/MassTests.cs
@@ -91,6 +91,13 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void MassDividedByMassFlowEqualsTimeSpan()
+        {
+            TimeSpan timeSpan = Mass.FromKilograms(20) / MassFlow.FromKilogramsPerSecond(2);
+            Assert.Equal(TimeSpan.FromSeconds(10), timeSpan);
+        }
+
+        [Fact]
         public void MassDividedByVolumeEqualsDensity()
         {
             Density density = Mass.FromKilograms(18)/Volume.FromCubicMeters(3);

--- a/UnitsNet/CustomCode/Quantities/Mass.extra.cs
+++ b/UnitsNet/CustomCode/Quantities/Mass.extra.cs
@@ -58,6 +58,12 @@ namespace UnitsNet
             return MassFlow.FromKilogramsPerSecond(mass.Kilograms/duration.Seconds);
         }
 
+        /// <summary>Get <see cref="TimeSpan"/> from <see cref="Mass"/> divided by <see cref="MassFlow"/>.</summary>
+        public static TimeSpan operator /(Mass mass, MassFlow massFlow)
+        {
+            return TimeSpan.FromSeconds(mass.Kilograms/massFlow.KilogramsPerSecond);
+        }
+
         /// <summary>Get <see cref="Density"/> from <see cref="MassFlow"/> divided by <see cref="Volume"/>.</summary>
         public static Density operator /(Mass mass, Volume volume)
         {


### PR DESCRIPTION
This implements a missing operator (when compared with e.g. Volume, which has `Volume / VolumeFlow => TimeSpan`).