### PR TITLE
Removing the FrequencyUnit.BUnit

### DIFF
--- a/Common/UnitDefinitions/Frequency.json
+++ b/Common/UnitDefinitions/Frequency.json
@@ -108,18 +108,6 @@
           "Abbreviations": [ "с⁻¹" ]
         }
       ]
-    },
-    {
-      "SingularName": "BUnit",
-      "PluralName": "BUnits",
-      "FromUnitToBaseFunc": "Math.Sqrt({x} * 1e3)",
-      "FromBaseToUnitFunc": "{x} * {x} * 1e-3",
-      "Localization": [
-        {
-          "Culture": "en-US",
-          "Abbreviations": [ "B Units" ]
-        }
-      ]
     }
   ]
 }

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/Frequency.g.cs
@@ -84,11 +84,6 @@ namespace UnitsNet
         public double BeatsPerMinute => As(FrequencyUnit.BeatPerMinute);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="FrequencyUnit.BUnit"/>
-        /// </summary>
-        public double BUnits => As(FrequencyUnit.BUnit);
-
-        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="FrequencyUnit.CyclePerHour"/>
         /// </summary>
         public double CyclesPerHour => As(FrequencyUnit.CyclePerHour);
@@ -151,11 +146,6 @@ namespace UnitsNet
         ///     Creates a <see cref="Frequency"/> from <see cref="FrequencyUnit.BeatPerMinute"/>.
         /// </summary>
         public static Frequency FromBeatsPerMinute(double beatsperminute) => new Frequency(beatsperminute, FrequencyUnit.BeatPerMinute);
-
-        /// <summary>
-        ///     Creates a <see cref="Frequency"/> from <see cref="FrequencyUnit.BUnit"/>.
-        /// </summary>
-        public static Frequency FromBUnits(double bunits) => new Frequency(bunits, FrequencyUnit.BUnit);
 
         /// <summary>
         ///     Creates a <see cref="Frequency"/> from <see cref="FrequencyUnit.CyclePerHour"/>.
