### PR TITLE
SpecificWeight: Update wiki link

### DIFF
--- a/Common/UnitDefinitions/SpecificWeight.json
+++ b/Common/UnitDefinitions/SpecificWeight.json
@@ -2,7 +2,7 @@
   "Name": "SpecificWeight",
   "BaseUnit": "NewtonPerCubicMeter",
   "XmlDocSummary": "The SpecificWeight, or more precisely, the volumetric weight density, of a substance is its weight per unit volume.",
-  "XmlDocRemarks": "http://en.wikipedia.org/wiki/Specificweight",
+  "XmlDocRemarks": "https://en.wikipedia.org/wiki/Specific_weight",
   "BaseDimensions": {
     "L": -2,
     "M": 1,


### PR DESCRIPTION
This PR fixes the broken link for SpecificWeight.


Before: http://en.wikipedia.org/wiki/Specificweight
> ![image](https://github.com/user-attachments/assets/3a153e9f-3ab4-4b0e-9ad0-e40b58633c64)


And now: https://en.wikipedia.org/wiki/Specific_weight
> ![image](https://github.com/user-attachments/assets/c0badc69-bf95-4c3d-b1d5-cee2c7e7a114)
