### PR TITLE
♻️Move extension methods to UnitInfo

### DIFF
--- a/UnitsNet/CustomCode/QuantityInfo/QuantityInfoExtensions.cs
+++ b/UnitsNet/CustomCode/QuantityInfo/QuantityInfoExtensions.cs
@@ -27,62 +27,6 @@ internal static class QuantityInfoExtensions
     }
 
     /// <summary>
-    ///     Filters a collection of unit information based on the specified base units.
-    /// </summary>
-    /// <typeparam name="TUnitInfo">The type of the unit information.</typeparam>
-    /// <param name="unitInfos">The collection of unit information to filter.</param>
-    /// <param name="baseUnits">The base units to filter by.</param>
-    /// <returns>An <see cref="IEnumerable{T}" /> containing the unit information that matches the specified base units.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="baseUnits" /> is null.</exception>
-    public static IEnumerable<TUnitInfo> GetUnitInfosFor<TUnitInfo>(this IEnumerable<TUnitInfo> unitInfos, BaseUnits baseUnits)
-        where TUnitInfo : UnitInfo
-    {
-        if (baseUnits is null)
-        {
-            throw new ArgumentNullException(nameof(baseUnits));
-        }
-
-        return unitInfos.Where(unitInfo => unitInfo.BaseUnits.IsSubsetOf(baseUnits));
-    }
-
-    /// <summary>
-    ///     Gets the <see cref="UnitInfo" /> whose <see cref="BaseUnits" /> is a subset of <paramref name="baseUnits" />.
-    /// </summary>
-    /// <example>
-    ///     Length.Info.GetUnitInfoFor(unitSystemWithFootAsLengthUnit) returns <see cref="UnitInfo" /> for
-    ///     <see cref="LengthUnit.Foot" />.
-    /// </example>
-    /// <param name="unitInfos">The collection of unit information to filter.</param>
-    /// <param name="baseUnits">The <see cref="BaseUnits" /> to check against.</param>
-    /// <returns>
-    ///     The <see cref="UnitInfo" /> that has <see cref="BaseUnits" /> that is a subset of
-    ///     <paramref name="baseUnits" />.
-    /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="baseUnits" /> is null.</exception>
-    /// <exception cref="InvalidOperationException">No unit was found that is a subset of <paramref name="baseUnits" />.</exception>
-    /// <exception cref="InvalidOperationException">
-    ///     More than one unit was found that is a subset of
-    ///     <paramref name="baseUnits" />.
-    /// </exception>
-    public static TUnitInfo GetUnitInfoFor<TUnitInfo>(this IEnumerable<TUnitInfo> unitInfos, BaseUnits baseUnits)
-        where TUnitInfo : UnitInfo
-    {
-        using IEnumerator<TUnitInfo> enumerator = unitInfos.GetUnitInfosFor(baseUnits).GetEnumerator();
-        if (!enumerator.MoveNext())
-        {
-            throw new InvalidOperationException($"No unit was found that is a subset of {nameof(baseUnits)}");
-        }
-
-        TUnitInfo firstUnitInfo = enumerator.Current!;
-        if (enumerator.MoveNext())
-        {
-            throw new InvalidOperationException($"More than one unit was found that is a subset of {nameof(baseUnits)}");
-        }
-
-        return firstUnitInfo;
-    }
-    
-    /// <summary>
     ///     Retrieves the default unit for a specified quantity and unit system.
     /// </summary>
     /// <typeparam name="TUnit">The type of the unit, which is a value type and an enumeration.</typeparam>

--- a/UnitsNet/QuantityInfo.cs
+++ b/UnitsNet/QuantityInfo.cs
@@ -93,13 +93,13 @@ public abstract class QuantityInfo : IQuantityInfo
     /// <inheritdoc />
     public UnitInfo GetUnitInfoFor(BaseUnits baseUnits)
     {
-        return UnitInfos.GetUnitInfoFor(baseUnits);
+        return UnitInfo.Get(UnitInfos, baseUnits);
     }
 
     /// <inheritdoc />
     public IEnumerable<UnitInfo> GetUnitInfosFor(BaseUnits baseUnits)
     {
-        return UnitInfos.GetUnitInfosFor(baseUnits);
+        return UnitInfo.FilterBy(UnitInfos, baseUnits);
     }
 
     /// <summary>
@@ -186,13 +186,13 @@ public abstract class QuantityInfo<TUnit> : QuantityInfo//, IQuantityInfo<TUnit>
     /// <inheritdoc cref="QuantityInfo.GetUnitInfoFor" />
     public new UnitInfo<TUnit> GetUnitInfoFor(BaseUnits baseUnits)
     {
-        return UnitInfos.GetUnitInfoFor(baseUnits);
+        return UnitInfo.Get(UnitInfos, baseUnits);
     }
     
     /// <inheritdoc cref="QuantityInfo.GetUnitInfosFor" />
     public new IEnumerable<UnitInfo<TUnit>> GetUnitInfosFor(BaseUnits baseUnits)
     {
-        return UnitInfos.GetUnitInfosFor(baseUnits);
+        return UnitInfo.FilterBy(UnitInfos, baseUnits);
     }
     
     /// <inheritdoc cref="QuantityInfo.From" />
@@ -307,13 +307,13 @@ public abstract class QuantityInfoBase<TQuantity, TUnit, TUnitInfo> : QuantityIn
     /// <inheritdoc cref="IQuantityInfo.GetUnitInfosFor" />
     public new IEnumerable<TUnitInfo> GetUnitInfosFor(BaseUnits baseUnits)
     {
-        return UnitInfos.GetUnitInfosFor(baseUnits);
+        return UnitInfo.FilterBy(UnitInfos, baseUnits);
     }
 
     /// <inheritdoc cref="IQuantityInfo.GetUnitInfoFor" />
     public new TUnitInfo GetUnitInfoFor(BaseUnits baseUnits)
     {
-        return UnitInfos.GetUnitInfoFor(baseUnits);
+        return UnitInfo.Get(UnitInfos, baseUnits);
     }
 
     /// <summary>


### PR DESCRIPTION
Extension methods on collections of a specific item type is not always easy to read or reason about. Convert to static utility methods and move to `UnitInfo`, the type of item the methods take.