@@ -253,7 +243,6 @@ namespace UnitsNet
                     return Unit switch
                     {
                         FrequencyUnit.BeatPerMinute => _value / 60,
-                        FrequencyUnit.BUnit => Math.Sqrt(_value * 1e3),
                         FrequencyUnit.CyclePerHour => _value / 3600,
                         FrequencyUnit.CyclePerMinute => _value / 60,
                         FrequencyUnit.Gigahertz => (_value) * 1e9d,
@@ -279,7 +268,6 @@ namespace UnitsNet
                     return unit switch
                     {
                         FrequencyUnit.BeatPerMinute => baseUnitValue * 60,
-                        FrequencyUnit.BUnit => baseUnitValue * baseUnitValue * 1e-3,
                         FrequencyUnit.CyclePerHour => baseUnitValue * 3600,
                         FrequencyUnit.CyclePerMinute => baseUnitValue * 60,
                         FrequencyUnit.Gigahertz => (baseUnitValue) / 1e9d,

--- a/UnitsNet.NanoFramework/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -26,7 +26,6 @@ namespace UnitsNet.Units
     public enum FrequencyUnit
     {
         BeatPerMinute = 1,
-        BUnit = 2,
         CyclePerHour = 3,
         CyclePerMinute = 4,
         Gigahertz = 5,

--- a/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToFrequencyExtensionsTest.g.cs
+++ b/UnitsNet.NumberExtensions.Tests/GeneratedCode/NumberToFrequencyExtensionsTest.g.cs
@@ -29,10 +29,6 @@ namespace UnitsNet.Tests
             Assert.Equal(Frequency.FromBeatsPerMinute(2), 2.BeatsPerMinute());
 
         [Fact]
-        public void NumberToBUnitsTest() =>
-            Assert.Equal(Frequency.FromBUnits(2), 2.BUnits());
-
-        [Fact]
         public void NumberToCyclesPerHourTest() =>
             Assert.Equal(Frequency.FromCyclesPerHour(2), 2.CyclesPerHour());
 

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToFrequencyExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToFrequencyExtensions.g.cs
@@ -43,17 +43,6 @@ namespace UnitsNet.NumberExtensions.NumberToFrequency
             => Frequency.FromBeatsPerMinute(value.ToDouble(null));
 #endif
 
-        /// <inheritdoc cref="Frequency.FromBUnits(double)" />
-        public static Frequency BUnits<T>(this T value)
-            where T : notnull
-#if NET7_0_OR_GREATER
-            , INumber<T>
-            => Frequency.FromBUnits(double.CreateChecked(value));
-#else
-            , IConvertible
-            => Frequency.FromBUnits(value.ToDouble(null));
-#endif
-
         /// <inheritdoc cref="Frequency.FromCyclesPerHour(double)" />
         public static Frequency CyclesPerHour<T>(this T value)
             where T : notnull

--- a/UnitsNet.Tests/CustomCode/FrequencyTests.cs
+++ b/UnitsNet.Tests/CustomCode/FrequencyTests.cs
@@ -32,7 +32,5 @@ namespace UnitsNet.Tests
         protected override double RadiansPerSecondInOneHertz => 2 * Math.PI;
 
         protected override double BeatsPerMinuteInOneHertz => 60;
-
-        protected override double BUnitsInOneHertz => 0.001;
     }
 }

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
@@ -40,7 +40,6 @@ namespace UnitsNet.Tests
     public abstract partial class FrequencyTestsBase : QuantityTestsBase
     {
         protected abstract double BeatsPerMinuteInOneHertz { get; }
-        protected abstract double BUnitsInOneHertz { get; }
         protected abstract double CyclesPerHourInOneHertz { get; }
         protected abstract double CyclesPerMinuteInOneHertz { get; }
         protected abstract double GigahertzInOneHertz { get; }
@@ -55,7 +54,6 @@ namespace UnitsNet.Tests
 
 // ReSharper disable VirtualMemberNeverOverriden.Global
         protected virtual double BeatsPerMinuteTolerance { get { return 1e-5; } }
-        protected virtual double BUnitsTolerance { get { return 1e-5; } }
         protected virtual double CyclesPerHourTolerance { get { return 1e-5; } }
         protected virtual double CyclesPerMinuteTolerance { get { return 1e-5; } }
         protected virtual double GigahertzTolerance { get { return 1e-5; } }
@@ -74,7 +72,6 @@ namespace UnitsNet.Tests
             return unit switch
             {
                 FrequencyUnit.BeatPerMinute => (BeatsPerMinuteInOneHertz, BeatsPerMinuteTolerance),
-                FrequencyUnit.BUnit => (BUnitsInOneHertz, BUnitsTolerance),
                 FrequencyUnit.CyclePerHour => (CyclesPerHourInOneHertz, CyclesPerHourTolerance),
                 FrequencyUnit.CyclePerMinute => (CyclesPerMinuteInOneHertz, CyclesPerMinuteTolerance),
                 FrequencyUnit.Gigahertz => (GigahertzInOneHertz, GigahertzTolerance),
@@ -93,7 +90,6 @@ namespace UnitsNet.Tests
         public static IEnumerable<object[]> UnitTypes = new List<object[]>
         {
             new object[] { FrequencyUnit.BeatPerMinute },
-            new object[] { FrequencyUnit.BUnit },
             new object[] { FrequencyUnit.CyclePerHour },
             new object[] { FrequencyUnit.CyclePerMinute },
             new object[] { FrequencyUnit.Gigahertz },
@@ -173,7 +169,6 @@ namespace UnitsNet.Tests
         {
             Frequency hertz = Frequency.FromHertz(1);
             AssertEx.EqualTolerance(BeatsPerMinuteInOneHertz, hertz.BeatsPerMinute, BeatsPerMinuteTolerance);
-            AssertEx.EqualTolerance(BUnitsInOneHertz, hertz.BUnits, BUnitsTolerance);
             AssertEx.EqualTolerance(CyclesPerHourInOneHertz, hertz.CyclesPerHour, CyclesPerHourTolerance);
             AssertEx.EqualTolerance(CyclesPerMinuteInOneHertz, hertz.CyclesPerMinute, CyclesPerMinuteTolerance);
             AssertEx.EqualTolerance(GigahertzInOneHertz, hertz.Gigahertz, GigahertzTolerance);
@@ -194,53 +189,49 @@ namespace UnitsNet.Tests
             AssertEx.EqualTolerance(1, quantity00.BeatsPerMinute, BeatsPerMinuteTolerance);
             Assert.Equal(FrequencyUnit.BeatPerMinute, quantity00.Unit);
 
-            var quantity01 = Frequency.From(1, FrequencyUnit.BUnit);
-            AssertEx.EqualTolerance(1, quantity01.BUnits, BUnitsTolerance);
-            Assert.Equal(FrequencyUnit.BUnit, quantity01.Unit);
+            var quantity01 = Frequency.From(1, FrequencyUnit.CyclePerHour);
+            AssertEx.EqualTolerance(1, quantity01.CyclesPerHour, CyclesPerHourTolerance);
+            Assert.Equal(FrequencyUnit.CyclePerHour, quantity01.Unit);
 
-            var quantity02 = Frequency.From(1, FrequencyUnit.CyclePerHour);
-            AssertEx.EqualTolerance(1, quantity02.CyclesPerHour, CyclesPerHourTolerance);
-            Assert.Equal(FrequencyUnit.CyclePerHour, quantity02.Unit);
+            var quantity02 = Frequency.From(1, FrequencyUnit.CyclePerMinute);
+            AssertEx.EqualTolerance(1, quantity02.CyclesPerMinute, CyclesPerMinuteTolerance);
+            Assert.Equal(FrequencyUnit.CyclePerMinute, quantity02.Unit);
 
-            var quantity03 = Frequency.From(1, FrequencyUnit.CyclePerMinute);
-            AssertEx.EqualTolerance(1, quantity03.CyclesPerMinute, CyclesPerMinuteTolerance);
-            Assert.Equal(FrequencyUnit.CyclePerMinute, quantity03.Unit);
+            var quantity03 = Frequency.From(1, FrequencyUnit.Gigahertz);
+            AssertEx.EqualTolerance(1, quantity03.Gigahertz, GigahertzTolerance);
+            Assert.Equal(FrequencyUnit.Gigahertz, quantity03.Unit);
 
-            var quantity04 = Frequency.From(1, FrequencyUnit.Gigahertz);
-            AssertEx.EqualTolerance(1, quantity04.Gigahertz, GigahertzTolerance);
-            Assert.Equal(FrequencyUnit.Gigahertz, quantity04.Unit);
+            var quantity04 = Frequency.From(1, FrequencyUnit.Hertz);
+            AssertEx.EqualTolerance(1, quantity04.Hertz, HertzTolerance);
+            Assert.Equal(FrequencyUnit.Hertz, quantity04.Unit);
 
-            var quantity05 = Frequency.From(1, FrequencyUnit.Hertz);
-            AssertEx.EqualTolerance(1, quantity05.Hertz, HertzTolerance);
-            Assert.Equal(FrequencyUnit.Hertz, quantity05.Unit);
+            var quantity05 = Frequency.From(1, FrequencyUnit.Kilohertz);
+            AssertEx.EqualTolerance(1, quantity05.Kilohertz, KilohertzTolerance);
+            Assert.Equal(FrequencyUnit.Kilohertz, quantity05.Unit);
 
-            var quantity06 = Frequency.From(1, FrequencyUnit.Kilohertz);
-            AssertEx.EqualTolerance(1, quantity06.Kilohertz, KilohertzTolerance);
-            Assert.Equal(FrequencyUnit.Kilohertz, quantity06.Unit);
+            var quantity06 = Frequency.From(1, FrequencyUnit.Megahertz);
+            AssertEx.EqualTolerance(1, quantity06.Megahertz, MegahertzTolerance);
+            Assert.Equal(FrequencyUnit.Megahertz, quantity06.Unit);
 
-            var quantity07 = Frequency.From(1, FrequencyUnit.Megahertz);
-            AssertEx.EqualTolerance(1, quantity07.Megahertz, MegahertzTolerance);
-            Assert.Equal(FrequencyUnit.Megahertz, quantity07.Unit);
+            var quantity07 = Frequency.From(1, FrequencyUnit.Microhertz);
+            AssertEx.EqualTolerance(1, quantity07.Microhertz, MicrohertzTolerance);
+            Assert.Equal(FrequencyUnit.Microhertz, quantity07.Unit);
 
-            var quantity08 = Frequency.From(1, FrequencyUnit.Microhertz);
-            AssertEx.EqualTolerance(1, quantity08.Microhertz, MicrohertzTolerance);
-            Assert.Equal(FrequencyUnit.Microhertz, quantity08.Unit);
+            var quantity08 = Frequency.From(1, FrequencyUnit.Millihertz);
+            AssertEx.EqualTolerance(1, quantity08.Millihertz, MillihertzTolerance);
+            Assert.Equal(FrequencyUnit.Millihertz, quantity08.Unit);
 
-            var quantity09 = Frequency.From(1, FrequencyUnit.Millihertz);
-            AssertEx.EqualTolerance(1, quantity09.Millihertz, MillihertzTolerance);
-            Assert.Equal(FrequencyUnit.Millihertz, quantity09.Unit);
+            var quantity09 = Frequency.From(1, FrequencyUnit.PerSecond);
+            AssertEx.EqualTolerance(1, quantity09.PerSecond, PerSecondTolerance);
+            Assert.Equal(FrequencyUnit.PerSecond, quantity09.Unit);
 
-            var quantity10 = Frequency.From(1, FrequencyUnit.PerSecond);
-            AssertEx.EqualTolerance(1, quantity10.PerSecond, PerSecondTolerance);
-            Assert.Equal(FrequencyUnit.PerSecond, quantity10.Unit);
+            var quantity10 = Frequency.From(1, FrequencyUnit.RadianPerSecond);
+            AssertEx.EqualTolerance(1, quantity10.RadiansPerSecond, RadiansPerSecondTolerance);
+            Assert.Equal(FrequencyUnit.RadianPerSecond, quantity10.Unit);
 
-            var quantity11 = Frequency.From(1, FrequencyUnit.RadianPerSecond);
-            AssertEx.EqualTolerance(1, quantity11.RadiansPerSecond, RadiansPerSecondTolerance);
-            Assert.Equal(FrequencyUnit.RadianPerSecond, quantity11.Unit);
-
-            var quantity12 = Frequency.From(1, FrequencyUnit.Terahertz);
-            AssertEx.EqualTolerance(1, quantity12.Terahertz, TerahertzTolerance);
-            Assert.Equal(FrequencyUnit.Terahertz, quantity12.Unit);
+            var quantity11 = Frequency.From(1, FrequencyUnit.Terahertz);
+            AssertEx.EqualTolerance(1, quantity11.Terahertz, TerahertzTolerance);
+            Assert.Equal(FrequencyUnit.Terahertz, quantity11.Unit);
 
         }
 
@@ -267,7 +258,6 @@ namespace UnitsNet.Tests
         {
             var hertz = Frequency.FromHertz(1);
             AssertEx.EqualTolerance(BeatsPerMinuteInOneHertz, hertz.As(FrequencyUnit.BeatPerMinute), BeatsPerMinuteTolerance);
-            AssertEx.EqualTolerance(BUnitsInOneHertz, hertz.As(FrequencyUnit.BUnit), BUnitsTolerance);
             AssertEx.EqualTolerance(CyclesPerHourInOneHertz, hertz.As(FrequencyUnit.CyclePerHour), CyclesPerHourTolerance);
             AssertEx.EqualTolerance(CyclesPerMinuteInOneHertz, hertz.As(FrequencyUnit.CyclePerMinute), CyclesPerMinuteTolerance);
             AssertEx.EqualTolerance(GigahertzInOneHertz, hertz.As(FrequencyUnit.Gigahertz), GigahertzTolerance);
@@ -395,13 +385,6 @@ namespace UnitsNet.Tests
                 var parsed = Frequency.Parse("1 bpm", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.BeatsPerMinute, BeatsPerMinuteTolerance);
                 Assert.Equal(FrequencyUnit.BeatPerMinute, parsed.Unit);
-            } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
-
-            try
-            {
-                var parsed = Frequency.Parse("1 B Units", CultureInfo.GetCultureInfo("en-US"));
-                AssertEx.EqualTolerance(1, parsed.BUnits, BUnitsTolerance);
-                Assert.Equal(FrequencyUnit.BUnit, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
             try
@@ -556,12 +539,6 @@ namespace UnitsNet.Tests
             }
 
             {
-                Assert.True(Frequency.TryParse("1 B Units", CultureInfo.GetCultureInfo("en-US"), out var parsed));
-                AssertEx.EqualTolerance(1, parsed.BUnits, BUnitsTolerance);
-                Assert.Equal(FrequencyUnit.BUnit, parsed.Unit);
-            }
-
-            {
                 Assert.True(Frequency.TryParse("1 cph", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.CyclesPerHour, CyclesPerHourTolerance);
                 Assert.Equal(FrequencyUnit.CyclePerHour, parsed.Unit);
@@ -661,7 +638,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("B Units", FrequencyUnit.BUnit)]
         [InlineData("cph", FrequencyUnit.CyclePerHour)]
         [InlineData("cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("GHz", FrequencyUnit.Gigahertz)]
@@ -683,7 +659,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("B Units", FrequencyUnit.BUnit)]
         [InlineData("cph", FrequencyUnit.CyclePerHour)]
         [InlineData("cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("GHz", FrequencyUnit.Gigahertz)]
@@ -705,7 +680,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("en-US", "bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("en-US", "B Units", FrequencyUnit.BUnit)]
         [InlineData("en-US", "cph", FrequencyUnit.CyclePerHour)]
         [InlineData("en-US", "cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("en-US", "GHz", FrequencyUnit.Gigahertz)]
@@ -735,7 +709,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("en-US", "bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("en-US", "B Units", FrequencyUnit.BUnit)]
         [InlineData("en-US", "cph", FrequencyUnit.CyclePerHour)]
         [InlineData("en-US", "cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("en-US", "GHz", FrequencyUnit.Gigahertz)]
@@ -764,7 +737,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("B Units", FrequencyUnit.BUnit)]
         [InlineData("cph", FrequencyUnit.CyclePerHour)]
         [InlineData("cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("GHz", FrequencyUnit.Gigahertz)]
@@ -786,7 +758,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("B Units", FrequencyUnit.BUnit)]
         [InlineData("cph", FrequencyUnit.CyclePerHour)]
         [InlineData("cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("GHz", FrequencyUnit.Gigahertz)]
@@ -808,7 +779,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("en-US", "bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("en-US", "B Units", FrequencyUnit.BUnit)]
         [InlineData("en-US", "cph", FrequencyUnit.CyclePerHour)]
         [InlineData("en-US", "cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("en-US", "GHz", FrequencyUnit.Gigahertz)]
@@ -838,7 +808,6 @@ namespace UnitsNet.Tests
 
         [Theory]
         [InlineData("en-US", "bpm", FrequencyUnit.BeatPerMinute)]
-        [InlineData("en-US", "B Units", FrequencyUnit.BUnit)]
         [InlineData("en-US", "cph", FrequencyUnit.CyclePerHour)]
         [InlineData("en-US", "cpm", FrequencyUnit.CyclePerMinute)]
         [InlineData("en-US", "GHz", FrequencyUnit.Gigahertz)]
@@ -931,7 +900,6 @@ namespace UnitsNet.Tests
         {
             Frequency hertz = Frequency.FromHertz(1);
             AssertEx.EqualTolerance(1, Frequency.FromBeatsPerMinute(hertz.BeatsPerMinute).Hertz, BeatsPerMinuteTolerance);
-            AssertEx.EqualTolerance(1, Frequency.FromBUnits(hertz.BUnits).Hertz, BUnitsTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromCyclesPerHour(hertz.CyclesPerHour).Hertz, CyclesPerHourTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromCyclesPerMinute(hertz.CyclesPerMinute).Hertz, CyclesPerMinuteTolerance);
             AssertEx.EqualTolerance(1, Frequency.FromGigahertz(hertz.Gigahertz).Hertz, GigahertzTolerance);
@@ -1091,7 +1059,6 @@ namespace UnitsNet.Tests
         {
             using var _ = new CultureScope("en-US");
             Assert.Equal("1 bpm", new Frequency(1, FrequencyUnit.BeatPerMinute).ToString());
-            Assert.Equal("1 B Units", new Frequency(1, FrequencyUnit.BUnit).ToString());
             Assert.Equal("1 cph", new Frequency(1, FrequencyUnit.CyclePerHour).ToString());
             Assert.Equal("1 cpm", new Frequency(1, FrequencyUnit.CyclePerMinute).ToString());
             Assert.Equal("1 GHz", new Frequency(1, FrequencyUnit.Gigahertz).ToString());
@@ -1112,7 +1079,6 @@ namespace UnitsNet.Tests
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
             Assert.Equal("1 bpm", new Frequency(1, FrequencyUnit.BeatPerMinute).ToString(swedishCulture));
-            Assert.Equal("1 B Units", new Frequency(1, FrequencyUnit.BUnit).ToString(swedishCulture));
             Assert.Equal("1 cph", new Frequency(1, FrequencyUnit.CyclePerHour).ToString(swedishCulture));
             Assert.Equal("1 cpm", new Frequency(1, FrequencyUnit.CyclePerMinute).ToString(swedishCulture));
             Assert.Equal("1 GHz", new Frequency(1, FrequencyUnit.Gigahertz).ToString(swedishCulture));

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -77,7 +77,6 @@ namespace UnitsNet
                 new UnitInfo<FrequencyUnit>[]
                 {
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.BeatPerMinute, "BeatsPerMinute", new BaseUnits(time: DurationUnit.Minute), "Frequency"),
-                    new UnitInfo<FrequencyUnit>(FrequencyUnit.BUnit, "BUnits", BaseUnits.Undefined, "Frequency"),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.CyclePerHour, "CyclesPerHour", new BaseUnits(time: DurationUnit.Hour), "Frequency"),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.CyclePerMinute, "CyclesPerMinute", new BaseUnits(time: DurationUnit.Minute), "Frequency"),
                     new UnitInfo<FrequencyUnit>(FrequencyUnit.Gigahertz, "Gigahertz", new BaseUnits(time: DurationUnit.Nanosecond), "Frequency"),
@@ -192,11 +191,6 @@ namespace UnitsNet
         public double BeatsPerMinute => As(FrequencyUnit.BeatPerMinute);
 
         /// <summary>
-        ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="FrequencyUnit.BUnit"/>
-        /// </summary>
-        public double BUnits => As(FrequencyUnit.BUnit);
-
-        /// <summary>
         ///     Gets a <see cref="double"/> value of this quantity converted into <see cref="FrequencyUnit.CyclePerHour"/>
         /// </summary>
         public double CyclesPerHour => As(FrequencyUnit.CyclePerHour);
@@ -263,7 +257,6 @@ namespace UnitsNet
         {
             // Register in unit converter: FrequencyUnit -> BaseUnit
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.BeatPerMinute, FrequencyUnit.Hertz, quantity => quantity.ToUnit(FrequencyUnit.Hertz));
-            unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.BUnit, FrequencyUnit.Hertz, quantity => quantity.ToUnit(FrequencyUnit.Hertz));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.CyclePerHour, FrequencyUnit.Hertz, quantity => quantity.ToUnit(FrequencyUnit.Hertz));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.CyclePerMinute, FrequencyUnit.Hertz, quantity => quantity.ToUnit(FrequencyUnit.Hertz));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Gigahertz, FrequencyUnit.Hertz, quantity => quantity.ToUnit(FrequencyUnit.Hertz));
@@ -280,7 +273,6 @@ namespace UnitsNet
 
             // Register in unit converter: BaseUnit -> FrequencyUnit
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Hertz, FrequencyUnit.BeatPerMinute, quantity => quantity.ToUnit(FrequencyUnit.BeatPerMinute));
-            unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Hertz, FrequencyUnit.BUnit, quantity => quantity.ToUnit(FrequencyUnit.BUnit));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Hertz, FrequencyUnit.CyclePerHour, quantity => quantity.ToUnit(FrequencyUnit.CyclePerHour));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Hertz, FrequencyUnit.CyclePerMinute, quantity => quantity.ToUnit(FrequencyUnit.CyclePerMinute));
             unitConverter.SetConversionFunction<Frequency>(FrequencyUnit.Hertz, FrequencyUnit.Gigahertz, quantity => quantity.ToUnit(FrequencyUnit.Gigahertz));
@@ -324,14 +316,6 @@ namespace UnitsNet
         public static Frequency FromBeatsPerMinute(double value)
         {
             return new Frequency(value, FrequencyUnit.BeatPerMinute);
-        }
-
-        /// <summary>
-        ///     Creates a <see cref="Frequency"/> from <see cref="FrequencyUnit.BUnit"/>.
-        /// </summary>
-        public static Frequency FromBUnits(double value)
-        {
-            return new Frequency(value, FrequencyUnit.BUnit);
         }
 
         /// <summary>
@@ -899,7 +883,6 @@ namespace UnitsNet
             {
                 // FrequencyUnit -> BaseUnit
                 (FrequencyUnit.BeatPerMinute, FrequencyUnit.Hertz) => new Frequency(_value / 60, FrequencyUnit.Hertz),
-                (FrequencyUnit.BUnit, FrequencyUnit.Hertz) => new Frequency(Math.Sqrt(_value * 1e3), FrequencyUnit.Hertz),
                 (FrequencyUnit.CyclePerHour, FrequencyUnit.Hertz) => new Frequency(_value / 3600, FrequencyUnit.Hertz),
                 (FrequencyUnit.CyclePerMinute, FrequencyUnit.Hertz) => new Frequency(_value / 60, FrequencyUnit.Hertz),
                 (FrequencyUnit.Gigahertz, FrequencyUnit.Hertz) => new Frequency((_value) * 1e9d, FrequencyUnit.Hertz),
@@ -913,7 +896,6 @@ namespace UnitsNet
 
                 // BaseUnit -> FrequencyUnit
                 (FrequencyUnit.Hertz, FrequencyUnit.BeatPerMinute) => new Frequency(_value * 60, FrequencyUnit.BeatPerMinute),
-                (FrequencyUnit.Hertz, FrequencyUnit.BUnit) => new Frequency(_value * _value * 1e-3, FrequencyUnit.BUnit),
                 (FrequencyUnit.Hertz, FrequencyUnit.CyclePerHour) => new Frequency(_value * 3600, FrequencyUnit.CyclePerHour),
                 (FrequencyUnit.Hertz, FrequencyUnit.CyclePerMinute) => new Frequency(_value * 60, FrequencyUnit.CyclePerMinute),
                 (FrequencyUnit.Hertz, FrequencyUnit.Gigahertz) => new Frequency((_value) / 1e9d, FrequencyUnit.Gigahertz),

--- a/UnitsNet/GeneratedCode/Resources/Frequency.restext
+++ b/UnitsNet/GeneratedCode/Resources/Frequency.restext
@@ -1,5 +1,4 @@
 BeatsPerMinute=bpm
-BUnits=B Units
 CyclesPerHour=cph
 CyclesPerMinute=cpm
 Gigahertz=GHz

--- a/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
+++ b/UnitsNet/GeneratedCode/Units/FrequencyUnit.g.cs
@@ -26,7 +26,6 @@ namespace UnitsNet.Units
     public enum FrequencyUnit
     {
         BeatPerMinute = 1,
-        BUnit = 2,
         CyclePerHour = 3,
         CyclePerMinute = 4,
         Gigahertz = 5,


### PR DESCRIPTION
Removing the `FrequencyUnit.BUnit`.

As discussed in https://github.com/angularsen/UnitsNet/pull/1393#issuecomment-2211588432 