### PR TITLE
Add .NET 9 to v6

### DIFF
--- a/CodeGen/CodeGen.csproj
+++ b/CodeGen/CodeGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <!-- Allow compile with various nullability warnings until fixed. -->

--- a/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
+++ b/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <Version>4.0.0.0</Version>
     <AssemblyVersion>4.0.0.0</AssemblyVersion>
     <AssemblyTitle>UnitsNet.Benchmark</AssemblyTitle>

--- a/UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj
+++ b/UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitsNet.NumberExtensions.Tests</RootNamespace>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -22,7 +22,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <RootNamespace>UnitsNet.Serialization.JsonNet.Tests</RootNamespace>
     <IsTestProject>true</IsTestProject>
     <NoWarn>CS0618</NoWarn>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -24,7 +24,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Strong name signing -->

--- a/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
@@ -92,7 +92,7 @@ namespace UnitsNet.Serialization.JsonNet
 
             if (registeredQuantity is not null)
             {
-                return (IQuantity)Activator.CreateInstance(registeredQuantity, valueUnit.Value, unit);
+                return (IQuantity)Activator.CreateInstance(registeredQuantity, valueUnit.Value, unit)!;
             }
 
             return Quantity.From(valueUnit.Value, unit);

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <IsTestProject>true</IsTestProject>
     <NoWarn>CS0618</NoWarn><!-- CS0618: 'member' is obsolete: 'text' (we often obsolete things before removal) -->

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -24,7 +24,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet</RootNamespace>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Strong name signing -->


### PR DESCRIPTION
Aiming to complete #1451 (the PR #1502 added .NET 9 for `master` but not `release/v6`. I touched a few more projects and handled `Activator.CreateInstance` differently - happy to simply copy #1502 exactly if you prefer.