### PR TITLE
♻️Change quantity info types to static factories

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -152,60 +152,60 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref=""{_quantity.Name}""/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class {quantityInfoClassName}: QuantityInfo<{_quantity.Name}, {_unitEnumName}>
+        private static class {quantityInfoClassName}
         {{");
             Writer.WL($@"
-            /// <inheritdoc />
-            public {quantityInfoClassName}(string name, {_unitEnumName} baseUnit, IEnumerable<IUnitDefinition<{_unitEnumName}>> unitMappings, {_quantity.Name} zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<{_quantity.Name}, {_unitEnumName}> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, {_quantity.Name}.RegisterDefaultConversions, unitAbbreviations)
-            {{
-            }}
-
-            /// <inheritdoc />
-            public {quantityInfoClassName}(string name, {_unitEnumName} baseUnit, IEnumerable<IUnitDefinition<{_unitEnumName}>> unitMappings, {_quantity.Name} zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, {_quantity.Name}.From, new ResourceManager(""UnitsNet.GeneratedCode.Resources.{_quantity.Name}"", typeof({_quantity.Name}).Assembly))
-            {{
-            }}
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref=""{quantityInfoClassName}""/> class with the default settings for the {_quantity.Name} quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref=""{quantityInfoClassName}""/> class with the default settings.</returns>
-            public static {quantityInfoClassName} CreateDefault()
-            {{
-                return new {quantityInfoClassName}(nameof({_quantity.Name}), DefaultBaseUnit, GetDefaultMappings(), new {_quantity.Name}(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }}
-
             /// <summary>
             ///     Creates a new instance of the <see cref=""{quantityInfoClassName}""/> class with the default settings for the {_quantity.Name} quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name=""unitAbbreviations"">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name=""customizeUnits"">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref=""{quantityInfoClassName}""/> class with the default settings.
             /// </returns>
-            public static {quantityInfoClassName} CreateDefault(Func<IEnumerable<UnitDefinition<{_unitEnumName}>>, IEnumerable<IUnitDefinition<{_unitEnumName}>>> customizeUnits)
+            private static QuantityInfo<{_quantity.Name}, {_unitEnumName}> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<{_unitEnumName}>>, IEnumerable<IUnitDefinition<{_unitEnumName}>>>? customizeUnits = null)
             {{
-                return new {quantityInfoClassName}(nameof({_quantity.Name}), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new {_quantity.Name}(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<{_unitEnumName}>> unitMappings = {_quantity.Name}Info.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<{_quantity.Name}, {_unitEnumName}>(
+                    name: nameof({_quantity.Name}),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new {_quantity.Name}(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }}
 
             /// <summary>
             ///     The <see cref=""BaseDimensions"" /> for <see cref=""{_quantity.Name}""/> is {_quantity.BaseDimensions}.
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions {{ get; }} = {createDimensionsExpression};
+            private static BaseDimensions DefaultBaseDimensions {{ get; }} = {createDimensionsExpression};
 
             /// <summary>
             ///     The default base unit of {_quantity.Name} is {_baseUnit.SingularName}. All conversions, as defined in the <see cref=""GetDefaultMappings""/>, go via this value.
             /// </summary>
-            public static {_unitEnumName} DefaultBaseUnit {{ get; }} = {_unitEnumName}.{_baseUnit.SingularName};
+            private static {_unitEnumName} DefaultBaseUnit {{ get; }} = {_unitEnumName}.{_baseUnit.SingularName};
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the {_quantity.Name} quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations {{ get; }} = new(""UnitsNet.GeneratedCode.Resources.{_quantity.Name}"", typeof({_quantity.Name}).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref=""{_unitEnumName}""/>.
             /// </summary>
             /// <returns>An <see cref=""IEnumerable{{T}}""/> of <see cref=""UnitDefinition{{{_unitEnumName}}}""/> representing the default unit mappings for {_quantity.Name}.</returns>
-            public static IEnumerable<UnitDefinition<{_unitEnumName}>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<{_unitEnumName}>> GetDefaultMappings()
             {{");
 
             foreach (Unit unit in _quantity.Units)
@@ -247,7 +247,7 @@ namespace UnitsNet
         static {_quantity.Name}()
         {{");
             Writer.WL($@"
-            Info = {_quantity.Name}Info.CreateDefault();
+            Info = {_quantity.Name}Info.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }}

--- a/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="AbsorbedDoseOfIonizingRadiation"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AbsorbedDoseOfIonizingRadiationInfo: QuantityInfo<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiationUnit>
+        private static class AbsorbedDoseOfIonizingRadiationInfo
         {
-            /// <inheritdoc />
-            public AbsorbedDoseOfIonizingRadiationInfo(string name, AbsorbedDoseOfIonizingRadiationUnit baseUnit, IEnumerable<IUnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>> unitMappings, AbsorbedDoseOfIonizingRadiation zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, AbsorbedDoseOfIonizingRadiation.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AbsorbedDoseOfIonizingRadiationInfo(string name, AbsorbedDoseOfIonizingRadiationUnit baseUnit, IEnumerable<IUnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>> unitMappings, AbsorbedDoseOfIonizingRadiation zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, AbsorbedDoseOfIonizingRadiation.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.AbsorbedDoseOfIonizingRadiation", typeof(AbsorbedDoseOfIonizingRadiation).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AbsorbedDoseOfIonizingRadiationInfo"/> class with the default settings for the AbsorbedDoseOfIonizingRadiation quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AbsorbedDoseOfIonizingRadiationInfo"/> class with the default settings.</returns>
-            public static AbsorbedDoseOfIonizingRadiationInfo CreateDefault()
-            {
-                return new AbsorbedDoseOfIonizingRadiationInfo(nameof(AbsorbedDoseOfIonizingRadiation), DefaultBaseUnit, GetDefaultMappings(), new AbsorbedDoseOfIonizingRadiation(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AbsorbedDoseOfIonizingRadiationInfo"/> class with the default settings for the AbsorbedDoseOfIonizingRadiation quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AbsorbedDoseOfIonizingRadiationInfo"/> class with the default settings.
             /// </returns>
-            public static AbsorbedDoseOfIonizingRadiationInfo CreateDefault(Func<IEnumerable<UnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>>, IEnumerable<IUnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>>> customizeUnits)
+            private static QuantityInfo<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>>, IEnumerable<IUnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>>>? customizeUnits = null)
             {
-                return new AbsorbedDoseOfIonizingRadiationInfo(nameof(AbsorbedDoseOfIonizingRadiation), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new AbsorbedDoseOfIonizingRadiation(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>> unitMappings = AbsorbedDoseOfIonizingRadiationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiationUnit>(
+                    name: nameof(AbsorbedDoseOfIonizingRadiation),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new AbsorbedDoseOfIonizingRadiation(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="AbsorbedDoseOfIonizingRadiation"/> is [T^-2][L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of AbsorbedDoseOfIonizingRadiation is Gray. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AbsorbedDoseOfIonizingRadiationUnit DefaultBaseUnit { get; } = AbsorbedDoseOfIonizingRadiationUnit.Gray;
+            private static AbsorbedDoseOfIonizingRadiationUnit DefaultBaseUnit { get; } = AbsorbedDoseOfIonizingRadiationUnit.Gray;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the AbsorbedDoseOfIonizingRadiation quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.AbsorbedDoseOfIonizingRadiation", typeof(AbsorbedDoseOfIonizingRadiation).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AbsorbedDoseOfIonizingRadiationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AbsorbedDoseOfIonizingRadiationUnit}"/> representing the default unit mappings for AbsorbedDoseOfIonizingRadiation.</returns>
-            public static IEnumerable<UnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AbsorbedDoseOfIonizingRadiationUnit>> GetDefaultMappings()
             {
                 yield return new (AbsorbedDoseOfIonizingRadiationUnit.Centigray, "Centigray", "Centigrays", new BaseUnits(length: LengthUnit.Decimeter, time: DurationUnit.Second));
                 yield return new (AbsorbedDoseOfIonizingRadiationUnit.Femtogray, "Femtogray", "Femtograys", BaseUnits.Undefined);
@@ -140,7 +140,7 @@ namespace UnitsNet
 
         static AbsorbedDoseOfIonizingRadiation()
         {
-            Info = AbsorbedDoseOfIonizingRadiationInfo.CreateDefault();
+            Info = AbsorbedDoseOfIonizingRadiationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -69,59 +69,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Acceleration"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AccelerationInfo: QuantityInfo<Acceleration, AccelerationUnit>
+        private static class AccelerationInfo
         {
-            /// <inheritdoc />
-            public AccelerationInfo(string name, AccelerationUnit baseUnit, IEnumerable<IUnitDefinition<AccelerationUnit>> unitMappings, Acceleration zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Acceleration, AccelerationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Acceleration.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AccelerationInfo(string name, AccelerationUnit baseUnit, IEnumerable<IUnitDefinition<AccelerationUnit>> unitMappings, Acceleration zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Acceleration.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Acceleration", typeof(Acceleration).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AccelerationInfo"/> class with the default settings for the Acceleration quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AccelerationInfo"/> class with the default settings.</returns>
-            public static AccelerationInfo CreateDefault()
-            {
-                return new AccelerationInfo(nameof(Acceleration), DefaultBaseUnit, GetDefaultMappings(), new Acceleration(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AccelerationInfo"/> class with the default settings for the Acceleration quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AccelerationInfo"/> class with the default settings.
             /// </returns>
-            public static AccelerationInfo CreateDefault(Func<IEnumerable<UnitDefinition<AccelerationUnit>>, IEnumerable<IUnitDefinition<AccelerationUnit>>> customizeUnits)
+            private static QuantityInfo<Acceleration, AccelerationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AccelerationUnit>>, IEnumerable<IUnitDefinition<AccelerationUnit>>>? customizeUnits = null)
             {
-                return new AccelerationInfo(nameof(Acceleration), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Acceleration(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AccelerationUnit>> unitMappings = AccelerationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Acceleration, AccelerationUnit>(
+                    name: nameof(Acceleration),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Acceleration(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Acceleration"/> is [T^-2][L].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Acceleration is MeterPerSecondSquared. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AccelerationUnit DefaultBaseUnit { get; } = AccelerationUnit.MeterPerSecondSquared;
+            private static AccelerationUnit DefaultBaseUnit { get; } = AccelerationUnit.MeterPerSecondSquared;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Acceleration quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Acceleration", typeof(Acceleration).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AccelerationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AccelerationUnit}"/> representing the default unit mappings for Acceleration.</returns>
-            public static IEnumerable<UnitDefinition<AccelerationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AccelerationUnit>> GetDefaultMappings()
             {
                 yield return new (AccelerationUnit.CentimeterPerSecondSquared, "CentimeterPerSecondSquared", "CentimetersPerSecondSquared", new BaseUnits(length: LengthUnit.Centimeter, time: DurationUnit.Second));
                 yield return new (AccelerationUnit.DecimeterPerSecondSquared, "DecimeterPerSecondSquared", "DecimetersPerSecondSquared", new BaseUnits(length: LengthUnit.Decimeter, time: DurationUnit.Second));
@@ -142,7 +142,7 @@ namespace UnitsNet
 
         static Acceleration()
         {
-            Info = AccelerationInfo.CreateDefault();
+            Info = AccelerationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -70,59 +70,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="AmountOfSubstance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AmountOfSubstanceInfo: QuantityInfo<AmountOfSubstance, AmountOfSubstanceUnit>
+        private static class AmountOfSubstanceInfo
         {
-            /// <inheritdoc />
-            public AmountOfSubstanceInfo(string name, AmountOfSubstanceUnit baseUnit, IEnumerable<IUnitDefinition<AmountOfSubstanceUnit>> unitMappings, AmountOfSubstance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<AmountOfSubstance, AmountOfSubstanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, AmountOfSubstance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AmountOfSubstanceInfo(string name, AmountOfSubstanceUnit baseUnit, IEnumerable<IUnitDefinition<AmountOfSubstanceUnit>> unitMappings, AmountOfSubstance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, AmountOfSubstance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.AmountOfSubstance", typeof(AmountOfSubstance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AmountOfSubstanceInfo"/> class with the default settings for the AmountOfSubstance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AmountOfSubstanceInfo"/> class with the default settings.</returns>
-            public static AmountOfSubstanceInfo CreateDefault()
-            {
-                return new AmountOfSubstanceInfo(nameof(AmountOfSubstance), DefaultBaseUnit, GetDefaultMappings(), new AmountOfSubstance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AmountOfSubstanceInfo"/> class with the default settings for the AmountOfSubstance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AmountOfSubstanceInfo"/> class with the default settings.
             /// </returns>
-            public static AmountOfSubstanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<AmountOfSubstanceUnit>>, IEnumerable<IUnitDefinition<AmountOfSubstanceUnit>>> customizeUnits)
+            private static QuantityInfo<AmountOfSubstance, AmountOfSubstanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AmountOfSubstanceUnit>>, IEnumerable<IUnitDefinition<AmountOfSubstanceUnit>>>? customizeUnits = null)
             {
-                return new AmountOfSubstanceInfo(nameof(AmountOfSubstance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new AmountOfSubstance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AmountOfSubstanceUnit>> unitMappings = AmountOfSubstanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<AmountOfSubstance, AmountOfSubstanceUnit>(
+                    name: nameof(AmountOfSubstance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new AmountOfSubstance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="AmountOfSubstance"/> is [N].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 0, 1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 0, 1, 0);
 
             /// <summary>
             ///     The default base unit of AmountOfSubstance is Mole. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AmountOfSubstanceUnit DefaultBaseUnit { get; } = AmountOfSubstanceUnit.Mole;
+            private static AmountOfSubstanceUnit DefaultBaseUnit { get; } = AmountOfSubstanceUnit.Mole;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the AmountOfSubstance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.AmountOfSubstance", typeof(AmountOfSubstance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AmountOfSubstanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AmountOfSubstanceUnit}"/> representing the default unit mappings for AmountOfSubstance.</returns>
-            public static IEnumerable<UnitDefinition<AmountOfSubstanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AmountOfSubstanceUnit>> GetDefaultMappings()
             {
                 yield return new (AmountOfSubstanceUnit.Centimole, "Centimole", "Centimoles", new BaseUnits(amount: AmountOfSubstanceUnit.Centimole));
                 yield return new (AmountOfSubstanceUnit.CentipoundMole, "CentipoundMole", "CentipoundMoles", new BaseUnits(amount: AmountOfSubstanceUnit.CentipoundMole));
@@ -146,7 +146,7 @@ namespace UnitsNet
 
         static AmountOfSubstance()
         {
-            Info = AmountOfSubstanceInfo.CreateDefault();
+            Info = AmountOfSubstanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="AmplitudeRatio"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AmplitudeRatioInfo: QuantityInfo<AmplitudeRatio, AmplitudeRatioUnit>
+        private static class AmplitudeRatioInfo
         {
-            /// <inheritdoc />
-            public AmplitudeRatioInfo(string name, AmplitudeRatioUnit baseUnit, IEnumerable<IUnitDefinition<AmplitudeRatioUnit>> unitMappings, AmplitudeRatio zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<AmplitudeRatio, AmplitudeRatioUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, AmplitudeRatio.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AmplitudeRatioInfo(string name, AmplitudeRatioUnit baseUnit, IEnumerable<IUnitDefinition<AmplitudeRatioUnit>> unitMappings, AmplitudeRatio zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, AmplitudeRatio.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.AmplitudeRatio", typeof(AmplitudeRatio).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AmplitudeRatioInfo"/> class with the default settings for the AmplitudeRatio quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AmplitudeRatioInfo"/> class with the default settings.</returns>
-            public static AmplitudeRatioInfo CreateDefault()
-            {
-                return new AmplitudeRatioInfo(nameof(AmplitudeRatio), DefaultBaseUnit, GetDefaultMappings(), new AmplitudeRatio(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AmplitudeRatioInfo"/> class with the default settings for the AmplitudeRatio quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AmplitudeRatioInfo"/> class with the default settings.
             /// </returns>
-            public static AmplitudeRatioInfo CreateDefault(Func<IEnumerable<UnitDefinition<AmplitudeRatioUnit>>, IEnumerable<IUnitDefinition<AmplitudeRatioUnit>>> customizeUnits)
+            private static QuantityInfo<AmplitudeRatio, AmplitudeRatioUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AmplitudeRatioUnit>>, IEnumerable<IUnitDefinition<AmplitudeRatioUnit>>>? customizeUnits = null)
             {
-                return new AmplitudeRatioInfo(nameof(AmplitudeRatio), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new AmplitudeRatio(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AmplitudeRatioUnit>> unitMappings = AmplitudeRatioInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<AmplitudeRatio, AmplitudeRatioUnit>(
+                    name: nameof(AmplitudeRatio),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new AmplitudeRatio(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="AmplitudeRatio"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of AmplitudeRatio is DecibelVolt. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AmplitudeRatioUnit DefaultBaseUnit { get; } = AmplitudeRatioUnit.DecibelVolt;
+            private static AmplitudeRatioUnit DefaultBaseUnit { get; } = AmplitudeRatioUnit.DecibelVolt;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the AmplitudeRatio quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.AmplitudeRatio", typeof(AmplitudeRatio).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AmplitudeRatioUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AmplitudeRatioUnit}"/> representing the default unit mappings for AmplitudeRatio.</returns>
-            public static IEnumerable<UnitDefinition<AmplitudeRatioUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AmplitudeRatioUnit>> GetDefaultMappings()
             {
                 yield return new (AmplitudeRatioUnit.DecibelMicrovolt, "DecibelMicrovolt", "DecibelMicrovolts", BaseUnits.Undefined);
                 yield return new (AmplitudeRatioUnit.DecibelMillivolt, "DecibelMillivolt", "DecibelMillivolts", BaseUnits.Undefined);
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static AmplitudeRatio()
         {
-            Info = AmplitudeRatioInfo.CreateDefault();
+            Info = AmplitudeRatioInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -67,59 +67,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Angle"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AngleInfo: QuantityInfo<Angle, AngleUnit>
+        private static class AngleInfo
         {
-            /// <inheritdoc />
-            public AngleInfo(string name, AngleUnit baseUnit, IEnumerable<IUnitDefinition<AngleUnit>> unitMappings, Angle zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Angle, AngleUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Angle.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AngleInfo(string name, AngleUnit baseUnit, IEnumerable<IUnitDefinition<AngleUnit>> unitMappings, Angle zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Angle.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Angle", typeof(Angle).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AngleInfo"/> class with the default settings for the Angle quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AngleInfo"/> class with the default settings.</returns>
-            public static AngleInfo CreateDefault()
-            {
-                return new AngleInfo(nameof(Angle), DefaultBaseUnit, GetDefaultMappings(), new Angle(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AngleInfo"/> class with the default settings for the Angle quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AngleInfo"/> class with the default settings.
             /// </returns>
-            public static AngleInfo CreateDefault(Func<IEnumerable<UnitDefinition<AngleUnit>>, IEnumerable<IUnitDefinition<AngleUnit>>> customizeUnits)
+            private static QuantityInfo<Angle, AngleUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AngleUnit>>, IEnumerable<IUnitDefinition<AngleUnit>>>? customizeUnits = null)
             {
-                return new AngleInfo(nameof(Angle), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Angle(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AngleUnit>> unitMappings = AngleInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Angle, AngleUnit>(
+                    name: nameof(Angle),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Angle(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Angle"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of Angle is Radian. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AngleUnit DefaultBaseUnit { get; } = AngleUnit.Radian;
+            private static AngleUnit DefaultBaseUnit { get; } = AngleUnit.Radian;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Angle quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Angle", typeof(Angle).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AngleUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AngleUnit}"/> representing the default unit mappings for Angle.</returns>
-            public static IEnumerable<UnitDefinition<AngleUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AngleUnit>> GetDefaultMappings()
             {
                 yield return new (AngleUnit.Arcminute, "Arcminute", "Arcminutes", BaseUnits.Undefined);
                 yield return new (AngleUnit.Arcsecond, "Arcsecond", "Arcseconds", BaseUnits.Undefined);
@@ -141,7 +141,7 @@ namespace UnitsNet
 
         static Angle()
         {
-            Info = AngleInfo.CreateDefault();
+            Info = AngleInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -80,59 +80,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Area"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AreaInfo: QuantityInfo<Area, AreaUnit>
+        private static class AreaInfo
         {
-            /// <inheritdoc />
-            public AreaInfo(string name, AreaUnit baseUnit, IEnumerable<IUnitDefinition<AreaUnit>> unitMappings, Area zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Area, AreaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Area.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AreaInfo(string name, AreaUnit baseUnit, IEnumerable<IUnitDefinition<AreaUnit>> unitMappings, Area zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Area.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Area", typeof(Area).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AreaInfo"/> class with the default settings for the Area quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AreaInfo"/> class with the default settings.</returns>
-            public static AreaInfo CreateDefault()
-            {
-                return new AreaInfo(nameof(Area), DefaultBaseUnit, GetDefaultMappings(), new Area(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AreaInfo"/> class with the default settings for the Area quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AreaInfo"/> class with the default settings.
             /// </returns>
-            public static AreaInfo CreateDefault(Func<IEnumerable<UnitDefinition<AreaUnit>>, IEnumerable<IUnitDefinition<AreaUnit>>> customizeUnits)
+            private static QuantityInfo<Area, AreaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AreaUnit>>, IEnumerable<IUnitDefinition<AreaUnit>>>? customizeUnits = null)
             {
-                return new AreaInfo(nameof(Area), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Area(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AreaUnit>> unitMappings = AreaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Area, AreaUnit>(
+                    name: nameof(Area),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Area(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Area"/> is [L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Area is SquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AreaUnit DefaultBaseUnit { get; } = AreaUnit.SquareMeter;
+            private static AreaUnit DefaultBaseUnit { get; } = AreaUnit.SquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Area quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Area", typeof(Area).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AreaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AreaUnit}"/> representing the default unit mappings for Area.</returns>
-            public static IEnumerable<UnitDefinition<AreaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AreaUnit>> GetDefaultMappings()
             {
                 yield return new (AreaUnit.Acre, "Acre", "Acres", BaseUnits.Undefined);
                 yield return new (AreaUnit.Hectare, "Hectare", "Hectares", BaseUnits.Undefined);
@@ -153,7 +153,7 @@ namespace UnitsNet
 
         static Area()
         {
-            Info = AreaInfo.CreateDefault();
+            Info = AreaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="AreaDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AreaDensityInfo: QuantityInfo<AreaDensity, AreaDensityUnit>
+        private static class AreaDensityInfo
         {
-            /// <inheritdoc />
-            public AreaDensityInfo(string name, AreaDensityUnit baseUnit, IEnumerable<IUnitDefinition<AreaDensityUnit>> unitMappings, AreaDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<AreaDensity, AreaDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, AreaDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AreaDensityInfo(string name, AreaDensityUnit baseUnit, IEnumerable<IUnitDefinition<AreaDensityUnit>> unitMappings, AreaDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, AreaDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.AreaDensity", typeof(AreaDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AreaDensityInfo"/> class with the default settings for the AreaDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AreaDensityInfo"/> class with the default settings.</returns>
-            public static AreaDensityInfo CreateDefault()
-            {
-                return new AreaDensityInfo(nameof(AreaDensity), DefaultBaseUnit, GetDefaultMappings(), new AreaDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AreaDensityInfo"/> class with the default settings for the AreaDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AreaDensityInfo"/> class with the default settings.
             /// </returns>
-            public static AreaDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<AreaDensityUnit>>, IEnumerable<IUnitDefinition<AreaDensityUnit>>> customizeUnits)
+            private static QuantityInfo<AreaDensity, AreaDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AreaDensityUnit>>, IEnumerable<IUnitDefinition<AreaDensityUnit>>>? customizeUnits = null)
             {
-                return new AreaDensityInfo(nameof(AreaDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new AreaDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AreaDensityUnit>> unitMappings = AreaDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<AreaDensity, AreaDensityUnit>(
+                    name: nameof(AreaDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new AreaDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="AreaDensity"/> is [L^-2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of AreaDensity is KilogramPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AreaDensityUnit DefaultBaseUnit { get; } = AreaDensityUnit.KilogramPerSquareMeter;
+            private static AreaDensityUnit DefaultBaseUnit { get; } = AreaDensityUnit.KilogramPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the AreaDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.AreaDensity", typeof(AreaDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AreaDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AreaDensityUnit}"/> representing the default unit mappings for AreaDensity.</returns>
-            public static IEnumerable<UnitDefinition<AreaDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AreaDensityUnit>> GetDefaultMappings()
             {
                 yield return new (AreaDensityUnit.GramPerSquareMeter, "GramPerSquareMeter", "GramsPerSquareMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Gram));
                 yield return new (AreaDensityUnit.KilogramPerSquareMeter, "KilogramPerSquareMeter", "KilogramsPerSquareMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static AreaDensity()
         {
-            Info = AreaDensityInfo.CreateDefault();
+            Info = AreaDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="AreaMomentOfInertia"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class AreaMomentOfInertiaInfo: QuantityInfo<AreaMomentOfInertia, AreaMomentOfInertiaUnit>
+        private static class AreaMomentOfInertiaInfo
         {
-            /// <inheritdoc />
-            public AreaMomentOfInertiaInfo(string name, AreaMomentOfInertiaUnit baseUnit, IEnumerable<IUnitDefinition<AreaMomentOfInertiaUnit>> unitMappings, AreaMomentOfInertia zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<AreaMomentOfInertia, AreaMomentOfInertiaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, AreaMomentOfInertia.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public AreaMomentOfInertiaInfo(string name, AreaMomentOfInertiaUnit baseUnit, IEnumerable<IUnitDefinition<AreaMomentOfInertiaUnit>> unitMappings, AreaMomentOfInertia zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, AreaMomentOfInertia.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.AreaMomentOfInertia", typeof(AreaMomentOfInertia).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="AreaMomentOfInertiaInfo"/> class with the default settings for the AreaMomentOfInertia quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="AreaMomentOfInertiaInfo"/> class with the default settings.</returns>
-            public static AreaMomentOfInertiaInfo CreateDefault()
-            {
-                return new AreaMomentOfInertiaInfo(nameof(AreaMomentOfInertia), DefaultBaseUnit, GetDefaultMappings(), new AreaMomentOfInertia(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="AreaMomentOfInertiaInfo"/> class with the default settings for the AreaMomentOfInertia quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="AreaMomentOfInertiaInfo"/> class with the default settings.
             /// </returns>
-            public static AreaMomentOfInertiaInfo CreateDefault(Func<IEnumerable<UnitDefinition<AreaMomentOfInertiaUnit>>, IEnumerable<IUnitDefinition<AreaMomentOfInertiaUnit>>> customizeUnits)
+            private static QuantityInfo<AreaMomentOfInertia, AreaMomentOfInertiaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<AreaMomentOfInertiaUnit>>, IEnumerable<IUnitDefinition<AreaMomentOfInertiaUnit>>>? customizeUnits = null)
             {
-                return new AreaMomentOfInertiaInfo(nameof(AreaMomentOfInertia), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new AreaMomentOfInertia(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<AreaMomentOfInertiaUnit>> unitMappings = AreaMomentOfInertiaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<AreaMomentOfInertia, AreaMomentOfInertiaUnit>(
+                    name: nameof(AreaMomentOfInertia),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new AreaMomentOfInertia(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="AreaMomentOfInertia"/> is [L^4].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(4, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(4, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of AreaMomentOfInertia is MeterToTheFourth. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static AreaMomentOfInertiaUnit DefaultBaseUnit { get; } = AreaMomentOfInertiaUnit.MeterToTheFourth;
+            private static AreaMomentOfInertiaUnit DefaultBaseUnit { get; } = AreaMomentOfInertiaUnit.MeterToTheFourth;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the AreaMomentOfInertia quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.AreaMomentOfInertia", typeof(AreaMomentOfInertia).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="AreaMomentOfInertiaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{AreaMomentOfInertiaUnit}"/> representing the default unit mappings for AreaMomentOfInertia.</returns>
-            public static IEnumerable<UnitDefinition<AreaMomentOfInertiaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<AreaMomentOfInertiaUnit>> GetDefaultMappings()
             {
                 yield return new (AreaMomentOfInertiaUnit.CentimeterToTheFourth, "CentimeterToTheFourth", "CentimetersToTheFourth", new BaseUnits(length: LengthUnit.Centimeter));
                 yield return new (AreaMomentOfInertiaUnit.DecimeterToTheFourth, "DecimeterToTheFourth", "DecimetersToTheFourth", new BaseUnits(length: LengthUnit.Decimeter));
@@ -131,7 +131,7 @@ namespace UnitsNet
 
         static AreaMomentOfInertia()
         {
-            Info = AreaMomentOfInertiaInfo.CreateDefault();
+            Info = AreaMomentOfInertiaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="BitRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class BitRateInfo: QuantityInfo<BitRate, BitRateUnit>
+        private static class BitRateInfo
         {
-            /// <inheritdoc />
-            public BitRateInfo(string name, BitRateUnit baseUnit, IEnumerable<IUnitDefinition<BitRateUnit>> unitMappings, BitRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<BitRate, BitRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, BitRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public BitRateInfo(string name, BitRateUnit baseUnit, IEnumerable<IUnitDefinition<BitRateUnit>> unitMappings, BitRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, BitRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.BitRate", typeof(BitRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="BitRateInfo"/> class with the default settings for the BitRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="BitRateInfo"/> class with the default settings.</returns>
-            public static BitRateInfo CreateDefault()
-            {
-                return new BitRateInfo(nameof(BitRate), DefaultBaseUnit, GetDefaultMappings(), new BitRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="BitRateInfo"/> class with the default settings for the BitRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="BitRateInfo"/> class with the default settings.
             /// </returns>
-            public static BitRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<BitRateUnit>>, IEnumerable<IUnitDefinition<BitRateUnit>>> customizeUnits)
+            private static QuantityInfo<BitRate, BitRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<BitRateUnit>>, IEnumerable<IUnitDefinition<BitRateUnit>>>? customizeUnits = null)
             {
-                return new BitRateInfo(nameof(BitRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new BitRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<BitRateUnit>> unitMappings = BitRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<BitRate, BitRateUnit>(
+                    name: nameof(BitRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new BitRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="BitRate"/> is [T^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of BitRate is BitPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static BitRateUnit DefaultBaseUnit { get; } = BitRateUnit.BitPerSecond;
+            private static BitRateUnit DefaultBaseUnit { get; } = BitRateUnit.BitPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the BitRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.BitRate", typeof(BitRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="BitRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{BitRateUnit}"/> representing the default unit mappings for BitRate.</returns>
-            public static IEnumerable<UnitDefinition<BitRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<BitRateUnit>> GetDefaultMappings()
             {
                 yield return new (BitRateUnit.BitPerSecond, "BitPerSecond", "BitsPerSecond", new BaseUnits(time: DurationUnit.Second));
                 yield return new (BitRateUnit.BytePerSecond, "BytePerSecond", "BytesPerSecond", BaseUnits.Undefined);
@@ -163,7 +163,7 @@ namespace UnitsNet
 
         static BitRate()
         {
-            Info = BitRateInfo.CreateDefault();
+            Info = BitRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="BrakeSpecificFuelConsumption"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class BrakeSpecificFuelConsumptionInfo: QuantityInfo<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumptionUnit>
+        private static class BrakeSpecificFuelConsumptionInfo
         {
-            /// <inheritdoc />
-            public BrakeSpecificFuelConsumptionInfo(string name, BrakeSpecificFuelConsumptionUnit baseUnit, IEnumerable<IUnitDefinition<BrakeSpecificFuelConsumptionUnit>> unitMappings, BrakeSpecificFuelConsumption zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumptionUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, BrakeSpecificFuelConsumption.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public BrakeSpecificFuelConsumptionInfo(string name, BrakeSpecificFuelConsumptionUnit baseUnit, IEnumerable<IUnitDefinition<BrakeSpecificFuelConsumptionUnit>> unitMappings, BrakeSpecificFuelConsumption zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, BrakeSpecificFuelConsumption.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.BrakeSpecificFuelConsumption", typeof(BrakeSpecificFuelConsumption).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="BrakeSpecificFuelConsumptionInfo"/> class with the default settings for the BrakeSpecificFuelConsumption quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="BrakeSpecificFuelConsumptionInfo"/> class with the default settings.</returns>
-            public static BrakeSpecificFuelConsumptionInfo CreateDefault()
-            {
-                return new BrakeSpecificFuelConsumptionInfo(nameof(BrakeSpecificFuelConsumption), DefaultBaseUnit, GetDefaultMappings(), new BrakeSpecificFuelConsumption(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="BrakeSpecificFuelConsumptionInfo"/> class with the default settings for the BrakeSpecificFuelConsumption quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="BrakeSpecificFuelConsumptionInfo"/> class with the default settings.
             /// </returns>
-            public static BrakeSpecificFuelConsumptionInfo CreateDefault(Func<IEnumerable<UnitDefinition<BrakeSpecificFuelConsumptionUnit>>, IEnumerable<IUnitDefinition<BrakeSpecificFuelConsumptionUnit>>> customizeUnits)
+            private static QuantityInfo<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumptionUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<BrakeSpecificFuelConsumptionUnit>>, IEnumerable<IUnitDefinition<BrakeSpecificFuelConsumptionUnit>>>? customizeUnits = null)
             {
-                return new BrakeSpecificFuelConsumptionInfo(nameof(BrakeSpecificFuelConsumption), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new BrakeSpecificFuelConsumption(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<BrakeSpecificFuelConsumptionUnit>> unitMappings = BrakeSpecificFuelConsumptionInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumptionUnit>(
+                    name: nameof(BrakeSpecificFuelConsumption),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new BrakeSpecificFuelConsumption(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="BrakeSpecificFuelConsumption"/> is [T^2][L^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of BrakeSpecificFuelConsumption is KilogramPerJoule. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static BrakeSpecificFuelConsumptionUnit DefaultBaseUnit { get; } = BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
+            private static BrakeSpecificFuelConsumptionUnit DefaultBaseUnit { get; } = BrakeSpecificFuelConsumptionUnit.KilogramPerJoule;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the BrakeSpecificFuelConsumption quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.BrakeSpecificFuelConsumption", typeof(BrakeSpecificFuelConsumption).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="BrakeSpecificFuelConsumptionUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{BrakeSpecificFuelConsumptionUnit}"/> representing the default unit mappings for BrakeSpecificFuelConsumption.</returns>
-            public static IEnumerable<UnitDefinition<BrakeSpecificFuelConsumptionUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<BrakeSpecificFuelConsumptionUnit>> GetDefaultMappings()
             {
                 yield return new (BrakeSpecificFuelConsumptionUnit.GramPerKiloWattHour, "GramPerKiloWattHour", "GramsPerKiloWattHour", BaseUnits.Undefined);
                 yield return new (BrakeSpecificFuelConsumptionUnit.KilogramPerJoule, "KilogramPerJoule", "KilogramsPerJoule", new BaseUnits(length: LengthUnit.Meter, time: DurationUnit.Second));
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static BrakeSpecificFuelConsumption()
         {
-            Info = BrakeSpecificFuelConsumptionInfo.CreateDefault();
+            Info = BrakeSpecificFuelConsumptionInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="CoefficientOfThermalExpansion"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class CoefficientOfThermalExpansionInfo: QuantityInfo<CoefficientOfThermalExpansion, CoefficientOfThermalExpansionUnit>
+        private static class CoefficientOfThermalExpansionInfo
         {
-            /// <inheritdoc />
-            public CoefficientOfThermalExpansionInfo(string name, CoefficientOfThermalExpansionUnit baseUnit, IEnumerable<IUnitDefinition<CoefficientOfThermalExpansionUnit>> unitMappings, CoefficientOfThermalExpansion zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<CoefficientOfThermalExpansion, CoefficientOfThermalExpansionUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, CoefficientOfThermalExpansion.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public CoefficientOfThermalExpansionInfo(string name, CoefficientOfThermalExpansionUnit baseUnit, IEnumerable<IUnitDefinition<CoefficientOfThermalExpansionUnit>> unitMappings, CoefficientOfThermalExpansion zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, CoefficientOfThermalExpansion.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.CoefficientOfThermalExpansion", typeof(CoefficientOfThermalExpansion).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="CoefficientOfThermalExpansionInfo"/> class with the default settings for the CoefficientOfThermalExpansion quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="CoefficientOfThermalExpansionInfo"/> class with the default settings.</returns>
-            public static CoefficientOfThermalExpansionInfo CreateDefault()
-            {
-                return new CoefficientOfThermalExpansionInfo(nameof(CoefficientOfThermalExpansion), DefaultBaseUnit, GetDefaultMappings(), new CoefficientOfThermalExpansion(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="CoefficientOfThermalExpansionInfo"/> class with the default settings for the CoefficientOfThermalExpansion quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="CoefficientOfThermalExpansionInfo"/> class with the default settings.
             /// </returns>
-            public static CoefficientOfThermalExpansionInfo CreateDefault(Func<IEnumerable<UnitDefinition<CoefficientOfThermalExpansionUnit>>, IEnumerable<IUnitDefinition<CoefficientOfThermalExpansionUnit>>> customizeUnits)
+            private static QuantityInfo<CoefficientOfThermalExpansion, CoefficientOfThermalExpansionUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<CoefficientOfThermalExpansionUnit>>, IEnumerable<IUnitDefinition<CoefficientOfThermalExpansionUnit>>>? customizeUnits = null)
             {
-                return new CoefficientOfThermalExpansionInfo(nameof(CoefficientOfThermalExpansion), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new CoefficientOfThermalExpansion(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<CoefficientOfThermalExpansionUnit>> unitMappings = CoefficientOfThermalExpansionInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<CoefficientOfThermalExpansion, CoefficientOfThermalExpansionUnit>(
+                    name: nameof(CoefficientOfThermalExpansion),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new CoefficientOfThermalExpansion(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="CoefficientOfThermalExpansion"/> is [Θ^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, -1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, -1, 0, 0);
 
             /// <summary>
             ///     The default base unit of CoefficientOfThermalExpansion is PerKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static CoefficientOfThermalExpansionUnit DefaultBaseUnit { get; } = CoefficientOfThermalExpansionUnit.PerKelvin;
+            private static CoefficientOfThermalExpansionUnit DefaultBaseUnit { get; } = CoefficientOfThermalExpansionUnit.PerKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the CoefficientOfThermalExpansion quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.CoefficientOfThermalExpansion", typeof(CoefficientOfThermalExpansion).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="CoefficientOfThermalExpansionUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{CoefficientOfThermalExpansionUnit}"/> representing the default unit mappings for CoefficientOfThermalExpansion.</returns>
-            public static IEnumerable<UnitDefinition<CoefficientOfThermalExpansionUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<CoefficientOfThermalExpansionUnit>> GetDefaultMappings()
             {
                 yield return new (CoefficientOfThermalExpansionUnit.PerDegreeCelsius, "PerDegreeCelsius", "PerDegreeCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius));
                 yield return new (CoefficientOfThermalExpansionUnit.PerDegreeFahrenheit, "PerDegreeFahrenheit", "PerDegreeFahrenheit", new BaseUnits(temperature: TemperatureUnit.DegreeFahrenheit));
@@ -130,7 +130,7 @@ namespace UnitsNet
 
         static CoefficientOfThermalExpansion()
         {
-            Info = CoefficientOfThermalExpansionInfo.CreateDefault();
+            Info = CoefficientOfThermalExpansionInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Compressibility"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class CompressibilityInfo: QuantityInfo<Compressibility, CompressibilityUnit>
+        private static class CompressibilityInfo
         {
-            /// <inheritdoc />
-            public CompressibilityInfo(string name, CompressibilityUnit baseUnit, IEnumerable<IUnitDefinition<CompressibilityUnit>> unitMappings, Compressibility zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Compressibility, CompressibilityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Compressibility.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public CompressibilityInfo(string name, CompressibilityUnit baseUnit, IEnumerable<IUnitDefinition<CompressibilityUnit>> unitMappings, Compressibility zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Compressibility.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Compressibility", typeof(Compressibility).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="CompressibilityInfo"/> class with the default settings for the Compressibility quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="CompressibilityInfo"/> class with the default settings.</returns>
-            public static CompressibilityInfo CreateDefault()
-            {
-                return new CompressibilityInfo(nameof(Compressibility), DefaultBaseUnit, GetDefaultMappings(), new Compressibility(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="CompressibilityInfo"/> class with the default settings for the Compressibility quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="CompressibilityInfo"/> class with the default settings.
             /// </returns>
-            public static CompressibilityInfo CreateDefault(Func<IEnumerable<UnitDefinition<CompressibilityUnit>>, IEnumerable<IUnitDefinition<CompressibilityUnit>>> customizeUnits)
+            private static QuantityInfo<Compressibility, CompressibilityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<CompressibilityUnit>>, IEnumerable<IUnitDefinition<CompressibilityUnit>>>? customizeUnits = null)
             {
-                return new CompressibilityInfo(nameof(Compressibility), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Compressibility(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<CompressibilityUnit>> unitMappings = CompressibilityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Compressibility, CompressibilityUnit>(
+                    name: nameof(Compressibility),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Compressibility(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Compressibility"/> is [T^2][L][M^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, -1, 2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, -1, 2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Compressibility is InversePascal. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static CompressibilityUnit DefaultBaseUnit { get; } = CompressibilityUnit.InversePascal;
+            private static CompressibilityUnit DefaultBaseUnit { get; } = CompressibilityUnit.InversePascal;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Compressibility quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Compressibility", typeof(Compressibility).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="CompressibilityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{CompressibilityUnit}"/> representing the default unit mappings for Compressibility.</returns>
-            public static IEnumerable<UnitDefinition<CompressibilityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<CompressibilityUnit>> GetDefaultMappings()
             {
                 yield return new (CompressibilityUnit.InverseAtmosphere, "InverseAtmosphere", "InverseAtmospheres", BaseUnits.Undefined);
                 yield return new (CompressibilityUnit.InverseBar, "InverseBar", "InverseBars", BaseUnits.Undefined);
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static Compressibility()
         {
-            Info = CompressibilityInfo.CreateDefault();
+            Info = CompressibilityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -74,59 +74,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Density"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class DensityInfo: QuantityInfo<Density, DensityUnit>
+        private static class DensityInfo
         {
-            /// <inheritdoc />
-            public DensityInfo(string name, DensityUnit baseUnit, IEnumerable<IUnitDefinition<DensityUnit>> unitMappings, Density zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Density, DensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Density.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public DensityInfo(string name, DensityUnit baseUnit, IEnumerable<IUnitDefinition<DensityUnit>> unitMappings, Density zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Density.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Density", typeof(Density).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="DensityInfo"/> class with the default settings for the Density quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="DensityInfo"/> class with the default settings.</returns>
-            public static DensityInfo CreateDefault()
-            {
-                return new DensityInfo(nameof(Density), DefaultBaseUnit, GetDefaultMappings(), new Density(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="DensityInfo"/> class with the default settings for the Density quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="DensityInfo"/> class with the default settings.
             /// </returns>
-            public static DensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<DensityUnit>>, IEnumerable<IUnitDefinition<DensityUnit>>> customizeUnits)
+            private static QuantityInfo<Density, DensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<DensityUnit>>, IEnumerable<IUnitDefinition<DensityUnit>>>? customizeUnits = null)
             {
-                return new DensityInfo(nameof(Density), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Density(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<DensityUnit>> unitMappings = DensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Density, DensityUnit>(
+                    name: nameof(Density),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Density(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Density"/> is [L^-3][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Density is KilogramPerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static DensityUnit DefaultBaseUnit { get; } = DensityUnit.KilogramPerCubicMeter;
+            private static DensityUnit DefaultBaseUnit { get; } = DensityUnit.KilogramPerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Density quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Density", typeof(Density).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="DensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{DensityUnit}"/> representing the default unit mappings for Density.</returns>
-            public static IEnumerable<UnitDefinition<DensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<DensityUnit>> GetDefaultMappings()
             {
                 yield return new (DensityUnit.CentigramPerDeciliter, "CentigramPerDeciliter", "CentigramsPerDeciliter", BaseUnits.Undefined);
                 yield return new (DensityUnit.CentigramPerLiter, "CentigramPerLiter", "CentigramsPerLiter", new BaseUnits(length: LengthUnit.Decimeter, mass: MassUnit.Centigram));
@@ -189,7 +189,7 @@ namespace UnitsNet
 
         static Density()
         {
-            Info = DensityInfo.CreateDefault();
+            Info = DensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="DoseAreaProduct"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class DoseAreaProductInfo: QuantityInfo<DoseAreaProduct, DoseAreaProductUnit>
+        private static class DoseAreaProductInfo
         {
-            /// <inheritdoc />
-            public DoseAreaProductInfo(string name, DoseAreaProductUnit baseUnit, IEnumerable<IUnitDefinition<DoseAreaProductUnit>> unitMappings, DoseAreaProduct zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<DoseAreaProduct, DoseAreaProductUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, DoseAreaProduct.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public DoseAreaProductInfo(string name, DoseAreaProductUnit baseUnit, IEnumerable<IUnitDefinition<DoseAreaProductUnit>> unitMappings, DoseAreaProduct zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, DoseAreaProduct.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.DoseAreaProduct", typeof(DoseAreaProduct).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="DoseAreaProductInfo"/> class with the default settings for the DoseAreaProduct quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="DoseAreaProductInfo"/> class with the default settings.</returns>
-            public static DoseAreaProductInfo CreateDefault()
-            {
-                return new DoseAreaProductInfo(nameof(DoseAreaProduct), DefaultBaseUnit, GetDefaultMappings(), new DoseAreaProduct(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="DoseAreaProductInfo"/> class with the default settings for the DoseAreaProduct quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="DoseAreaProductInfo"/> class with the default settings.
             /// </returns>
-            public static DoseAreaProductInfo CreateDefault(Func<IEnumerable<UnitDefinition<DoseAreaProductUnit>>, IEnumerable<IUnitDefinition<DoseAreaProductUnit>>> customizeUnits)
+            private static QuantityInfo<DoseAreaProduct, DoseAreaProductUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<DoseAreaProductUnit>>, IEnumerable<IUnitDefinition<DoseAreaProductUnit>>>? customizeUnits = null)
             {
-                return new DoseAreaProductInfo(nameof(DoseAreaProduct), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new DoseAreaProduct(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<DoseAreaProductUnit>> unitMappings = DoseAreaProductInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<DoseAreaProduct, DoseAreaProductUnit>(
+                    name: nameof(DoseAreaProduct),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new DoseAreaProduct(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="DoseAreaProduct"/> is [T^-2][L^4].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(4, 0, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(4, 0, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of DoseAreaProduct is GraySquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static DoseAreaProductUnit DefaultBaseUnit { get; } = DoseAreaProductUnit.GraySquareMeter;
+            private static DoseAreaProductUnit DefaultBaseUnit { get; } = DoseAreaProductUnit.GraySquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the DoseAreaProduct quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.DoseAreaProduct", typeof(DoseAreaProduct).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="DoseAreaProductUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{DoseAreaProductUnit}"/> representing the default unit mappings for DoseAreaProduct.</returns>
-            public static IEnumerable<UnitDefinition<DoseAreaProductUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<DoseAreaProductUnit>> GetDefaultMappings()
             {
                 yield return new (DoseAreaProductUnit.CentigraySquareCentimeter, "CentigraySquareCentimeter", "CentigraySquareCentimeters", BaseUnits.Undefined);
                 yield return new (DoseAreaProductUnit.CentigraySquareDecimeter, "CentigraySquareDecimeter", "CentigraySquareDecimeters", BaseUnits.Undefined);
@@ -144,7 +144,7 @@ namespace UnitsNet
 
         static DoseAreaProduct()
         {
-            Info = DoseAreaProductInfo.CreateDefault();
+            Info = DoseAreaProductInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -79,59 +79,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Duration"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class DurationInfo: QuantityInfo<Duration, DurationUnit>
+        private static class DurationInfo
         {
-            /// <inheritdoc />
-            public DurationInfo(string name, DurationUnit baseUnit, IEnumerable<IUnitDefinition<DurationUnit>> unitMappings, Duration zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Duration, DurationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Duration.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public DurationInfo(string name, DurationUnit baseUnit, IEnumerable<IUnitDefinition<DurationUnit>> unitMappings, Duration zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Duration.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Duration", typeof(Duration).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="DurationInfo"/> class with the default settings for the Duration quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="DurationInfo"/> class with the default settings.</returns>
-            public static DurationInfo CreateDefault()
-            {
-                return new DurationInfo(nameof(Duration), DefaultBaseUnit, GetDefaultMappings(), new Duration(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="DurationInfo"/> class with the default settings for the Duration quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="DurationInfo"/> class with the default settings.
             /// </returns>
-            public static DurationInfo CreateDefault(Func<IEnumerable<UnitDefinition<DurationUnit>>, IEnumerable<IUnitDefinition<DurationUnit>>> customizeUnits)
+            private static QuantityInfo<Duration, DurationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<DurationUnit>>, IEnumerable<IUnitDefinition<DurationUnit>>>? customizeUnits = null)
             {
-                return new DurationInfo(nameof(Duration), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Duration(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<DurationUnit>> unitMappings = DurationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Duration, DurationUnit>(
+                    name: nameof(Duration),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Duration(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Duration"/> is [T].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Duration is Second. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static DurationUnit DefaultBaseUnit { get; } = DurationUnit.Second;
+            private static DurationUnit DefaultBaseUnit { get; } = DurationUnit.Second;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Duration quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Duration", typeof(Duration).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="DurationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{DurationUnit}"/> representing the default unit mappings for Duration.</returns>
-            public static IEnumerable<UnitDefinition<DurationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<DurationUnit>> GetDefaultMappings()
             {
                 yield return new (DurationUnit.Day, "Day", "Days", new BaseUnits(time: DurationUnit.Day));
                 yield return new (DurationUnit.Hour, "Hour", "Hours", new BaseUnits(time: DurationUnit.Hour));
@@ -150,7 +150,7 @@ namespace UnitsNet
 
         static Duration()
         {
-            Info = DurationInfo.CreateDefault();
+            Info = DurationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -69,59 +69,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="DynamicViscosity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class DynamicViscosityInfo: QuantityInfo<DynamicViscosity, DynamicViscosityUnit>
+        private static class DynamicViscosityInfo
         {
-            /// <inheritdoc />
-            public DynamicViscosityInfo(string name, DynamicViscosityUnit baseUnit, IEnumerable<IUnitDefinition<DynamicViscosityUnit>> unitMappings, DynamicViscosity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<DynamicViscosity, DynamicViscosityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, DynamicViscosity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public DynamicViscosityInfo(string name, DynamicViscosityUnit baseUnit, IEnumerable<IUnitDefinition<DynamicViscosityUnit>> unitMappings, DynamicViscosity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, DynamicViscosity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.DynamicViscosity", typeof(DynamicViscosity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="DynamicViscosityInfo"/> class with the default settings for the DynamicViscosity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="DynamicViscosityInfo"/> class with the default settings.</returns>
-            public static DynamicViscosityInfo CreateDefault()
-            {
-                return new DynamicViscosityInfo(nameof(DynamicViscosity), DefaultBaseUnit, GetDefaultMappings(), new DynamicViscosity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="DynamicViscosityInfo"/> class with the default settings for the DynamicViscosity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="DynamicViscosityInfo"/> class with the default settings.
             /// </returns>
-            public static DynamicViscosityInfo CreateDefault(Func<IEnumerable<UnitDefinition<DynamicViscosityUnit>>, IEnumerable<IUnitDefinition<DynamicViscosityUnit>>> customizeUnits)
+            private static QuantityInfo<DynamicViscosity, DynamicViscosityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<DynamicViscosityUnit>>, IEnumerable<IUnitDefinition<DynamicViscosityUnit>>>? customizeUnits = null)
             {
-                return new DynamicViscosityInfo(nameof(DynamicViscosity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new DynamicViscosity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<DynamicViscosityUnit>> unitMappings = DynamicViscosityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<DynamicViscosity, DynamicViscosityUnit>(
+                    name: nameof(DynamicViscosity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new DynamicViscosity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="DynamicViscosity"/> is [T^-1][L^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of DynamicViscosity is NewtonSecondPerMeterSquared. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static DynamicViscosityUnit DefaultBaseUnit { get; } = DynamicViscosityUnit.NewtonSecondPerMeterSquared;
+            private static DynamicViscosityUnit DefaultBaseUnit { get; } = DynamicViscosityUnit.NewtonSecondPerMeterSquared;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the DynamicViscosity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.DynamicViscosity", typeof(DynamicViscosity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="DynamicViscosityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{DynamicViscosityUnit}"/> representing the default unit mappings for DynamicViscosity.</returns>
-            public static IEnumerable<UnitDefinition<DynamicViscosityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<DynamicViscosityUnit>> GetDefaultMappings()
             {
                 yield return new (DynamicViscosityUnit.Centipoise, "Centipoise", "Centipoise", BaseUnits.Undefined);
                 yield return new (DynamicViscosityUnit.MicropascalSecond, "MicropascalSecond", "MicropascalSeconds", BaseUnits.Undefined);
@@ -138,7 +138,7 @@ namespace UnitsNet
 
         static DynamicViscosity()
         {
-            Info = DynamicViscosityInfo.CreateDefault();
+            Info = DynamicViscosityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricAdmittance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricAdmittanceInfo: QuantityInfo<ElectricAdmittance, ElectricAdmittanceUnit>
+        private static class ElectricAdmittanceInfo
         {
-            /// <inheritdoc />
-            public ElectricAdmittanceInfo(string name, ElectricAdmittanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricAdmittanceUnit>> unitMappings, ElectricAdmittance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricAdmittance, ElectricAdmittanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricAdmittance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricAdmittanceInfo(string name, ElectricAdmittanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricAdmittanceUnit>> unitMappings, ElectricAdmittance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricAdmittance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricAdmittance", typeof(ElectricAdmittance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricAdmittanceInfo"/> class with the default settings for the ElectricAdmittance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricAdmittanceInfo"/> class with the default settings.</returns>
-            public static ElectricAdmittanceInfo CreateDefault()
-            {
-                return new ElectricAdmittanceInfo(nameof(ElectricAdmittance), DefaultBaseUnit, GetDefaultMappings(), new ElectricAdmittance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricAdmittanceInfo"/> class with the default settings for the ElectricAdmittance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricAdmittanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricAdmittanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricAdmittanceUnit>>, IEnumerable<IUnitDefinition<ElectricAdmittanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricAdmittance, ElectricAdmittanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricAdmittanceUnit>>, IEnumerable<IUnitDefinition<ElectricAdmittanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricAdmittanceInfo(nameof(ElectricAdmittance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricAdmittance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricAdmittanceUnit>> unitMappings = ElectricAdmittanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricAdmittance, ElectricAdmittanceUnit>(
+                    name: nameof(ElectricAdmittance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricAdmittance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricAdmittance"/> is [T^3][L^-2][M^-1][I^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricAdmittance is Siemens. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricAdmittanceUnit DefaultBaseUnit { get; } = ElectricAdmittanceUnit.Siemens;
+            private static ElectricAdmittanceUnit DefaultBaseUnit { get; } = ElectricAdmittanceUnit.Siemens;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricAdmittance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricAdmittance", typeof(ElectricAdmittance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricAdmittanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricAdmittanceUnit}"/> representing the default unit mappings for ElectricAdmittance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricAdmittanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricAdmittanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricAdmittanceUnit.Gigamho, "Gigamho", "Gigamhos", BaseUnits.Undefined);
                 yield return new (ElectricAdmittanceUnit.Gigasiemens, "Gigasiemens", "Gigasiemens", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Microgram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -141,7 +141,7 @@ namespace UnitsNet
 
         static ElectricAdmittance()
         {
-            Info = ElectricAdmittanceInfo.CreateDefault();
+            Info = ElectricAdmittanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricApparentEnergy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricApparentEnergyInfo: QuantityInfo<ElectricApparentEnergy, ElectricApparentEnergyUnit>
+        private static class ElectricApparentEnergyInfo
         {
-            /// <inheritdoc />
-            public ElectricApparentEnergyInfo(string name, ElectricApparentEnergyUnit baseUnit, IEnumerable<IUnitDefinition<ElectricApparentEnergyUnit>> unitMappings, ElectricApparentEnergy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricApparentEnergy, ElectricApparentEnergyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricApparentEnergy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricApparentEnergyInfo(string name, ElectricApparentEnergyUnit baseUnit, IEnumerable<IUnitDefinition<ElectricApparentEnergyUnit>> unitMappings, ElectricApparentEnergy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricApparentEnergy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricApparentEnergy", typeof(ElectricApparentEnergy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricApparentEnergyInfo"/> class with the default settings for the ElectricApparentEnergy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricApparentEnergyInfo"/> class with the default settings.</returns>
-            public static ElectricApparentEnergyInfo CreateDefault()
-            {
-                return new ElectricApparentEnergyInfo(nameof(ElectricApparentEnergy), DefaultBaseUnit, GetDefaultMappings(), new ElectricApparentEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricApparentEnergyInfo"/> class with the default settings for the ElectricApparentEnergy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricApparentEnergyInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricApparentEnergyInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricApparentEnergyUnit>>, IEnumerable<IUnitDefinition<ElectricApparentEnergyUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricApparentEnergy, ElectricApparentEnergyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricApparentEnergyUnit>>, IEnumerable<IUnitDefinition<ElectricApparentEnergyUnit>>>? customizeUnits = null)
             {
-                return new ElectricApparentEnergyInfo(nameof(ElectricApparentEnergy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricApparentEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricApparentEnergyUnit>> unitMappings = ElectricApparentEnergyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricApparentEnergy, ElectricApparentEnergyUnit>(
+                    name: nameof(ElectricApparentEnergy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricApparentEnergy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricApparentEnergy"/> is [T^-2][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricApparentEnergy is VoltampereHour. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricApparentEnergyUnit DefaultBaseUnit { get; } = ElectricApparentEnergyUnit.VoltampereHour;
+            private static ElectricApparentEnergyUnit DefaultBaseUnit { get; } = ElectricApparentEnergyUnit.VoltampereHour;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricApparentEnergy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricApparentEnergy", typeof(ElectricApparentEnergy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricApparentEnergyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricApparentEnergyUnit}"/> representing the default unit mappings for ElectricApparentEnergy.</returns>
-            public static IEnumerable<UnitDefinition<ElectricApparentEnergyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricApparentEnergyUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricApparentEnergyUnit.KilovoltampereHour, "KilovoltampereHour", "KilovoltampereHours", BaseUnits.Undefined);
                 yield return new (ElectricApparentEnergyUnit.MegavoltampereHour, "MegavoltampereHour", "MegavoltampereHours", BaseUnits.Undefined);
@@ -124,7 +124,7 @@ namespace UnitsNet
 
         static ElectricApparentEnergy()
         {
-            Info = ElectricApparentEnergyInfo.CreateDefault();
+            Info = ElectricApparentEnergyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricApparentPower"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricApparentPowerInfo: QuantityInfo<ElectricApparentPower, ElectricApparentPowerUnit>
+        private static class ElectricApparentPowerInfo
         {
-            /// <inheritdoc />
-            public ElectricApparentPowerInfo(string name, ElectricApparentPowerUnit baseUnit, IEnumerable<IUnitDefinition<ElectricApparentPowerUnit>> unitMappings, ElectricApparentPower zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricApparentPower, ElectricApparentPowerUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricApparentPower.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricApparentPowerInfo(string name, ElectricApparentPowerUnit baseUnit, IEnumerable<IUnitDefinition<ElectricApparentPowerUnit>> unitMappings, ElectricApparentPower zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricApparentPower.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricApparentPower", typeof(ElectricApparentPower).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricApparentPowerInfo"/> class with the default settings for the ElectricApparentPower quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricApparentPowerInfo"/> class with the default settings.</returns>
-            public static ElectricApparentPowerInfo CreateDefault()
-            {
-                return new ElectricApparentPowerInfo(nameof(ElectricApparentPower), DefaultBaseUnit, GetDefaultMappings(), new ElectricApparentPower(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricApparentPowerInfo"/> class with the default settings for the ElectricApparentPower quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricApparentPowerInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricApparentPowerInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricApparentPowerUnit>>, IEnumerable<IUnitDefinition<ElectricApparentPowerUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricApparentPower, ElectricApparentPowerUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricApparentPowerUnit>>, IEnumerable<IUnitDefinition<ElectricApparentPowerUnit>>>? customizeUnits = null)
             {
-                return new ElectricApparentPowerInfo(nameof(ElectricApparentPower), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricApparentPower(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricApparentPowerUnit>> unitMappings = ElectricApparentPowerInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricApparentPower, ElectricApparentPowerUnit>(
+                    name: nameof(ElectricApparentPower),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricApparentPower(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricApparentPower"/> is [T^-3][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricApparentPower is Voltampere. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricApparentPowerUnit DefaultBaseUnit { get; } = ElectricApparentPowerUnit.Voltampere;
+            private static ElectricApparentPowerUnit DefaultBaseUnit { get; } = ElectricApparentPowerUnit.Voltampere;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricApparentPower quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricApparentPower", typeof(ElectricApparentPower).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricApparentPowerUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricApparentPowerUnit}"/> representing the default unit mappings for ElectricApparentPower.</returns>
-            public static IEnumerable<UnitDefinition<ElectricApparentPowerUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricApparentPowerUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricApparentPowerUnit.Gigavoltampere, "Gigavoltampere", "Gigavoltamperes", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Millisecond));
                 yield return new (ElectricApparentPowerUnit.Kilovoltampere, "Kilovoltampere", "Kilovoltamperes", BaseUnits.Undefined);
@@ -130,7 +130,7 @@ namespace UnitsNet
 
         static ElectricApparentPower()
         {
-            Info = ElectricApparentPowerInfo.CreateDefault();
+            Info = ElectricApparentPowerInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricCapacitance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricCapacitanceInfo: QuantityInfo<ElectricCapacitance, ElectricCapacitanceUnit>
+        private static class ElectricCapacitanceInfo
         {
-            /// <inheritdoc />
-            public ElectricCapacitanceInfo(string name, ElectricCapacitanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCapacitanceUnit>> unitMappings, ElectricCapacitance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricCapacitance, ElectricCapacitanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricCapacitance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricCapacitanceInfo(string name, ElectricCapacitanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCapacitanceUnit>> unitMappings, ElectricCapacitance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricCapacitance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricCapacitance", typeof(ElectricCapacitance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricCapacitanceInfo"/> class with the default settings for the ElectricCapacitance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricCapacitanceInfo"/> class with the default settings.</returns>
-            public static ElectricCapacitanceInfo CreateDefault()
-            {
-                return new ElectricCapacitanceInfo(nameof(ElectricCapacitance), DefaultBaseUnit, GetDefaultMappings(), new ElectricCapacitance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricCapacitanceInfo"/> class with the default settings for the ElectricCapacitance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricCapacitanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricCapacitanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricCapacitanceUnit>>, IEnumerable<IUnitDefinition<ElectricCapacitanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricCapacitance, ElectricCapacitanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricCapacitanceUnit>>, IEnumerable<IUnitDefinition<ElectricCapacitanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricCapacitanceInfo(nameof(ElectricCapacitance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricCapacitance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricCapacitanceUnit>> unitMappings = ElectricCapacitanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricCapacitance, ElectricCapacitanceUnit>(
+                    name: nameof(ElectricCapacitance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricCapacitance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricCapacitance"/> is [T^4][L^-2][M^-1][I^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 4, 2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricCapacitance is Farad. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricCapacitanceUnit DefaultBaseUnit { get; } = ElectricCapacitanceUnit.Farad;
+            private static ElectricCapacitanceUnit DefaultBaseUnit { get; } = ElectricCapacitanceUnit.Farad;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricCapacitance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricCapacitance", typeof(ElectricCapacitance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricCapacitanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricCapacitanceUnit}"/> representing the default unit mappings for ElectricCapacitance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricCapacitanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricCapacitanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricCapacitanceUnit.Farad, "Farad", "Farads", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricCapacitanceUnit.Kilofarad, "Kilofarad", "Kilofarads", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Gram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -131,7 +131,7 @@ namespace UnitsNet
 
         static ElectricCapacitance()
         {
-            Info = ElectricCapacitanceInfo.CreateDefault();
+            Info = ElectricCapacitanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -70,59 +70,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricCharge"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricChargeInfo: QuantityInfo<ElectricCharge, ElectricChargeUnit>
+        private static class ElectricChargeInfo
         {
-            /// <inheritdoc />
-            public ElectricChargeInfo(string name, ElectricChargeUnit baseUnit, IEnumerable<IUnitDefinition<ElectricChargeUnit>> unitMappings, ElectricCharge zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricCharge, ElectricChargeUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricCharge.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricChargeInfo(string name, ElectricChargeUnit baseUnit, IEnumerable<IUnitDefinition<ElectricChargeUnit>> unitMappings, ElectricCharge zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricCharge.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricCharge", typeof(ElectricCharge).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricChargeInfo"/> class with the default settings for the ElectricCharge quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricChargeInfo"/> class with the default settings.</returns>
-            public static ElectricChargeInfo CreateDefault()
-            {
-                return new ElectricChargeInfo(nameof(ElectricCharge), DefaultBaseUnit, GetDefaultMappings(), new ElectricCharge(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricChargeInfo"/> class with the default settings for the ElectricCharge quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricChargeInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricChargeInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricChargeUnit>>, IEnumerable<IUnitDefinition<ElectricChargeUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricCharge, ElectricChargeUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricChargeUnit>>, IEnumerable<IUnitDefinition<ElectricChargeUnit>>>? customizeUnits = null)
             {
-                return new ElectricChargeInfo(nameof(ElectricCharge), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricCharge(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricChargeUnit>> unitMappings = ElectricChargeInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricCharge, ElectricChargeUnit>(
+                    name: nameof(ElectricCharge),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricCharge(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricCharge"/> is [T][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 1, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 1, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricCharge is Coulomb. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricChargeUnit DefaultBaseUnit { get; } = ElectricChargeUnit.Coulomb;
+            private static ElectricChargeUnit DefaultBaseUnit { get; } = ElectricChargeUnit.Coulomb;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricCharge quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricCharge", typeof(ElectricCharge).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricChargeUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricChargeUnit}"/> representing the default unit mappings for ElectricCharge.</returns>
-            public static IEnumerable<UnitDefinition<ElectricChargeUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricChargeUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricChargeUnit.AmpereHour, "AmpereHour", "AmpereHours", new BaseUnits(time: DurationUnit.Hour, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricChargeUnit.Coulomb, "Coulomb", "Coulombs", new BaseUnits(time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -140,7 +140,7 @@ namespace UnitsNet
 
         static ElectricCharge()
         {
-            Info = ElectricChargeInfo.CreateDefault();
+            Info = ElectricChargeInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricChargeDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricChargeDensityInfo: QuantityInfo<ElectricChargeDensity, ElectricChargeDensityUnit>
+        private static class ElectricChargeDensityInfo
         {
-            /// <inheritdoc />
-            public ElectricChargeDensityInfo(string name, ElectricChargeDensityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricChargeDensityUnit>> unitMappings, ElectricChargeDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricChargeDensity, ElectricChargeDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricChargeDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricChargeDensityInfo(string name, ElectricChargeDensityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricChargeDensityUnit>> unitMappings, ElectricChargeDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricChargeDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricChargeDensity", typeof(ElectricChargeDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricChargeDensityInfo"/> class with the default settings for the ElectricChargeDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricChargeDensityInfo"/> class with the default settings.</returns>
-            public static ElectricChargeDensityInfo CreateDefault()
-            {
-                return new ElectricChargeDensityInfo(nameof(ElectricChargeDensity), DefaultBaseUnit, GetDefaultMappings(), new ElectricChargeDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricChargeDensityInfo"/> class with the default settings for the ElectricChargeDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricChargeDensityInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricChargeDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricChargeDensityUnit>>, IEnumerable<IUnitDefinition<ElectricChargeDensityUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricChargeDensity, ElectricChargeDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricChargeDensityUnit>>, IEnumerable<IUnitDefinition<ElectricChargeDensityUnit>>>? customizeUnits = null)
             {
-                return new ElectricChargeDensityInfo(nameof(ElectricChargeDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricChargeDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricChargeDensityUnit>> unitMappings = ElectricChargeDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricChargeDensity, ElectricChargeDensityUnit>(
+                    name: nameof(ElectricChargeDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricChargeDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricChargeDensity"/> is [T][L^-3][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 0, 1, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricChargeDensity is CoulombPerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricChargeDensityUnit DefaultBaseUnit { get; } = ElectricChargeDensityUnit.CoulombPerCubicMeter;
+            private static ElectricChargeDensityUnit DefaultBaseUnit { get; } = ElectricChargeDensityUnit.CoulombPerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricChargeDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricChargeDensity", typeof(ElectricChargeDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricChargeDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricChargeDensityUnit}"/> representing the default unit mappings for ElectricChargeDensity.</returns>
-            public static IEnumerable<UnitDefinition<ElectricChargeDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricChargeDensityUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricChargeDensityUnit.CoulombPerCubicMeter, "CoulombPerCubicMeter", "CoulombsPerCubicMeter", new BaseUnits(length: LengthUnit.Meter, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static ElectricChargeDensity()
         {
-            Info = ElectricChargeDensityInfo.CreateDefault();
+            Info = ElectricChargeDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricConductance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricConductanceInfo: QuantityInfo<ElectricConductance, ElectricConductanceUnit>
+        private static class ElectricConductanceInfo
         {
-            /// <inheritdoc />
-            public ElectricConductanceInfo(string name, ElectricConductanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricConductanceUnit>> unitMappings, ElectricConductance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricConductance, ElectricConductanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricConductance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricConductanceInfo(string name, ElectricConductanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricConductanceUnit>> unitMappings, ElectricConductance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricConductance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricConductance", typeof(ElectricConductance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricConductanceInfo"/> class with the default settings for the ElectricConductance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricConductanceInfo"/> class with the default settings.</returns>
-            public static ElectricConductanceInfo CreateDefault()
-            {
-                return new ElectricConductanceInfo(nameof(ElectricConductance), DefaultBaseUnit, GetDefaultMappings(), new ElectricConductance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricConductanceInfo"/> class with the default settings for the ElectricConductance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricConductanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricConductanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricConductanceUnit>>, IEnumerable<IUnitDefinition<ElectricConductanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricConductance, ElectricConductanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricConductanceUnit>>, IEnumerable<IUnitDefinition<ElectricConductanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricConductanceInfo(nameof(ElectricConductance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricConductance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricConductanceUnit>> unitMappings = ElectricConductanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricConductance, ElectricConductanceUnit>(
+                    name: nameof(ElectricConductance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricConductance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricConductance"/> is [T^3][L^-2][M^-1][I^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricConductance is Siemens. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricConductanceUnit DefaultBaseUnit { get; } = ElectricConductanceUnit.Siemens;
+            private static ElectricConductanceUnit DefaultBaseUnit { get; } = ElectricConductanceUnit.Siemens;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricConductance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricConductance", typeof(ElectricConductance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricConductanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricConductanceUnit}"/> representing the default unit mappings for ElectricConductance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricConductanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricConductanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricConductanceUnit.Gigamho, "Gigamho", "Gigamhos", BaseUnits.Undefined);
                 yield return new (ElectricConductanceUnit.Gigasiemens, "Gigasiemens", "Gigasiemens", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Microgram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -140,7 +140,7 @@ namespace UnitsNet
 
         static ElectricConductance()
         {
-            Info = ElectricConductanceInfo.CreateDefault();
+            Info = ElectricConductanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricConductivity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricConductivityInfo: QuantityInfo<ElectricConductivity, ElectricConductivityUnit>
+        private static class ElectricConductivityInfo
         {
-            /// <inheritdoc />
-            public ElectricConductivityInfo(string name, ElectricConductivityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricConductivityUnit>> unitMappings, ElectricConductivity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricConductivity, ElectricConductivityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricConductivity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricConductivityInfo(string name, ElectricConductivityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricConductivityUnit>> unitMappings, ElectricConductivity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricConductivity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricConductivity", typeof(ElectricConductivity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricConductivityInfo"/> class with the default settings for the ElectricConductivity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricConductivityInfo"/> class with the default settings.</returns>
-            public static ElectricConductivityInfo CreateDefault()
-            {
-                return new ElectricConductivityInfo(nameof(ElectricConductivity), DefaultBaseUnit, GetDefaultMappings(), new ElectricConductivity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricConductivityInfo"/> class with the default settings for the ElectricConductivity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricConductivityInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricConductivityInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricConductivityUnit>>, IEnumerable<IUnitDefinition<ElectricConductivityUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricConductivity, ElectricConductivityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricConductivityUnit>>, IEnumerable<IUnitDefinition<ElectricConductivityUnit>>>? customizeUnits = null)
             {
-                return new ElectricConductivityInfo(nameof(ElectricConductivity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricConductivity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricConductivityUnit>> unitMappings = ElectricConductivityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricConductivity, ElectricConductivityUnit>(
+                    name: nameof(ElectricConductivity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricConductivity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricConductivity"/> is [T^3][L^-3][M^-1][I^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, -1, 3, 2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricConductivity is SiemensPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricConductivityUnit DefaultBaseUnit { get; } = ElectricConductivityUnit.SiemensPerMeter;
+            private static ElectricConductivityUnit DefaultBaseUnit { get; } = ElectricConductivityUnit.SiemensPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricConductivity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricConductivity", typeof(ElectricConductivity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricConductivityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricConductivityUnit}"/> representing the default unit mappings for ElectricConductivity.</returns>
-            public static IEnumerable<UnitDefinition<ElectricConductivityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricConductivityUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricConductivityUnit.MicrosiemensPerCentimeter, "MicrosiemensPerCentimeter", "MicrosiemensPerCentimeter", BaseUnits.Undefined);
                 yield return new (ElectricConductivityUnit.MillisiemensPerCentimeter, "MillisiemensPerCentimeter", "MillisiemensPerCentimeter", BaseUnits.Undefined);
@@ -130,7 +130,7 @@ namespace UnitsNet
 
         static ElectricConductivity()
         {
-            Info = ElectricConductivityInfo.CreateDefault();
+            Info = ElectricConductivityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -72,59 +72,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricCurrent"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricCurrentInfo: QuantityInfo<ElectricCurrent, ElectricCurrentUnit>
+        private static class ElectricCurrentInfo
         {
-            /// <inheritdoc />
-            public ElectricCurrentInfo(string name, ElectricCurrentUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCurrentUnit>> unitMappings, ElectricCurrent zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricCurrent, ElectricCurrentUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricCurrent.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricCurrentInfo(string name, ElectricCurrentUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCurrentUnit>> unitMappings, ElectricCurrent zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricCurrent.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricCurrent", typeof(ElectricCurrent).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricCurrentInfo"/> class with the default settings for the ElectricCurrent quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricCurrentInfo"/> class with the default settings.</returns>
-            public static ElectricCurrentInfo CreateDefault()
-            {
-                return new ElectricCurrentInfo(nameof(ElectricCurrent), DefaultBaseUnit, GetDefaultMappings(), new ElectricCurrent(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricCurrentInfo"/> class with the default settings for the ElectricCurrent quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricCurrentInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricCurrentInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricCurrentUnit>>, IEnumerable<IUnitDefinition<ElectricCurrentUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricCurrent, ElectricCurrentUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricCurrentUnit>>, IEnumerable<IUnitDefinition<ElectricCurrentUnit>>>? customizeUnits = null)
             {
-                return new ElectricCurrentInfo(nameof(ElectricCurrent), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricCurrent(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricCurrentUnit>> unitMappings = ElectricCurrentInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricCurrent, ElectricCurrentUnit>(
+                    name: nameof(ElectricCurrent),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricCurrent(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricCurrent"/> is [I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricCurrent is Ampere. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricCurrentUnit DefaultBaseUnit { get; } = ElectricCurrentUnit.Ampere;
+            private static ElectricCurrentUnit DefaultBaseUnit { get; } = ElectricCurrentUnit.Ampere;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricCurrent quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricCurrent", typeof(ElectricCurrent).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricCurrentUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricCurrentUnit}"/> representing the default unit mappings for ElectricCurrent.</returns>
-            public static IEnumerable<UnitDefinition<ElectricCurrentUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricCurrentUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricCurrentUnit.Ampere, "Ampere", "Amperes", new BaseUnits(current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricCurrentUnit.Centiampere, "Centiampere", "Centiamperes", new BaseUnits(current: ElectricCurrentUnit.Centiampere));
@@ -140,7 +140,7 @@ namespace UnitsNet
 
         static ElectricCurrent()
         {
-            Info = ElectricCurrentInfo.CreateDefault();
+            Info = ElectricCurrentInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricCurrentDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricCurrentDensityInfo: QuantityInfo<ElectricCurrentDensity, ElectricCurrentDensityUnit>
+        private static class ElectricCurrentDensityInfo
         {
-            /// <inheritdoc />
-            public ElectricCurrentDensityInfo(string name, ElectricCurrentDensityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCurrentDensityUnit>> unitMappings, ElectricCurrentDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricCurrentDensity, ElectricCurrentDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricCurrentDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricCurrentDensityInfo(string name, ElectricCurrentDensityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCurrentDensityUnit>> unitMappings, ElectricCurrentDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricCurrentDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricCurrentDensity", typeof(ElectricCurrentDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricCurrentDensityInfo"/> class with the default settings for the ElectricCurrentDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricCurrentDensityInfo"/> class with the default settings.</returns>
-            public static ElectricCurrentDensityInfo CreateDefault()
-            {
-                return new ElectricCurrentDensityInfo(nameof(ElectricCurrentDensity), DefaultBaseUnit, GetDefaultMappings(), new ElectricCurrentDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricCurrentDensityInfo"/> class with the default settings for the ElectricCurrentDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricCurrentDensityInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricCurrentDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricCurrentDensityUnit>>, IEnumerable<IUnitDefinition<ElectricCurrentDensityUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricCurrentDensity, ElectricCurrentDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricCurrentDensityUnit>>, IEnumerable<IUnitDefinition<ElectricCurrentDensityUnit>>>? customizeUnits = null)
             {
-                return new ElectricCurrentDensityInfo(nameof(ElectricCurrentDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricCurrentDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricCurrentDensityUnit>> unitMappings = ElectricCurrentDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricCurrentDensity, ElectricCurrentDensityUnit>(
+                    name: nameof(ElectricCurrentDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricCurrentDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricCurrentDensity"/> is [L^-2][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricCurrentDensity is AmperePerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricCurrentDensityUnit DefaultBaseUnit { get; } = ElectricCurrentDensityUnit.AmperePerSquareMeter;
+            private static ElectricCurrentDensityUnit DefaultBaseUnit { get; } = ElectricCurrentDensityUnit.AmperePerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricCurrentDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricCurrentDensity", typeof(ElectricCurrentDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricCurrentDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricCurrentDensityUnit}"/> representing the default unit mappings for ElectricCurrentDensity.</returns>
-            public static IEnumerable<UnitDefinition<ElectricCurrentDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricCurrentDensityUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricCurrentDensityUnit.AmperePerSquareFoot, "AmperePerSquareFoot", "AmperesPerSquareFoot", new BaseUnits(length: LengthUnit.Foot, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricCurrentDensityUnit.AmperePerSquareInch, "AmperePerSquareInch", "AmperesPerSquareInch", new BaseUnits(length: LengthUnit.Inch, current: ElectricCurrentUnit.Ampere));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static ElectricCurrentDensity()
         {
-            Info = ElectricCurrentDensityInfo.CreateDefault();
+            Info = ElectricCurrentDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricCurrentGradient"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricCurrentGradientInfo: QuantityInfo<ElectricCurrentGradient, ElectricCurrentGradientUnit>
+        private static class ElectricCurrentGradientInfo
         {
-            /// <inheritdoc />
-            public ElectricCurrentGradientInfo(string name, ElectricCurrentGradientUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCurrentGradientUnit>> unitMappings, ElectricCurrentGradient zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricCurrentGradient, ElectricCurrentGradientUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricCurrentGradient.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricCurrentGradientInfo(string name, ElectricCurrentGradientUnit baseUnit, IEnumerable<IUnitDefinition<ElectricCurrentGradientUnit>> unitMappings, ElectricCurrentGradient zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricCurrentGradient.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricCurrentGradient", typeof(ElectricCurrentGradient).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricCurrentGradientInfo"/> class with the default settings for the ElectricCurrentGradient quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricCurrentGradientInfo"/> class with the default settings.</returns>
-            public static ElectricCurrentGradientInfo CreateDefault()
-            {
-                return new ElectricCurrentGradientInfo(nameof(ElectricCurrentGradient), DefaultBaseUnit, GetDefaultMappings(), new ElectricCurrentGradient(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricCurrentGradientInfo"/> class with the default settings for the ElectricCurrentGradient quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricCurrentGradientInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricCurrentGradientInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricCurrentGradientUnit>>, IEnumerable<IUnitDefinition<ElectricCurrentGradientUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricCurrentGradient, ElectricCurrentGradientUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricCurrentGradientUnit>>, IEnumerable<IUnitDefinition<ElectricCurrentGradientUnit>>>? customizeUnits = null)
             {
-                return new ElectricCurrentGradientInfo(nameof(ElectricCurrentGradient), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricCurrentGradient(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricCurrentGradientUnit>> unitMappings = ElectricCurrentGradientInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricCurrentGradient, ElectricCurrentGradientUnit>(
+                    name: nameof(ElectricCurrentGradient),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricCurrentGradient(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricCurrentGradient"/> is [T^-1][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricCurrentGradient is AmperePerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricCurrentGradientUnit DefaultBaseUnit { get; } = ElectricCurrentGradientUnit.AmperePerSecond;
+            private static ElectricCurrentGradientUnit DefaultBaseUnit { get; } = ElectricCurrentGradientUnit.AmperePerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricCurrentGradient quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricCurrentGradient", typeof(ElectricCurrentGradient).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricCurrentGradientUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricCurrentGradientUnit}"/> representing the default unit mappings for ElectricCurrentGradient.</returns>
-            public static IEnumerable<UnitDefinition<ElectricCurrentGradientUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricCurrentGradientUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricCurrentGradientUnit.AmperePerMicrosecond, "AmperePerMicrosecond", "AmperesPerMicrosecond", new BaseUnits(time: DurationUnit.Microsecond, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricCurrentGradientUnit.AmperePerMillisecond, "AmperePerMillisecond", "AmperesPerMillisecond", new BaseUnits(time: DurationUnit.Millisecond, current: ElectricCurrentUnit.Ampere));
@@ -131,7 +131,7 @@ namespace UnitsNet
 
         static ElectricCurrentGradient()
         {
-            Info = ElectricCurrentGradientInfo.CreateDefault();
+            Info = ElectricCurrentGradientInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricField"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricFieldInfo: QuantityInfo<ElectricField, ElectricFieldUnit>
+        private static class ElectricFieldInfo
         {
-            /// <inheritdoc />
-            public ElectricFieldInfo(string name, ElectricFieldUnit baseUnit, IEnumerable<IUnitDefinition<ElectricFieldUnit>> unitMappings, ElectricField zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricField, ElectricFieldUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricField.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricFieldInfo(string name, ElectricFieldUnit baseUnit, IEnumerable<IUnitDefinition<ElectricFieldUnit>> unitMappings, ElectricField zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricField.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricField", typeof(ElectricField).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricFieldInfo"/> class with the default settings for the ElectricField quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricFieldInfo"/> class with the default settings.</returns>
-            public static ElectricFieldInfo CreateDefault()
-            {
-                return new ElectricFieldInfo(nameof(ElectricField), DefaultBaseUnit, GetDefaultMappings(), new ElectricField(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricFieldInfo"/> class with the default settings for the ElectricField quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricFieldInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricFieldInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricFieldUnit>>, IEnumerable<IUnitDefinition<ElectricFieldUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricField, ElectricFieldUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricFieldUnit>>, IEnumerable<IUnitDefinition<ElectricFieldUnit>>>? customizeUnits = null)
             {
-                return new ElectricFieldInfo(nameof(ElectricField), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricField(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricFieldUnit>> unitMappings = ElectricFieldInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricField, ElectricFieldUnit>(
+                    name: nameof(ElectricField),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricField(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricField"/> is [T^-3][L][M][I^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, -1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, -1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricField is VoltPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricFieldUnit DefaultBaseUnit { get; } = ElectricFieldUnit.VoltPerMeter;
+            private static ElectricFieldUnit DefaultBaseUnit { get; } = ElectricFieldUnit.VoltPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricField quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricField", typeof(ElectricField).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricFieldUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricFieldUnit}"/> representing the default unit mappings for ElectricField.</returns>
-            public static IEnumerable<UnitDefinition<ElectricFieldUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricFieldUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricFieldUnit.VoltPerMeter, "VoltPerMeter", "VoltsPerMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static ElectricField()
         {
-            Info = ElectricFieldInfo.CreateDefault();
+            Info = ElectricFieldInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricImpedance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricImpedanceInfo: QuantityInfo<ElectricImpedance, ElectricImpedanceUnit>
+        private static class ElectricImpedanceInfo
         {
-            /// <inheritdoc />
-            public ElectricImpedanceInfo(string name, ElectricImpedanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricImpedanceUnit>> unitMappings, ElectricImpedance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricImpedance, ElectricImpedanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricImpedance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricImpedanceInfo(string name, ElectricImpedanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricImpedanceUnit>> unitMappings, ElectricImpedance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricImpedance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricImpedance", typeof(ElectricImpedance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricImpedanceInfo"/> class with the default settings for the ElectricImpedance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricImpedanceInfo"/> class with the default settings.</returns>
-            public static ElectricImpedanceInfo CreateDefault()
-            {
-                return new ElectricImpedanceInfo(nameof(ElectricImpedance), DefaultBaseUnit, GetDefaultMappings(), new ElectricImpedance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricImpedanceInfo"/> class with the default settings for the ElectricImpedance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricImpedanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricImpedanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricImpedanceUnit>>, IEnumerable<IUnitDefinition<ElectricImpedanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricImpedance, ElectricImpedanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricImpedanceUnit>>, IEnumerable<IUnitDefinition<ElectricImpedanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricImpedanceInfo(nameof(ElectricImpedance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricImpedance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricImpedanceUnit>> unitMappings = ElectricImpedanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricImpedance, ElectricImpedanceUnit>(
+                    name: nameof(ElectricImpedance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricImpedance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricImpedance"/> is [T^-3][L^2][M][I^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricImpedance is Ohm. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricImpedanceUnit DefaultBaseUnit { get; } = ElectricImpedanceUnit.Ohm;
+            private static ElectricImpedanceUnit DefaultBaseUnit { get; } = ElectricImpedanceUnit.Ohm;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricImpedance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricImpedance", typeof(ElectricImpedance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricImpedanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricImpedanceUnit}"/> representing the default unit mappings for ElectricImpedance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricImpedanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricImpedanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricImpedanceUnit.Gigaohm, "Gigaohm", "Gigaohms", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Millisecond, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricImpedanceUnit.Kiloohm, "Kiloohm", "Kiloohms", BaseUnits.Undefined);
@@ -133,7 +133,7 @@ namespace UnitsNet
 
         static ElectricImpedance()
         {
-            Info = ElectricImpedanceInfo.CreateDefault();
+            Info = ElectricImpedanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricInductance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricInductanceInfo: QuantityInfo<ElectricInductance, ElectricInductanceUnit>
+        private static class ElectricInductanceInfo
         {
-            /// <inheritdoc />
-            public ElectricInductanceInfo(string name, ElectricInductanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricInductanceUnit>> unitMappings, ElectricInductance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricInductance, ElectricInductanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricInductance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricInductanceInfo(string name, ElectricInductanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricInductanceUnit>> unitMappings, ElectricInductance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricInductance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricInductance", typeof(ElectricInductance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricInductanceInfo"/> class with the default settings for the ElectricInductance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricInductanceInfo"/> class with the default settings.</returns>
-            public static ElectricInductanceInfo CreateDefault()
-            {
-                return new ElectricInductanceInfo(nameof(ElectricInductance), DefaultBaseUnit, GetDefaultMappings(), new ElectricInductance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricInductanceInfo"/> class with the default settings for the ElectricInductance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricInductanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricInductanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricInductanceUnit>>, IEnumerable<IUnitDefinition<ElectricInductanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricInductance, ElectricInductanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricInductanceUnit>>, IEnumerable<IUnitDefinition<ElectricInductanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricInductanceInfo(nameof(ElectricInductance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricInductance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricInductanceUnit>> unitMappings = ElectricInductanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricInductance, ElectricInductanceUnit>(
+                    name: nameof(ElectricInductance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricInductance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricInductance"/> is [T^-2][L^2][M][I^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, -2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, -2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricInductance is Henry. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricInductanceUnit DefaultBaseUnit { get; } = ElectricInductanceUnit.Henry;
+            private static ElectricInductanceUnit DefaultBaseUnit { get; } = ElectricInductanceUnit.Henry;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricInductance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricInductance", typeof(ElectricInductance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricInductanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricInductanceUnit}"/> representing the default unit mappings for ElectricInductance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricInductanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricInductanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricInductanceUnit.Henry, "Henry", "Henries", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricInductanceUnit.Microhenry, "Microhenry", "Microhenries", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Milligram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -129,7 +129,7 @@ namespace UnitsNet
 
         static ElectricInductance()
         {
-            Info = ElectricInductanceInfo.CreateDefault();
+            Info = ElectricInductanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -71,59 +71,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricPotential"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricPotentialInfo: QuantityInfo<ElectricPotential, ElectricPotentialUnit>
+        private static class ElectricPotentialInfo
         {
-            /// <inheritdoc />
-            public ElectricPotentialInfo(string name, ElectricPotentialUnit baseUnit, IEnumerable<IUnitDefinition<ElectricPotentialUnit>> unitMappings, ElectricPotential zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricPotential, ElectricPotentialUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricPotential.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricPotentialInfo(string name, ElectricPotentialUnit baseUnit, IEnumerable<IUnitDefinition<ElectricPotentialUnit>> unitMappings, ElectricPotential zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricPotential.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricPotential", typeof(ElectricPotential).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricPotentialInfo"/> class with the default settings for the ElectricPotential quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricPotentialInfo"/> class with the default settings.</returns>
-            public static ElectricPotentialInfo CreateDefault()
-            {
-                return new ElectricPotentialInfo(nameof(ElectricPotential), DefaultBaseUnit, GetDefaultMappings(), new ElectricPotential(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricPotentialInfo"/> class with the default settings for the ElectricPotential quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricPotentialInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricPotentialInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricPotentialUnit>>, IEnumerable<IUnitDefinition<ElectricPotentialUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricPotential, ElectricPotentialUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricPotentialUnit>>, IEnumerable<IUnitDefinition<ElectricPotentialUnit>>>? customizeUnits = null)
             {
-                return new ElectricPotentialInfo(nameof(ElectricPotential), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricPotential(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricPotentialUnit>> unitMappings = ElectricPotentialInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricPotential, ElectricPotentialUnit>(
+                    name: nameof(ElectricPotential),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricPotential(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricPotential"/> is [T^-3][L^2][M][I^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricPotential is Volt. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricPotentialUnit DefaultBaseUnit { get; } = ElectricPotentialUnit.Volt;
+            private static ElectricPotentialUnit DefaultBaseUnit { get; } = ElectricPotentialUnit.Volt;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricPotential quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricPotential", typeof(ElectricPotential).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricPotentialUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricPotentialUnit}"/> representing the default unit mappings for ElectricPotential.</returns>
-            public static IEnumerable<UnitDefinition<ElectricPotentialUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricPotentialUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricPotentialUnit.Kilovolt, "Kilovolt", "Kilovolts", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Milliampere));
                 yield return new (ElectricPotentialUnit.Megavolt, "Megavolt", "Megavolts", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Microampere));
@@ -136,7 +136,7 @@ namespace UnitsNet
 
         static ElectricPotential()
         {
-            Info = ElectricPotentialInfo.CreateDefault();
+            Info = ElectricPotentialInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricPotentialChangeRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricPotentialChangeRateInfo: QuantityInfo<ElectricPotentialChangeRate, ElectricPotentialChangeRateUnit>
+        private static class ElectricPotentialChangeRateInfo
         {
-            /// <inheritdoc />
-            public ElectricPotentialChangeRateInfo(string name, ElectricPotentialChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<ElectricPotentialChangeRateUnit>> unitMappings, ElectricPotentialChangeRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricPotentialChangeRate, ElectricPotentialChangeRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricPotentialChangeRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricPotentialChangeRateInfo(string name, ElectricPotentialChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<ElectricPotentialChangeRateUnit>> unitMappings, ElectricPotentialChangeRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricPotentialChangeRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricPotentialChangeRate", typeof(ElectricPotentialChangeRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricPotentialChangeRateInfo"/> class with the default settings for the ElectricPotentialChangeRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricPotentialChangeRateInfo"/> class with the default settings.</returns>
-            public static ElectricPotentialChangeRateInfo CreateDefault()
-            {
-                return new ElectricPotentialChangeRateInfo(nameof(ElectricPotentialChangeRate), DefaultBaseUnit, GetDefaultMappings(), new ElectricPotentialChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricPotentialChangeRateInfo"/> class with the default settings for the ElectricPotentialChangeRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricPotentialChangeRateInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricPotentialChangeRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricPotentialChangeRateUnit>>, IEnumerable<IUnitDefinition<ElectricPotentialChangeRateUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricPotentialChangeRate, ElectricPotentialChangeRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricPotentialChangeRateUnit>>, IEnumerable<IUnitDefinition<ElectricPotentialChangeRateUnit>>>? customizeUnits = null)
             {
-                return new ElectricPotentialChangeRateInfo(nameof(ElectricPotentialChangeRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricPotentialChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricPotentialChangeRateUnit>> unitMappings = ElectricPotentialChangeRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricPotentialChangeRate, ElectricPotentialChangeRateUnit>(
+                    name: nameof(ElectricPotentialChangeRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricPotentialChangeRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricPotentialChangeRate"/> is [T^-4][L^2][M][I^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -4, -1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -4, -1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricPotentialChangeRate is VoltPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricPotentialChangeRateUnit DefaultBaseUnit { get; } = ElectricPotentialChangeRateUnit.VoltPerSecond;
+            private static ElectricPotentialChangeRateUnit DefaultBaseUnit { get; } = ElectricPotentialChangeRateUnit.VoltPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricPotentialChangeRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricPotentialChangeRate", typeof(ElectricPotentialChangeRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricPotentialChangeRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricPotentialChangeRateUnit}"/> representing the default unit mappings for ElectricPotentialChangeRate.</returns>
-            public static IEnumerable<UnitDefinition<ElectricPotentialChangeRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricPotentialChangeRateUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricPotentialChangeRateUnit.KilovoltPerHour, "KilovoltPerHour", "KilovoltsPerHour", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Hour, current: ElectricCurrentUnit.Milliampere));
                 yield return new (ElectricPotentialChangeRateUnit.KilovoltPerMicrosecond, "KilovoltPerMicrosecond", "KilovoltsPerMicrosecond", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Microsecond, current: ElectricCurrentUnit.Milliampere));
@@ -141,7 +141,7 @@ namespace UnitsNet
 
         static ElectricPotentialChangeRate()
         {
-            Info = ElectricPotentialChangeRateInfo.CreateDefault();
+            Info = ElectricPotentialChangeRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricReactance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricReactanceInfo: QuantityInfo<ElectricReactance, ElectricReactanceUnit>
+        private static class ElectricReactanceInfo
         {
-            /// <inheritdoc />
-            public ElectricReactanceInfo(string name, ElectricReactanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricReactanceUnit>> unitMappings, ElectricReactance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricReactance, ElectricReactanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricReactance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricReactanceInfo(string name, ElectricReactanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricReactanceUnit>> unitMappings, ElectricReactance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricReactance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricReactance", typeof(ElectricReactance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricReactanceInfo"/> class with the default settings for the ElectricReactance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricReactanceInfo"/> class with the default settings.</returns>
-            public static ElectricReactanceInfo CreateDefault()
-            {
-                return new ElectricReactanceInfo(nameof(ElectricReactance), DefaultBaseUnit, GetDefaultMappings(), new ElectricReactance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricReactanceInfo"/> class with the default settings for the ElectricReactance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricReactanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricReactanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricReactanceUnit>>, IEnumerable<IUnitDefinition<ElectricReactanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricReactance, ElectricReactanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricReactanceUnit>>, IEnumerable<IUnitDefinition<ElectricReactanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricReactanceInfo(nameof(ElectricReactance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricReactance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricReactanceUnit>> unitMappings = ElectricReactanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricReactance, ElectricReactanceUnit>(
+                    name: nameof(ElectricReactance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricReactance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricReactance"/> is [T^-3][L^2][M][I^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricReactance is Ohm. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricReactanceUnit DefaultBaseUnit { get; } = ElectricReactanceUnit.Ohm;
+            private static ElectricReactanceUnit DefaultBaseUnit { get; } = ElectricReactanceUnit.Ohm;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricReactance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricReactance", typeof(ElectricReactance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricReactanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricReactanceUnit}"/> representing the default unit mappings for ElectricReactance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricReactanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricReactanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricReactanceUnit.Gigaohm, "Gigaohm", "Gigaohms", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Millisecond, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricReactanceUnit.Kiloohm, "Kiloohm", "Kiloohms", BaseUnits.Undefined);
@@ -132,7 +132,7 @@ namespace UnitsNet
 
         static ElectricReactance()
         {
-            Info = ElectricReactanceInfo.CreateDefault();
+            Info = ElectricReactanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricReactiveEnergy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricReactiveEnergyInfo: QuantityInfo<ElectricReactiveEnergy, ElectricReactiveEnergyUnit>
+        private static class ElectricReactiveEnergyInfo
         {
-            /// <inheritdoc />
-            public ElectricReactiveEnergyInfo(string name, ElectricReactiveEnergyUnit baseUnit, IEnumerable<IUnitDefinition<ElectricReactiveEnergyUnit>> unitMappings, ElectricReactiveEnergy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricReactiveEnergy, ElectricReactiveEnergyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricReactiveEnergy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricReactiveEnergyInfo(string name, ElectricReactiveEnergyUnit baseUnit, IEnumerable<IUnitDefinition<ElectricReactiveEnergyUnit>> unitMappings, ElectricReactiveEnergy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricReactiveEnergy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricReactiveEnergy", typeof(ElectricReactiveEnergy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricReactiveEnergyInfo"/> class with the default settings for the ElectricReactiveEnergy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricReactiveEnergyInfo"/> class with the default settings.</returns>
-            public static ElectricReactiveEnergyInfo CreateDefault()
-            {
-                return new ElectricReactiveEnergyInfo(nameof(ElectricReactiveEnergy), DefaultBaseUnit, GetDefaultMappings(), new ElectricReactiveEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricReactiveEnergyInfo"/> class with the default settings for the ElectricReactiveEnergy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricReactiveEnergyInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricReactiveEnergyInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricReactiveEnergyUnit>>, IEnumerable<IUnitDefinition<ElectricReactiveEnergyUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricReactiveEnergy, ElectricReactiveEnergyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricReactiveEnergyUnit>>, IEnumerable<IUnitDefinition<ElectricReactiveEnergyUnit>>>? customizeUnits = null)
             {
-                return new ElectricReactiveEnergyInfo(nameof(ElectricReactiveEnergy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricReactiveEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricReactiveEnergyUnit>> unitMappings = ElectricReactiveEnergyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricReactiveEnergy, ElectricReactiveEnergyUnit>(
+                    name: nameof(ElectricReactiveEnergy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricReactiveEnergy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricReactiveEnergy"/> is [T^-2][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricReactiveEnergy is VoltampereReactiveHour. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricReactiveEnergyUnit DefaultBaseUnit { get; } = ElectricReactiveEnergyUnit.VoltampereReactiveHour;
+            private static ElectricReactiveEnergyUnit DefaultBaseUnit { get; } = ElectricReactiveEnergyUnit.VoltampereReactiveHour;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricReactiveEnergy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricReactiveEnergy", typeof(ElectricReactiveEnergy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricReactiveEnergyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricReactiveEnergyUnit}"/> representing the default unit mappings for ElectricReactiveEnergy.</returns>
-            public static IEnumerable<UnitDefinition<ElectricReactiveEnergyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricReactiveEnergyUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricReactiveEnergyUnit.KilovoltampereReactiveHour, "KilovoltampereReactiveHour", "KilovoltampereReactiveHours", BaseUnits.Undefined);
                 yield return new (ElectricReactiveEnergyUnit.MegavoltampereReactiveHour, "MegavoltampereReactiveHour", "MegavoltampereReactiveHours", BaseUnits.Undefined);
@@ -124,7 +124,7 @@ namespace UnitsNet
 
         static ElectricReactiveEnergy()
         {
-            Info = ElectricReactiveEnergyInfo.CreateDefault();
+            Info = ElectricReactiveEnergyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricReactivePower"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricReactivePowerInfo: QuantityInfo<ElectricReactivePower, ElectricReactivePowerUnit>
+        private static class ElectricReactivePowerInfo
         {
-            /// <inheritdoc />
-            public ElectricReactivePowerInfo(string name, ElectricReactivePowerUnit baseUnit, IEnumerable<IUnitDefinition<ElectricReactivePowerUnit>> unitMappings, ElectricReactivePower zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricReactivePower, ElectricReactivePowerUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricReactivePower.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricReactivePowerInfo(string name, ElectricReactivePowerUnit baseUnit, IEnumerable<IUnitDefinition<ElectricReactivePowerUnit>> unitMappings, ElectricReactivePower zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricReactivePower.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricReactivePower", typeof(ElectricReactivePower).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricReactivePowerInfo"/> class with the default settings for the ElectricReactivePower quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricReactivePowerInfo"/> class with the default settings.</returns>
-            public static ElectricReactivePowerInfo CreateDefault()
-            {
-                return new ElectricReactivePowerInfo(nameof(ElectricReactivePower), DefaultBaseUnit, GetDefaultMappings(), new ElectricReactivePower(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricReactivePowerInfo"/> class with the default settings for the ElectricReactivePower quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricReactivePowerInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricReactivePowerInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricReactivePowerUnit>>, IEnumerable<IUnitDefinition<ElectricReactivePowerUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricReactivePower, ElectricReactivePowerUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricReactivePowerUnit>>, IEnumerable<IUnitDefinition<ElectricReactivePowerUnit>>>? customizeUnits = null)
             {
-                return new ElectricReactivePowerInfo(nameof(ElectricReactivePower), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricReactivePower(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricReactivePowerUnit>> unitMappings = ElectricReactivePowerInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricReactivePower, ElectricReactivePowerUnit>(
+                    name: nameof(ElectricReactivePower),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricReactivePower(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricReactivePower"/> is [T^-3][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricReactivePower is VoltampereReactive. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricReactivePowerUnit DefaultBaseUnit { get; } = ElectricReactivePowerUnit.VoltampereReactive;
+            private static ElectricReactivePowerUnit DefaultBaseUnit { get; } = ElectricReactivePowerUnit.VoltampereReactive;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricReactivePower quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricReactivePower", typeof(ElectricReactivePower).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricReactivePowerUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricReactivePowerUnit}"/> representing the default unit mappings for ElectricReactivePower.</returns>
-            public static IEnumerable<UnitDefinition<ElectricReactivePowerUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricReactivePowerUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricReactivePowerUnit.GigavoltampereReactive, "GigavoltampereReactive", "GigavoltamperesReactive", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Millisecond));
                 yield return new (ElectricReactivePowerUnit.KilovoltampereReactive, "KilovoltampereReactive", "KilovoltamperesReactive", BaseUnits.Undefined);
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static ElectricReactivePower()
         {
-            Info = ElectricReactivePowerInfo.CreateDefault();
+            Info = ElectricReactivePowerInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -68,59 +68,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricResistance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricResistanceInfo: QuantityInfo<ElectricResistance, ElectricResistanceUnit>
+        private static class ElectricResistanceInfo
         {
-            /// <inheritdoc />
-            public ElectricResistanceInfo(string name, ElectricResistanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricResistanceUnit>> unitMappings, ElectricResistance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricResistance, ElectricResistanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricResistance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricResistanceInfo(string name, ElectricResistanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricResistanceUnit>> unitMappings, ElectricResistance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricResistance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricResistance", typeof(ElectricResistance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricResistanceInfo"/> class with the default settings for the ElectricResistance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricResistanceInfo"/> class with the default settings.</returns>
-            public static ElectricResistanceInfo CreateDefault()
-            {
-                return new ElectricResistanceInfo(nameof(ElectricResistance), DefaultBaseUnit, GetDefaultMappings(), new ElectricResistance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricResistanceInfo"/> class with the default settings for the ElectricResistance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricResistanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricResistanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricResistanceUnit>>, IEnumerable<IUnitDefinition<ElectricResistanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricResistance, ElectricResistanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricResistanceUnit>>, IEnumerable<IUnitDefinition<ElectricResistanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricResistanceInfo(nameof(ElectricResistance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricResistance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricResistanceUnit>> unitMappings = ElectricResistanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricResistance, ElectricResistanceUnit>(
+                    name: nameof(ElectricResistance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricResistance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricResistance"/> is [T^-3][L^2][M][I^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, -2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricResistance is Ohm. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricResistanceUnit DefaultBaseUnit { get; } = ElectricResistanceUnit.Ohm;
+            private static ElectricResistanceUnit DefaultBaseUnit { get; } = ElectricResistanceUnit.Ohm;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricResistance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricResistance", typeof(ElectricResistance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricResistanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricResistanceUnit}"/> representing the default unit mappings for ElectricResistance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricResistanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricResistanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricResistanceUnit.Gigaohm, "Gigaohm", "Gigaohms", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Millisecond, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricResistanceUnit.Kiloohm, "Kiloohm", "Kiloohms", BaseUnits.Undefined);
@@ -135,7 +135,7 @@ namespace UnitsNet
 
         static ElectricResistance()
         {
-            Info = ElectricResistanceInfo.CreateDefault();
+            Info = ElectricResistanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricResistivity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricResistivityInfo: QuantityInfo<ElectricResistivity, ElectricResistivityUnit>
+        private static class ElectricResistivityInfo
         {
-            /// <inheritdoc />
-            public ElectricResistivityInfo(string name, ElectricResistivityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricResistivityUnit>> unitMappings, ElectricResistivity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricResistivity, ElectricResistivityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricResistivity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricResistivityInfo(string name, ElectricResistivityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricResistivityUnit>> unitMappings, ElectricResistivity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricResistivity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricResistivity", typeof(ElectricResistivity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricResistivityInfo"/> class with the default settings for the ElectricResistivity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricResistivityInfo"/> class with the default settings.</returns>
-            public static ElectricResistivityInfo CreateDefault()
-            {
-                return new ElectricResistivityInfo(nameof(ElectricResistivity), DefaultBaseUnit, GetDefaultMappings(), new ElectricResistivity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricResistivityInfo"/> class with the default settings for the ElectricResistivity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricResistivityInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricResistivityInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricResistivityUnit>>, IEnumerable<IUnitDefinition<ElectricResistivityUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricResistivity, ElectricResistivityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricResistivityUnit>>, IEnumerable<IUnitDefinition<ElectricResistivityUnit>>>? customizeUnits = null)
             {
-                return new ElectricResistivityInfo(nameof(ElectricResistivity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricResistivity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricResistivityUnit>> unitMappings = ElectricResistivityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricResistivity, ElectricResistivityUnit>(
+                    name: nameof(ElectricResistivity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricResistivity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricResistivity"/> is [T^-3][L^3][M][I^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, 1, -3, -2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, 1, -3, -2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricResistivity is OhmMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricResistivityUnit DefaultBaseUnit { get; } = ElectricResistivityUnit.OhmMeter;
+            private static ElectricResistivityUnit DefaultBaseUnit { get; } = ElectricResistivityUnit.OhmMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricResistivity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricResistivity", typeof(ElectricResistivity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricResistivityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricResistivityUnit}"/> representing the default unit mappings for ElectricResistivity.</returns>
-            public static IEnumerable<UnitDefinition<ElectricResistivityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricResistivityUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricResistivityUnit.KiloohmCentimeter, "KiloohmCentimeter", "KiloohmsCentimeter", BaseUnits.Undefined);
                 yield return new (ElectricResistivityUnit.KiloohmMeter, "KiloohmMeter", "KiloohmMeters", new BaseUnits(length: LengthUnit.Decameter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -138,7 +138,7 @@ namespace UnitsNet
 
         static ElectricResistivity()
         {
-            Info = ElectricResistivityInfo.CreateDefault();
+            Info = ElectricResistivityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricSurfaceChargeDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricSurfaceChargeDensityInfo: QuantityInfo<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensityUnit>
+        private static class ElectricSurfaceChargeDensityInfo
         {
-            /// <inheritdoc />
-            public ElectricSurfaceChargeDensityInfo(string name, ElectricSurfaceChargeDensityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricSurfaceChargeDensityUnit>> unitMappings, ElectricSurfaceChargeDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricSurfaceChargeDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricSurfaceChargeDensityInfo(string name, ElectricSurfaceChargeDensityUnit baseUnit, IEnumerable<IUnitDefinition<ElectricSurfaceChargeDensityUnit>> unitMappings, ElectricSurfaceChargeDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricSurfaceChargeDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricSurfaceChargeDensity", typeof(ElectricSurfaceChargeDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricSurfaceChargeDensityInfo"/> class with the default settings for the ElectricSurfaceChargeDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricSurfaceChargeDensityInfo"/> class with the default settings.</returns>
-            public static ElectricSurfaceChargeDensityInfo CreateDefault()
-            {
-                return new ElectricSurfaceChargeDensityInfo(nameof(ElectricSurfaceChargeDensity), DefaultBaseUnit, GetDefaultMappings(), new ElectricSurfaceChargeDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricSurfaceChargeDensityInfo"/> class with the default settings for the ElectricSurfaceChargeDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricSurfaceChargeDensityInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricSurfaceChargeDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricSurfaceChargeDensityUnit>>, IEnumerable<IUnitDefinition<ElectricSurfaceChargeDensityUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricSurfaceChargeDensityUnit>>, IEnumerable<IUnitDefinition<ElectricSurfaceChargeDensityUnit>>>? customizeUnits = null)
             {
-                return new ElectricSurfaceChargeDensityInfo(nameof(ElectricSurfaceChargeDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricSurfaceChargeDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricSurfaceChargeDensityUnit>> unitMappings = ElectricSurfaceChargeDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensityUnit>(
+                    name: nameof(ElectricSurfaceChargeDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricSurfaceChargeDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricSurfaceChargeDensity"/> is [T][L^-2][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 1, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 1, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricSurfaceChargeDensity is CoulombPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricSurfaceChargeDensityUnit DefaultBaseUnit { get; } = ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter;
+            private static ElectricSurfaceChargeDensityUnit DefaultBaseUnit { get; } = ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricSurfaceChargeDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricSurfaceChargeDensity", typeof(ElectricSurfaceChargeDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricSurfaceChargeDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricSurfaceChargeDensityUnit}"/> representing the default unit mappings for ElectricSurfaceChargeDensity.</returns>
-            public static IEnumerable<UnitDefinition<ElectricSurfaceChargeDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricSurfaceChargeDensityUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricSurfaceChargeDensityUnit.CoulombPerSquareCentimeter, "CoulombPerSquareCentimeter", "CoulombsPerSquareCentimeter", new BaseUnits(length: LengthUnit.Centimeter, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
                 yield return new (ElectricSurfaceChargeDensityUnit.CoulombPerSquareInch, "CoulombPerSquareInch", "CoulombsPerSquareInch", new BaseUnits(length: LengthUnit.Inch, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static ElectricSurfaceChargeDensity()
         {
-            Info = ElectricSurfaceChargeDensityInfo.CreateDefault();
+            Info = ElectricSurfaceChargeDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ElectricSusceptance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ElectricSusceptanceInfo: QuantityInfo<ElectricSusceptance, ElectricSusceptanceUnit>
+        private static class ElectricSusceptanceInfo
         {
-            /// <inheritdoc />
-            public ElectricSusceptanceInfo(string name, ElectricSusceptanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricSusceptanceUnit>> unitMappings, ElectricSusceptance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ElectricSusceptance, ElectricSusceptanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ElectricSusceptance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ElectricSusceptanceInfo(string name, ElectricSusceptanceUnit baseUnit, IEnumerable<IUnitDefinition<ElectricSusceptanceUnit>> unitMappings, ElectricSusceptance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ElectricSusceptance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ElectricSusceptance", typeof(ElectricSusceptance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ElectricSusceptanceInfo"/> class with the default settings for the ElectricSusceptance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ElectricSusceptanceInfo"/> class with the default settings.</returns>
-            public static ElectricSusceptanceInfo CreateDefault()
-            {
-                return new ElectricSusceptanceInfo(nameof(ElectricSusceptance), DefaultBaseUnit, GetDefaultMappings(), new ElectricSusceptance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ElectricSusceptanceInfo"/> class with the default settings for the ElectricSusceptance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ElectricSusceptanceInfo"/> class with the default settings.
             /// </returns>
-            public static ElectricSusceptanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ElectricSusceptanceUnit>>, IEnumerable<IUnitDefinition<ElectricSusceptanceUnit>>> customizeUnits)
+            private static QuantityInfo<ElectricSusceptance, ElectricSusceptanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ElectricSusceptanceUnit>>, IEnumerable<IUnitDefinition<ElectricSusceptanceUnit>>>? customizeUnits = null)
             {
-                return new ElectricSusceptanceInfo(nameof(ElectricSusceptance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ElectricSusceptance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ElectricSusceptanceUnit>> unitMappings = ElectricSusceptanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ElectricSusceptance, ElectricSusceptanceUnit>(
+                    name: nameof(ElectricSusceptance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ElectricSusceptance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ElectricSusceptance"/> is [T^3][L^-2][M^-1][I^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, -1, 3, 2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ElectricSusceptance is Siemens. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ElectricSusceptanceUnit DefaultBaseUnit { get; } = ElectricSusceptanceUnit.Siemens;
+            private static ElectricSusceptanceUnit DefaultBaseUnit { get; } = ElectricSusceptanceUnit.Siemens;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ElectricSusceptance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ElectricSusceptance", typeof(ElectricSusceptance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ElectricSusceptanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ElectricSusceptanceUnit}"/> representing the default unit mappings for ElectricSusceptance.</returns>
-            public static IEnumerable<UnitDefinition<ElectricSusceptanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ElectricSusceptanceUnit>> GetDefaultMappings()
             {
                 yield return new (ElectricSusceptanceUnit.Gigamho, "Gigamho", "Gigamhos", BaseUnits.Undefined);
                 yield return new (ElectricSusceptanceUnit.Gigasiemens, "Gigasiemens", "Gigasiemens", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Microgram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
@@ -140,7 +140,7 @@ namespace UnitsNet
 
         static ElectricSusceptance()
         {
-            Info = ElectricSusceptanceInfo.CreateDefault();
+            Info = ElectricSusceptanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -77,59 +77,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Energy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class EnergyInfo: QuantityInfo<Energy, EnergyUnit>
+        private static class EnergyInfo
         {
-            /// <inheritdoc />
-            public EnergyInfo(string name, EnergyUnit baseUnit, IEnumerable<IUnitDefinition<EnergyUnit>> unitMappings, Energy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Energy, EnergyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Energy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public EnergyInfo(string name, EnergyUnit baseUnit, IEnumerable<IUnitDefinition<EnergyUnit>> unitMappings, Energy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Energy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Energy", typeof(Energy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="EnergyInfo"/> class with the default settings for the Energy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="EnergyInfo"/> class with the default settings.</returns>
-            public static EnergyInfo CreateDefault()
-            {
-                return new EnergyInfo(nameof(Energy), DefaultBaseUnit, GetDefaultMappings(), new Energy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="EnergyInfo"/> class with the default settings for the Energy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="EnergyInfo"/> class with the default settings.
             /// </returns>
-            public static EnergyInfo CreateDefault(Func<IEnumerable<UnitDefinition<EnergyUnit>>, IEnumerable<IUnitDefinition<EnergyUnit>>> customizeUnits)
+            private static QuantityInfo<Energy, EnergyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<EnergyUnit>>, IEnumerable<IUnitDefinition<EnergyUnit>>>? customizeUnits = null)
             {
-                return new EnergyInfo(nameof(Energy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Energy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<EnergyUnit>> unitMappings = EnergyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Energy, EnergyUnit>(
+                    name: nameof(Energy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Energy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Energy"/> is [T^-2][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Energy is Joule. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static EnergyUnit DefaultBaseUnit { get; } = EnergyUnit.Joule;
+            private static EnergyUnit DefaultBaseUnit { get; } = EnergyUnit.Joule;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Energy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Energy", typeof(Energy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="EnergyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{EnergyUnit}"/> representing the default unit mappings for Energy.</returns>
-            public static IEnumerable<UnitDefinition<EnergyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<EnergyUnit>> GetDefaultMappings()
             {
                 yield return new (EnergyUnit.BritishThermalUnit, "BritishThermalUnit", "BritishThermalUnits", BaseUnits.Undefined);
                 yield return new (EnergyUnit.Calorie, "Calorie", "Calories", BaseUnits.Undefined);
@@ -176,7 +176,7 @@ namespace UnitsNet
 
         static Energy()
         {
-            Info = EnergyInfo.CreateDefault();
+            Info = EnergyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="EnergyDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class EnergyDensityInfo: QuantityInfo<EnergyDensity, EnergyDensityUnit>
+        private static class EnergyDensityInfo
         {
-            /// <inheritdoc />
-            public EnergyDensityInfo(string name, EnergyDensityUnit baseUnit, IEnumerable<IUnitDefinition<EnergyDensityUnit>> unitMappings, EnergyDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<EnergyDensity, EnergyDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, EnergyDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public EnergyDensityInfo(string name, EnergyDensityUnit baseUnit, IEnumerable<IUnitDefinition<EnergyDensityUnit>> unitMappings, EnergyDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, EnergyDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.EnergyDensity", typeof(EnergyDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="EnergyDensityInfo"/> class with the default settings for the EnergyDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="EnergyDensityInfo"/> class with the default settings.</returns>
-            public static EnergyDensityInfo CreateDefault()
-            {
-                return new EnergyDensityInfo(nameof(EnergyDensity), DefaultBaseUnit, GetDefaultMappings(), new EnergyDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="EnergyDensityInfo"/> class with the default settings for the EnergyDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="EnergyDensityInfo"/> class with the default settings.
             /// </returns>
-            public static EnergyDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<EnergyDensityUnit>>, IEnumerable<IUnitDefinition<EnergyDensityUnit>>> customizeUnits)
+            private static QuantityInfo<EnergyDensity, EnergyDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<EnergyDensityUnit>>, IEnumerable<IUnitDefinition<EnergyDensityUnit>>>? customizeUnits = null)
             {
-                return new EnergyDensityInfo(nameof(EnergyDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new EnergyDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<EnergyDensityUnit>> unitMappings = EnergyDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<EnergyDensity, EnergyDensityUnit>(
+                    name: nameof(EnergyDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new EnergyDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="EnergyDensity"/> is [T^-2][L^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of EnergyDensity is JoulePerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static EnergyDensityUnit DefaultBaseUnit { get; } = EnergyDensityUnit.JoulePerCubicMeter;
+            private static EnergyDensityUnit DefaultBaseUnit { get; } = EnergyDensityUnit.JoulePerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the EnergyDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.EnergyDensity", typeof(EnergyDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="EnergyDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{EnergyDensityUnit}"/> representing the default unit mappings for EnergyDensity.</returns>
-            public static IEnumerable<UnitDefinition<EnergyDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<EnergyDensityUnit>> GetDefaultMappings()
             {
                 yield return new (EnergyDensityUnit.GigajoulePerCubicMeter, "GigajoulePerCubicMeter", "GigajoulesPerCubicMeter", new BaseUnits(length: LengthUnit.Nanometer, mass: MassUnit.Kilogram, time: DurationUnit.Second));
                 yield return new (EnergyDensityUnit.GigawattHourPerCubicMeter, "GigawattHourPerCubicMeter", "GigawattHoursPerCubicMeter", BaseUnits.Undefined);
@@ -136,7 +136,7 @@ namespace UnitsNet
 
         static EnergyDensity()
         {
-            Info = EnergyDensityInfo.CreateDefault();
+            Info = EnergyDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -67,59 +67,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Entropy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class EntropyInfo: QuantityInfo<Entropy, EntropyUnit>
+        private static class EntropyInfo
         {
-            /// <inheritdoc />
-            public EntropyInfo(string name, EntropyUnit baseUnit, IEnumerable<IUnitDefinition<EntropyUnit>> unitMappings, Entropy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Entropy, EntropyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Entropy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public EntropyInfo(string name, EntropyUnit baseUnit, IEnumerable<IUnitDefinition<EntropyUnit>> unitMappings, Entropy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Entropy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Entropy", typeof(Entropy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="EntropyInfo"/> class with the default settings for the Entropy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="EntropyInfo"/> class with the default settings.</returns>
-            public static EntropyInfo CreateDefault()
-            {
-                return new EntropyInfo(nameof(Entropy), DefaultBaseUnit, GetDefaultMappings(), new Entropy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="EntropyInfo"/> class with the default settings for the Entropy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="EntropyInfo"/> class with the default settings.
             /// </returns>
-            public static EntropyInfo CreateDefault(Func<IEnumerable<UnitDefinition<EntropyUnit>>, IEnumerable<IUnitDefinition<EntropyUnit>>> customizeUnits)
+            private static QuantityInfo<Entropy, EntropyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<EntropyUnit>>, IEnumerable<IUnitDefinition<EntropyUnit>>>? customizeUnits = null)
             {
-                return new EntropyInfo(nameof(Entropy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Entropy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<EntropyUnit>> unitMappings = EntropyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Entropy, EntropyUnit>(
+                    name: nameof(Entropy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Entropy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Entropy"/> is [T^-2][L^2][M][Θ^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, -1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, -1, 0, 0);
 
             /// <summary>
             ///     The default base unit of Entropy is JoulePerKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static EntropyUnit DefaultBaseUnit { get; } = EntropyUnit.JoulePerKelvin;
+            private static EntropyUnit DefaultBaseUnit { get; } = EntropyUnit.JoulePerKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Entropy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Entropy", typeof(Entropy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="EntropyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{EntropyUnit}"/> representing the default unit mappings for Entropy.</returns>
-            public static IEnumerable<UnitDefinition<EntropyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<EntropyUnit>> GetDefaultMappings()
             {
                 yield return new (EntropyUnit.CaloriePerKelvin, "CaloriePerKelvin", "CaloriesPerKelvin", BaseUnits.Undefined);
                 yield return new (EntropyUnit.JoulePerDegreeCelsius, "JoulePerDegreeCelsius", "JoulesPerDegreeCelsius", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, temperature: TemperatureUnit.DegreeCelsius));
@@ -133,7 +133,7 @@ namespace UnitsNet
 
         static Entropy()
         {
-            Info = EntropyInfo.CreateDefault();
+            Info = EntropyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="FluidResistance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class FluidResistanceInfo: QuantityInfo<FluidResistance, FluidResistanceUnit>
+        private static class FluidResistanceInfo
         {
-            /// <inheritdoc />
-            public FluidResistanceInfo(string name, FluidResistanceUnit baseUnit, IEnumerable<IUnitDefinition<FluidResistanceUnit>> unitMappings, FluidResistance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<FluidResistance, FluidResistanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, FluidResistance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public FluidResistanceInfo(string name, FluidResistanceUnit baseUnit, IEnumerable<IUnitDefinition<FluidResistanceUnit>> unitMappings, FluidResistance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, FluidResistance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.FluidResistance", typeof(FluidResistance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="FluidResistanceInfo"/> class with the default settings for the FluidResistance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="FluidResistanceInfo"/> class with the default settings.</returns>
-            public static FluidResistanceInfo CreateDefault()
-            {
-                return new FluidResistanceInfo(nameof(FluidResistance), DefaultBaseUnit, GetDefaultMappings(), new FluidResistance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="FluidResistanceInfo"/> class with the default settings for the FluidResistance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="FluidResistanceInfo"/> class with the default settings.
             /// </returns>
-            public static FluidResistanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<FluidResistanceUnit>>, IEnumerable<IUnitDefinition<FluidResistanceUnit>>> customizeUnits)
+            private static QuantityInfo<FluidResistance, FluidResistanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<FluidResistanceUnit>>, IEnumerable<IUnitDefinition<FluidResistanceUnit>>>? customizeUnits = null)
             {
-                return new FluidResistanceInfo(nameof(FluidResistance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new FluidResistance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<FluidResistanceUnit>> unitMappings = FluidResistanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<FluidResistance, FluidResistanceUnit>(
+                    name: nameof(FluidResistance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new FluidResistance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="FluidResistance"/> is [T^-1][L^-4][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-4, 1, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-4, 1, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of FluidResistance is PascalSecondPerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static FluidResistanceUnit DefaultBaseUnit { get; } = FluidResistanceUnit.PascalSecondPerCubicMeter;
+            private static FluidResistanceUnit DefaultBaseUnit { get; } = FluidResistanceUnit.PascalSecondPerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the FluidResistance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.FluidResistance", typeof(FluidResistance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="FluidResistanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{FluidResistanceUnit}"/> representing the default unit mappings for FluidResistance.</returns>
-            public static IEnumerable<UnitDefinition<FluidResistanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<FluidResistanceUnit>> GetDefaultMappings()
             {
                 yield return new (FluidResistanceUnit.DyneSecondPerCentimeterToTheFifth, "DyneSecondPerCentimeterToTheFifth", "DyneSecondsPerCentimeterToTheFifth", BaseUnits.Undefined);
                 yield return new (FluidResistanceUnit.MegapascalSecondPerCubicMeter, "MegapascalSecondPerCubicMeter", "MegapascalSecondsPerCubicMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Microsecond));
@@ -143,7 +143,7 @@ namespace UnitsNet
 
         static FluidResistance()
         {
-            Info = FluidResistanceInfo.CreateDefault();
+            Info = FluidResistanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -76,59 +76,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Force"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ForceInfo: QuantityInfo<Force, ForceUnit>
+        private static class ForceInfo
         {
-            /// <inheritdoc />
-            public ForceInfo(string name, ForceUnit baseUnit, IEnumerable<IUnitDefinition<ForceUnit>> unitMappings, Force zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Force, ForceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Force.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ForceInfo(string name, ForceUnit baseUnit, IEnumerable<IUnitDefinition<ForceUnit>> unitMappings, Force zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Force.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Force", typeof(Force).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ForceInfo"/> class with the default settings for the Force quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ForceInfo"/> class with the default settings.</returns>
-            public static ForceInfo CreateDefault()
-            {
-                return new ForceInfo(nameof(Force), DefaultBaseUnit, GetDefaultMappings(), new Force(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ForceInfo"/> class with the default settings for the Force quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ForceInfo"/> class with the default settings.
             /// </returns>
-            public static ForceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ForceUnit>>, IEnumerable<IUnitDefinition<ForceUnit>>> customizeUnits)
+            private static QuantityInfo<Force, ForceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ForceUnit>>, IEnumerable<IUnitDefinition<ForceUnit>>>? customizeUnits = null)
             {
-                return new ForceInfo(nameof(Force), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Force(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ForceUnit>> unitMappings = ForceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Force, ForceUnit>(
+                    name: nameof(Force),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Force(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Force"/> is [T^-2][L][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Force is Newton. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ForceUnit DefaultBaseUnit { get; } = ForceUnit.Newton;
+            private static ForceUnit DefaultBaseUnit { get; } = ForceUnit.Newton;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Force quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Force", typeof(Force).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ForceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ForceUnit}"/> representing the default unit mappings for Force.</returns>
-            public static IEnumerable<UnitDefinition<ForceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ForceUnit>> GetDefaultMappings()
             {
                 yield return new (ForceUnit.Decanewton, "Decanewton", "Decanewtons", new BaseUnits(length: LengthUnit.Decameter, mass: MassUnit.Kilogram, time: DurationUnit.Second));
                 yield return new (ForceUnit.Dyn, "Dyn", "Dyne", new BaseUnits(length: LengthUnit.Centimeter, mass: MassUnit.Gram, time: DurationUnit.Second));
@@ -150,7 +150,7 @@ namespace UnitsNet
 
         static Force()
         {
-            Info = ForceInfo.CreateDefault();
+            Info = ForceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ForceChangeRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ForceChangeRateInfo: QuantityInfo<ForceChangeRate, ForceChangeRateUnit>
+        private static class ForceChangeRateInfo
         {
-            /// <inheritdoc />
-            public ForceChangeRateInfo(string name, ForceChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<ForceChangeRateUnit>> unitMappings, ForceChangeRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ForceChangeRate, ForceChangeRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ForceChangeRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ForceChangeRateInfo(string name, ForceChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<ForceChangeRateUnit>> unitMappings, ForceChangeRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ForceChangeRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ForceChangeRate", typeof(ForceChangeRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ForceChangeRateInfo"/> class with the default settings for the ForceChangeRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ForceChangeRateInfo"/> class with the default settings.</returns>
-            public static ForceChangeRateInfo CreateDefault()
-            {
-                return new ForceChangeRateInfo(nameof(ForceChangeRate), DefaultBaseUnit, GetDefaultMappings(), new ForceChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ForceChangeRateInfo"/> class with the default settings for the ForceChangeRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ForceChangeRateInfo"/> class with the default settings.
             /// </returns>
-            public static ForceChangeRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<ForceChangeRateUnit>>, IEnumerable<IUnitDefinition<ForceChangeRateUnit>>> customizeUnits)
+            private static QuantityInfo<ForceChangeRate, ForceChangeRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ForceChangeRateUnit>>, IEnumerable<IUnitDefinition<ForceChangeRateUnit>>>? customizeUnits = null)
             {
-                return new ForceChangeRateInfo(nameof(ForceChangeRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ForceChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ForceChangeRateUnit>> unitMappings = ForceChangeRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ForceChangeRate, ForceChangeRateUnit>(
+                    name: nameof(ForceChangeRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ForceChangeRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ForceChangeRate"/> is [T^-3][L][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ForceChangeRate is NewtonPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ForceChangeRateUnit DefaultBaseUnit { get; } = ForceChangeRateUnit.NewtonPerSecond;
+            private static ForceChangeRateUnit DefaultBaseUnit { get; } = ForceChangeRateUnit.NewtonPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ForceChangeRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ForceChangeRate", typeof(ForceChangeRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ForceChangeRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ForceChangeRateUnit}"/> representing the default unit mappings for ForceChangeRate.</returns>
-            public static IEnumerable<UnitDefinition<ForceChangeRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ForceChangeRateUnit>> GetDefaultMappings()
             {
                 yield return new (ForceChangeRateUnit.CentinewtonPerSecond, "CentinewtonPerSecond", "CentinewtonsPerSecond", new BaseUnits(length: LengthUnit.Centimeter, mass: MassUnit.Kilogram, time: DurationUnit.Second));
                 yield return new (ForceChangeRateUnit.DecanewtonPerMinute, "DecanewtonPerMinute", "DecanewtonsPerMinute", BaseUnits.Undefined);
@@ -139,7 +139,7 @@ namespace UnitsNet
 
         static ForceChangeRate()
         {
-            Info = ForceChangeRateInfo.CreateDefault();
+            Info = ForceChangeRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -73,59 +73,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ForcePerLength"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ForcePerLengthInfo: QuantityInfo<ForcePerLength, ForcePerLengthUnit>
+        private static class ForcePerLengthInfo
         {
-            /// <inheritdoc />
-            public ForcePerLengthInfo(string name, ForcePerLengthUnit baseUnit, IEnumerable<IUnitDefinition<ForcePerLengthUnit>> unitMappings, ForcePerLength zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ForcePerLength, ForcePerLengthUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ForcePerLength.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ForcePerLengthInfo(string name, ForcePerLengthUnit baseUnit, IEnumerable<IUnitDefinition<ForcePerLengthUnit>> unitMappings, ForcePerLength zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ForcePerLength.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ForcePerLength", typeof(ForcePerLength).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ForcePerLengthInfo"/> class with the default settings for the ForcePerLength quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ForcePerLengthInfo"/> class with the default settings.</returns>
-            public static ForcePerLengthInfo CreateDefault()
-            {
-                return new ForcePerLengthInfo(nameof(ForcePerLength), DefaultBaseUnit, GetDefaultMappings(), new ForcePerLength(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ForcePerLengthInfo"/> class with the default settings for the ForcePerLength quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ForcePerLengthInfo"/> class with the default settings.
             /// </returns>
-            public static ForcePerLengthInfo CreateDefault(Func<IEnumerable<UnitDefinition<ForcePerLengthUnit>>, IEnumerable<IUnitDefinition<ForcePerLengthUnit>>> customizeUnits)
+            private static QuantityInfo<ForcePerLength, ForcePerLengthUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ForcePerLengthUnit>>, IEnumerable<IUnitDefinition<ForcePerLengthUnit>>>? customizeUnits = null)
             {
-                return new ForcePerLengthInfo(nameof(ForcePerLength), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ForcePerLength(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ForcePerLengthUnit>> unitMappings = ForcePerLengthInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ForcePerLength, ForcePerLengthUnit>(
+                    name: nameof(ForcePerLength),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ForcePerLength(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ForcePerLength"/> is [T^-2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ForcePerLength is NewtonPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ForcePerLengthUnit DefaultBaseUnit { get; } = ForcePerLengthUnit.NewtonPerMeter;
+            private static ForcePerLengthUnit DefaultBaseUnit { get; } = ForcePerLengthUnit.NewtonPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ForcePerLength quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ForcePerLength", typeof(ForcePerLength).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ForcePerLengthUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ForcePerLengthUnit}"/> representing the default unit mappings for ForcePerLength.</returns>
-            public static IEnumerable<UnitDefinition<ForcePerLengthUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ForcePerLengthUnit>> GetDefaultMappings()
             {
                 yield return new (ForcePerLengthUnit.CentinewtonPerCentimeter, "CentinewtonPerCentimeter", "CentinewtonsPerCentimeter", BaseUnits.Undefined);
                 yield return new (ForcePerLengthUnit.CentinewtonPerMeter, "CentinewtonPerMeter", "CentinewtonsPerMeter", new BaseUnits(mass: MassUnit.Decagram, time: DurationUnit.Second));
@@ -170,7 +170,7 @@ namespace UnitsNet
 
         static ForcePerLength()
         {
-            Info = ForcePerLengthInfo.CreateDefault();
+            Info = ForcePerLengthInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Frequency"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class FrequencyInfo: QuantityInfo<Frequency, FrequencyUnit>
+        private static class FrequencyInfo
         {
-            /// <inheritdoc />
-            public FrequencyInfo(string name, FrequencyUnit baseUnit, IEnumerable<IUnitDefinition<FrequencyUnit>> unitMappings, Frequency zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Frequency, FrequencyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Frequency.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public FrequencyInfo(string name, FrequencyUnit baseUnit, IEnumerable<IUnitDefinition<FrequencyUnit>> unitMappings, Frequency zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Frequency.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Frequency", typeof(Frequency).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="FrequencyInfo"/> class with the default settings for the Frequency quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="FrequencyInfo"/> class with the default settings.</returns>
-            public static FrequencyInfo CreateDefault()
-            {
-                return new FrequencyInfo(nameof(Frequency), DefaultBaseUnit, GetDefaultMappings(), new Frequency(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="FrequencyInfo"/> class with the default settings for the Frequency quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="FrequencyInfo"/> class with the default settings.
             /// </returns>
-            public static FrequencyInfo CreateDefault(Func<IEnumerable<UnitDefinition<FrequencyUnit>>, IEnumerable<IUnitDefinition<FrequencyUnit>>> customizeUnits)
+            private static QuantityInfo<Frequency, FrequencyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<FrequencyUnit>>, IEnumerable<IUnitDefinition<FrequencyUnit>>>? customizeUnits = null)
             {
-                return new FrequencyInfo(nameof(Frequency), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Frequency(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<FrequencyUnit>> unitMappings = FrequencyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Frequency, FrequencyUnit>(
+                    name: nameof(Frequency),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Frequency(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Frequency"/> is [T^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Frequency is Hertz. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static FrequencyUnit DefaultBaseUnit { get; } = FrequencyUnit.Hertz;
+            private static FrequencyUnit DefaultBaseUnit { get; } = FrequencyUnit.Hertz;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Frequency quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Frequency", typeof(Frequency).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="FrequencyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{FrequencyUnit}"/> representing the default unit mappings for Frequency.</returns>
-            public static IEnumerable<UnitDefinition<FrequencyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<FrequencyUnit>> GetDefaultMappings()
             {
                 yield return new (FrequencyUnit.BeatPerMinute, "BeatPerMinute", "BeatsPerMinute", new BaseUnits(time: DurationUnit.Minute));
                 yield return new (FrequencyUnit.CyclePerHour, "CyclePerHour", "CyclesPerHour", new BaseUnits(time: DurationUnit.Hour));
@@ -136,7 +136,7 @@ namespace UnitsNet
 
         static Frequency()
         {
-            Info = FrequencyInfo.CreateDefault();
+            Info = FrequencyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="FuelEfficiency"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class FuelEfficiencyInfo: QuantityInfo<FuelEfficiency, FuelEfficiencyUnit>
+        private static class FuelEfficiencyInfo
         {
-            /// <inheritdoc />
-            public FuelEfficiencyInfo(string name, FuelEfficiencyUnit baseUnit, IEnumerable<IUnitDefinition<FuelEfficiencyUnit>> unitMappings, FuelEfficiency zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<FuelEfficiency, FuelEfficiencyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, FuelEfficiency.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public FuelEfficiencyInfo(string name, FuelEfficiencyUnit baseUnit, IEnumerable<IUnitDefinition<FuelEfficiencyUnit>> unitMappings, FuelEfficiency zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, FuelEfficiency.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.FuelEfficiency", typeof(FuelEfficiency).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="FuelEfficiencyInfo"/> class with the default settings for the FuelEfficiency quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="FuelEfficiencyInfo"/> class with the default settings.</returns>
-            public static FuelEfficiencyInfo CreateDefault()
-            {
-                return new FuelEfficiencyInfo(nameof(FuelEfficiency), DefaultBaseUnit, GetDefaultMappings(), new FuelEfficiency(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="FuelEfficiencyInfo"/> class with the default settings for the FuelEfficiency quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="FuelEfficiencyInfo"/> class with the default settings.
             /// </returns>
-            public static FuelEfficiencyInfo CreateDefault(Func<IEnumerable<UnitDefinition<FuelEfficiencyUnit>>, IEnumerable<IUnitDefinition<FuelEfficiencyUnit>>> customizeUnits)
+            private static QuantityInfo<FuelEfficiency, FuelEfficiencyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<FuelEfficiencyUnit>>, IEnumerable<IUnitDefinition<FuelEfficiencyUnit>>>? customizeUnits = null)
             {
-                return new FuelEfficiencyInfo(nameof(FuelEfficiency), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new FuelEfficiency(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<FuelEfficiencyUnit>> unitMappings = FuelEfficiencyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<FuelEfficiency, FuelEfficiencyUnit>(
+                    name: nameof(FuelEfficiency),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new FuelEfficiency(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="FuelEfficiency"/> is [L^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of FuelEfficiency is KilometerPerLiter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static FuelEfficiencyUnit DefaultBaseUnit { get; } = FuelEfficiencyUnit.KilometerPerLiter;
+            private static FuelEfficiencyUnit DefaultBaseUnit { get; } = FuelEfficiencyUnit.KilometerPerLiter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the FuelEfficiency quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.FuelEfficiency", typeof(FuelEfficiency).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="FuelEfficiencyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{FuelEfficiencyUnit}"/> representing the default unit mappings for FuelEfficiency.</returns>
-            public static IEnumerable<UnitDefinition<FuelEfficiencyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<FuelEfficiencyUnit>> GetDefaultMappings()
             {
                 yield return new (FuelEfficiencyUnit.KilometerPerLiter, "KilometerPerLiter", "KilometersPerLiter", BaseUnits.Undefined);
                 yield return new (FuelEfficiencyUnit.LiterPer100Kilometers, "LiterPer100Kilometers", "LitersPer100Kilometers", BaseUnits.Undefined);
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static FuelEfficiency()
         {
-            Info = FuelEfficiencyInfo.CreateDefault();
+            Info = FuelEfficiencyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="HeatFlux"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class HeatFluxInfo: QuantityInfo<HeatFlux, HeatFluxUnit>
+        private static class HeatFluxInfo
         {
-            /// <inheritdoc />
-            public HeatFluxInfo(string name, HeatFluxUnit baseUnit, IEnumerable<IUnitDefinition<HeatFluxUnit>> unitMappings, HeatFlux zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<HeatFlux, HeatFluxUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, HeatFlux.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public HeatFluxInfo(string name, HeatFluxUnit baseUnit, IEnumerable<IUnitDefinition<HeatFluxUnit>> unitMappings, HeatFlux zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, HeatFlux.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.HeatFlux", typeof(HeatFlux).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="HeatFluxInfo"/> class with the default settings for the HeatFlux quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="HeatFluxInfo"/> class with the default settings.</returns>
-            public static HeatFluxInfo CreateDefault()
-            {
-                return new HeatFluxInfo(nameof(HeatFlux), DefaultBaseUnit, GetDefaultMappings(), new HeatFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="HeatFluxInfo"/> class with the default settings for the HeatFlux quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="HeatFluxInfo"/> class with the default settings.
             /// </returns>
-            public static HeatFluxInfo CreateDefault(Func<IEnumerable<UnitDefinition<HeatFluxUnit>>, IEnumerable<IUnitDefinition<HeatFluxUnit>>> customizeUnits)
+            private static QuantityInfo<HeatFlux, HeatFluxUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<HeatFluxUnit>>, IEnumerable<IUnitDefinition<HeatFluxUnit>>>? customizeUnits = null)
             {
-                return new HeatFluxInfo(nameof(HeatFlux), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new HeatFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<HeatFluxUnit>> unitMappings = HeatFluxInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<HeatFlux, HeatFluxUnit>(
+                    name: nameof(HeatFlux),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new HeatFlux(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="HeatFlux"/> is [T^-3][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of HeatFlux is WattPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static HeatFluxUnit DefaultBaseUnit { get; } = HeatFluxUnit.WattPerSquareMeter;
+            private static HeatFluxUnit DefaultBaseUnit { get; } = HeatFluxUnit.WattPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the HeatFlux quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.HeatFlux", typeof(HeatFlux).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="HeatFluxUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{HeatFluxUnit}"/> representing the default unit mappings for HeatFlux.</returns>
-            public static IEnumerable<UnitDefinition<HeatFluxUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<HeatFluxUnit>> GetDefaultMappings()
             {
                 yield return new (HeatFluxUnit.BtuPerHourSquareFoot, "BtuPerHourSquareFoot", "BtusPerHourSquareFoot", BaseUnits.Undefined);
                 yield return new (HeatFluxUnit.BtuPerMinuteSquareFoot, "BtuPerMinuteSquareFoot", "BtusPerMinuteSquareFoot", BaseUnits.Undefined);
@@ -142,7 +142,7 @@ namespace UnitsNet
 
         static HeatFlux()
         {
-            Info = HeatFluxInfo.CreateDefault();
+            Info = HeatFluxInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="HeatTransferCoefficient"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class HeatTransferCoefficientInfo: QuantityInfo<HeatTransferCoefficient, HeatTransferCoefficientUnit>
+        private static class HeatTransferCoefficientInfo
         {
-            /// <inheritdoc />
-            public HeatTransferCoefficientInfo(string name, HeatTransferCoefficientUnit baseUnit, IEnumerable<IUnitDefinition<HeatTransferCoefficientUnit>> unitMappings, HeatTransferCoefficient zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<HeatTransferCoefficient, HeatTransferCoefficientUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, HeatTransferCoefficient.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public HeatTransferCoefficientInfo(string name, HeatTransferCoefficientUnit baseUnit, IEnumerable<IUnitDefinition<HeatTransferCoefficientUnit>> unitMappings, HeatTransferCoefficient zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, HeatTransferCoefficient.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.HeatTransferCoefficient", typeof(HeatTransferCoefficient).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="HeatTransferCoefficientInfo"/> class with the default settings for the HeatTransferCoefficient quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="HeatTransferCoefficientInfo"/> class with the default settings.</returns>
-            public static HeatTransferCoefficientInfo CreateDefault()
-            {
-                return new HeatTransferCoefficientInfo(nameof(HeatTransferCoefficient), DefaultBaseUnit, GetDefaultMappings(), new HeatTransferCoefficient(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="HeatTransferCoefficientInfo"/> class with the default settings for the HeatTransferCoefficient quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="HeatTransferCoefficientInfo"/> class with the default settings.
             /// </returns>
-            public static HeatTransferCoefficientInfo CreateDefault(Func<IEnumerable<UnitDefinition<HeatTransferCoefficientUnit>>, IEnumerable<IUnitDefinition<HeatTransferCoefficientUnit>>> customizeUnits)
+            private static QuantityInfo<HeatTransferCoefficient, HeatTransferCoefficientUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<HeatTransferCoefficientUnit>>, IEnumerable<IUnitDefinition<HeatTransferCoefficientUnit>>>? customizeUnits = null)
             {
-                return new HeatTransferCoefficientInfo(nameof(HeatTransferCoefficient), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new HeatTransferCoefficient(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<HeatTransferCoefficientUnit>> unitMappings = HeatTransferCoefficientInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<HeatTransferCoefficient, HeatTransferCoefficientUnit>(
+                    name: nameof(HeatTransferCoefficient),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new HeatTransferCoefficient(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="HeatTransferCoefficient"/> is [T^-3][M][Θ^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -3, 0, -1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -3, 0, -1, 0, 0);
 
             /// <summary>
             ///     The default base unit of HeatTransferCoefficient is WattPerSquareMeterKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static HeatTransferCoefficientUnit DefaultBaseUnit { get; } = HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
+            private static HeatTransferCoefficientUnit DefaultBaseUnit { get; } = HeatTransferCoefficientUnit.WattPerSquareMeterKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the HeatTransferCoefficient quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.HeatTransferCoefficient", typeof(HeatTransferCoefficient).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="HeatTransferCoefficientUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{HeatTransferCoefficientUnit}"/> representing the default unit mappings for HeatTransferCoefficient.</returns>
-            public static IEnumerable<UnitDefinition<HeatTransferCoefficientUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<HeatTransferCoefficientUnit>> GetDefaultMappings()
             {
                 yield return new (HeatTransferCoefficientUnit.BtuPerHourSquareFootDegreeFahrenheit, "BtuPerHourSquareFootDegreeFahrenheit", "BtusPerHourSquareFootDegreeFahrenheit", BaseUnits.Undefined);
                 yield return new (HeatTransferCoefficientUnit.CaloriePerHourSquareMeterDegreeCelsius, "CaloriePerHourSquareMeterDegreeCelsius", "CaloriesPerHourSquareMeterDegreeCelsius", BaseUnits.Undefined);
@@ -126,7 +126,7 @@ namespace UnitsNet
 
         static HeatTransferCoefficient()
         {
-            Info = HeatTransferCoefficientInfo.CreateDefault();
+            Info = HeatTransferCoefficientInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -68,59 +68,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Illuminance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class IlluminanceInfo: QuantityInfo<Illuminance, IlluminanceUnit>
+        private static class IlluminanceInfo
         {
-            /// <inheritdoc />
-            public IlluminanceInfo(string name, IlluminanceUnit baseUnit, IEnumerable<IUnitDefinition<IlluminanceUnit>> unitMappings, Illuminance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Illuminance, IlluminanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Illuminance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public IlluminanceInfo(string name, IlluminanceUnit baseUnit, IEnumerable<IUnitDefinition<IlluminanceUnit>> unitMappings, Illuminance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Illuminance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Illuminance", typeof(Illuminance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="IlluminanceInfo"/> class with the default settings for the Illuminance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="IlluminanceInfo"/> class with the default settings.</returns>
-            public static IlluminanceInfo CreateDefault()
-            {
-                return new IlluminanceInfo(nameof(Illuminance), DefaultBaseUnit, GetDefaultMappings(), new Illuminance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="IlluminanceInfo"/> class with the default settings for the Illuminance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="IlluminanceInfo"/> class with the default settings.
             /// </returns>
-            public static IlluminanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<IlluminanceUnit>>, IEnumerable<IUnitDefinition<IlluminanceUnit>>> customizeUnits)
+            private static QuantityInfo<Illuminance, IlluminanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<IlluminanceUnit>>, IEnumerable<IUnitDefinition<IlluminanceUnit>>>? customizeUnits = null)
             {
-                return new IlluminanceInfo(nameof(Illuminance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Illuminance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<IlluminanceUnit>> unitMappings = IlluminanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Illuminance, IlluminanceUnit>(
+                    name: nameof(Illuminance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Illuminance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Illuminance"/> is [L^-2][J].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
 
             /// <summary>
             ///     The default base unit of Illuminance is Lux. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static IlluminanceUnit DefaultBaseUnit { get; } = IlluminanceUnit.Lux;
+            private static IlluminanceUnit DefaultBaseUnit { get; } = IlluminanceUnit.Lux;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Illuminance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Illuminance", typeof(Illuminance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="IlluminanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{IlluminanceUnit}"/> representing the default unit mappings for Illuminance.</returns>
-            public static IEnumerable<UnitDefinition<IlluminanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<IlluminanceUnit>> GetDefaultMappings()
             {
                 yield return new (IlluminanceUnit.Kilolux, "Kilolux", "Kilolux", BaseUnits.Undefined);
                 yield return new (IlluminanceUnit.Lux, "Lux", "Lux", new BaseUnits(length: LengthUnit.Meter, luminousIntensity: LuminousIntensityUnit.Candela));
@@ -131,7 +131,7 @@ namespace UnitsNet
 
         static Illuminance()
         {
-            Info = IlluminanceInfo.CreateDefault();
+            Info = IlluminanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Impulse"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ImpulseInfo: QuantityInfo<Impulse, ImpulseUnit>
+        private static class ImpulseInfo
         {
-            /// <inheritdoc />
-            public ImpulseInfo(string name, ImpulseUnit baseUnit, IEnumerable<IUnitDefinition<ImpulseUnit>> unitMappings, Impulse zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Impulse, ImpulseUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Impulse.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ImpulseInfo(string name, ImpulseUnit baseUnit, IEnumerable<IUnitDefinition<ImpulseUnit>> unitMappings, Impulse zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Impulse.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Impulse", typeof(Impulse).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ImpulseInfo"/> class with the default settings for the Impulse quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ImpulseInfo"/> class with the default settings.</returns>
-            public static ImpulseInfo CreateDefault()
-            {
-                return new ImpulseInfo(nameof(Impulse), DefaultBaseUnit, GetDefaultMappings(), new Impulse(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ImpulseInfo"/> class with the default settings for the Impulse quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ImpulseInfo"/> class with the default settings.
             /// </returns>
-            public static ImpulseInfo CreateDefault(Func<IEnumerable<UnitDefinition<ImpulseUnit>>, IEnumerable<IUnitDefinition<ImpulseUnit>>> customizeUnits)
+            private static QuantityInfo<Impulse, ImpulseUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ImpulseUnit>>, IEnumerable<IUnitDefinition<ImpulseUnit>>>? customizeUnits = null)
             {
-                return new ImpulseInfo(nameof(Impulse), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Impulse(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ImpulseUnit>> unitMappings = ImpulseInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Impulse, ImpulseUnit>(
+                    name: nameof(Impulse),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Impulse(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Impulse"/> is [T^-1][L][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Impulse is NewtonSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ImpulseUnit DefaultBaseUnit { get; } = ImpulseUnit.NewtonSecond;
+            private static ImpulseUnit DefaultBaseUnit { get; } = ImpulseUnit.NewtonSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Impulse quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Impulse", typeof(Impulse).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ImpulseUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ImpulseUnit}"/> representing the default unit mappings for Impulse.</returns>
-            public static IEnumerable<UnitDefinition<ImpulseUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ImpulseUnit>> GetDefaultMappings()
             {
                 yield return new (ImpulseUnit.CentinewtonSecond, "CentinewtonSecond", "CentinewtonSeconds", new BaseUnits(length: LengthUnit.Centimeter, mass: MassUnit.Kilogram, time: DurationUnit.Second));
                 yield return new (ImpulseUnit.DecanewtonSecond, "DecanewtonSecond", "DecanewtonSeconds", new BaseUnits(length: LengthUnit.Decameter, mass: MassUnit.Kilogram, time: DurationUnit.Second));
@@ -134,7 +134,7 @@ namespace UnitsNet
 
         static Impulse()
         {
-            Info = ImpulseInfo.CreateDefault();
+            Info = ImpulseInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Information"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class InformationInfo: QuantityInfo<Information, InformationUnit>
+        private static class InformationInfo
         {
-            /// <inheritdoc />
-            public InformationInfo(string name, InformationUnit baseUnit, IEnumerable<IUnitDefinition<InformationUnit>> unitMappings, Information zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Information, InformationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Information.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public InformationInfo(string name, InformationUnit baseUnit, IEnumerable<IUnitDefinition<InformationUnit>> unitMappings, Information zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Information.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Information", typeof(Information).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="InformationInfo"/> class with the default settings for the Information quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="InformationInfo"/> class with the default settings.</returns>
-            public static InformationInfo CreateDefault()
-            {
-                return new InformationInfo(nameof(Information), DefaultBaseUnit, GetDefaultMappings(), new Information(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="InformationInfo"/> class with the default settings for the Information quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="InformationInfo"/> class with the default settings.
             /// </returns>
-            public static InformationInfo CreateDefault(Func<IEnumerable<UnitDefinition<InformationUnit>>, IEnumerable<IUnitDefinition<InformationUnit>>> customizeUnits)
+            private static QuantityInfo<Information, InformationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<InformationUnit>>, IEnumerable<IUnitDefinition<InformationUnit>>>? customizeUnits = null)
             {
-                return new InformationInfo(nameof(Information), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Information(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<InformationUnit>> unitMappings = InformationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Information, InformationUnit>(
+                    name: nameof(Information),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Information(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Information"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of Information is Bit. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static InformationUnit DefaultBaseUnit { get; } = InformationUnit.Bit;
+            private static InformationUnit DefaultBaseUnit { get; } = InformationUnit.Bit;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Information quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Information", typeof(Information).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="InformationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{InformationUnit}"/> representing the default unit mappings for Information.</returns>
-            public static IEnumerable<UnitDefinition<InformationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<InformationUnit>> GetDefaultMappings()
             {
                 yield return new (InformationUnit.Bit, "Bit", "Bits", BaseUnits.Undefined);
                 yield return new (InformationUnit.Byte, "Byte", "Bytes", BaseUnits.Undefined);
@@ -160,7 +160,7 @@ namespace UnitsNet
 
         static Information()
         {
-            Info = InformationInfo.CreateDefault();
+            Info = InformationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Irradiance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class IrradianceInfo: QuantityInfo<Irradiance, IrradianceUnit>
+        private static class IrradianceInfo
         {
-            /// <inheritdoc />
-            public IrradianceInfo(string name, IrradianceUnit baseUnit, IEnumerable<IUnitDefinition<IrradianceUnit>> unitMappings, Irradiance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Irradiance, IrradianceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Irradiance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public IrradianceInfo(string name, IrradianceUnit baseUnit, IEnumerable<IUnitDefinition<IrradianceUnit>> unitMappings, Irradiance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Irradiance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Irradiance", typeof(Irradiance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="IrradianceInfo"/> class with the default settings for the Irradiance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="IrradianceInfo"/> class with the default settings.</returns>
-            public static IrradianceInfo CreateDefault()
-            {
-                return new IrradianceInfo(nameof(Irradiance), DefaultBaseUnit, GetDefaultMappings(), new Irradiance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="IrradianceInfo"/> class with the default settings for the Irradiance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="IrradianceInfo"/> class with the default settings.
             /// </returns>
-            public static IrradianceInfo CreateDefault(Func<IEnumerable<UnitDefinition<IrradianceUnit>>, IEnumerable<IUnitDefinition<IrradianceUnit>>> customizeUnits)
+            private static QuantityInfo<Irradiance, IrradianceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<IrradianceUnit>>, IEnumerable<IUnitDefinition<IrradianceUnit>>>? customizeUnits = null)
             {
-                return new IrradianceInfo(nameof(Irradiance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Irradiance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<IrradianceUnit>> unitMappings = IrradianceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Irradiance, IrradianceUnit>(
+                    name: nameof(Irradiance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Irradiance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Irradiance"/> is [T^-3][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Irradiance is WattPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static IrradianceUnit DefaultBaseUnit { get; } = IrradianceUnit.WattPerSquareMeter;
+            private static IrradianceUnit DefaultBaseUnit { get; } = IrradianceUnit.WattPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Irradiance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Irradiance", typeof(Irradiance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="IrradianceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{IrradianceUnit}"/> representing the default unit mappings for Irradiance.</returns>
-            public static IEnumerable<UnitDefinition<IrradianceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<IrradianceUnit>> GetDefaultMappings()
             {
                 yield return new (IrradianceUnit.KilowattPerSquareCentimeter, "KilowattPerSquareCentimeter", "KilowattsPerSquareCentimeter", BaseUnits.Undefined);
                 yield return new (IrradianceUnit.KilowattPerSquareMeter, "KilowattPerSquareMeter", "KilowattsPerSquareMeter", BaseUnits.Undefined);
@@ -135,7 +135,7 @@ namespace UnitsNet
 
         static Irradiance()
         {
-            Info = IrradianceInfo.CreateDefault();
+            Info = IrradianceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Irradiation"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class IrradiationInfo: QuantityInfo<Irradiation, IrradiationUnit>
+        private static class IrradiationInfo
         {
-            /// <inheritdoc />
-            public IrradiationInfo(string name, IrradiationUnit baseUnit, IEnumerable<IUnitDefinition<IrradiationUnit>> unitMappings, Irradiation zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Irradiation, IrradiationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Irradiation.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public IrradiationInfo(string name, IrradiationUnit baseUnit, IEnumerable<IUnitDefinition<IrradiationUnit>> unitMappings, Irradiation zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Irradiation.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Irradiation", typeof(Irradiation).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="IrradiationInfo"/> class with the default settings for the Irradiation quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="IrradiationInfo"/> class with the default settings.</returns>
-            public static IrradiationInfo CreateDefault()
-            {
-                return new IrradiationInfo(nameof(Irradiation), DefaultBaseUnit, GetDefaultMappings(), new Irradiation(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="IrradiationInfo"/> class with the default settings for the Irradiation quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="IrradiationInfo"/> class with the default settings.
             /// </returns>
-            public static IrradiationInfo CreateDefault(Func<IEnumerable<UnitDefinition<IrradiationUnit>>, IEnumerable<IUnitDefinition<IrradiationUnit>>> customizeUnits)
+            private static QuantityInfo<Irradiation, IrradiationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<IrradiationUnit>>, IEnumerable<IUnitDefinition<IrradiationUnit>>>? customizeUnits = null)
             {
-                return new IrradiationInfo(nameof(Irradiation), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Irradiation(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<IrradiationUnit>> unitMappings = IrradiationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Irradiation, IrradiationUnit>(
+                    name: nameof(Irradiation),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Irradiation(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Irradiation"/> is [T^-2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Irradiation is JoulePerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static IrradiationUnit DefaultBaseUnit { get; } = IrradiationUnit.JoulePerSquareMeter;
+            private static IrradiationUnit DefaultBaseUnit { get; } = IrradiationUnit.JoulePerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Irradiation quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Irradiation", typeof(Irradiation).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="IrradiationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{IrradiationUnit}"/> representing the default unit mappings for Irradiation.</returns>
-            public static IEnumerable<UnitDefinition<IrradiationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<IrradiationUnit>> GetDefaultMappings()
             {
                 yield return new (IrradiationUnit.BtuPerSquareFoot, "BtuPerSquareFoot", "BtusPerSquareFoot", BaseUnits.Undefined);
                 yield return new (IrradiationUnit.JoulePerSquareCentimeter, "JoulePerSquareCentimeter", "JoulesPerSquareCentimeter", BaseUnits.Undefined);
@@ -133,7 +133,7 @@ namespace UnitsNet
 
         static Irradiation()
         {
-            Info = IrradiationInfo.CreateDefault();
+            Info = IrradiationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Jerk"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class JerkInfo: QuantityInfo<Jerk, JerkUnit>
+        private static class JerkInfo
         {
-            /// <inheritdoc />
-            public JerkInfo(string name, JerkUnit baseUnit, IEnumerable<IUnitDefinition<JerkUnit>> unitMappings, Jerk zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Jerk, JerkUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Jerk.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public JerkInfo(string name, JerkUnit baseUnit, IEnumerable<IUnitDefinition<JerkUnit>> unitMappings, Jerk zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Jerk.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Jerk", typeof(Jerk).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="JerkInfo"/> class with the default settings for the Jerk quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="JerkInfo"/> class with the default settings.</returns>
-            public static JerkInfo CreateDefault()
-            {
-                return new JerkInfo(nameof(Jerk), DefaultBaseUnit, GetDefaultMappings(), new Jerk(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="JerkInfo"/> class with the default settings for the Jerk quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="JerkInfo"/> class with the default settings.
             /// </returns>
-            public static JerkInfo CreateDefault(Func<IEnumerable<UnitDefinition<JerkUnit>>, IEnumerable<IUnitDefinition<JerkUnit>>> customizeUnits)
+            private static QuantityInfo<Jerk, JerkUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<JerkUnit>>, IEnumerable<IUnitDefinition<JerkUnit>>>? customizeUnits = null)
             {
-                return new JerkInfo(nameof(Jerk), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Jerk(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<JerkUnit>> unitMappings = JerkInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Jerk, JerkUnit>(
+                    name: nameof(Jerk),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Jerk(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Jerk"/> is [T^-3][L].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Jerk is MeterPerSecondCubed. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static JerkUnit DefaultBaseUnit { get; } = JerkUnit.MeterPerSecondCubed;
+            private static JerkUnit DefaultBaseUnit { get; } = JerkUnit.MeterPerSecondCubed;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Jerk quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Jerk", typeof(Jerk).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="JerkUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{JerkUnit}"/> representing the default unit mappings for Jerk.</returns>
-            public static IEnumerable<UnitDefinition<JerkUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<JerkUnit>> GetDefaultMappings()
             {
                 yield return new (JerkUnit.CentimeterPerSecondCubed, "CentimeterPerSecondCubed", "CentimetersPerSecondCubed", new BaseUnits(length: LengthUnit.Centimeter, time: DurationUnit.Second));
                 yield return new (JerkUnit.DecimeterPerSecondCubed, "DecimeterPerSecondCubed", "DecimetersPerSecondCubed", new BaseUnits(length: LengthUnit.Decimeter, time: DurationUnit.Second));
@@ -135,7 +135,7 @@ namespace UnitsNet
 
         static Jerk()
         {
-            Info = JerkInfo.CreateDefault();
+            Info = JerkInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -71,59 +71,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="KinematicViscosity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class KinematicViscosityInfo: QuantityInfo<KinematicViscosity, KinematicViscosityUnit>
+        private static class KinematicViscosityInfo
         {
-            /// <inheritdoc />
-            public KinematicViscosityInfo(string name, KinematicViscosityUnit baseUnit, IEnumerable<IUnitDefinition<KinematicViscosityUnit>> unitMappings, KinematicViscosity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<KinematicViscosity, KinematicViscosityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, KinematicViscosity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public KinematicViscosityInfo(string name, KinematicViscosityUnit baseUnit, IEnumerable<IUnitDefinition<KinematicViscosityUnit>> unitMappings, KinematicViscosity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, KinematicViscosity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.KinematicViscosity", typeof(KinematicViscosity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="KinematicViscosityInfo"/> class with the default settings for the KinematicViscosity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="KinematicViscosityInfo"/> class with the default settings.</returns>
-            public static KinematicViscosityInfo CreateDefault()
-            {
-                return new KinematicViscosityInfo(nameof(KinematicViscosity), DefaultBaseUnit, GetDefaultMappings(), new KinematicViscosity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="KinematicViscosityInfo"/> class with the default settings for the KinematicViscosity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="KinematicViscosityInfo"/> class with the default settings.
             /// </returns>
-            public static KinematicViscosityInfo CreateDefault(Func<IEnumerable<UnitDefinition<KinematicViscosityUnit>>, IEnumerable<IUnitDefinition<KinematicViscosityUnit>>> customizeUnits)
+            private static QuantityInfo<KinematicViscosity, KinematicViscosityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<KinematicViscosityUnit>>, IEnumerable<IUnitDefinition<KinematicViscosityUnit>>>? customizeUnits = null)
             {
-                return new KinematicViscosityInfo(nameof(KinematicViscosity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new KinematicViscosity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<KinematicViscosityUnit>> unitMappings = KinematicViscosityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<KinematicViscosity, KinematicViscosityUnit>(
+                    name: nameof(KinematicViscosity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new KinematicViscosity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="KinematicViscosity"/> is [T^-1][L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of KinematicViscosity is SquareMeterPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static KinematicViscosityUnit DefaultBaseUnit { get; } = KinematicViscosityUnit.SquareMeterPerSecond;
+            private static KinematicViscosityUnit DefaultBaseUnit { get; } = KinematicViscosityUnit.SquareMeterPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the KinematicViscosity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.KinematicViscosity", typeof(KinematicViscosity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="KinematicViscosityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{KinematicViscosityUnit}"/> representing the default unit mappings for KinematicViscosity.</returns>
-            public static IEnumerable<UnitDefinition<KinematicViscosityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<KinematicViscosityUnit>> GetDefaultMappings()
             {
                 yield return new (KinematicViscosityUnit.Centistokes, "Centistokes", "Centistokes", BaseUnits.Undefined);
                 yield return new (KinematicViscosityUnit.Decistokes, "Decistokes", "Decistokes", BaseUnits.Undefined);
@@ -139,7 +139,7 @@ namespace UnitsNet
 
         static KinematicViscosity()
         {
-            Info = KinematicViscosityInfo.CreateDefault();
+            Info = KinematicViscosityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="LeakRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LeakRateInfo: QuantityInfo<LeakRate, LeakRateUnit>
+        private static class LeakRateInfo
         {
-            /// <inheritdoc />
-            public LeakRateInfo(string name, LeakRateUnit baseUnit, IEnumerable<IUnitDefinition<LeakRateUnit>> unitMappings, LeakRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<LeakRate, LeakRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, LeakRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LeakRateInfo(string name, LeakRateUnit baseUnit, IEnumerable<IUnitDefinition<LeakRateUnit>> unitMappings, LeakRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, LeakRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.LeakRate", typeof(LeakRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LeakRateInfo"/> class with the default settings for the LeakRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LeakRateInfo"/> class with the default settings.</returns>
-            public static LeakRateInfo CreateDefault()
-            {
-                return new LeakRateInfo(nameof(LeakRate), DefaultBaseUnit, GetDefaultMappings(), new LeakRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LeakRateInfo"/> class with the default settings for the LeakRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LeakRateInfo"/> class with the default settings.
             /// </returns>
-            public static LeakRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<LeakRateUnit>>, IEnumerable<IUnitDefinition<LeakRateUnit>>> customizeUnits)
+            private static QuantityInfo<LeakRate, LeakRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LeakRateUnit>>, IEnumerable<IUnitDefinition<LeakRateUnit>>>? customizeUnits = null)
             {
-                return new LeakRateInfo(nameof(LeakRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new LeakRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LeakRateUnit>> unitMappings = LeakRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<LeakRate, LeakRateUnit>(
+                    name: nameof(LeakRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new LeakRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="LeakRate"/> is [T^-3][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of LeakRate is PascalCubicMeterPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LeakRateUnit DefaultBaseUnit { get; } = LeakRateUnit.PascalCubicMeterPerSecond;
+            private static LeakRateUnit DefaultBaseUnit { get; } = LeakRateUnit.PascalCubicMeterPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the LeakRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.LeakRate", typeof(LeakRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LeakRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LeakRateUnit}"/> representing the default unit mappings for LeakRate.</returns>
-            public static IEnumerable<UnitDefinition<LeakRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LeakRateUnit>> GetDefaultMappings()
             {
                 yield return new (LeakRateUnit.MillibarLiterPerSecond, "MillibarLiterPerSecond", "MillibarLitersPerSecond", BaseUnits.Undefined);
                 yield return new (LeakRateUnit.PascalCubicMeterPerSecond, "PascalCubicMeterPerSecond", "PascalCubicMetersPerSecond", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static LeakRate()
         {
-            Info = LeakRateInfo.CreateDefault();
+            Info = LeakRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -82,59 +82,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Length"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LengthInfo: QuantityInfo<Length, LengthUnit>
+        private static class LengthInfo
         {
-            /// <inheritdoc />
-            public LengthInfo(string name, LengthUnit baseUnit, IEnumerable<IUnitDefinition<LengthUnit>> unitMappings, Length zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Length, LengthUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Length.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LengthInfo(string name, LengthUnit baseUnit, IEnumerable<IUnitDefinition<LengthUnit>> unitMappings, Length zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Length.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Length", typeof(Length).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LengthInfo"/> class with the default settings for the Length quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LengthInfo"/> class with the default settings.</returns>
-            public static LengthInfo CreateDefault()
-            {
-                return new LengthInfo(nameof(Length), DefaultBaseUnit, GetDefaultMappings(), new Length(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LengthInfo"/> class with the default settings for the Length quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LengthInfo"/> class with the default settings.
             /// </returns>
-            public static LengthInfo CreateDefault(Func<IEnumerable<UnitDefinition<LengthUnit>>, IEnumerable<IUnitDefinition<LengthUnit>>> customizeUnits)
+            private static QuantityInfo<Length, LengthUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LengthUnit>>, IEnumerable<IUnitDefinition<LengthUnit>>>? customizeUnits = null)
             {
-                return new LengthInfo(nameof(Length), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Length(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LengthUnit>> unitMappings = LengthInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Length, LengthUnit>(
+                    name: nameof(Length),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Length(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Length"/> is [L].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Length is Meter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LengthUnit DefaultBaseUnit { get; } = LengthUnit.Meter;
+            private static LengthUnit DefaultBaseUnit { get; } = LengthUnit.Meter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Length quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Length", typeof(Length).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LengthUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LengthUnit}"/> representing the default unit mappings for Length.</returns>
-            public static IEnumerable<UnitDefinition<LengthUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LengthUnit>> GetDefaultMappings()
             {
                 yield return new (LengthUnit.Angstrom, "Angstrom", "Angstroms", new BaseUnits(length: LengthUnit.Angstrom));
                 yield return new (LengthUnit.AstronomicalUnit, "AstronomicalUnit", "AstronomicalUnits", new BaseUnits(length: LengthUnit.AstronomicalUnit));
@@ -183,7 +183,7 @@ namespace UnitsNet
 
         static Length()
         {
-            Info = LengthInfo.CreateDefault();
+            Info = LengthInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Level"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LevelInfo: QuantityInfo<Level, LevelUnit>
+        private static class LevelInfo
         {
-            /// <inheritdoc />
-            public LevelInfo(string name, LevelUnit baseUnit, IEnumerable<IUnitDefinition<LevelUnit>> unitMappings, Level zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Level, LevelUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Level.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LevelInfo(string name, LevelUnit baseUnit, IEnumerable<IUnitDefinition<LevelUnit>> unitMappings, Level zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Level.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Level", typeof(Level).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LevelInfo"/> class with the default settings for the Level quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LevelInfo"/> class with the default settings.</returns>
-            public static LevelInfo CreateDefault()
-            {
-                return new LevelInfo(nameof(Level), DefaultBaseUnit, GetDefaultMappings(), new Level(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LevelInfo"/> class with the default settings for the Level quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LevelInfo"/> class with the default settings.
             /// </returns>
-            public static LevelInfo CreateDefault(Func<IEnumerable<UnitDefinition<LevelUnit>>, IEnumerable<IUnitDefinition<LevelUnit>>> customizeUnits)
+            private static QuantityInfo<Level, LevelUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LevelUnit>>, IEnumerable<IUnitDefinition<LevelUnit>>>? customizeUnits = null)
             {
-                return new LevelInfo(nameof(Level), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Level(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LevelUnit>> unitMappings = LevelInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Level, LevelUnit>(
+                    name: nameof(Level),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Level(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Level"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of Level is Decibel. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LevelUnit DefaultBaseUnit { get; } = LevelUnit.Decibel;
+            private static LevelUnit DefaultBaseUnit { get; } = LevelUnit.Decibel;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Level quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Level", typeof(Level).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LevelUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LevelUnit}"/> representing the default unit mappings for Level.</returns>
-            public static IEnumerable<UnitDefinition<LevelUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LevelUnit>> GetDefaultMappings()
             {
                 yield return new (LevelUnit.Decibel, "Decibel", "Decibels", BaseUnits.Undefined);
                 yield return new (LevelUnit.Neper, "Neper", "Nepers", BaseUnits.Undefined);
@@ -123,7 +123,7 @@ namespace UnitsNet
 
         static Level()
         {
-            Info = LevelInfo.CreateDefault();
+            Info = LevelInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -70,59 +70,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="LinearDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LinearDensityInfo: QuantityInfo<LinearDensity, LinearDensityUnit>
+        private static class LinearDensityInfo
         {
-            /// <inheritdoc />
-            public LinearDensityInfo(string name, LinearDensityUnit baseUnit, IEnumerable<IUnitDefinition<LinearDensityUnit>> unitMappings, LinearDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<LinearDensity, LinearDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, LinearDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LinearDensityInfo(string name, LinearDensityUnit baseUnit, IEnumerable<IUnitDefinition<LinearDensityUnit>> unitMappings, LinearDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, LinearDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.LinearDensity", typeof(LinearDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LinearDensityInfo"/> class with the default settings for the LinearDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LinearDensityInfo"/> class with the default settings.</returns>
-            public static LinearDensityInfo CreateDefault()
-            {
-                return new LinearDensityInfo(nameof(LinearDensity), DefaultBaseUnit, GetDefaultMappings(), new LinearDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LinearDensityInfo"/> class with the default settings for the LinearDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LinearDensityInfo"/> class with the default settings.
             /// </returns>
-            public static LinearDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<LinearDensityUnit>>, IEnumerable<IUnitDefinition<LinearDensityUnit>>> customizeUnits)
+            private static QuantityInfo<LinearDensity, LinearDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LinearDensityUnit>>, IEnumerable<IUnitDefinition<LinearDensityUnit>>>? customizeUnits = null)
             {
-                return new LinearDensityInfo(nameof(LinearDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new LinearDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LinearDensityUnit>> unitMappings = LinearDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<LinearDensity, LinearDensityUnit>(
+                    name: nameof(LinearDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new LinearDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="LinearDensity"/> is [L^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of LinearDensity is KilogramPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LinearDensityUnit DefaultBaseUnit { get; } = LinearDensityUnit.KilogramPerMeter;
+            private static LinearDensityUnit DefaultBaseUnit { get; } = LinearDensityUnit.KilogramPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the LinearDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.LinearDensity", typeof(LinearDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LinearDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LinearDensityUnit}"/> representing the default unit mappings for LinearDensity.</returns>
-            public static IEnumerable<UnitDefinition<LinearDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LinearDensityUnit>> GetDefaultMappings()
             {
                 yield return new (LinearDensityUnit.GramPerCentimeter, "GramPerCentimeter", "GramsPerCentimeter", new BaseUnits(length: LengthUnit.Centimeter, mass: MassUnit.Gram));
                 yield return new (LinearDensityUnit.GramPerFoot, "GramPerFoot", "GramsPerFoot", new BaseUnits(length: LengthUnit.Foot, mass: MassUnit.Gram));
@@ -147,7 +147,7 @@ namespace UnitsNet
 
         static LinearDensity()
         {
-            Info = LinearDensityInfo.CreateDefault();
+            Info = LinearDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="LinearPowerDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LinearPowerDensityInfo: QuantityInfo<LinearPowerDensity, LinearPowerDensityUnit>
+        private static class LinearPowerDensityInfo
         {
-            /// <inheritdoc />
-            public LinearPowerDensityInfo(string name, LinearPowerDensityUnit baseUnit, IEnumerable<IUnitDefinition<LinearPowerDensityUnit>> unitMappings, LinearPowerDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<LinearPowerDensity, LinearPowerDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, LinearPowerDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LinearPowerDensityInfo(string name, LinearPowerDensityUnit baseUnit, IEnumerable<IUnitDefinition<LinearPowerDensityUnit>> unitMappings, LinearPowerDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, LinearPowerDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.LinearPowerDensity", typeof(LinearPowerDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LinearPowerDensityInfo"/> class with the default settings for the LinearPowerDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LinearPowerDensityInfo"/> class with the default settings.</returns>
-            public static LinearPowerDensityInfo CreateDefault()
-            {
-                return new LinearPowerDensityInfo(nameof(LinearPowerDensity), DefaultBaseUnit, GetDefaultMappings(), new LinearPowerDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LinearPowerDensityInfo"/> class with the default settings for the LinearPowerDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LinearPowerDensityInfo"/> class with the default settings.
             /// </returns>
-            public static LinearPowerDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<LinearPowerDensityUnit>>, IEnumerable<IUnitDefinition<LinearPowerDensityUnit>>> customizeUnits)
+            private static QuantityInfo<LinearPowerDensity, LinearPowerDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LinearPowerDensityUnit>>, IEnumerable<IUnitDefinition<LinearPowerDensityUnit>>>? customizeUnits = null)
             {
-                return new LinearPowerDensityInfo(nameof(LinearPowerDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new LinearPowerDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LinearPowerDensityUnit>> unitMappings = LinearPowerDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<LinearPowerDensity, LinearPowerDensityUnit>(
+                    name: nameof(LinearPowerDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new LinearPowerDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="LinearPowerDensity"/> is [T^-3][L][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of LinearPowerDensity is WattPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LinearPowerDensityUnit DefaultBaseUnit { get; } = LinearPowerDensityUnit.WattPerMeter;
+            private static LinearPowerDensityUnit DefaultBaseUnit { get; } = LinearPowerDensityUnit.WattPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the LinearPowerDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.LinearPowerDensity", typeof(LinearPowerDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LinearPowerDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LinearPowerDensityUnit}"/> representing the default unit mappings for LinearPowerDensity.</returns>
-            public static IEnumerable<UnitDefinition<LinearPowerDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LinearPowerDensityUnit>> GetDefaultMappings()
             {
                 yield return new (LinearPowerDensityUnit.GigawattPerCentimeter, "GigawattPerCentimeter", "GigawattsPerCentimeter", BaseUnits.Undefined);
                 yield return new (LinearPowerDensityUnit.GigawattPerFoot, "GigawattPerFoot", "GigawattsPerFoot", BaseUnits.Undefined);
@@ -149,7 +149,7 @@ namespace UnitsNet
 
         static LinearPowerDensity()
         {
-            Info = LinearPowerDensityInfo.CreateDefault();
+            Info = LinearPowerDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
@@ -68,59 +68,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Luminance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LuminanceInfo: QuantityInfo<Luminance, LuminanceUnit>
+        private static class LuminanceInfo
         {
-            /// <inheritdoc />
-            public LuminanceInfo(string name, LuminanceUnit baseUnit, IEnumerable<IUnitDefinition<LuminanceUnit>> unitMappings, Luminance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Luminance, LuminanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Luminance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LuminanceInfo(string name, LuminanceUnit baseUnit, IEnumerable<IUnitDefinition<LuminanceUnit>> unitMappings, Luminance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Luminance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Luminance", typeof(Luminance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LuminanceInfo"/> class with the default settings for the Luminance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LuminanceInfo"/> class with the default settings.</returns>
-            public static LuminanceInfo CreateDefault()
-            {
-                return new LuminanceInfo(nameof(Luminance), DefaultBaseUnit, GetDefaultMappings(), new Luminance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LuminanceInfo"/> class with the default settings for the Luminance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LuminanceInfo"/> class with the default settings.
             /// </returns>
-            public static LuminanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<LuminanceUnit>>, IEnumerable<IUnitDefinition<LuminanceUnit>>> customizeUnits)
+            private static QuantityInfo<Luminance, LuminanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LuminanceUnit>>, IEnumerable<IUnitDefinition<LuminanceUnit>>>? customizeUnits = null)
             {
-                return new LuminanceInfo(nameof(Luminance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Luminance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LuminanceUnit>> unitMappings = LuminanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Luminance, LuminanceUnit>(
+                    name: nameof(Luminance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Luminance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Luminance"/> is [L^-2][J].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 1);
 
             /// <summary>
             ///     The default base unit of Luminance is CandelaPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LuminanceUnit DefaultBaseUnit { get; } = LuminanceUnit.CandelaPerSquareMeter;
+            private static LuminanceUnit DefaultBaseUnit { get; } = LuminanceUnit.CandelaPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Luminance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Luminance", typeof(Luminance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LuminanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LuminanceUnit}"/> representing the default unit mappings for Luminance.</returns>
-            public static IEnumerable<UnitDefinition<LuminanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LuminanceUnit>> GetDefaultMappings()
             {
                 yield return new (LuminanceUnit.CandelaPerSquareFoot, "CandelaPerSquareFoot", "CandelasPerSquareFoot", BaseUnits.Undefined);
                 yield return new (LuminanceUnit.CandelaPerSquareInch, "CandelaPerSquareInch", "CandelasPerSquareInch", BaseUnits.Undefined);
@@ -137,7 +137,7 @@ namespace UnitsNet
 
         static Luminance()
         {
-            Info = LuminanceInfo.CreateDefault();
+            Info = LuminanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Luminosity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LuminosityInfo: QuantityInfo<Luminosity, LuminosityUnit>
+        private static class LuminosityInfo
         {
-            /// <inheritdoc />
-            public LuminosityInfo(string name, LuminosityUnit baseUnit, IEnumerable<IUnitDefinition<LuminosityUnit>> unitMappings, Luminosity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Luminosity, LuminosityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Luminosity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LuminosityInfo(string name, LuminosityUnit baseUnit, IEnumerable<IUnitDefinition<LuminosityUnit>> unitMappings, Luminosity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Luminosity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Luminosity", typeof(Luminosity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LuminosityInfo"/> class with the default settings for the Luminosity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LuminosityInfo"/> class with the default settings.</returns>
-            public static LuminosityInfo CreateDefault()
-            {
-                return new LuminosityInfo(nameof(Luminosity), DefaultBaseUnit, GetDefaultMappings(), new Luminosity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LuminosityInfo"/> class with the default settings for the Luminosity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LuminosityInfo"/> class with the default settings.
             /// </returns>
-            public static LuminosityInfo CreateDefault(Func<IEnumerable<UnitDefinition<LuminosityUnit>>, IEnumerable<IUnitDefinition<LuminosityUnit>>> customizeUnits)
+            private static QuantityInfo<Luminosity, LuminosityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LuminosityUnit>>, IEnumerable<IUnitDefinition<LuminosityUnit>>>? customizeUnits = null)
             {
-                return new LuminosityInfo(nameof(Luminosity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Luminosity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LuminosityUnit>> unitMappings = LuminosityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Luminosity, LuminosityUnit>(
+                    name: nameof(Luminosity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Luminosity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Luminosity"/> is [T^-3][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Luminosity is Watt. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LuminosityUnit DefaultBaseUnit { get; } = LuminosityUnit.Watt;
+            private static LuminosityUnit DefaultBaseUnit { get; } = LuminosityUnit.Watt;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Luminosity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Luminosity", typeof(Luminosity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LuminosityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LuminosityUnit}"/> representing the default unit mappings for Luminosity.</returns>
-            public static IEnumerable<UnitDefinition<LuminosityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LuminosityUnit>> GetDefaultMappings()
             {
                 yield return new (LuminosityUnit.Decawatt, "Decawatt", "Decawatts", BaseUnits.Undefined);
                 yield return new (LuminosityUnit.Deciwatt, "Deciwatt", "Deciwatts", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Hectogram, time: DurationUnit.Second));
@@ -138,7 +138,7 @@ namespace UnitsNet
 
         static Luminosity()
         {
-            Info = LuminosityInfo.CreateDefault();
+            Info = LuminosityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -69,59 +69,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="LuminousFlux"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LuminousFluxInfo: QuantityInfo<LuminousFlux, LuminousFluxUnit>
+        private static class LuminousFluxInfo
         {
-            /// <inheritdoc />
-            public LuminousFluxInfo(string name, LuminousFluxUnit baseUnit, IEnumerable<IUnitDefinition<LuminousFluxUnit>> unitMappings, LuminousFlux zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<LuminousFlux, LuminousFluxUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, LuminousFlux.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LuminousFluxInfo(string name, LuminousFluxUnit baseUnit, IEnumerable<IUnitDefinition<LuminousFluxUnit>> unitMappings, LuminousFlux zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, LuminousFlux.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.LuminousFlux", typeof(LuminousFlux).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LuminousFluxInfo"/> class with the default settings for the LuminousFlux quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LuminousFluxInfo"/> class with the default settings.</returns>
-            public static LuminousFluxInfo CreateDefault()
-            {
-                return new LuminousFluxInfo(nameof(LuminousFlux), DefaultBaseUnit, GetDefaultMappings(), new LuminousFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LuminousFluxInfo"/> class with the default settings for the LuminousFlux quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LuminousFluxInfo"/> class with the default settings.
             /// </returns>
-            public static LuminousFluxInfo CreateDefault(Func<IEnumerable<UnitDefinition<LuminousFluxUnit>>, IEnumerable<IUnitDefinition<LuminousFluxUnit>>> customizeUnits)
+            private static QuantityInfo<LuminousFlux, LuminousFluxUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LuminousFluxUnit>>, IEnumerable<IUnitDefinition<LuminousFluxUnit>>>? customizeUnits = null)
             {
-                return new LuminousFluxInfo(nameof(LuminousFlux), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new LuminousFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LuminousFluxUnit>> unitMappings = LuminousFluxInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<LuminousFlux, LuminousFluxUnit>(
+                    name: nameof(LuminousFlux),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new LuminousFlux(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="LuminousFlux"/> is [J].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
 
             /// <summary>
             ///     The default base unit of LuminousFlux is Lumen. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LuminousFluxUnit DefaultBaseUnit { get; } = LuminousFluxUnit.Lumen;
+            private static LuminousFluxUnit DefaultBaseUnit { get; } = LuminousFluxUnit.Lumen;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the LuminousFlux quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.LuminousFlux", typeof(LuminousFlux).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LuminousFluxUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LuminousFluxUnit}"/> representing the default unit mappings for LuminousFlux.</returns>
-            public static IEnumerable<UnitDefinition<LuminousFluxUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LuminousFluxUnit>> GetDefaultMappings()
             {
                 yield return new (LuminousFluxUnit.Lumen, "Lumen", "Lumens", new BaseUnits(luminousIntensity: LuminousIntensityUnit.Candela));
             }
@@ -129,7 +129,7 @@ namespace UnitsNet
 
         static LuminousFlux()
         {
-            Info = LuminousFluxInfo.CreateDefault();
+            Info = LuminousFluxInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -69,59 +69,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="LuminousIntensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class LuminousIntensityInfo: QuantityInfo<LuminousIntensity, LuminousIntensityUnit>
+        private static class LuminousIntensityInfo
         {
-            /// <inheritdoc />
-            public LuminousIntensityInfo(string name, LuminousIntensityUnit baseUnit, IEnumerable<IUnitDefinition<LuminousIntensityUnit>> unitMappings, LuminousIntensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<LuminousIntensity, LuminousIntensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, LuminousIntensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public LuminousIntensityInfo(string name, LuminousIntensityUnit baseUnit, IEnumerable<IUnitDefinition<LuminousIntensityUnit>> unitMappings, LuminousIntensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, LuminousIntensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.LuminousIntensity", typeof(LuminousIntensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="LuminousIntensityInfo"/> class with the default settings for the LuminousIntensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="LuminousIntensityInfo"/> class with the default settings.</returns>
-            public static LuminousIntensityInfo CreateDefault()
-            {
-                return new LuminousIntensityInfo(nameof(LuminousIntensity), DefaultBaseUnit, GetDefaultMappings(), new LuminousIntensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="LuminousIntensityInfo"/> class with the default settings for the LuminousIntensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="LuminousIntensityInfo"/> class with the default settings.
             /// </returns>
-            public static LuminousIntensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<LuminousIntensityUnit>>, IEnumerable<IUnitDefinition<LuminousIntensityUnit>>> customizeUnits)
+            private static QuantityInfo<LuminousIntensity, LuminousIntensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<LuminousIntensityUnit>>, IEnumerable<IUnitDefinition<LuminousIntensityUnit>>>? customizeUnits = null)
             {
-                return new LuminousIntensityInfo(nameof(LuminousIntensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new LuminousIntensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<LuminousIntensityUnit>> unitMappings = LuminousIntensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<LuminousIntensity, LuminousIntensityUnit>(
+                    name: nameof(LuminousIntensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new LuminousIntensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="LuminousIntensity"/> is [J].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 0, 0, 1);
 
             /// <summary>
             ///     The default base unit of LuminousIntensity is Candela. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static LuminousIntensityUnit DefaultBaseUnit { get; } = LuminousIntensityUnit.Candela;
+            private static LuminousIntensityUnit DefaultBaseUnit { get; } = LuminousIntensityUnit.Candela;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the LuminousIntensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.LuminousIntensity", typeof(LuminousIntensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="LuminousIntensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{LuminousIntensityUnit}"/> representing the default unit mappings for LuminousIntensity.</returns>
-            public static IEnumerable<UnitDefinition<LuminousIntensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<LuminousIntensityUnit>> GetDefaultMappings()
             {
                 yield return new (LuminousIntensityUnit.Candela, "Candela", "Candela", new BaseUnits(luminousIntensity: LuminousIntensityUnit.Candela));
             }
@@ -129,7 +129,7 @@ namespace UnitsNet
 
         static LuminousIntensity()
         {
-            Info = LuminousIntensityInfo.CreateDefault();
+            Info = LuminousIntensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MagneticField"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MagneticFieldInfo: QuantityInfo<MagneticField, MagneticFieldUnit>
+        private static class MagneticFieldInfo
         {
-            /// <inheritdoc />
-            public MagneticFieldInfo(string name, MagneticFieldUnit baseUnit, IEnumerable<IUnitDefinition<MagneticFieldUnit>> unitMappings, MagneticField zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MagneticField, MagneticFieldUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MagneticField.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MagneticFieldInfo(string name, MagneticFieldUnit baseUnit, IEnumerable<IUnitDefinition<MagneticFieldUnit>> unitMappings, MagneticField zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MagneticField.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MagneticField", typeof(MagneticField).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MagneticFieldInfo"/> class with the default settings for the MagneticField quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MagneticFieldInfo"/> class with the default settings.</returns>
-            public static MagneticFieldInfo CreateDefault()
-            {
-                return new MagneticFieldInfo(nameof(MagneticField), DefaultBaseUnit, GetDefaultMappings(), new MagneticField(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MagneticFieldInfo"/> class with the default settings for the MagneticField quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MagneticFieldInfo"/> class with the default settings.
             /// </returns>
-            public static MagneticFieldInfo CreateDefault(Func<IEnumerable<UnitDefinition<MagneticFieldUnit>>, IEnumerable<IUnitDefinition<MagneticFieldUnit>>> customizeUnits)
+            private static QuantityInfo<MagneticField, MagneticFieldUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MagneticFieldUnit>>, IEnumerable<IUnitDefinition<MagneticFieldUnit>>>? customizeUnits = null)
             {
-                return new MagneticFieldInfo(nameof(MagneticField), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MagneticField(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MagneticFieldUnit>> unitMappings = MagneticFieldInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MagneticField, MagneticFieldUnit>(
+                    name: nameof(MagneticField),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MagneticField(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MagneticField"/> is [T^-2][M][I^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -2, -1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -2, -1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of MagneticField is Tesla. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MagneticFieldUnit DefaultBaseUnit { get; } = MagneticFieldUnit.Tesla;
+            private static MagneticFieldUnit DefaultBaseUnit { get; } = MagneticFieldUnit.Tesla;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MagneticField quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MagneticField", typeof(MagneticField).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MagneticFieldUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MagneticFieldUnit}"/> representing the default unit mappings for MagneticField.</returns>
-            public static IEnumerable<UnitDefinition<MagneticFieldUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MagneticFieldUnit>> GetDefaultMappings()
             {
                 yield return new (MagneticFieldUnit.Gauss, "Gauss", "Gausses", BaseUnits.Undefined);
                 yield return new (MagneticFieldUnit.Microtesla, "Microtesla", "Microteslas", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Milligram, current: ElectricCurrentUnit.Ampere));
@@ -130,7 +130,7 @@ namespace UnitsNet
 
         static MagneticField()
         {
-            Info = MagneticFieldInfo.CreateDefault();
+            Info = MagneticFieldInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MagneticFlux"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MagneticFluxInfo: QuantityInfo<MagneticFlux, MagneticFluxUnit>
+        private static class MagneticFluxInfo
         {
-            /// <inheritdoc />
-            public MagneticFluxInfo(string name, MagneticFluxUnit baseUnit, IEnumerable<IUnitDefinition<MagneticFluxUnit>> unitMappings, MagneticFlux zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MagneticFlux, MagneticFluxUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MagneticFlux.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MagneticFluxInfo(string name, MagneticFluxUnit baseUnit, IEnumerable<IUnitDefinition<MagneticFluxUnit>> unitMappings, MagneticFlux zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MagneticFlux.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MagneticFlux", typeof(MagneticFlux).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MagneticFluxInfo"/> class with the default settings for the MagneticFlux quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MagneticFluxInfo"/> class with the default settings.</returns>
-            public static MagneticFluxInfo CreateDefault()
-            {
-                return new MagneticFluxInfo(nameof(MagneticFlux), DefaultBaseUnit, GetDefaultMappings(), new MagneticFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MagneticFluxInfo"/> class with the default settings for the MagneticFlux quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MagneticFluxInfo"/> class with the default settings.
             /// </returns>
-            public static MagneticFluxInfo CreateDefault(Func<IEnumerable<UnitDefinition<MagneticFluxUnit>>, IEnumerable<IUnitDefinition<MagneticFluxUnit>>> customizeUnits)
+            private static QuantityInfo<MagneticFlux, MagneticFluxUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MagneticFluxUnit>>, IEnumerable<IUnitDefinition<MagneticFluxUnit>>>? customizeUnits = null)
             {
-                return new MagneticFluxInfo(nameof(MagneticFlux), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MagneticFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MagneticFluxUnit>> unitMappings = MagneticFluxInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MagneticFlux, MagneticFluxUnit>(
+                    name: nameof(MagneticFlux),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MagneticFlux(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MagneticFlux"/> is [T^-2][L^2][M][I^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, -1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, -1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of MagneticFlux is Weber. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MagneticFluxUnit DefaultBaseUnit { get; } = MagneticFluxUnit.Weber;
+            private static MagneticFluxUnit DefaultBaseUnit { get; } = MagneticFluxUnit.Weber;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MagneticFlux quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MagneticFlux", typeof(MagneticFlux).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MagneticFluxUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MagneticFluxUnit}"/> representing the default unit mappings for MagneticFlux.</returns>
-            public static IEnumerable<UnitDefinition<MagneticFluxUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MagneticFluxUnit>> GetDefaultMappings()
             {
                 yield return new (MagneticFluxUnit.Weber, "Weber", "Webers", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static MagneticFlux()
         {
-            Info = MagneticFluxInfo.CreateDefault();
+            Info = MagneticFluxInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Magnetization"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MagnetizationInfo: QuantityInfo<Magnetization, MagnetizationUnit>
+        private static class MagnetizationInfo
         {
-            /// <inheritdoc />
-            public MagnetizationInfo(string name, MagnetizationUnit baseUnit, IEnumerable<IUnitDefinition<MagnetizationUnit>> unitMappings, Magnetization zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Magnetization, MagnetizationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Magnetization.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MagnetizationInfo(string name, MagnetizationUnit baseUnit, IEnumerable<IUnitDefinition<MagnetizationUnit>> unitMappings, Magnetization zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Magnetization.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Magnetization", typeof(Magnetization).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MagnetizationInfo"/> class with the default settings for the Magnetization quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MagnetizationInfo"/> class with the default settings.</returns>
-            public static MagnetizationInfo CreateDefault()
-            {
-                return new MagnetizationInfo(nameof(Magnetization), DefaultBaseUnit, GetDefaultMappings(), new Magnetization(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MagnetizationInfo"/> class with the default settings for the Magnetization quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MagnetizationInfo"/> class with the default settings.
             /// </returns>
-            public static MagnetizationInfo CreateDefault(Func<IEnumerable<UnitDefinition<MagnetizationUnit>>, IEnumerable<IUnitDefinition<MagnetizationUnit>>> customizeUnits)
+            private static QuantityInfo<Magnetization, MagnetizationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MagnetizationUnit>>, IEnumerable<IUnitDefinition<MagnetizationUnit>>>? customizeUnits = null)
             {
-                return new MagnetizationInfo(nameof(Magnetization), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Magnetization(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MagnetizationUnit>> unitMappings = MagnetizationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Magnetization, MagnetizationUnit>(
+                    name: nameof(Magnetization),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Magnetization(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Magnetization"/> is [L^-1][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 0, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Magnetization is AmperePerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MagnetizationUnit DefaultBaseUnit { get; } = MagnetizationUnit.AmperePerMeter;
+            private static MagnetizationUnit DefaultBaseUnit { get; } = MagnetizationUnit.AmperePerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Magnetization quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Magnetization", typeof(Magnetization).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MagnetizationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MagnetizationUnit}"/> representing the default unit mappings for Magnetization.</returns>
-            public static IEnumerable<UnitDefinition<MagnetizationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MagnetizationUnit>> GetDefaultMappings()
             {
                 yield return new (MagnetizationUnit.AmperePerMeter, "AmperePerMeter", "AmperesPerMeter", new BaseUnits(length: LengthUnit.Meter, current: ElectricCurrentUnit.Ampere));
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static Magnetization()
         {
-            Info = MagnetizationInfo.CreateDefault();
+            Info = MagnetizationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -80,59 +80,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Mass"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MassInfo: QuantityInfo<Mass, MassUnit>
+        private static class MassInfo
         {
-            /// <inheritdoc />
-            public MassInfo(string name, MassUnit baseUnit, IEnumerable<IUnitDefinition<MassUnit>> unitMappings, Mass zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Mass, MassUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Mass.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MassInfo(string name, MassUnit baseUnit, IEnumerable<IUnitDefinition<MassUnit>> unitMappings, Mass zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Mass.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Mass", typeof(Mass).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MassInfo"/> class with the default settings for the Mass quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MassInfo"/> class with the default settings.</returns>
-            public static MassInfo CreateDefault()
-            {
-                return new MassInfo(nameof(Mass), DefaultBaseUnit, GetDefaultMappings(), new Mass(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MassInfo"/> class with the default settings for the Mass quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MassInfo"/> class with the default settings.
             /// </returns>
-            public static MassInfo CreateDefault(Func<IEnumerable<UnitDefinition<MassUnit>>, IEnumerable<IUnitDefinition<MassUnit>>> customizeUnits)
+            private static QuantityInfo<Mass, MassUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MassUnit>>, IEnumerable<IUnitDefinition<MassUnit>>>? customizeUnits = null)
             {
-                return new MassInfo(nameof(Mass), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Mass(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MassUnit>> unitMappings = MassInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Mass, MassUnit>(
+                    name: nameof(Mass),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Mass(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Mass"/> is [M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Mass is Kilogram. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MassUnit DefaultBaseUnit { get; } = MassUnit.Kilogram;
+            private static MassUnit DefaultBaseUnit { get; } = MassUnit.Kilogram;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Mass quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Mass", typeof(Mass).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MassUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MassUnit}"/> representing the default unit mappings for Mass.</returns>
-            public static IEnumerable<UnitDefinition<MassUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MassUnit>> GetDefaultMappings()
             {
                 yield return new (MassUnit.Centigram, "Centigram", "Centigrams", new BaseUnits(mass: MassUnit.Centigram));
                 yield return new (MassUnit.Decagram, "Decagram", "Decagrams", new BaseUnits(mass: MassUnit.Decagram));
@@ -166,7 +166,7 @@ namespace UnitsNet
 
         static Mass()
         {
-            Info = MassInfo.CreateDefault();
+            Info = MassInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -72,59 +72,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MassConcentration"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MassConcentrationInfo: QuantityInfo<MassConcentration, MassConcentrationUnit>
+        private static class MassConcentrationInfo
         {
-            /// <inheritdoc />
-            public MassConcentrationInfo(string name, MassConcentrationUnit baseUnit, IEnumerable<IUnitDefinition<MassConcentrationUnit>> unitMappings, MassConcentration zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MassConcentration, MassConcentrationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MassConcentration.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MassConcentrationInfo(string name, MassConcentrationUnit baseUnit, IEnumerable<IUnitDefinition<MassConcentrationUnit>> unitMappings, MassConcentration zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MassConcentration.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MassConcentration", typeof(MassConcentration).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MassConcentrationInfo"/> class with the default settings for the MassConcentration quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MassConcentrationInfo"/> class with the default settings.</returns>
-            public static MassConcentrationInfo CreateDefault()
-            {
-                return new MassConcentrationInfo(nameof(MassConcentration), DefaultBaseUnit, GetDefaultMappings(), new MassConcentration(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MassConcentrationInfo"/> class with the default settings for the MassConcentration quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MassConcentrationInfo"/> class with the default settings.
             /// </returns>
-            public static MassConcentrationInfo CreateDefault(Func<IEnumerable<UnitDefinition<MassConcentrationUnit>>, IEnumerable<IUnitDefinition<MassConcentrationUnit>>> customizeUnits)
+            private static QuantityInfo<MassConcentration, MassConcentrationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MassConcentrationUnit>>, IEnumerable<IUnitDefinition<MassConcentrationUnit>>>? customizeUnits = null)
             {
-                return new MassConcentrationInfo(nameof(MassConcentration), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MassConcentration(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MassConcentrationUnit>> unitMappings = MassConcentrationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MassConcentration, MassConcentrationUnit>(
+                    name: nameof(MassConcentration),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MassConcentration(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MassConcentration"/> is [L^-3][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of MassConcentration is KilogramPerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MassConcentrationUnit DefaultBaseUnit { get; } = MassConcentrationUnit.KilogramPerCubicMeter;
+            private static MassConcentrationUnit DefaultBaseUnit { get; } = MassConcentrationUnit.KilogramPerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MassConcentration quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MassConcentration", typeof(MassConcentration).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MassConcentrationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MassConcentrationUnit}"/> representing the default unit mappings for MassConcentration.</returns>
-            public static IEnumerable<UnitDefinition<MassConcentrationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MassConcentrationUnit>> GetDefaultMappings()
             {
                 yield return new (MassConcentrationUnit.CentigramPerDeciliter, "CentigramPerDeciliter", "CentigramsPerDeciliter", BaseUnits.Undefined);
                 yield return new (MassConcentrationUnit.CentigramPerLiter, "CentigramPerLiter", "CentigramsPerLiter", new BaseUnits(length: LengthUnit.Decimeter, mass: MassUnit.Centigram));
@@ -180,7 +180,7 @@ namespace UnitsNet
 
         static MassConcentration()
         {
-            Info = MassConcentrationInfo.CreateDefault();
+            Info = MassConcentrationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -74,59 +74,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MassFlow"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MassFlowInfo: QuantityInfo<MassFlow, MassFlowUnit>
+        private static class MassFlowInfo
         {
-            /// <inheritdoc />
-            public MassFlowInfo(string name, MassFlowUnit baseUnit, IEnumerable<IUnitDefinition<MassFlowUnit>> unitMappings, MassFlow zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MassFlow, MassFlowUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MassFlow.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MassFlowInfo(string name, MassFlowUnit baseUnit, IEnumerable<IUnitDefinition<MassFlowUnit>> unitMappings, MassFlow zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MassFlow.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MassFlow", typeof(MassFlow).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MassFlowInfo"/> class with the default settings for the MassFlow quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MassFlowInfo"/> class with the default settings.</returns>
-            public static MassFlowInfo CreateDefault()
-            {
-                return new MassFlowInfo(nameof(MassFlow), DefaultBaseUnit, GetDefaultMappings(), new MassFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MassFlowInfo"/> class with the default settings for the MassFlow quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MassFlowInfo"/> class with the default settings.
             /// </returns>
-            public static MassFlowInfo CreateDefault(Func<IEnumerable<UnitDefinition<MassFlowUnit>>, IEnumerable<IUnitDefinition<MassFlowUnit>>> customizeUnits)
+            private static QuantityInfo<MassFlow, MassFlowUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MassFlowUnit>>, IEnumerable<IUnitDefinition<MassFlowUnit>>>? customizeUnits = null)
             {
-                return new MassFlowInfo(nameof(MassFlow), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MassFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MassFlowUnit>> unitMappings = MassFlowInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MassFlow, MassFlowUnit>(
+                    name: nameof(MassFlow),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MassFlow(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MassFlow"/> is [T^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of MassFlow is GramPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MassFlowUnit DefaultBaseUnit { get; } = MassFlowUnit.GramPerSecond;
+            private static MassFlowUnit DefaultBaseUnit { get; } = MassFlowUnit.GramPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MassFlow quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MassFlow", typeof(MassFlow).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MassFlowUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MassFlowUnit}"/> representing the default unit mappings for MassFlow.</returns>
-            public static IEnumerable<UnitDefinition<MassFlowUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MassFlowUnit>> GetDefaultMappings()
             {
                 yield return new (MassFlowUnit.CentigramPerDay, "CentigramPerDay", "CentigramsPerDay", new BaseUnits(mass: MassUnit.Centigram, time: DurationUnit.Day));
                 yield return new (MassFlowUnit.CentigramPerSecond, "CentigramPerSecond", "CentigramsPerSecond", new BaseUnits(mass: MassUnit.Centigram, time: DurationUnit.Second));
@@ -166,7 +166,7 @@ namespace UnitsNet
 
         static MassFlow()
         {
-            Info = MassFlowInfo.CreateDefault();
+            Info = MassFlowInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -67,59 +67,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MassFlux"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MassFluxInfo: QuantityInfo<MassFlux, MassFluxUnit>
+        private static class MassFluxInfo
         {
-            /// <inheritdoc />
-            public MassFluxInfo(string name, MassFluxUnit baseUnit, IEnumerable<IUnitDefinition<MassFluxUnit>> unitMappings, MassFlux zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MassFlux, MassFluxUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MassFlux.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MassFluxInfo(string name, MassFluxUnit baseUnit, IEnumerable<IUnitDefinition<MassFluxUnit>> unitMappings, MassFlux zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MassFlux.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MassFlux", typeof(MassFlux).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MassFluxInfo"/> class with the default settings for the MassFlux quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MassFluxInfo"/> class with the default settings.</returns>
-            public static MassFluxInfo CreateDefault()
-            {
-                return new MassFluxInfo(nameof(MassFlux), DefaultBaseUnit, GetDefaultMappings(), new MassFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MassFluxInfo"/> class with the default settings for the MassFlux quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MassFluxInfo"/> class with the default settings.
             /// </returns>
-            public static MassFluxInfo CreateDefault(Func<IEnumerable<UnitDefinition<MassFluxUnit>>, IEnumerable<IUnitDefinition<MassFluxUnit>>> customizeUnits)
+            private static QuantityInfo<MassFlux, MassFluxUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MassFluxUnit>>, IEnumerable<IUnitDefinition<MassFluxUnit>>>? customizeUnits = null)
             {
-                return new MassFluxInfo(nameof(MassFlux), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MassFlux(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MassFluxUnit>> unitMappings = MassFluxInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MassFlux, MassFluxUnit>(
+                    name: nameof(MassFlux),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MassFlux(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MassFlux"/> is [T^-1][L^-2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 1, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of MassFlux is KilogramPerSecondPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MassFluxUnit DefaultBaseUnit { get; } = MassFluxUnit.KilogramPerSecondPerSquareMeter;
+            private static MassFluxUnit DefaultBaseUnit { get; } = MassFluxUnit.KilogramPerSecondPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MassFlux quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MassFlux", typeof(MassFlux).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MassFluxUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MassFluxUnit}"/> representing the default unit mappings for MassFlux.</returns>
-            public static IEnumerable<UnitDefinition<MassFluxUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MassFluxUnit>> GetDefaultMappings()
             {
                 yield return new (MassFluxUnit.GramPerHourPerSquareCentimeter, "GramPerHourPerSquareCentimeter", "GramsPerHourPerSquareCentimeter", new BaseUnits(length: LengthUnit.Centimeter, mass: MassUnit.Gram, time: DurationUnit.Hour));
                 yield return new (MassFluxUnit.GramPerHourPerSquareMeter, "GramPerHourPerSquareMeter", "GramsPerHourPerSquareMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Gram, time: DurationUnit.Hour));
@@ -138,7 +138,7 @@ namespace UnitsNet
 
         static MassFlux()
         {
-            Info = MassFluxInfo.CreateDefault();
+            Info = MassFluxInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
@@ -68,59 +68,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MassFraction"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MassFractionInfo: QuantityInfo<MassFraction, MassFractionUnit>
+        private static class MassFractionInfo
         {
-            /// <inheritdoc />
-            public MassFractionInfo(string name, MassFractionUnit baseUnit, IEnumerable<IUnitDefinition<MassFractionUnit>> unitMappings, MassFraction zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MassFraction, MassFractionUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MassFraction.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MassFractionInfo(string name, MassFractionUnit baseUnit, IEnumerable<IUnitDefinition<MassFractionUnit>> unitMappings, MassFraction zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MassFraction.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MassFraction", typeof(MassFraction).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MassFractionInfo"/> class with the default settings for the MassFraction quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MassFractionInfo"/> class with the default settings.</returns>
-            public static MassFractionInfo CreateDefault()
-            {
-                return new MassFractionInfo(nameof(MassFraction), DefaultBaseUnit, GetDefaultMappings(), new MassFraction(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MassFractionInfo"/> class with the default settings for the MassFraction quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MassFractionInfo"/> class with the default settings.
             /// </returns>
-            public static MassFractionInfo CreateDefault(Func<IEnumerable<UnitDefinition<MassFractionUnit>>, IEnumerable<IUnitDefinition<MassFractionUnit>>> customizeUnits)
+            private static QuantityInfo<MassFraction, MassFractionUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MassFractionUnit>>, IEnumerable<IUnitDefinition<MassFractionUnit>>>? customizeUnits = null)
             {
-                return new MassFractionInfo(nameof(MassFraction), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MassFraction(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MassFractionUnit>> unitMappings = MassFractionInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MassFraction, MassFractionUnit>(
+                    name: nameof(MassFraction),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MassFraction(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MassFraction"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of MassFraction is DecimalFraction. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MassFractionUnit DefaultBaseUnit { get; } = MassFractionUnit.DecimalFraction;
+            private static MassFractionUnit DefaultBaseUnit { get; } = MassFractionUnit.DecimalFraction;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MassFraction quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MassFraction", typeof(MassFraction).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MassFractionUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MassFractionUnit}"/> representing the default unit mappings for MassFraction.</returns>
-            public static IEnumerable<UnitDefinition<MassFractionUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MassFractionUnit>> GetDefaultMappings()
             {
                 yield return new (MassFractionUnit.CentigramPerGram, "CentigramPerGram", "CentigramsPerGram", BaseUnits.Undefined);
                 yield return new (MassFractionUnit.CentigramPerKilogram, "CentigramPerKilogram", "CentigramsPerKilogram", BaseUnits.Undefined);
@@ -151,7 +151,7 @@ namespace UnitsNet
 
         static MassFraction()
         {
-            Info = MassFractionInfo.CreateDefault();
+            Info = MassFractionInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MassMomentOfInertia"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MassMomentOfInertiaInfo: QuantityInfo<MassMomentOfInertia, MassMomentOfInertiaUnit>
+        private static class MassMomentOfInertiaInfo
         {
-            /// <inheritdoc />
-            public MassMomentOfInertiaInfo(string name, MassMomentOfInertiaUnit baseUnit, IEnumerable<IUnitDefinition<MassMomentOfInertiaUnit>> unitMappings, MassMomentOfInertia zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MassMomentOfInertia, MassMomentOfInertiaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MassMomentOfInertia.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MassMomentOfInertiaInfo(string name, MassMomentOfInertiaUnit baseUnit, IEnumerable<IUnitDefinition<MassMomentOfInertiaUnit>> unitMappings, MassMomentOfInertia zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MassMomentOfInertia.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MassMomentOfInertia", typeof(MassMomentOfInertia).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MassMomentOfInertiaInfo"/> class with the default settings for the MassMomentOfInertia quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MassMomentOfInertiaInfo"/> class with the default settings.</returns>
-            public static MassMomentOfInertiaInfo CreateDefault()
-            {
-                return new MassMomentOfInertiaInfo(nameof(MassMomentOfInertia), DefaultBaseUnit, GetDefaultMappings(), new MassMomentOfInertia(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MassMomentOfInertiaInfo"/> class with the default settings for the MassMomentOfInertia quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MassMomentOfInertiaInfo"/> class with the default settings.
             /// </returns>
-            public static MassMomentOfInertiaInfo CreateDefault(Func<IEnumerable<UnitDefinition<MassMomentOfInertiaUnit>>, IEnumerable<IUnitDefinition<MassMomentOfInertiaUnit>>> customizeUnits)
+            private static QuantityInfo<MassMomentOfInertia, MassMomentOfInertiaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MassMomentOfInertiaUnit>>, IEnumerable<IUnitDefinition<MassMomentOfInertiaUnit>>>? customizeUnits = null)
             {
-                return new MassMomentOfInertiaInfo(nameof(MassMomentOfInertia), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MassMomentOfInertia(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MassMomentOfInertiaUnit>> unitMappings = MassMomentOfInertiaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MassMomentOfInertia, MassMomentOfInertiaUnit>(
+                    name: nameof(MassMomentOfInertia),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MassMomentOfInertia(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MassMomentOfInertia"/> is [L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of MassMomentOfInertia is KilogramSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MassMomentOfInertiaUnit DefaultBaseUnit { get; } = MassMomentOfInertiaUnit.KilogramSquareMeter;
+            private static MassMomentOfInertiaUnit DefaultBaseUnit { get; } = MassMomentOfInertiaUnit.KilogramSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MassMomentOfInertia quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MassMomentOfInertia", typeof(MassMomentOfInertia).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MassMomentOfInertiaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MassMomentOfInertiaUnit}"/> representing the default unit mappings for MassMomentOfInertia.</returns>
-            public static IEnumerable<UnitDefinition<MassMomentOfInertiaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MassMomentOfInertiaUnit>> GetDefaultMappings()
             {
                 yield return new (MassMomentOfInertiaUnit.GramSquareCentimeter, "GramSquareCentimeter", "GramSquareCentimeters", new BaseUnits(length: LengthUnit.Centimeter, mass: MassUnit.Gram));
                 yield return new (MassMomentOfInertiaUnit.GramSquareDecimeter, "GramSquareDecimeter", "GramSquareDecimeters", new BaseUnits(length: LengthUnit.Decimeter, mass: MassUnit.Gram));
@@ -149,7 +149,7 @@ namespace UnitsNet
 
         static MassMomentOfInertia()
         {
-            Info = MassMomentOfInertiaInfo.CreateDefault();
+            Info = MassMomentOfInertiaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Molality"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MolalityInfo: QuantityInfo<Molality, MolalityUnit>
+        private static class MolalityInfo
         {
-            /// <inheritdoc />
-            public MolalityInfo(string name, MolalityUnit baseUnit, IEnumerable<IUnitDefinition<MolalityUnit>> unitMappings, Molality zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Molality, MolalityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Molality.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MolalityInfo(string name, MolalityUnit baseUnit, IEnumerable<IUnitDefinition<MolalityUnit>> unitMappings, Molality zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Molality.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Molality", typeof(Molality).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MolalityInfo"/> class with the default settings for the Molality quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MolalityInfo"/> class with the default settings.</returns>
-            public static MolalityInfo CreateDefault()
-            {
-                return new MolalityInfo(nameof(Molality), DefaultBaseUnit, GetDefaultMappings(), new Molality(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MolalityInfo"/> class with the default settings for the Molality quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MolalityInfo"/> class with the default settings.
             /// </returns>
-            public static MolalityInfo CreateDefault(Func<IEnumerable<UnitDefinition<MolalityUnit>>, IEnumerable<IUnitDefinition<MolalityUnit>>> customizeUnits)
+            private static QuantityInfo<Molality, MolalityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MolalityUnit>>, IEnumerable<IUnitDefinition<MolalityUnit>>>? customizeUnits = null)
             {
-                return new MolalityInfo(nameof(Molality), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Molality(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MolalityUnit>> unitMappings = MolalityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Molality, MolalityUnit>(
+                    name: nameof(Molality),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Molality(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Molality"/> is [M^-1][N].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, -1, 0, 0, 0, 1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, -1, 0, 0, 0, 1, 0);
 
             /// <summary>
             ///     The default base unit of Molality is MolePerKilogram. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MolalityUnit DefaultBaseUnit { get; } = MolalityUnit.MolePerKilogram;
+            private static MolalityUnit DefaultBaseUnit { get; } = MolalityUnit.MolePerKilogram;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Molality quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Molality", typeof(Molality).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MolalityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MolalityUnit}"/> representing the default unit mappings for Molality.</returns>
-            public static IEnumerable<UnitDefinition<MolalityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MolalityUnit>> GetDefaultMappings()
             {
                 yield return new (MolalityUnit.MillimolePerKilogram, "MillimolePerKilogram", "MillimolesPerKilogram", new BaseUnits(mass: MassUnit.Kilogram, amount: AmountOfSubstanceUnit.Millimole));
                 yield return new (MolalityUnit.MolePerGram, "MolePerGram", "MolesPerGram", new BaseUnits(mass: MassUnit.Gram, amount: AmountOfSubstanceUnit.Mole));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static Molality()
         {
-            Info = MolalityInfo.CreateDefault();
+            Info = MolalityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MolarEnergy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MolarEnergyInfo: QuantityInfo<MolarEnergy, MolarEnergyUnit>
+        private static class MolarEnergyInfo
         {
-            /// <inheritdoc />
-            public MolarEnergyInfo(string name, MolarEnergyUnit baseUnit, IEnumerable<IUnitDefinition<MolarEnergyUnit>> unitMappings, MolarEnergy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MolarEnergy, MolarEnergyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MolarEnergy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MolarEnergyInfo(string name, MolarEnergyUnit baseUnit, IEnumerable<IUnitDefinition<MolarEnergyUnit>> unitMappings, MolarEnergy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MolarEnergy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MolarEnergy", typeof(MolarEnergy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MolarEnergyInfo"/> class with the default settings for the MolarEnergy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MolarEnergyInfo"/> class with the default settings.</returns>
-            public static MolarEnergyInfo CreateDefault()
-            {
-                return new MolarEnergyInfo(nameof(MolarEnergy), DefaultBaseUnit, GetDefaultMappings(), new MolarEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MolarEnergyInfo"/> class with the default settings for the MolarEnergy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MolarEnergyInfo"/> class with the default settings.
             /// </returns>
-            public static MolarEnergyInfo CreateDefault(Func<IEnumerable<UnitDefinition<MolarEnergyUnit>>, IEnumerable<IUnitDefinition<MolarEnergyUnit>>> customizeUnits)
+            private static QuantityInfo<MolarEnergy, MolarEnergyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MolarEnergyUnit>>, IEnumerable<IUnitDefinition<MolarEnergyUnit>>>? customizeUnits = null)
             {
-                return new MolarEnergyInfo(nameof(MolarEnergy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MolarEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MolarEnergyUnit>> unitMappings = MolarEnergyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MolarEnergy, MolarEnergyUnit>(
+                    name: nameof(MolarEnergy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MolarEnergy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MolarEnergy"/> is [T^-2][L^2][M][N^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, -1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, -1, 0);
 
             /// <summary>
             ///     The default base unit of MolarEnergy is JoulePerMole. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MolarEnergyUnit DefaultBaseUnit { get; } = MolarEnergyUnit.JoulePerMole;
+            private static MolarEnergyUnit DefaultBaseUnit { get; } = MolarEnergyUnit.JoulePerMole;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MolarEnergy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MolarEnergy", typeof(MolarEnergy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MolarEnergyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MolarEnergyUnit}"/> representing the default unit mappings for MolarEnergy.</returns>
-            public static IEnumerable<UnitDefinition<MolarEnergyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MolarEnergyUnit>> GetDefaultMappings()
             {
                 yield return new (MolarEnergyUnit.JoulePerMole, "JoulePerMole", "JoulesPerMole", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, amount: AmountOfSubstanceUnit.Mole));
                 yield return new (MolarEnergyUnit.KilojoulePerMole, "KilojoulePerMole", "KilojoulesPerMole", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, amount: AmountOfSubstanceUnit.Millimole));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static MolarEnergy()
         {
-            Info = MolarEnergyInfo.CreateDefault();
+            Info = MolarEnergyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MolarEntropy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MolarEntropyInfo: QuantityInfo<MolarEntropy, MolarEntropyUnit>
+        private static class MolarEntropyInfo
         {
-            /// <inheritdoc />
-            public MolarEntropyInfo(string name, MolarEntropyUnit baseUnit, IEnumerable<IUnitDefinition<MolarEntropyUnit>> unitMappings, MolarEntropy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MolarEntropy, MolarEntropyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MolarEntropy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MolarEntropyInfo(string name, MolarEntropyUnit baseUnit, IEnumerable<IUnitDefinition<MolarEntropyUnit>> unitMappings, MolarEntropy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MolarEntropy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MolarEntropy", typeof(MolarEntropy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MolarEntropyInfo"/> class with the default settings for the MolarEntropy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MolarEntropyInfo"/> class with the default settings.</returns>
-            public static MolarEntropyInfo CreateDefault()
-            {
-                return new MolarEntropyInfo(nameof(MolarEntropy), DefaultBaseUnit, GetDefaultMappings(), new MolarEntropy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MolarEntropyInfo"/> class with the default settings for the MolarEntropy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MolarEntropyInfo"/> class with the default settings.
             /// </returns>
-            public static MolarEntropyInfo CreateDefault(Func<IEnumerable<UnitDefinition<MolarEntropyUnit>>, IEnumerable<IUnitDefinition<MolarEntropyUnit>>> customizeUnits)
+            private static QuantityInfo<MolarEntropy, MolarEntropyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MolarEntropyUnit>>, IEnumerable<IUnitDefinition<MolarEntropyUnit>>>? customizeUnits = null)
             {
-                return new MolarEntropyInfo(nameof(MolarEntropy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MolarEntropy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MolarEntropyUnit>> unitMappings = MolarEntropyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MolarEntropy, MolarEntropyUnit>(
+                    name: nameof(MolarEntropy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MolarEntropy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MolarEntropy"/> is [T^-2][L^2][M][Θ^-1][N^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, -1, -1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, -1, -1, 0);
 
             /// <summary>
             ///     The default base unit of MolarEntropy is JoulePerMoleKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MolarEntropyUnit DefaultBaseUnit { get; } = MolarEntropyUnit.JoulePerMoleKelvin;
+            private static MolarEntropyUnit DefaultBaseUnit { get; } = MolarEntropyUnit.JoulePerMoleKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MolarEntropy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MolarEntropy", typeof(MolarEntropy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MolarEntropyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MolarEntropyUnit}"/> representing the default unit mappings for MolarEntropy.</returns>
-            public static IEnumerable<UnitDefinition<MolarEntropyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MolarEntropyUnit>> GetDefaultMappings()
             {
                 yield return new (MolarEntropyUnit.JoulePerMoleKelvin, "JoulePerMoleKelvin", "JoulesPerMoleKelvin", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, temperature: TemperatureUnit.Kelvin, amount: AmountOfSubstanceUnit.Mole));
                 yield return new (MolarEntropyUnit.KilojoulePerMoleKelvin, "KilojoulePerMoleKelvin", "KilojoulesPerMoleKelvin", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, temperature: TemperatureUnit.Kelvin, amount: AmountOfSubstanceUnit.Millimole));
@@ -124,7 +124,7 @@ namespace UnitsNet
 
         static MolarEntropy()
         {
-            Info = MolarEntropyInfo.CreateDefault();
+            Info = MolarEntropyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
@@ -68,59 +68,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MolarFlow"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MolarFlowInfo: QuantityInfo<MolarFlow, MolarFlowUnit>
+        private static class MolarFlowInfo
         {
-            /// <inheritdoc />
-            public MolarFlowInfo(string name, MolarFlowUnit baseUnit, IEnumerable<IUnitDefinition<MolarFlowUnit>> unitMappings, MolarFlow zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MolarFlow, MolarFlowUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MolarFlow.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MolarFlowInfo(string name, MolarFlowUnit baseUnit, IEnumerable<IUnitDefinition<MolarFlowUnit>> unitMappings, MolarFlow zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MolarFlow.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MolarFlow", typeof(MolarFlow).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MolarFlowInfo"/> class with the default settings for the MolarFlow quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MolarFlowInfo"/> class with the default settings.</returns>
-            public static MolarFlowInfo CreateDefault()
-            {
-                return new MolarFlowInfo(nameof(MolarFlow), DefaultBaseUnit, GetDefaultMappings(), new MolarFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MolarFlowInfo"/> class with the default settings for the MolarFlow quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MolarFlowInfo"/> class with the default settings.
             /// </returns>
-            public static MolarFlowInfo CreateDefault(Func<IEnumerable<UnitDefinition<MolarFlowUnit>>, IEnumerable<IUnitDefinition<MolarFlowUnit>>> customizeUnits)
+            private static QuantityInfo<MolarFlow, MolarFlowUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MolarFlowUnit>>, IEnumerable<IUnitDefinition<MolarFlowUnit>>>? customizeUnits = null)
             {
-                return new MolarFlowInfo(nameof(MolarFlow), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MolarFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MolarFlowUnit>> unitMappings = MolarFlowInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MolarFlow, MolarFlowUnit>(
+                    name: nameof(MolarFlow),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MolarFlow(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MolarFlow"/> is [T^-1][N].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 1, 0);
 
             /// <summary>
             ///     The default base unit of MolarFlow is MolePerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MolarFlowUnit DefaultBaseUnit { get; } = MolarFlowUnit.MolePerSecond;
+            private static MolarFlowUnit DefaultBaseUnit { get; } = MolarFlowUnit.MolePerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MolarFlow quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MolarFlow", typeof(MolarFlow).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MolarFlowUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MolarFlowUnit}"/> representing the default unit mappings for MolarFlow.</returns>
-            public static IEnumerable<UnitDefinition<MolarFlowUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MolarFlowUnit>> GetDefaultMappings()
             {
                 yield return new (MolarFlowUnit.KilomolePerHour, "KilomolePerHour", "KilomolesPerHour", new BaseUnits(time: DurationUnit.Hour, amount: AmountOfSubstanceUnit.Kilomole));
                 yield return new (MolarFlowUnit.KilomolePerMinute, "KilomolePerMinute", "KilomolesPerMinute", new BaseUnits(time: DurationUnit.Minute, amount: AmountOfSubstanceUnit.Kilomole));
@@ -136,7 +136,7 @@ namespace UnitsNet
 
         static MolarFlow()
         {
-            Info = MolarFlowInfo.CreateDefault();
+            Info = MolarFlowInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -67,59 +67,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="MolarMass"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MolarMassInfo: QuantityInfo<MolarMass, MolarMassUnit>
+        private static class MolarMassInfo
         {
-            /// <inheritdoc />
-            public MolarMassInfo(string name, MolarMassUnit baseUnit, IEnumerable<IUnitDefinition<MolarMassUnit>> unitMappings, MolarMass zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<MolarMass, MolarMassUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, MolarMass.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MolarMassInfo(string name, MolarMassUnit baseUnit, IEnumerable<IUnitDefinition<MolarMassUnit>> unitMappings, MolarMass zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, MolarMass.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.MolarMass", typeof(MolarMass).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MolarMassInfo"/> class with the default settings for the MolarMass quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MolarMassInfo"/> class with the default settings.</returns>
-            public static MolarMassInfo CreateDefault()
-            {
-                return new MolarMassInfo(nameof(MolarMass), DefaultBaseUnit, GetDefaultMappings(), new MolarMass(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MolarMassInfo"/> class with the default settings for the MolarMass quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MolarMassInfo"/> class with the default settings.
             /// </returns>
-            public static MolarMassInfo CreateDefault(Func<IEnumerable<UnitDefinition<MolarMassUnit>>, IEnumerable<IUnitDefinition<MolarMassUnit>>> customizeUnits)
+            private static QuantityInfo<MolarMass, MolarMassUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MolarMassUnit>>, IEnumerable<IUnitDefinition<MolarMassUnit>>>? customizeUnits = null)
             {
-                return new MolarMassInfo(nameof(MolarMass), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new MolarMass(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MolarMassUnit>> unitMappings = MolarMassInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<MolarMass, MolarMassUnit>(
+                    name: nameof(MolarMass),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new MolarMass(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="MolarMass"/> is [M][N^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, 0, 0, 0, -1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, 0, 0, 0, -1, 0);
 
             /// <summary>
             ///     The default base unit of MolarMass is KilogramPerMole. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MolarMassUnit DefaultBaseUnit { get; } = MolarMassUnit.KilogramPerMole;
+            private static MolarMassUnit DefaultBaseUnit { get; } = MolarMassUnit.KilogramPerMole;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the MolarMass quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.MolarMass", typeof(MolarMass).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MolarMassUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MolarMassUnit}"/> representing the default unit mappings for MolarMass.</returns>
-            public static IEnumerable<UnitDefinition<MolarMassUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MolarMassUnit>> GetDefaultMappings()
             {
                 yield return new (MolarMassUnit.CentigramPerMole, "CentigramPerMole", "CentigramsPerMole", new BaseUnits(mass: MassUnit.Centigram, amount: AmountOfSubstanceUnit.Mole));
                 yield return new (MolarMassUnit.DecagramPerMole, "DecagramPerMole", "DecagramsPerMole", new BaseUnits(mass: MassUnit.Decagram, amount: AmountOfSubstanceUnit.Mole));
@@ -139,7 +139,7 @@ namespace UnitsNet
 
         static MolarMass()
         {
-            Info = MolarMassInfo.CreateDefault();
+            Info = MolarMassInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -72,59 +72,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Molarity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class MolarityInfo: QuantityInfo<Molarity, MolarityUnit>
+        private static class MolarityInfo
         {
-            /// <inheritdoc />
-            public MolarityInfo(string name, MolarityUnit baseUnit, IEnumerable<IUnitDefinition<MolarityUnit>> unitMappings, Molarity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Molarity, MolarityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Molarity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public MolarityInfo(string name, MolarityUnit baseUnit, IEnumerable<IUnitDefinition<MolarityUnit>> unitMappings, Molarity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Molarity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Molarity", typeof(Molarity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="MolarityInfo"/> class with the default settings for the Molarity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="MolarityInfo"/> class with the default settings.</returns>
-            public static MolarityInfo CreateDefault()
-            {
-                return new MolarityInfo(nameof(Molarity), DefaultBaseUnit, GetDefaultMappings(), new Molarity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="MolarityInfo"/> class with the default settings for the Molarity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="MolarityInfo"/> class with the default settings.
             /// </returns>
-            public static MolarityInfo CreateDefault(Func<IEnumerable<UnitDefinition<MolarityUnit>>, IEnumerable<IUnitDefinition<MolarityUnit>>> customizeUnits)
+            private static QuantityInfo<Molarity, MolarityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<MolarityUnit>>, IEnumerable<IUnitDefinition<MolarityUnit>>>? customizeUnits = null)
             {
-                return new MolarityInfo(nameof(Molarity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Molarity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<MolarityUnit>> unitMappings = MolarityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Molarity, MolarityUnit>(
+                    name: nameof(Molarity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Molarity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Molarity"/> is [L^-3][N].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, 0, 0, 0, 0, 1, 0);
 
             /// <summary>
             ///     The default base unit of Molarity is MolePerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static MolarityUnit DefaultBaseUnit { get; } = MolarityUnit.MolePerCubicMeter;
+            private static MolarityUnit DefaultBaseUnit { get; } = MolarityUnit.MolePerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Molarity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Molarity", typeof(Molarity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="MolarityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{MolarityUnit}"/> representing the default unit mappings for Molarity.</returns>
-            public static IEnumerable<UnitDefinition<MolarityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<MolarityUnit>> GetDefaultMappings()
             {
                 yield return new (MolarityUnit.CentimolePerLiter, "CentimolePerLiter", "CentimolesPerLiter", new BaseUnits(length: LengthUnit.Decimeter, amount: AmountOfSubstanceUnit.Centimole));
                 yield return new (MolarityUnit.DecimolePerLiter, "DecimolePerLiter", "DecimolesPerLiter", new BaseUnits(length: LengthUnit.Decimeter, amount: AmountOfSubstanceUnit.Decimole));
@@ -142,7 +142,7 @@ namespace UnitsNet
 
         static Molarity()
         {
-            Info = MolarityInfo.CreateDefault();
+            Info = MolarityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Permeability"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PermeabilityInfo: QuantityInfo<Permeability, PermeabilityUnit>
+        private static class PermeabilityInfo
         {
-            /// <inheritdoc />
-            public PermeabilityInfo(string name, PermeabilityUnit baseUnit, IEnumerable<IUnitDefinition<PermeabilityUnit>> unitMappings, Permeability zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Permeability, PermeabilityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Permeability.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PermeabilityInfo(string name, PermeabilityUnit baseUnit, IEnumerable<IUnitDefinition<PermeabilityUnit>> unitMappings, Permeability zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Permeability.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Permeability", typeof(Permeability).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PermeabilityInfo"/> class with the default settings for the Permeability quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PermeabilityInfo"/> class with the default settings.</returns>
-            public static PermeabilityInfo CreateDefault()
-            {
-                return new PermeabilityInfo(nameof(Permeability), DefaultBaseUnit, GetDefaultMappings(), new Permeability(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PermeabilityInfo"/> class with the default settings for the Permeability quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PermeabilityInfo"/> class with the default settings.
             /// </returns>
-            public static PermeabilityInfo CreateDefault(Func<IEnumerable<UnitDefinition<PermeabilityUnit>>, IEnumerable<IUnitDefinition<PermeabilityUnit>>> customizeUnits)
+            private static QuantityInfo<Permeability, PermeabilityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PermeabilityUnit>>, IEnumerable<IUnitDefinition<PermeabilityUnit>>>? customizeUnits = null)
             {
-                return new PermeabilityInfo(nameof(Permeability), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Permeability(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PermeabilityUnit>> unitMappings = PermeabilityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Permeability, PermeabilityUnit>(
+                    name: nameof(Permeability),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Permeability(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Permeability"/> is [T^-2][L][M][I^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -2, -2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -2, -2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Permeability is HenryPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PermeabilityUnit DefaultBaseUnit { get; } = PermeabilityUnit.HenryPerMeter;
+            private static PermeabilityUnit DefaultBaseUnit { get; } = PermeabilityUnit.HenryPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Permeability quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Permeability", typeof(Permeability).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PermeabilityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PermeabilityUnit}"/> representing the default unit mappings for Permeability.</returns>
-            public static IEnumerable<UnitDefinition<PermeabilityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PermeabilityUnit>> GetDefaultMappings()
             {
                 yield return new (PermeabilityUnit.HenryPerMeter, "HenryPerMeter", "HenriesPerMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static Permeability()
         {
-            Info = PermeabilityInfo.CreateDefault();
+            Info = PermeabilityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Permittivity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PermittivityInfo: QuantityInfo<Permittivity, PermittivityUnit>
+        private static class PermittivityInfo
         {
-            /// <inheritdoc />
-            public PermittivityInfo(string name, PermittivityUnit baseUnit, IEnumerable<IUnitDefinition<PermittivityUnit>> unitMappings, Permittivity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Permittivity, PermittivityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Permittivity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PermittivityInfo(string name, PermittivityUnit baseUnit, IEnumerable<IUnitDefinition<PermittivityUnit>> unitMappings, Permittivity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Permittivity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Permittivity", typeof(Permittivity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PermittivityInfo"/> class with the default settings for the Permittivity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PermittivityInfo"/> class with the default settings.</returns>
-            public static PermittivityInfo CreateDefault()
-            {
-                return new PermittivityInfo(nameof(Permittivity), DefaultBaseUnit, GetDefaultMappings(), new Permittivity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PermittivityInfo"/> class with the default settings for the Permittivity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PermittivityInfo"/> class with the default settings.
             /// </returns>
-            public static PermittivityInfo CreateDefault(Func<IEnumerable<UnitDefinition<PermittivityUnit>>, IEnumerable<IUnitDefinition<PermittivityUnit>>> customizeUnits)
+            private static QuantityInfo<Permittivity, PermittivityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PermittivityUnit>>, IEnumerable<IUnitDefinition<PermittivityUnit>>>? customizeUnits = null)
             {
-                return new PermittivityInfo(nameof(Permittivity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Permittivity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PermittivityUnit>> unitMappings = PermittivityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Permittivity, PermittivityUnit>(
+                    name: nameof(Permittivity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Permittivity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Permittivity"/> is [T^4][L^-3][M^-1][I^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-3, -1, 4, 2, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Permittivity is FaradPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PermittivityUnit DefaultBaseUnit { get; } = PermittivityUnit.FaradPerMeter;
+            private static PermittivityUnit DefaultBaseUnit { get; } = PermittivityUnit.FaradPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Permittivity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Permittivity", typeof(Permittivity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PermittivityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PermittivityUnit}"/> representing the default unit mappings for Permittivity.</returns>
-            public static IEnumerable<UnitDefinition<PermittivityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PermittivityUnit>> GetDefaultMappings()
             {
                 yield return new (PermittivityUnit.FaradPerMeter, "FaradPerMeter", "FaradsPerMeter", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static Permittivity()
         {
-            Info = PermittivityInfo.CreateDefault();
+            Info = PermittivityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="PorousMediumPermeability"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PorousMediumPermeabilityInfo: QuantityInfo<PorousMediumPermeability, PorousMediumPermeabilityUnit>
+        private static class PorousMediumPermeabilityInfo
         {
-            /// <inheritdoc />
-            public PorousMediumPermeabilityInfo(string name, PorousMediumPermeabilityUnit baseUnit, IEnumerable<IUnitDefinition<PorousMediumPermeabilityUnit>> unitMappings, PorousMediumPermeability zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<PorousMediumPermeability, PorousMediumPermeabilityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, PorousMediumPermeability.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PorousMediumPermeabilityInfo(string name, PorousMediumPermeabilityUnit baseUnit, IEnumerable<IUnitDefinition<PorousMediumPermeabilityUnit>> unitMappings, PorousMediumPermeability zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, PorousMediumPermeability.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.PorousMediumPermeability", typeof(PorousMediumPermeability).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PorousMediumPermeabilityInfo"/> class with the default settings for the PorousMediumPermeability quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PorousMediumPermeabilityInfo"/> class with the default settings.</returns>
-            public static PorousMediumPermeabilityInfo CreateDefault()
-            {
-                return new PorousMediumPermeabilityInfo(nameof(PorousMediumPermeability), DefaultBaseUnit, GetDefaultMappings(), new PorousMediumPermeability(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PorousMediumPermeabilityInfo"/> class with the default settings for the PorousMediumPermeability quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PorousMediumPermeabilityInfo"/> class with the default settings.
             /// </returns>
-            public static PorousMediumPermeabilityInfo CreateDefault(Func<IEnumerable<UnitDefinition<PorousMediumPermeabilityUnit>>, IEnumerable<IUnitDefinition<PorousMediumPermeabilityUnit>>> customizeUnits)
+            private static QuantityInfo<PorousMediumPermeability, PorousMediumPermeabilityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PorousMediumPermeabilityUnit>>, IEnumerable<IUnitDefinition<PorousMediumPermeabilityUnit>>>? customizeUnits = null)
             {
-                return new PorousMediumPermeabilityInfo(nameof(PorousMediumPermeability), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new PorousMediumPermeability(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PorousMediumPermeabilityUnit>> unitMappings = PorousMediumPermeabilityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<PorousMediumPermeability, PorousMediumPermeabilityUnit>(
+                    name: nameof(PorousMediumPermeability),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new PorousMediumPermeability(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="PorousMediumPermeability"/> is [L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of PorousMediumPermeability is SquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PorousMediumPermeabilityUnit DefaultBaseUnit { get; } = PorousMediumPermeabilityUnit.SquareMeter;
+            private static PorousMediumPermeabilityUnit DefaultBaseUnit { get; } = PorousMediumPermeabilityUnit.SquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the PorousMediumPermeability quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.PorousMediumPermeability", typeof(PorousMediumPermeability).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PorousMediumPermeabilityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PorousMediumPermeabilityUnit}"/> representing the default unit mappings for PorousMediumPermeability.</returns>
-            public static IEnumerable<UnitDefinition<PorousMediumPermeabilityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PorousMediumPermeabilityUnit>> GetDefaultMappings()
             {
                 yield return new (PorousMediumPermeabilityUnit.Darcy, "Darcy", "Darcys", BaseUnits.Undefined);
                 yield return new (PorousMediumPermeabilityUnit.Microdarcy, "Microdarcy", "Microdarcys", BaseUnits.Undefined);
@@ -129,7 +129,7 @@ namespace UnitsNet
 
         static PorousMediumPermeability()
         {
-            Info = PorousMediumPermeabilityInfo.CreateDefault();
+            Info = PorousMediumPermeabilityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -78,59 +78,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Power"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PowerInfo: QuantityInfo<Power, PowerUnit>
+        private static class PowerInfo
         {
-            /// <inheritdoc />
-            public PowerInfo(string name, PowerUnit baseUnit, IEnumerable<IUnitDefinition<PowerUnit>> unitMappings, Power zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Power, PowerUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Power.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PowerInfo(string name, PowerUnit baseUnit, IEnumerable<IUnitDefinition<PowerUnit>> unitMappings, Power zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Power.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Power", typeof(Power).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PowerInfo"/> class with the default settings for the Power quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PowerInfo"/> class with the default settings.</returns>
-            public static PowerInfo CreateDefault()
-            {
-                return new PowerInfo(nameof(Power), DefaultBaseUnit, GetDefaultMappings(), new Power(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PowerInfo"/> class with the default settings for the Power quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PowerInfo"/> class with the default settings.
             /// </returns>
-            public static PowerInfo CreateDefault(Func<IEnumerable<UnitDefinition<PowerUnit>>, IEnumerable<IUnitDefinition<PowerUnit>>> customizeUnits)
+            private static QuantityInfo<Power, PowerUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PowerUnit>>, IEnumerable<IUnitDefinition<PowerUnit>>>? customizeUnits = null)
             {
-                return new PowerInfo(nameof(Power), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Power(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PowerUnit>> unitMappings = PowerInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Power, PowerUnit>(
+                    name: nameof(Power),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Power(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Power"/> is [T^-3][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Power is Watt. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PowerUnit DefaultBaseUnit { get; } = PowerUnit.Watt;
+            private static PowerUnit DefaultBaseUnit { get; } = PowerUnit.Watt;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Power quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Power", typeof(Power).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PowerUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PowerUnit}"/> representing the default unit mappings for Power.</returns>
-            public static IEnumerable<UnitDefinition<PowerUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PowerUnit>> GetDefaultMappings()
             {
                 yield return new (PowerUnit.BoilerHorsepower, "BoilerHorsepower", "BoilerHorsepower", BaseUnits.Undefined);
                 yield return new (PowerUnit.BritishThermalUnitPerHour, "BritishThermalUnitPerHour", "BritishThermalUnitsPerHour", BaseUnits.Undefined);
@@ -164,7 +164,7 @@ namespace UnitsNet
 
         static Power()
         {
-            Info = PowerInfo.CreateDefault();
+            Info = PowerInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="PowerDensity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PowerDensityInfo: QuantityInfo<PowerDensity, PowerDensityUnit>
+        private static class PowerDensityInfo
         {
-            /// <inheritdoc />
-            public PowerDensityInfo(string name, PowerDensityUnit baseUnit, IEnumerable<IUnitDefinition<PowerDensityUnit>> unitMappings, PowerDensity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<PowerDensity, PowerDensityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, PowerDensity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PowerDensityInfo(string name, PowerDensityUnit baseUnit, IEnumerable<IUnitDefinition<PowerDensityUnit>> unitMappings, PowerDensity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, PowerDensity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.PowerDensity", typeof(PowerDensity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PowerDensityInfo"/> class with the default settings for the PowerDensity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PowerDensityInfo"/> class with the default settings.</returns>
-            public static PowerDensityInfo CreateDefault()
-            {
-                return new PowerDensityInfo(nameof(PowerDensity), DefaultBaseUnit, GetDefaultMappings(), new PowerDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PowerDensityInfo"/> class with the default settings for the PowerDensity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PowerDensityInfo"/> class with the default settings.
             /// </returns>
-            public static PowerDensityInfo CreateDefault(Func<IEnumerable<UnitDefinition<PowerDensityUnit>>, IEnumerable<IUnitDefinition<PowerDensityUnit>>> customizeUnits)
+            private static QuantityInfo<PowerDensity, PowerDensityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PowerDensityUnit>>, IEnumerable<IUnitDefinition<PowerDensityUnit>>>? customizeUnits = null)
             {
-                return new PowerDensityInfo(nameof(PowerDensity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new PowerDensity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PowerDensityUnit>> unitMappings = PowerDensityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<PowerDensity, PowerDensityUnit>(
+                    name: nameof(PowerDensity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new PowerDensity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="PowerDensity"/> is [T^-3][L^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of PowerDensity is WattPerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PowerDensityUnit DefaultBaseUnit { get; } = PowerDensityUnit.WattPerCubicMeter;
+            private static PowerDensityUnit DefaultBaseUnit { get; } = PowerDensityUnit.WattPerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the PowerDensity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.PowerDensity", typeof(PowerDensity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PowerDensityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PowerDensityUnit}"/> representing the default unit mappings for PowerDensity.</returns>
-            public static IEnumerable<UnitDefinition<PowerDensityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PowerDensityUnit>> GetDefaultMappings()
             {
                 yield return new (PowerDensityUnit.DecawattPerCubicFoot, "DecawattPerCubicFoot", "DecawattsPerCubicFoot", BaseUnits.Undefined);
                 yield return new (PowerDensityUnit.DecawattPerCubicInch, "DecawattPerCubicInch", "DecawattsPerCubicInch", BaseUnits.Undefined);
@@ -165,7 +165,7 @@ namespace UnitsNet
 
         static PowerDensity()
         {
-            Info = PowerDensityInfo.CreateDefault();
+            Info = PowerDensityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="PowerRatio"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PowerRatioInfo: QuantityInfo<PowerRatio, PowerRatioUnit>
+        private static class PowerRatioInfo
         {
-            /// <inheritdoc />
-            public PowerRatioInfo(string name, PowerRatioUnit baseUnit, IEnumerable<IUnitDefinition<PowerRatioUnit>> unitMappings, PowerRatio zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<PowerRatio, PowerRatioUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, PowerRatio.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PowerRatioInfo(string name, PowerRatioUnit baseUnit, IEnumerable<IUnitDefinition<PowerRatioUnit>> unitMappings, PowerRatio zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, PowerRatio.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.PowerRatio", typeof(PowerRatio).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PowerRatioInfo"/> class with the default settings for the PowerRatio quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PowerRatioInfo"/> class with the default settings.</returns>
-            public static PowerRatioInfo CreateDefault()
-            {
-                return new PowerRatioInfo(nameof(PowerRatio), DefaultBaseUnit, GetDefaultMappings(), new PowerRatio(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PowerRatioInfo"/> class with the default settings for the PowerRatio quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PowerRatioInfo"/> class with the default settings.
             /// </returns>
-            public static PowerRatioInfo CreateDefault(Func<IEnumerable<UnitDefinition<PowerRatioUnit>>, IEnumerable<IUnitDefinition<PowerRatioUnit>>> customizeUnits)
+            private static QuantityInfo<PowerRatio, PowerRatioUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PowerRatioUnit>>, IEnumerable<IUnitDefinition<PowerRatioUnit>>>? customizeUnits = null)
             {
-                return new PowerRatioInfo(nameof(PowerRatio), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new PowerRatio(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PowerRatioUnit>> unitMappings = PowerRatioInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<PowerRatio, PowerRatioUnit>(
+                    name: nameof(PowerRatio),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new PowerRatio(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="PowerRatio"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of PowerRatio is DecibelWatt. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PowerRatioUnit DefaultBaseUnit { get; } = PowerRatioUnit.DecibelWatt;
+            private static PowerRatioUnit DefaultBaseUnit { get; } = PowerRatioUnit.DecibelWatt;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the PowerRatio quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.PowerRatio", typeof(PowerRatio).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PowerRatioUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PowerRatioUnit}"/> representing the default unit mappings for PowerRatio.</returns>
-            public static IEnumerable<UnitDefinition<PowerRatioUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PowerRatioUnit>> GetDefaultMappings()
             {
                 yield return new (PowerRatioUnit.DecibelMilliwatt, "DecibelMilliwatt", "DecibelMilliwatts", BaseUnits.Undefined);
                 yield return new (PowerRatioUnit.DecibelWatt, "DecibelWatt", "DecibelWatts", BaseUnits.Undefined);
@@ -123,7 +123,7 @@ namespace UnitsNet
 
         static PowerRatio()
         {
-            Info = PowerRatioInfo.CreateDefault();
+            Info = PowerRatioInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -74,59 +74,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Pressure"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PressureInfo: QuantityInfo<Pressure, PressureUnit>
+        private static class PressureInfo
         {
-            /// <inheritdoc />
-            public PressureInfo(string name, PressureUnit baseUnit, IEnumerable<IUnitDefinition<PressureUnit>> unitMappings, Pressure zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Pressure, PressureUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Pressure.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PressureInfo(string name, PressureUnit baseUnit, IEnumerable<IUnitDefinition<PressureUnit>> unitMappings, Pressure zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Pressure.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Pressure", typeof(Pressure).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PressureInfo"/> class with the default settings for the Pressure quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PressureInfo"/> class with the default settings.</returns>
-            public static PressureInfo CreateDefault()
-            {
-                return new PressureInfo(nameof(Pressure), DefaultBaseUnit, GetDefaultMappings(), new Pressure(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PressureInfo"/> class with the default settings for the Pressure quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PressureInfo"/> class with the default settings.
             /// </returns>
-            public static PressureInfo CreateDefault(Func<IEnumerable<UnitDefinition<PressureUnit>>, IEnumerable<IUnitDefinition<PressureUnit>>> customizeUnits)
+            private static QuantityInfo<Pressure, PressureUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PressureUnit>>, IEnumerable<IUnitDefinition<PressureUnit>>>? customizeUnits = null)
             {
-                return new PressureInfo(nameof(Pressure), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Pressure(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PressureUnit>> unitMappings = PressureInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Pressure, PressureUnit>(
+                    name: nameof(Pressure),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Pressure(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Pressure"/> is [T^-2][L^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Pressure is Pascal. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PressureUnit DefaultBaseUnit { get; } = PressureUnit.Pascal;
+            private static PressureUnit DefaultBaseUnit { get; } = PressureUnit.Pascal;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Pressure quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Pressure", typeof(Pressure).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PressureUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PressureUnit}"/> representing the default unit mappings for Pressure.</returns>
-            public static IEnumerable<UnitDefinition<PressureUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PressureUnit>> GetDefaultMappings()
             {
                 yield return new (PressureUnit.Atmosphere, "Atmosphere", "Atmospheres", BaseUnits.Undefined);
                 yield return new (PressureUnit.Bar, "Bar", "Bars", BaseUnits.Undefined);
@@ -180,7 +180,7 @@ namespace UnitsNet
 
         static Pressure()
         {
-            Info = PressureInfo.CreateDefault();
+            Info = PressureInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="PressureChangeRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class PressureChangeRateInfo: QuantityInfo<PressureChangeRate, PressureChangeRateUnit>
+        private static class PressureChangeRateInfo
         {
-            /// <inheritdoc />
-            public PressureChangeRateInfo(string name, PressureChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<PressureChangeRateUnit>> unitMappings, PressureChangeRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<PressureChangeRate, PressureChangeRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, PressureChangeRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public PressureChangeRateInfo(string name, PressureChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<PressureChangeRateUnit>> unitMappings, PressureChangeRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, PressureChangeRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.PressureChangeRate", typeof(PressureChangeRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="PressureChangeRateInfo"/> class with the default settings for the PressureChangeRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="PressureChangeRateInfo"/> class with the default settings.</returns>
-            public static PressureChangeRateInfo CreateDefault()
-            {
-                return new PressureChangeRateInfo(nameof(PressureChangeRate), DefaultBaseUnit, GetDefaultMappings(), new PressureChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="PressureChangeRateInfo"/> class with the default settings for the PressureChangeRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="PressureChangeRateInfo"/> class with the default settings.
             /// </returns>
-            public static PressureChangeRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<PressureChangeRateUnit>>, IEnumerable<IUnitDefinition<PressureChangeRateUnit>>> customizeUnits)
+            private static QuantityInfo<PressureChangeRate, PressureChangeRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<PressureChangeRateUnit>>, IEnumerable<IUnitDefinition<PressureChangeRateUnit>>>? customizeUnits = null)
             {
-                return new PressureChangeRateInfo(nameof(PressureChangeRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new PressureChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<PressureChangeRateUnit>> unitMappings = PressureChangeRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<PressureChangeRate, PressureChangeRateUnit>(
+                    name: nameof(PressureChangeRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new PressureChangeRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="PressureChangeRate"/> is [T^-3][L^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of PressureChangeRate is PascalPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static PressureChangeRateUnit DefaultBaseUnit { get; } = PressureChangeRateUnit.PascalPerSecond;
+            private static PressureChangeRateUnit DefaultBaseUnit { get; } = PressureChangeRateUnit.PascalPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the PressureChangeRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.PressureChangeRate", typeof(PressureChangeRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="PressureChangeRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{PressureChangeRateUnit}"/> representing the default unit mappings for PressureChangeRate.</returns>
-            public static IEnumerable<UnitDefinition<PressureChangeRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<PressureChangeRateUnit>> GetDefaultMappings()
             {
                 yield return new (PressureChangeRateUnit.AtmospherePerSecond, "AtmospherePerSecond", "AtmospheresPerSecond", BaseUnits.Undefined);
                 yield return new (PressureChangeRateUnit.BarPerMinute, "BarPerMinute", "BarsPerMinute", BaseUnits.Undefined);
@@ -142,7 +142,7 @@ namespace UnitsNet
 
         static PressureChangeRate()
         {
-            Info = PressureChangeRateInfo.CreateDefault();
+            Info = PressureChangeRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RadiationEquivalentDose"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RadiationEquivalentDoseInfo: QuantityInfo<RadiationEquivalentDose, RadiationEquivalentDoseUnit>
+        private static class RadiationEquivalentDoseInfo
         {
-            /// <inheritdoc />
-            public RadiationEquivalentDoseInfo(string name, RadiationEquivalentDoseUnit baseUnit, IEnumerable<IUnitDefinition<RadiationEquivalentDoseUnit>> unitMappings, RadiationEquivalentDose zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RadiationEquivalentDose, RadiationEquivalentDoseUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RadiationEquivalentDose.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RadiationEquivalentDoseInfo(string name, RadiationEquivalentDoseUnit baseUnit, IEnumerable<IUnitDefinition<RadiationEquivalentDoseUnit>> unitMappings, RadiationEquivalentDose zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RadiationEquivalentDose.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RadiationEquivalentDose", typeof(RadiationEquivalentDose).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RadiationEquivalentDoseInfo"/> class with the default settings for the RadiationEquivalentDose quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RadiationEquivalentDoseInfo"/> class with the default settings.</returns>
-            public static RadiationEquivalentDoseInfo CreateDefault()
-            {
-                return new RadiationEquivalentDoseInfo(nameof(RadiationEquivalentDose), DefaultBaseUnit, GetDefaultMappings(), new RadiationEquivalentDose(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RadiationEquivalentDoseInfo"/> class with the default settings for the RadiationEquivalentDose quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RadiationEquivalentDoseInfo"/> class with the default settings.
             /// </returns>
-            public static RadiationEquivalentDoseInfo CreateDefault(Func<IEnumerable<UnitDefinition<RadiationEquivalentDoseUnit>>, IEnumerable<IUnitDefinition<RadiationEquivalentDoseUnit>>> customizeUnits)
+            private static QuantityInfo<RadiationEquivalentDose, RadiationEquivalentDoseUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RadiationEquivalentDoseUnit>>, IEnumerable<IUnitDefinition<RadiationEquivalentDoseUnit>>>? customizeUnits = null)
             {
-                return new RadiationEquivalentDoseInfo(nameof(RadiationEquivalentDose), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RadiationEquivalentDose(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RadiationEquivalentDoseUnit>> unitMappings = RadiationEquivalentDoseInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RadiationEquivalentDose, RadiationEquivalentDoseUnit>(
+                    name: nameof(RadiationEquivalentDose),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RadiationEquivalentDose(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RadiationEquivalentDose"/> is [T^-2][L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RadiationEquivalentDose is Sievert. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RadiationEquivalentDoseUnit DefaultBaseUnit { get; } = RadiationEquivalentDoseUnit.Sievert;
+            private static RadiationEquivalentDoseUnit DefaultBaseUnit { get; } = RadiationEquivalentDoseUnit.Sievert;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RadiationEquivalentDose quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RadiationEquivalentDose", typeof(RadiationEquivalentDose).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RadiationEquivalentDoseUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RadiationEquivalentDoseUnit}"/> representing the default unit mappings for RadiationEquivalentDose.</returns>
-            public static IEnumerable<UnitDefinition<RadiationEquivalentDoseUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RadiationEquivalentDoseUnit>> GetDefaultMappings()
             {
                 yield return new (RadiationEquivalentDoseUnit.Microsievert, "Microsievert", "Microsieverts", new BaseUnits(length: LengthUnit.Millimeter, time: DurationUnit.Second));
                 yield return new (RadiationEquivalentDoseUnit.MilliroentgenEquivalentMan, "MilliroentgenEquivalentMan", "MilliroentgensEquivalentMan", BaseUnits.Undefined);
@@ -131,7 +131,7 @@ namespace UnitsNet
 
         static RadiationEquivalentDose()
         {
-            Info = RadiationEquivalentDoseInfo.CreateDefault();
+            Info = RadiationEquivalentDoseInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RadiationEquivalentDoseRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RadiationEquivalentDoseRateInfo: QuantityInfo<RadiationEquivalentDoseRate, RadiationEquivalentDoseRateUnit>
+        private static class RadiationEquivalentDoseRateInfo
         {
-            /// <inheritdoc />
-            public RadiationEquivalentDoseRateInfo(string name, RadiationEquivalentDoseRateUnit baseUnit, IEnumerable<IUnitDefinition<RadiationEquivalentDoseRateUnit>> unitMappings, RadiationEquivalentDoseRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RadiationEquivalentDoseRate, RadiationEquivalentDoseRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RadiationEquivalentDoseRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RadiationEquivalentDoseRateInfo(string name, RadiationEquivalentDoseRateUnit baseUnit, IEnumerable<IUnitDefinition<RadiationEquivalentDoseRateUnit>> unitMappings, RadiationEquivalentDoseRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RadiationEquivalentDoseRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RadiationEquivalentDoseRate", typeof(RadiationEquivalentDoseRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RadiationEquivalentDoseRateInfo"/> class with the default settings for the RadiationEquivalentDoseRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RadiationEquivalentDoseRateInfo"/> class with the default settings.</returns>
-            public static RadiationEquivalentDoseRateInfo CreateDefault()
-            {
-                return new RadiationEquivalentDoseRateInfo(nameof(RadiationEquivalentDoseRate), DefaultBaseUnit, GetDefaultMappings(), new RadiationEquivalentDoseRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RadiationEquivalentDoseRateInfo"/> class with the default settings for the RadiationEquivalentDoseRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RadiationEquivalentDoseRateInfo"/> class with the default settings.
             /// </returns>
-            public static RadiationEquivalentDoseRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<RadiationEquivalentDoseRateUnit>>, IEnumerable<IUnitDefinition<RadiationEquivalentDoseRateUnit>>> customizeUnits)
+            private static QuantityInfo<RadiationEquivalentDoseRate, RadiationEquivalentDoseRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RadiationEquivalentDoseRateUnit>>, IEnumerable<IUnitDefinition<RadiationEquivalentDoseRateUnit>>>? customizeUnits = null)
             {
-                return new RadiationEquivalentDoseRateInfo(nameof(RadiationEquivalentDoseRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RadiationEquivalentDoseRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RadiationEquivalentDoseRateUnit>> unitMappings = RadiationEquivalentDoseRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RadiationEquivalentDoseRate, RadiationEquivalentDoseRateUnit>(
+                    name: nameof(RadiationEquivalentDoseRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RadiationEquivalentDoseRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RadiationEquivalentDoseRate"/> is [T^-3][L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -3, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -3, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RadiationEquivalentDoseRate is SievertPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RadiationEquivalentDoseRateUnit DefaultBaseUnit { get; } = RadiationEquivalentDoseRateUnit.SievertPerSecond;
+            private static RadiationEquivalentDoseRateUnit DefaultBaseUnit { get; } = RadiationEquivalentDoseRateUnit.SievertPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RadiationEquivalentDoseRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RadiationEquivalentDoseRate", typeof(RadiationEquivalentDoseRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RadiationEquivalentDoseRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RadiationEquivalentDoseRateUnit}"/> representing the default unit mappings for RadiationEquivalentDoseRate.</returns>
-            public static IEnumerable<UnitDefinition<RadiationEquivalentDoseRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RadiationEquivalentDoseRateUnit>> GetDefaultMappings()
             {
                 yield return new (RadiationEquivalentDoseRateUnit.MicrosievertPerHour, "MicrosievertPerHour", "MicrosievertsPerHour", BaseUnits.Undefined);
                 yield return new (RadiationEquivalentDoseRateUnit.MicrosievertPerSecond, "MicrosievertPerSecond", "MicrosievertsPerSecond", new BaseUnits(length: LengthUnit.Millimeter, time: DurationUnit.Second));
@@ -134,7 +134,7 @@ namespace UnitsNet
 
         static RadiationEquivalentDoseRate()
         {
-            Info = RadiationEquivalentDoseRateInfo.CreateDefault();
+            Info = RadiationEquivalentDoseRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RadiationExposure"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RadiationExposureInfo: QuantityInfo<RadiationExposure, RadiationExposureUnit>
+        private static class RadiationExposureInfo
         {
-            /// <inheritdoc />
-            public RadiationExposureInfo(string name, RadiationExposureUnit baseUnit, IEnumerable<IUnitDefinition<RadiationExposureUnit>> unitMappings, RadiationExposure zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RadiationExposure, RadiationExposureUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RadiationExposure.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RadiationExposureInfo(string name, RadiationExposureUnit baseUnit, IEnumerable<IUnitDefinition<RadiationExposureUnit>> unitMappings, RadiationExposure zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RadiationExposure.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RadiationExposure", typeof(RadiationExposure).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RadiationExposureInfo"/> class with the default settings for the RadiationExposure quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RadiationExposureInfo"/> class with the default settings.</returns>
-            public static RadiationExposureInfo CreateDefault()
-            {
-                return new RadiationExposureInfo(nameof(RadiationExposure), DefaultBaseUnit, GetDefaultMappings(), new RadiationExposure(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RadiationExposureInfo"/> class with the default settings for the RadiationExposure quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RadiationExposureInfo"/> class with the default settings.
             /// </returns>
-            public static RadiationExposureInfo CreateDefault(Func<IEnumerable<UnitDefinition<RadiationExposureUnit>>, IEnumerable<IUnitDefinition<RadiationExposureUnit>>> customizeUnits)
+            private static QuantityInfo<RadiationExposure, RadiationExposureUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RadiationExposureUnit>>, IEnumerable<IUnitDefinition<RadiationExposureUnit>>>? customizeUnits = null)
             {
-                return new RadiationExposureInfo(nameof(RadiationExposure), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RadiationExposure(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RadiationExposureUnit>> unitMappings = RadiationExposureInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RadiationExposure, RadiationExposureUnit>(
+                    name: nameof(RadiationExposure),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RadiationExposure(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RadiationExposure"/> is [T][M^-1][I].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, -1, 1, 1, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, -1, 1, 1, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RadiationExposure is CoulombPerKilogram. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RadiationExposureUnit DefaultBaseUnit { get; } = RadiationExposureUnit.CoulombPerKilogram;
+            private static RadiationExposureUnit DefaultBaseUnit { get; } = RadiationExposureUnit.CoulombPerKilogram;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RadiationExposure quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RadiationExposure", typeof(RadiationExposure).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RadiationExposureUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RadiationExposureUnit}"/> representing the default unit mappings for RadiationExposure.</returns>
-            public static IEnumerable<UnitDefinition<RadiationExposureUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RadiationExposureUnit>> GetDefaultMappings()
             {
                 yield return new (RadiationExposureUnit.CoulombPerKilogram, "CoulombPerKilogram", "CoulombsPerKilogram", new BaseUnits(mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Ampere));
                 yield return new (RadiationExposureUnit.MicrocoulombPerKilogram, "MicrocoulombPerKilogram", "MicrocoulombsPerKilogram", new BaseUnits(mass: MassUnit.Kilogram, time: DurationUnit.Second, current: ElectricCurrentUnit.Microampere));
@@ -129,7 +129,7 @@ namespace UnitsNet
 
         static RadiationExposure()
         {
-            Info = RadiationExposureInfo.CreateDefault();
+            Info = RadiationExposureInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Radioactivity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RadioactivityInfo: QuantityInfo<Radioactivity, RadioactivityUnit>
+        private static class RadioactivityInfo
         {
-            /// <inheritdoc />
-            public RadioactivityInfo(string name, RadioactivityUnit baseUnit, IEnumerable<IUnitDefinition<RadioactivityUnit>> unitMappings, Radioactivity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Radioactivity, RadioactivityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Radioactivity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RadioactivityInfo(string name, RadioactivityUnit baseUnit, IEnumerable<IUnitDefinition<RadioactivityUnit>> unitMappings, Radioactivity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Radioactivity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Radioactivity", typeof(Radioactivity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RadioactivityInfo"/> class with the default settings for the Radioactivity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RadioactivityInfo"/> class with the default settings.</returns>
-            public static RadioactivityInfo CreateDefault()
-            {
-                return new RadioactivityInfo(nameof(Radioactivity), DefaultBaseUnit, GetDefaultMappings(), new Radioactivity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RadioactivityInfo"/> class with the default settings for the Radioactivity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RadioactivityInfo"/> class with the default settings.
             /// </returns>
-            public static RadioactivityInfo CreateDefault(Func<IEnumerable<UnitDefinition<RadioactivityUnit>>, IEnumerable<IUnitDefinition<RadioactivityUnit>>> customizeUnits)
+            private static QuantityInfo<Radioactivity, RadioactivityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RadioactivityUnit>>, IEnumerable<IUnitDefinition<RadioactivityUnit>>>? customizeUnits = null)
             {
-                return new RadioactivityInfo(nameof(Radioactivity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Radioactivity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RadioactivityUnit>> unitMappings = RadioactivityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Radioactivity, RadioactivityUnit>(
+                    name: nameof(Radioactivity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Radioactivity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Radioactivity"/> is [T^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Radioactivity is Becquerel. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RadioactivityUnit DefaultBaseUnit { get; } = RadioactivityUnit.Becquerel;
+            private static RadioactivityUnit DefaultBaseUnit { get; } = RadioactivityUnit.Becquerel;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Radioactivity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Radioactivity", typeof(Radioactivity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RadioactivityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RadioactivityUnit}"/> representing the default unit mappings for Radioactivity.</returns>
-            public static IEnumerable<UnitDefinition<RadioactivityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RadioactivityUnit>> GetDefaultMappings()
             {
                 yield return new (RadioactivityUnit.Becquerel, "Becquerel", "Becquerels", new BaseUnits(time: DurationUnit.Second));
                 yield return new (RadioactivityUnit.Curie, "Curie", "Curies", new BaseUnits(time: DurationUnit.Second));
@@ -150,7 +150,7 @@ namespace UnitsNet
 
         static Radioactivity()
         {
-            Info = RadioactivityInfo.CreateDefault();
+            Info = RadioactivityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Ratio"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RatioInfo: QuantityInfo<Ratio, RatioUnit>
+        private static class RatioInfo
         {
-            /// <inheritdoc />
-            public RatioInfo(string name, RatioUnit baseUnit, IEnumerable<IUnitDefinition<RatioUnit>> unitMappings, Ratio zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Ratio, RatioUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Ratio.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RatioInfo(string name, RatioUnit baseUnit, IEnumerable<IUnitDefinition<RatioUnit>> unitMappings, Ratio zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Ratio.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Ratio", typeof(Ratio).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RatioInfo"/> class with the default settings for the Ratio quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RatioInfo"/> class with the default settings.</returns>
-            public static RatioInfo CreateDefault()
-            {
-                return new RatioInfo(nameof(Ratio), DefaultBaseUnit, GetDefaultMappings(), new Ratio(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RatioInfo"/> class with the default settings for the Ratio quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RatioInfo"/> class with the default settings.
             /// </returns>
-            public static RatioInfo CreateDefault(Func<IEnumerable<UnitDefinition<RatioUnit>>, IEnumerable<IUnitDefinition<RatioUnit>>> customizeUnits)
+            private static QuantityInfo<Ratio, RatioUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RatioUnit>>, IEnumerable<IUnitDefinition<RatioUnit>>>? customizeUnits = null)
             {
-                return new RatioInfo(nameof(Ratio), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Ratio(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RatioUnit>> unitMappings = RatioInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Ratio, RatioUnit>(
+                    name: nameof(Ratio),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Ratio(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Ratio"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of Ratio is DecimalFraction. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RatioUnit DefaultBaseUnit { get; } = RatioUnit.DecimalFraction;
+            private static RatioUnit DefaultBaseUnit { get; } = RatioUnit.DecimalFraction;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Ratio quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Ratio", typeof(Ratio).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RatioUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RatioUnit}"/> representing the default unit mappings for Ratio.</returns>
-            public static IEnumerable<UnitDefinition<RatioUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RatioUnit>> GetDefaultMappings()
             {
                 yield return new (RatioUnit.DecimalFraction, "DecimalFraction", "DecimalFractions", BaseUnits.Undefined);
                 yield return new (RatioUnit.PartPerBillion, "PartPerBillion", "PartsPerBillion", BaseUnits.Undefined);
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static Ratio()
         {
-            Info = RatioInfo.CreateDefault();
+            Info = RatioInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RatioChangeRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RatioChangeRateInfo: QuantityInfo<RatioChangeRate, RatioChangeRateUnit>
+        private static class RatioChangeRateInfo
         {
-            /// <inheritdoc />
-            public RatioChangeRateInfo(string name, RatioChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<RatioChangeRateUnit>> unitMappings, RatioChangeRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RatioChangeRate, RatioChangeRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RatioChangeRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RatioChangeRateInfo(string name, RatioChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<RatioChangeRateUnit>> unitMappings, RatioChangeRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RatioChangeRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RatioChangeRate", typeof(RatioChangeRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RatioChangeRateInfo"/> class with the default settings for the RatioChangeRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RatioChangeRateInfo"/> class with the default settings.</returns>
-            public static RatioChangeRateInfo CreateDefault()
-            {
-                return new RatioChangeRateInfo(nameof(RatioChangeRate), DefaultBaseUnit, GetDefaultMappings(), new RatioChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RatioChangeRateInfo"/> class with the default settings for the RatioChangeRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RatioChangeRateInfo"/> class with the default settings.
             /// </returns>
-            public static RatioChangeRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<RatioChangeRateUnit>>, IEnumerable<IUnitDefinition<RatioChangeRateUnit>>> customizeUnits)
+            private static QuantityInfo<RatioChangeRate, RatioChangeRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RatioChangeRateUnit>>, IEnumerable<IUnitDefinition<RatioChangeRateUnit>>>? customizeUnits = null)
             {
-                return new RatioChangeRateInfo(nameof(RatioChangeRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RatioChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RatioChangeRateUnit>> unitMappings = RatioChangeRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RatioChangeRate, RatioChangeRateUnit>(
+                    name: nameof(RatioChangeRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RatioChangeRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RatioChangeRate"/> is [T^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RatioChangeRate is DecimalFractionPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RatioChangeRateUnit DefaultBaseUnit { get; } = RatioChangeRateUnit.DecimalFractionPerSecond;
+            private static RatioChangeRateUnit DefaultBaseUnit { get; } = RatioChangeRateUnit.DecimalFractionPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RatioChangeRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RatioChangeRate", typeof(RatioChangeRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RatioChangeRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RatioChangeRateUnit}"/> representing the default unit mappings for RatioChangeRate.</returns>
-            public static IEnumerable<UnitDefinition<RatioChangeRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RatioChangeRateUnit>> GetDefaultMappings()
             {
                 yield return new (RatioChangeRateUnit.DecimalFractionPerSecond, "DecimalFractionPerSecond", "DecimalFractionsPerSecond", new BaseUnits(time: DurationUnit.Second));
                 yield return new (RatioChangeRateUnit.PercentPerSecond, "PercentPerSecond", "PercentsPerSecond", BaseUnits.Undefined);
@@ -123,7 +123,7 @@ namespace UnitsNet
 
         static RatioChangeRate()
         {
-            Info = RatioChangeRateInfo.CreateDefault();
+            Info = RatioChangeRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -72,59 +72,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ReciprocalArea"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ReciprocalAreaInfo: QuantityInfo<ReciprocalArea, ReciprocalAreaUnit>
+        private static class ReciprocalAreaInfo
         {
-            /// <inheritdoc />
-            public ReciprocalAreaInfo(string name, ReciprocalAreaUnit baseUnit, IEnumerable<IUnitDefinition<ReciprocalAreaUnit>> unitMappings, ReciprocalArea zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ReciprocalArea, ReciprocalAreaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ReciprocalArea.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ReciprocalAreaInfo(string name, ReciprocalAreaUnit baseUnit, IEnumerable<IUnitDefinition<ReciprocalAreaUnit>> unitMappings, ReciprocalArea zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ReciprocalArea.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ReciprocalArea", typeof(ReciprocalArea).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ReciprocalAreaInfo"/> class with the default settings for the ReciprocalArea quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ReciprocalAreaInfo"/> class with the default settings.</returns>
-            public static ReciprocalAreaInfo CreateDefault()
-            {
-                return new ReciprocalAreaInfo(nameof(ReciprocalArea), DefaultBaseUnit, GetDefaultMappings(), new ReciprocalArea(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ReciprocalAreaInfo"/> class with the default settings for the ReciprocalArea quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ReciprocalAreaInfo"/> class with the default settings.
             /// </returns>
-            public static ReciprocalAreaInfo CreateDefault(Func<IEnumerable<UnitDefinition<ReciprocalAreaUnit>>, IEnumerable<IUnitDefinition<ReciprocalAreaUnit>>> customizeUnits)
+            private static QuantityInfo<ReciprocalArea, ReciprocalAreaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ReciprocalAreaUnit>>, IEnumerable<IUnitDefinition<ReciprocalAreaUnit>>>? customizeUnits = null)
             {
-                return new ReciprocalAreaInfo(nameof(ReciprocalArea), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ReciprocalArea(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ReciprocalAreaUnit>> unitMappings = ReciprocalAreaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ReciprocalArea, ReciprocalAreaUnit>(
+                    name: nameof(ReciprocalArea),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ReciprocalArea(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ReciprocalArea"/> is [L^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ReciprocalArea is InverseSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ReciprocalAreaUnit DefaultBaseUnit { get; } = ReciprocalAreaUnit.InverseSquareMeter;
+            private static ReciprocalAreaUnit DefaultBaseUnit { get; } = ReciprocalAreaUnit.InverseSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ReciprocalArea quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ReciprocalArea", typeof(ReciprocalArea).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ReciprocalAreaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ReciprocalAreaUnit}"/> representing the default unit mappings for ReciprocalArea.</returns>
-            public static IEnumerable<UnitDefinition<ReciprocalAreaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ReciprocalAreaUnit>> GetDefaultMappings()
             {
                 yield return new (ReciprocalAreaUnit.InverseSquareCentimeter, "InverseSquareCentimeter", "InverseSquareCentimeters", new BaseUnits(length: LengthUnit.Centimeter));
                 yield return new (ReciprocalAreaUnit.InverseSquareDecimeter, "InverseSquareDecimeter", "InverseSquareDecimeters", new BaseUnits(length: LengthUnit.Decimeter));
@@ -142,7 +142,7 @@ namespace UnitsNet
 
         static ReciprocalArea()
         {
-            Info = ReciprocalAreaInfo.CreateDefault();
+            Info = ReciprocalAreaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -74,59 +74,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ReciprocalLength"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ReciprocalLengthInfo: QuantityInfo<ReciprocalLength, ReciprocalLengthUnit>
+        private static class ReciprocalLengthInfo
         {
-            /// <inheritdoc />
-            public ReciprocalLengthInfo(string name, ReciprocalLengthUnit baseUnit, IEnumerable<IUnitDefinition<ReciprocalLengthUnit>> unitMappings, ReciprocalLength zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ReciprocalLength, ReciprocalLengthUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ReciprocalLength.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ReciprocalLengthInfo(string name, ReciprocalLengthUnit baseUnit, IEnumerable<IUnitDefinition<ReciprocalLengthUnit>> unitMappings, ReciprocalLength zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ReciprocalLength.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ReciprocalLength", typeof(ReciprocalLength).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ReciprocalLengthInfo"/> class with the default settings for the ReciprocalLength quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ReciprocalLengthInfo"/> class with the default settings.</returns>
-            public static ReciprocalLengthInfo CreateDefault()
-            {
-                return new ReciprocalLengthInfo(nameof(ReciprocalLength), DefaultBaseUnit, GetDefaultMappings(), new ReciprocalLength(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ReciprocalLengthInfo"/> class with the default settings for the ReciprocalLength quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ReciprocalLengthInfo"/> class with the default settings.
             /// </returns>
-            public static ReciprocalLengthInfo CreateDefault(Func<IEnumerable<UnitDefinition<ReciprocalLengthUnit>>, IEnumerable<IUnitDefinition<ReciprocalLengthUnit>>> customizeUnits)
+            private static QuantityInfo<ReciprocalLength, ReciprocalLengthUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ReciprocalLengthUnit>>, IEnumerable<IUnitDefinition<ReciprocalLengthUnit>>>? customizeUnits = null)
             {
-                return new ReciprocalLengthInfo(nameof(ReciprocalLength), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ReciprocalLength(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ReciprocalLengthUnit>> unitMappings = ReciprocalLengthInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ReciprocalLength, ReciprocalLengthUnit>(
+                    name: nameof(ReciprocalLength),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ReciprocalLength(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ReciprocalLength"/> is [L^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of ReciprocalLength is InverseMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ReciprocalLengthUnit DefaultBaseUnit { get; } = ReciprocalLengthUnit.InverseMeter;
+            private static ReciprocalLengthUnit DefaultBaseUnit { get; } = ReciprocalLengthUnit.InverseMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ReciprocalLength quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ReciprocalLength", typeof(ReciprocalLength).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ReciprocalLengthUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ReciprocalLengthUnit}"/> representing the default unit mappings for ReciprocalLength.</returns>
-            public static IEnumerable<UnitDefinition<ReciprocalLengthUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ReciprocalLengthUnit>> GetDefaultMappings()
             {
                 yield return new (ReciprocalLengthUnit.InverseCentimeter, "InverseCentimeter", "InverseCentimeters", new BaseUnits(length: LengthUnit.Centimeter));
                 yield return new (ReciprocalLengthUnit.InverseFoot, "InverseFoot", "InverseFeet", new BaseUnits(length: LengthUnit.Foot));
@@ -143,7 +143,7 @@ namespace UnitsNet
 
         static ReciprocalLength()
         {
-            Info = ReciprocalLengthInfo.CreateDefault();
+            Info = ReciprocalLengthInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RelativeHumidity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RelativeHumidityInfo: QuantityInfo<RelativeHumidity, RelativeHumidityUnit>
+        private static class RelativeHumidityInfo
         {
-            /// <inheritdoc />
-            public RelativeHumidityInfo(string name, RelativeHumidityUnit baseUnit, IEnumerable<IUnitDefinition<RelativeHumidityUnit>> unitMappings, RelativeHumidity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RelativeHumidity, RelativeHumidityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RelativeHumidity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RelativeHumidityInfo(string name, RelativeHumidityUnit baseUnit, IEnumerable<IUnitDefinition<RelativeHumidityUnit>> unitMappings, RelativeHumidity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RelativeHumidity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RelativeHumidity", typeof(RelativeHumidity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RelativeHumidityInfo"/> class with the default settings for the RelativeHumidity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RelativeHumidityInfo"/> class with the default settings.</returns>
-            public static RelativeHumidityInfo CreateDefault()
-            {
-                return new RelativeHumidityInfo(nameof(RelativeHumidity), DefaultBaseUnit, GetDefaultMappings(), new RelativeHumidity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RelativeHumidityInfo"/> class with the default settings for the RelativeHumidity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RelativeHumidityInfo"/> class with the default settings.
             /// </returns>
-            public static RelativeHumidityInfo CreateDefault(Func<IEnumerable<UnitDefinition<RelativeHumidityUnit>>, IEnumerable<IUnitDefinition<RelativeHumidityUnit>>> customizeUnits)
+            private static QuantityInfo<RelativeHumidity, RelativeHumidityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RelativeHumidityUnit>>, IEnumerable<IUnitDefinition<RelativeHumidityUnit>>>? customizeUnits = null)
             {
-                return new RelativeHumidityInfo(nameof(RelativeHumidity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RelativeHumidity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RelativeHumidityUnit>> unitMappings = RelativeHumidityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RelativeHumidity, RelativeHumidityUnit>(
+                    name: nameof(RelativeHumidity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RelativeHumidity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RelativeHumidity"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of RelativeHumidity is Percent. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RelativeHumidityUnit DefaultBaseUnit { get; } = RelativeHumidityUnit.Percent;
+            private static RelativeHumidityUnit DefaultBaseUnit { get; } = RelativeHumidityUnit.Percent;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RelativeHumidity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RelativeHumidity", typeof(RelativeHumidity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RelativeHumidityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RelativeHumidityUnit}"/> representing the default unit mappings for RelativeHumidity.</returns>
-            public static IEnumerable<UnitDefinition<RelativeHumidityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RelativeHumidityUnit>> GetDefaultMappings()
             {
                 yield return new (RelativeHumidityUnit.Percent, "Percent", "Percent", BaseUnits.Undefined);
             }
@@ -122,7 +122,7 @@ namespace UnitsNet
 
         static RelativeHumidity()
         {
-            Info = RelativeHumidityInfo.CreateDefault();
+            Info = RelativeHumidityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RotationalAcceleration"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RotationalAccelerationInfo: QuantityInfo<RotationalAcceleration, RotationalAccelerationUnit>
+        private static class RotationalAccelerationInfo
         {
-            /// <inheritdoc />
-            public RotationalAccelerationInfo(string name, RotationalAccelerationUnit baseUnit, IEnumerable<IUnitDefinition<RotationalAccelerationUnit>> unitMappings, RotationalAcceleration zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RotationalAcceleration, RotationalAccelerationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RotationalAcceleration.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RotationalAccelerationInfo(string name, RotationalAccelerationUnit baseUnit, IEnumerable<IUnitDefinition<RotationalAccelerationUnit>> unitMappings, RotationalAcceleration zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RotationalAcceleration.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RotationalAcceleration", typeof(RotationalAcceleration).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RotationalAccelerationInfo"/> class with the default settings for the RotationalAcceleration quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RotationalAccelerationInfo"/> class with the default settings.</returns>
-            public static RotationalAccelerationInfo CreateDefault()
-            {
-                return new RotationalAccelerationInfo(nameof(RotationalAcceleration), DefaultBaseUnit, GetDefaultMappings(), new RotationalAcceleration(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RotationalAccelerationInfo"/> class with the default settings for the RotationalAcceleration quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RotationalAccelerationInfo"/> class with the default settings.
             /// </returns>
-            public static RotationalAccelerationInfo CreateDefault(Func<IEnumerable<UnitDefinition<RotationalAccelerationUnit>>, IEnumerable<IUnitDefinition<RotationalAccelerationUnit>>> customizeUnits)
+            private static QuantityInfo<RotationalAcceleration, RotationalAccelerationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RotationalAccelerationUnit>>, IEnumerable<IUnitDefinition<RotationalAccelerationUnit>>>? customizeUnits = null)
             {
-                return new RotationalAccelerationInfo(nameof(RotationalAcceleration), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RotationalAcceleration(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RotationalAccelerationUnit>> unitMappings = RotationalAccelerationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RotationalAcceleration, RotationalAccelerationUnit>(
+                    name: nameof(RotationalAcceleration),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RotationalAcceleration(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RotationalAcceleration"/> is [T^-2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RotationalAcceleration is RadianPerSecondSquared. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RotationalAccelerationUnit DefaultBaseUnit { get; } = RotationalAccelerationUnit.RadianPerSecondSquared;
+            private static RotationalAccelerationUnit DefaultBaseUnit { get; } = RotationalAccelerationUnit.RadianPerSecondSquared;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RotationalAcceleration quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RotationalAcceleration", typeof(RotationalAcceleration).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RotationalAccelerationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RotationalAccelerationUnit}"/> representing the default unit mappings for RotationalAcceleration.</returns>
-            public static IEnumerable<UnitDefinition<RotationalAccelerationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RotationalAccelerationUnit>> GetDefaultMappings()
             {
                 yield return new (RotationalAccelerationUnit.DegreePerSecondSquared, "DegreePerSecondSquared", "DegreesPerSecondSquared", BaseUnits.Undefined);
                 yield return new (RotationalAccelerationUnit.RadianPerSecondSquared, "RadianPerSecondSquared", "RadiansPerSecondSquared", new BaseUnits(time: DurationUnit.Second));
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static RotationalAcceleration()
         {
-            Info = RotationalAccelerationInfo.CreateDefault();
+            Info = RotationalAccelerationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RotationalSpeed"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RotationalSpeedInfo: QuantityInfo<RotationalSpeed, RotationalSpeedUnit>
+        private static class RotationalSpeedInfo
         {
-            /// <inheritdoc />
-            public RotationalSpeedInfo(string name, RotationalSpeedUnit baseUnit, IEnumerable<IUnitDefinition<RotationalSpeedUnit>> unitMappings, RotationalSpeed zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RotationalSpeed, RotationalSpeedUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RotationalSpeed.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RotationalSpeedInfo(string name, RotationalSpeedUnit baseUnit, IEnumerable<IUnitDefinition<RotationalSpeedUnit>> unitMappings, RotationalSpeed zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RotationalSpeed.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RotationalSpeed", typeof(RotationalSpeed).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RotationalSpeedInfo"/> class with the default settings for the RotationalSpeed quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RotationalSpeedInfo"/> class with the default settings.</returns>
-            public static RotationalSpeedInfo CreateDefault()
-            {
-                return new RotationalSpeedInfo(nameof(RotationalSpeed), DefaultBaseUnit, GetDefaultMappings(), new RotationalSpeed(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RotationalSpeedInfo"/> class with the default settings for the RotationalSpeed quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RotationalSpeedInfo"/> class with the default settings.
             /// </returns>
-            public static RotationalSpeedInfo CreateDefault(Func<IEnumerable<UnitDefinition<RotationalSpeedUnit>>, IEnumerable<IUnitDefinition<RotationalSpeedUnit>>> customizeUnits)
+            private static QuantityInfo<RotationalSpeed, RotationalSpeedUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RotationalSpeedUnit>>, IEnumerable<IUnitDefinition<RotationalSpeedUnit>>>? customizeUnits = null)
             {
-                return new RotationalSpeedInfo(nameof(RotationalSpeed), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RotationalSpeed(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RotationalSpeedUnit>> unitMappings = RotationalSpeedInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RotationalSpeed, RotationalSpeedUnit>(
+                    name: nameof(RotationalSpeed),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RotationalSpeed(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RotationalSpeed"/> is [T^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RotationalSpeed is RadianPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RotationalSpeedUnit DefaultBaseUnit { get; } = RotationalSpeedUnit.RadianPerSecond;
+            private static RotationalSpeedUnit DefaultBaseUnit { get; } = RotationalSpeedUnit.RadianPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RotationalSpeed quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RotationalSpeed", typeof(RotationalSpeed).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RotationalSpeedUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RotationalSpeedUnit}"/> representing the default unit mappings for RotationalSpeed.</returns>
-            public static IEnumerable<UnitDefinition<RotationalSpeedUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RotationalSpeedUnit>> GetDefaultMappings()
             {
                 yield return new (RotationalSpeedUnit.CentiradianPerSecond, "CentiradianPerSecond", "CentiradiansPerSecond", BaseUnits.Undefined);
                 yield return new (RotationalSpeedUnit.DeciradianPerSecond, "DeciradianPerSecond", "DeciradiansPerSecond", BaseUnits.Undefined);
@@ -138,7 +138,7 @@ namespace UnitsNet
 
         static RotationalSpeed()
         {
-            Info = RotationalSpeedInfo.CreateDefault();
+            Info = RotationalSpeedInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -67,59 +67,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RotationalStiffness"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RotationalStiffnessInfo: QuantityInfo<RotationalStiffness, RotationalStiffnessUnit>
+        private static class RotationalStiffnessInfo
         {
-            /// <inheritdoc />
-            public RotationalStiffnessInfo(string name, RotationalStiffnessUnit baseUnit, IEnumerable<IUnitDefinition<RotationalStiffnessUnit>> unitMappings, RotationalStiffness zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RotationalStiffness, RotationalStiffnessUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RotationalStiffness.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RotationalStiffnessInfo(string name, RotationalStiffnessUnit baseUnit, IEnumerable<IUnitDefinition<RotationalStiffnessUnit>> unitMappings, RotationalStiffness zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RotationalStiffness.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RotationalStiffness", typeof(RotationalStiffness).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RotationalStiffnessInfo"/> class with the default settings for the RotationalStiffness quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RotationalStiffnessInfo"/> class with the default settings.</returns>
-            public static RotationalStiffnessInfo CreateDefault()
-            {
-                return new RotationalStiffnessInfo(nameof(RotationalStiffness), DefaultBaseUnit, GetDefaultMappings(), new RotationalStiffness(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RotationalStiffnessInfo"/> class with the default settings for the RotationalStiffness quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RotationalStiffnessInfo"/> class with the default settings.
             /// </returns>
-            public static RotationalStiffnessInfo CreateDefault(Func<IEnumerable<UnitDefinition<RotationalStiffnessUnit>>, IEnumerable<IUnitDefinition<RotationalStiffnessUnit>>> customizeUnits)
+            private static QuantityInfo<RotationalStiffness, RotationalStiffnessUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RotationalStiffnessUnit>>, IEnumerable<IUnitDefinition<RotationalStiffnessUnit>>>? customizeUnits = null)
             {
-                return new RotationalStiffnessInfo(nameof(RotationalStiffness), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RotationalStiffness(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RotationalStiffnessUnit>> unitMappings = RotationalStiffnessInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RotationalStiffness, RotationalStiffnessUnit>(
+                    name: nameof(RotationalStiffness),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RotationalStiffness(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RotationalStiffness"/> is [T^-2][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RotationalStiffness is NewtonMeterPerRadian. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RotationalStiffnessUnit DefaultBaseUnit { get; } = RotationalStiffnessUnit.NewtonMeterPerRadian;
+            private static RotationalStiffnessUnit DefaultBaseUnit { get; } = RotationalStiffnessUnit.NewtonMeterPerRadian;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RotationalStiffness quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RotationalStiffness", typeof(RotationalStiffness).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RotationalStiffnessUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RotationalStiffnessUnit}"/> representing the default unit mappings for RotationalStiffness.</returns>
-            public static IEnumerable<UnitDefinition<RotationalStiffnessUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RotationalStiffnessUnit>> GetDefaultMappings()
             {
                 yield return new (RotationalStiffnessUnit.CentinewtonMeterPerDegree, "CentinewtonMeterPerDegree", "CentinewtonMetersPerDegree", BaseUnits.Undefined);
                 yield return new (RotationalStiffnessUnit.CentinewtonMillimeterPerDegree, "CentinewtonMillimeterPerDegree", "CentinewtonMillimetersPerDegree", BaseUnits.Undefined);
@@ -159,7 +159,7 @@ namespace UnitsNet
 
         static RotationalStiffness()
         {
-            Info = RotationalStiffnessInfo.CreateDefault();
+            Info = RotationalStiffnessInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="RotationalStiffnessPerLength"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class RotationalStiffnessPerLengthInfo: QuantityInfo<RotationalStiffnessPerLength, RotationalStiffnessPerLengthUnit>
+        private static class RotationalStiffnessPerLengthInfo
         {
-            /// <inheritdoc />
-            public RotationalStiffnessPerLengthInfo(string name, RotationalStiffnessPerLengthUnit baseUnit, IEnumerable<IUnitDefinition<RotationalStiffnessPerLengthUnit>> unitMappings, RotationalStiffnessPerLength zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<RotationalStiffnessPerLength, RotationalStiffnessPerLengthUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, RotationalStiffnessPerLength.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public RotationalStiffnessPerLengthInfo(string name, RotationalStiffnessPerLengthUnit baseUnit, IEnumerable<IUnitDefinition<RotationalStiffnessPerLengthUnit>> unitMappings, RotationalStiffnessPerLength zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, RotationalStiffnessPerLength.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.RotationalStiffnessPerLength", typeof(RotationalStiffnessPerLength).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="RotationalStiffnessPerLengthInfo"/> class with the default settings for the RotationalStiffnessPerLength quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="RotationalStiffnessPerLengthInfo"/> class with the default settings.</returns>
-            public static RotationalStiffnessPerLengthInfo CreateDefault()
-            {
-                return new RotationalStiffnessPerLengthInfo(nameof(RotationalStiffnessPerLength), DefaultBaseUnit, GetDefaultMappings(), new RotationalStiffnessPerLength(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="RotationalStiffnessPerLengthInfo"/> class with the default settings for the RotationalStiffnessPerLength quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="RotationalStiffnessPerLengthInfo"/> class with the default settings.
             /// </returns>
-            public static RotationalStiffnessPerLengthInfo CreateDefault(Func<IEnumerable<UnitDefinition<RotationalStiffnessPerLengthUnit>>, IEnumerable<IUnitDefinition<RotationalStiffnessPerLengthUnit>>> customizeUnits)
+            private static QuantityInfo<RotationalStiffnessPerLength, RotationalStiffnessPerLengthUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<RotationalStiffnessPerLengthUnit>>, IEnumerable<IUnitDefinition<RotationalStiffnessPerLengthUnit>>>? customizeUnits = null)
             {
-                return new RotationalStiffnessPerLengthInfo(nameof(RotationalStiffnessPerLength), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new RotationalStiffnessPerLength(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<RotationalStiffnessPerLengthUnit>> unitMappings = RotationalStiffnessPerLengthInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<RotationalStiffnessPerLength, RotationalStiffnessPerLengthUnit>(
+                    name: nameof(RotationalStiffnessPerLength),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new RotationalStiffnessPerLength(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="RotationalStiffnessPerLength"/> is [T^-2][L][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of RotationalStiffnessPerLength is NewtonMeterPerRadianPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static RotationalStiffnessPerLengthUnit DefaultBaseUnit { get; } = RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
+            private static RotationalStiffnessPerLengthUnit DefaultBaseUnit { get; } = RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the RotationalStiffnessPerLength quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.RotationalStiffnessPerLength", typeof(RotationalStiffnessPerLength).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="RotationalStiffnessPerLengthUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{RotationalStiffnessPerLengthUnit}"/> representing the default unit mappings for RotationalStiffnessPerLength.</returns>
-            public static IEnumerable<UnitDefinition<RotationalStiffnessPerLengthUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<RotationalStiffnessPerLengthUnit>> GetDefaultMappings()
             {
                 yield return new (RotationalStiffnessPerLengthUnit.KilonewtonMeterPerRadianPerMeter, "KilonewtonMeterPerRadianPerMeter", "KilonewtonMetersPerRadianPerMeter", new BaseUnits(length: LengthUnit.Kilometer, mass: MassUnit.Kilogram, time: DurationUnit.Second));
                 yield return new (RotationalStiffnessPerLengthUnit.KilopoundForceFootPerDegreesPerFoot, "KilopoundForceFootPerDegreesPerFoot", "KilopoundForceFeetPerDegreesPerFeet", BaseUnits.Undefined);
@@ -129,7 +129,7 @@ namespace UnitsNet
 
         static RotationalStiffnessPerLength()
         {
-            Info = RotationalStiffnessPerLengthInfo.CreateDefault();
+            Info = RotationalStiffnessPerLengthInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Scalar"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ScalarInfo: QuantityInfo<Scalar, ScalarUnit>
+        private static class ScalarInfo
         {
-            /// <inheritdoc />
-            public ScalarInfo(string name, ScalarUnit baseUnit, IEnumerable<IUnitDefinition<ScalarUnit>> unitMappings, Scalar zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Scalar, ScalarUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Scalar.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ScalarInfo(string name, ScalarUnit baseUnit, IEnumerable<IUnitDefinition<ScalarUnit>> unitMappings, Scalar zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Scalar.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Scalar", typeof(Scalar).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ScalarInfo"/> class with the default settings for the Scalar quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ScalarInfo"/> class with the default settings.</returns>
-            public static ScalarInfo CreateDefault()
-            {
-                return new ScalarInfo(nameof(Scalar), DefaultBaseUnit, GetDefaultMappings(), new Scalar(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ScalarInfo"/> class with the default settings for the Scalar quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ScalarInfo"/> class with the default settings.
             /// </returns>
-            public static ScalarInfo CreateDefault(Func<IEnumerable<UnitDefinition<ScalarUnit>>, IEnumerable<IUnitDefinition<ScalarUnit>>> customizeUnits)
+            private static QuantityInfo<Scalar, ScalarUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ScalarUnit>>, IEnumerable<IUnitDefinition<ScalarUnit>>>? customizeUnits = null)
             {
-                return new ScalarInfo(nameof(Scalar), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Scalar(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ScalarUnit>> unitMappings = ScalarInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Scalar, ScalarUnit>(
+                    name: nameof(Scalar),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Scalar(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Scalar"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of Scalar is Amount. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ScalarUnit DefaultBaseUnit { get; } = ScalarUnit.Amount;
+            private static ScalarUnit DefaultBaseUnit { get; } = ScalarUnit.Amount;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Scalar quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Scalar", typeof(Scalar).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ScalarUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ScalarUnit}"/> representing the default unit mappings for Scalar.</returns>
-            public static IEnumerable<UnitDefinition<ScalarUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ScalarUnit>> GetDefaultMappings()
             {
                 yield return new (ScalarUnit.Amount, "Amount", "Amount", BaseUnits.Undefined);
             }
@@ -122,7 +122,7 @@ namespace UnitsNet
 
         static Scalar()
         {
-            Info = ScalarInfo.CreateDefault();
+            Info = ScalarInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="SolidAngle"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SolidAngleInfo: QuantityInfo<SolidAngle, SolidAngleUnit>
+        private static class SolidAngleInfo
         {
-            /// <inheritdoc />
-            public SolidAngleInfo(string name, SolidAngleUnit baseUnit, IEnumerable<IUnitDefinition<SolidAngleUnit>> unitMappings, SolidAngle zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<SolidAngle, SolidAngleUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, SolidAngle.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SolidAngleInfo(string name, SolidAngleUnit baseUnit, IEnumerable<IUnitDefinition<SolidAngleUnit>> unitMappings, SolidAngle zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, SolidAngle.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.SolidAngle", typeof(SolidAngle).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SolidAngleInfo"/> class with the default settings for the SolidAngle quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SolidAngleInfo"/> class with the default settings.</returns>
-            public static SolidAngleInfo CreateDefault()
-            {
-                return new SolidAngleInfo(nameof(SolidAngle), DefaultBaseUnit, GetDefaultMappings(), new SolidAngle(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SolidAngleInfo"/> class with the default settings for the SolidAngle quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SolidAngleInfo"/> class with the default settings.
             /// </returns>
-            public static SolidAngleInfo CreateDefault(Func<IEnumerable<UnitDefinition<SolidAngleUnit>>, IEnumerable<IUnitDefinition<SolidAngleUnit>>> customizeUnits)
+            private static QuantityInfo<SolidAngle, SolidAngleUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SolidAngleUnit>>, IEnumerable<IUnitDefinition<SolidAngleUnit>>>? customizeUnits = null)
             {
-                return new SolidAngleInfo(nameof(SolidAngle), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new SolidAngle(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SolidAngleUnit>> unitMappings = SolidAngleInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<SolidAngle, SolidAngleUnit>(
+                    name: nameof(SolidAngle),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new SolidAngle(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="SolidAngle"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of SolidAngle is Steradian. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SolidAngleUnit DefaultBaseUnit { get; } = SolidAngleUnit.Steradian;
+            private static SolidAngleUnit DefaultBaseUnit { get; } = SolidAngleUnit.Steradian;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the SolidAngle quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.SolidAngle", typeof(SolidAngle).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SolidAngleUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SolidAngleUnit}"/> representing the default unit mappings for SolidAngle.</returns>
-            public static IEnumerable<UnitDefinition<SolidAngleUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SolidAngleUnit>> GetDefaultMappings()
             {
                 yield return new (SolidAngleUnit.Steradian, "Steradian", "Steradians", BaseUnits.Undefined);
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static SolidAngle()
         {
-            Info = SolidAngleInfo.CreateDefault();
+            Info = SolidAngleInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -73,59 +73,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="SpecificEnergy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SpecificEnergyInfo: QuantityInfo<SpecificEnergy, SpecificEnergyUnit>
+        private static class SpecificEnergyInfo
         {
-            /// <inheritdoc />
-            public SpecificEnergyInfo(string name, SpecificEnergyUnit baseUnit, IEnumerable<IUnitDefinition<SpecificEnergyUnit>> unitMappings, SpecificEnergy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<SpecificEnergy, SpecificEnergyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, SpecificEnergy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SpecificEnergyInfo(string name, SpecificEnergyUnit baseUnit, IEnumerable<IUnitDefinition<SpecificEnergyUnit>> unitMappings, SpecificEnergy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, SpecificEnergy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.SpecificEnergy", typeof(SpecificEnergy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SpecificEnergyInfo"/> class with the default settings for the SpecificEnergy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SpecificEnergyInfo"/> class with the default settings.</returns>
-            public static SpecificEnergyInfo CreateDefault()
-            {
-                return new SpecificEnergyInfo(nameof(SpecificEnergy), DefaultBaseUnit, GetDefaultMappings(), new SpecificEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SpecificEnergyInfo"/> class with the default settings for the SpecificEnergy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SpecificEnergyInfo"/> class with the default settings.
             /// </returns>
-            public static SpecificEnergyInfo CreateDefault(Func<IEnumerable<UnitDefinition<SpecificEnergyUnit>>, IEnumerable<IUnitDefinition<SpecificEnergyUnit>>> customizeUnits)
+            private static QuantityInfo<SpecificEnergy, SpecificEnergyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SpecificEnergyUnit>>, IEnumerable<IUnitDefinition<SpecificEnergyUnit>>>? customizeUnits = null)
             {
-                return new SpecificEnergyInfo(nameof(SpecificEnergy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new SpecificEnergy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SpecificEnergyUnit>> unitMappings = SpecificEnergyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<SpecificEnergy, SpecificEnergyUnit>(
+                    name: nameof(SpecificEnergy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new SpecificEnergy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="SpecificEnergy"/> is [T^-2][L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of SpecificEnergy is JoulePerKilogram. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SpecificEnergyUnit DefaultBaseUnit { get; } = SpecificEnergyUnit.JoulePerKilogram;
+            private static SpecificEnergyUnit DefaultBaseUnit { get; } = SpecificEnergyUnit.JoulePerKilogram;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the SpecificEnergy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.SpecificEnergy", typeof(SpecificEnergy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SpecificEnergyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SpecificEnergyUnit}"/> representing the default unit mappings for SpecificEnergy.</returns>
-            public static IEnumerable<UnitDefinition<SpecificEnergyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SpecificEnergyUnit>> GetDefaultMappings()
             {
                 yield return new (SpecificEnergyUnit.BtuPerPound, "BtuPerPound", "BtuPerPound", BaseUnits.Undefined);
                 yield return new (SpecificEnergyUnit.CaloriePerGram, "CaloriePerGram", "CaloriesPerGram", BaseUnits.Undefined);
@@ -162,7 +162,7 @@ namespace UnitsNet
 
         static SpecificEnergy()
         {
-            Info = SpecificEnergyInfo.CreateDefault();
+            Info = SpecificEnergyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -66,59 +66,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="SpecificEntropy"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SpecificEntropyInfo: QuantityInfo<SpecificEntropy, SpecificEntropyUnit>
+        private static class SpecificEntropyInfo
         {
-            /// <inheritdoc />
-            public SpecificEntropyInfo(string name, SpecificEntropyUnit baseUnit, IEnumerable<IUnitDefinition<SpecificEntropyUnit>> unitMappings, SpecificEntropy zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<SpecificEntropy, SpecificEntropyUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, SpecificEntropy.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SpecificEntropyInfo(string name, SpecificEntropyUnit baseUnit, IEnumerable<IUnitDefinition<SpecificEntropyUnit>> unitMappings, SpecificEntropy zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, SpecificEntropy.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.SpecificEntropy", typeof(SpecificEntropy).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SpecificEntropyInfo"/> class with the default settings for the SpecificEntropy quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SpecificEntropyInfo"/> class with the default settings.</returns>
-            public static SpecificEntropyInfo CreateDefault()
-            {
-                return new SpecificEntropyInfo(nameof(SpecificEntropy), DefaultBaseUnit, GetDefaultMappings(), new SpecificEntropy(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SpecificEntropyInfo"/> class with the default settings for the SpecificEntropy quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SpecificEntropyInfo"/> class with the default settings.
             /// </returns>
-            public static SpecificEntropyInfo CreateDefault(Func<IEnumerable<UnitDefinition<SpecificEntropyUnit>>, IEnumerable<IUnitDefinition<SpecificEntropyUnit>>> customizeUnits)
+            private static QuantityInfo<SpecificEntropy, SpecificEntropyUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SpecificEntropyUnit>>, IEnumerable<IUnitDefinition<SpecificEntropyUnit>>>? customizeUnits = null)
             {
-                return new SpecificEntropyInfo(nameof(SpecificEntropy), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new SpecificEntropy(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SpecificEntropyUnit>> unitMappings = SpecificEntropyInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<SpecificEntropy, SpecificEntropyUnit>(
+                    name: nameof(SpecificEntropy),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new SpecificEntropy(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="SpecificEntropy"/> is [T^-2][L^2][Θ^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, -1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, -2, 0, -1, 0, 0);
 
             /// <summary>
             ///     The default base unit of SpecificEntropy is JoulePerKilogramKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SpecificEntropyUnit DefaultBaseUnit { get; } = SpecificEntropyUnit.JoulePerKilogramKelvin;
+            private static SpecificEntropyUnit DefaultBaseUnit { get; } = SpecificEntropyUnit.JoulePerKilogramKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the SpecificEntropy quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.SpecificEntropy", typeof(SpecificEntropy).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SpecificEntropyUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SpecificEntropyUnit}"/> representing the default unit mappings for SpecificEntropy.</returns>
-            public static IEnumerable<UnitDefinition<SpecificEntropyUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SpecificEntropyUnit>> GetDefaultMappings()
             {
                 yield return new (SpecificEntropyUnit.BtuPerPoundFahrenheit, "BtuPerPoundFahrenheit", "BtusPerPoundFahrenheit", BaseUnits.Undefined);
                 yield return new (SpecificEntropyUnit.CaloriePerGramKelvin, "CaloriePerGramKelvin", "CaloriesPerGramKelvin", BaseUnits.Undefined);
@@ -134,7 +134,7 @@ namespace UnitsNet
 
         static SpecificEntropy()
         {
-            Info = SpecificEntropyInfo.CreateDefault();
+            Info = SpecificEntropyInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="SpecificFuelConsumption"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SpecificFuelConsumptionInfo: QuantityInfo<SpecificFuelConsumption, SpecificFuelConsumptionUnit>
+        private static class SpecificFuelConsumptionInfo
         {
-            /// <inheritdoc />
-            public SpecificFuelConsumptionInfo(string name, SpecificFuelConsumptionUnit baseUnit, IEnumerable<IUnitDefinition<SpecificFuelConsumptionUnit>> unitMappings, SpecificFuelConsumption zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<SpecificFuelConsumption, SpecificFuelConsumptionUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, SpecificFuelConsumption.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SpecificFuelConsumptionInfo(string name, SpecificFuelConsumptionUnit baseUnit, IEnumerable<IUnitDefinition<SpecificFuelConsumptionUnit>> unitMappings, SpecificFuelConsumption zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, SpecificFuelConsumption.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.SpecificFuelConsumption", typeof(SpecificFuelConsumption).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SpecificFuelConsumptionInfo"/> class with the default settings for the SpecificFuelConsumption quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SpecificFuelConsumptionInfo"/> class with the default settings.</returns>
-            public static SpecificFuelConsumptionInfo CreateDefault()
-            {
-                return new SpecificFuelConsumptionInfo(nameof(SpecificFuelConsumption), DefaultBaseUnit, GetDefaultMappings(), new SpecificFuelConsumption(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SpecificFuelConsumptionInfo"/> class with the default settings for the SpecificFuelConsumption quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SpecificFuelConsumptionInfo"/> class with the default settings.
             /// </returns>
-            public static SpecificFuelConsumptionInfo CreateDefault(Func<IEnumerable<UnitDefinition<SpecificFuelConsumptionUnit>>, IEnumerable<IUnitDefinition<SpecificFuelConsumptionUnit>>> customizeUnits)
+            private static QuantityInfo<SpecificFuelConsumption, SpecificFuelConsumptionUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SpecificFuelConsumptionUnit>>, IEnumerable<IUnitDefinition<SpecificFuelConsumptionUnit>>>? customizeUnits = null)
             {
-                return new SpecificFuelConsumptionInfo(nameof(SpecificFuelConsumption), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new SpecificFuelConsumption(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SpecificFuelConsumptionUnit>> unitMappings = SpecificFuelConsumptionInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<SpecificFuelConsumption, SpecificFuelConsumptionUnit>(
+                    name: nameof(SpecificFuelConsumption),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new SpecificFuelConsumption(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="SpecificFuelConsumption"/> is [T][L^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of SpecificFuelConsumption is GramPerKilonewtonSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SpecificFuelConsumptionUnit DefaultBaseUnit { get; } = SpecificFuelConsumptionUnit.GramPerKilonewtonSecond;
+            private static SpecificFuelConsumptionUnit DefaultBaseUnit { get; } = SpecificFuelConsumptionUnit.GramPerKilonewtonSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the SpecificFuelConsumption quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.SpecificFuelConsumption", typeof(SpecificFuelConsumption).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SpecificFuelConsumptionUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SpecificFuelConsumptionUnit}"/> representing the default unit mappings for SpecificFuelConsumption.</returns>
-            public static IEnumerable<UnitDefinition<SpecificFuelConsumptionUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SpecificFuelConsumptionUnit>> GetDefaultMappings()
             {
                 yield return new (SpecificFuelConsumptionUnit.GramPerKilonewtonSecond, "GramPerKilonewtonSecond", "GramsPerKilonewtonSecond", new BaseUnits(length: LengthUnit.Meter, time: DurationUnit.Second));
                 yield return new (SpecificFuelConsumptionUnit.KilogramPerKilogramForceHour, "KilogramPerKilogramForceHour", "KilogramsPerKilogramForceHour", BaseUnits.Undefined);
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static SpecificFuelConsumption()
         {
-            Info = SpecificFuelConsumptionInfo.CreateDefault();
+            Info = SpecificFuelConsumptionInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="SpecificVolume"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SpecificVolumeInfo: QuantityInfo<SpecificVolume, SpecificVolumeUnit>
+        private static class SpecificVolumeInfo
         {
-            /// <inheritdoc />
-            public SpecificVolumeInfo(string name, SpecificVolumeUnit baseUnit, IEnumerable<IUnitDefinition<SpecificVolumeUnit>> unitMappings, SpecificVolume zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<SpecificVolume, SpecificVolumeUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, SpecificVolume.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SpecificVolumeInfo(string name, SpecificVolumeUnit baseUnit, IEnumerable<IUnitDefinition<SpecificVolumeUnit>> unitMappings, SpecificVolume zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, SpecificVolume.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.SpecificVolume", typeof(SpecificVolume).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SpecificVolumeInfo"/> class with the default settings for the SpecificVolume quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SpecificVolumeInfo"/> class with the default settings.</returns>
-            public static SpecificVolumeInfo CreateDefault()
-            {
-                return new SpecificVolumeInfo(nameof(SpecificVolume), DefaultBaseUnit, GetDefaultMappings(), new SpecificVolume(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SpecificVolumeInfo"/> class with the default settings for the SpecificVolume quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SpecificVolumeInfo"/> class with the default settings.
             /// </returns>
-            public static SpecificVolumeInfo CreateDefault(Func<IEnumerable<UnitDefinition<SpecificVolumeUnit>>, IEnumerable<IUnitDefinition<SpecificVolumeUnit>>> customizeUnits)
+            private static QuantityInfo<SpecificVolume, SpecificVolumeUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SpecificVolumeUnit>>, IEnumerable<IUnitDefinition<SpecificVolumeUnit>>>? customizeUnits = null)
             {
-                return new SpecificVolumeInfo(nameof(SpecificVolume), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new SpecificVolume(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SpecificVolumeUnit>> unitMappings = SpecificVolumeInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<SpecificVolume, SpecificVolumeUnit>(
+                    name: nameof(SpecificVolume),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new SpecificVolume(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="SpecificVolume"/> is [L^3][M^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, -1, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, -1, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of SpecificVolume is CubicMeterPerKilogram. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SpecificVolumeUnit DefaultBaseUnit { get; } = SpecificVolumeUnit.CubicMeterPerKilogram;
+            private static SpecificVolumeUnit DefaultBaseUnit { get; } = SpecificVolumeUnit.CubicMeterPerKilogram;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the SpecificVolume quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.SpecificVolume", typeof(SpecificVolume).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SpecificVolumeUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SpecificVolumeUnit}"/> representing the default unit mappings for SpecificVolume.</returns>
-            public static IEnumerable<UnitDefinition<SpecificVolumeUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SpecificVolumeUnit>> GetDefaultMappings()
             {
                 yield return new (SpecificVolumeUnit.CubicFootPerPound, "CubicFootPerPound", "CubicFeetPerPound", new BaseUnits(length: LengthUnit.Foot, mass: MassUnit.Pound));
                 yield return new (SpecificVolumeUnit.CubicMeterPerKilogram, "CubicMeterPerKilogram", "CubicMetersPerKilogram", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static SpecificVolume()
         {
-            Info = SpecificVolumeInfo.CreateDefault();
+            Info = SpecificVolumeInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -71,59 +71,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="SpecificWeight"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SpecificWeightInfo: QuantityInfo<SpecificWeight, SpecificWeightUnit>
+        private static class SpecificWeightInfo
         {
-            /// <inheritdoc />
-            public SpecificWeightInfo(string name, SpecificWeightUnit baseUnit, IEnumerable<IUnitDefinition<SpecificWeightUnit>> unitMappings, SpecificWeight zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<SpecificWeight, SpecificWeightUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, SpecificWeight.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SpecificWeightInfo(string name, SpecificWeightUnit baseUnit, IEnumerable<IUnitDefinition<SpecificWeightUnit>> unitMappings, SpecificWeight zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, SpecificWeight.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.SpecificWeight", typeof(SpecificWeight).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SpecificWeightInfo"/> class with the default settings for the SpecificWeight quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SpecificWeightInfo"/> class with the default settings.</returns>
-            public static SpecificWeightInfo CreateDefault()
-            {
-                return new SpecificWeightInfo(nameof(SpecificWeight), DefaultBaseUnit, GetDefaultMappings(), new SpecificWeight(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SpecificWeightInfo"/> class with the default settings for the SpecificWeight quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SpecificWeightInfo"/> class with the default settings.
             /// </returns>
-            public static SpecificWeightInfo CreateDefault(Func<IEnumerable<UnitDefinition<SpecificWeightUnit>>, IEnumerable<IUnitDefinition<SpecificWeightUnit>>> customizeUnits)
+            private static QuantityInfo<SpecificWeight, SpecificWeightUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SpecificWeightUnit>>, IEnumerable<IUnitDefinition<SpecificWeightUnit>>>? customizeUnits = null)
             {
-                return new SpecificWeightInfo(nameof(SpecificWeight), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new SpecificWeight(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SpecificWeightUnit>> unitMappings = SpecificWeightInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<SpecificWeight, SpecificWeightUnit>(
+                    name: nameof(SpecificWeight),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new SpecificWeight(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="SpecificWeight"/> is [T^-2][L^-2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-2, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of SpecificWeight is NewtonPerCubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SpecificWeightUnit DefaultBaseUnit { get; } = SpecificWeightUnit.NewtonPerCubicMeter;
+            private static SpecificWeightUnit DefaultBaseUnit { get; } = SpecificWeightUnit.NewtonPerCubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the SpecificWeight quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.SpecificWeight", typeof(SpecificWeight).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SpecificWeightUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SpecificWeightUnit}"/> representing the default unit mappings for SpecificWeight.</returns>
-            public static IEnumerable<UnitDefinition<SpecificWeightUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SpecificWeightUnit>> GetDefaultMappings()
             {
                 yield return new (SpecificWeightUnit.KilogramForcePerCubicCentimeter, "KilogramForcePerCubicCentimeter", "KilogramsForcePerCubicCentimeter", BaseUnits.Undefined);
                 yield return new (SpecificWeightUnit.KilogramForcePerCubicMeter, "KilogramForcePerCubicMeter", "KilogramsForcePerCubicMeter", BaseUnits.Undefined);
@@ -147,7 +147,7 @@ namespace UnitsNet
 
         static SpecificWeight()
         {
-            Info = SpecificWeightInfo.CreateDefault();
+            Info = SpecificWeightInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -72,59 +72,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Speed"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class SpeedInfo: QuantityInfo<Speed, SpeedUnit>
+        private static class SpeedInfo
         {
-            /// <inheritdoc />
-            public SpeedInfo(string name, SpeedUnit baseUnit, IEnumerable<IUnitDefinition<SpeedUnit>> unitMappings, Speed zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Speed, SpeedUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Speed.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public SpeedInfo(string name, SpeedUnit baseUnit, IEnumerable<IUnitDefinition<SpeedUnit>> unitMappings, Speed zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Speed.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Speed", typeof(Speed).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="SpeedInfo"/> class with the default settings for the Speed quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="SpeedInfo"/> class with the default settings.</returns>
-            public static SpeedInfo CreateDefault()
-            {
-                return new SpeedInfo(nameof(Speed), DefaultBaseUnit, GetDefaultMappings(), new Speed(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="SpeedInfo"/> class with the default settings for the Speed quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="SpeedInfo"/> class with the default settings.
             /// </returns>
-            public static SpeedInfo CreateDefault(Func<IEnumerable<UnitDefinition<SpeedUnit>>, IEnumerable<IUnitDefinition<SpeedUnit>>> customizeUnits)
+            private static QuantityInfo<Speed, SpeedUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<SpeedUnit>>, IEnumerable<IUnitDefinition<SpeedUnit>>>? customizeUnits = null)
             {
-                return new SpeedInfo(nameof(Speed), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Speed(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<SpeedUnit>> unitMappings = SpeedInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Speed, SpeedUnit>(
+                    name: nameof(Speed),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Speed(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Speed"/> is [T^-1][L].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Speed is MeterPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static SpeedUnit DefaultBaseUnit { get; } = SpeedUnit.MeterPerSecond;
+            private static SpeedUnit DefaultBaseUnit { get; } = SpeedUnit.MeterPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Speed quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Speed", typeof(Speed).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="SpeedUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{SpeedUnit}"/> representing the default unit mappings for Speed.</returns>
-            public static IEnumerable<UnitDefinition<SpeedUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<SpeedUnit>> GetDefaultMappings()
             {
                 yield return new (SpeedUnit.CentimeterPerHour, "CentimeterPerHour", "CentimetersPerHour", new BaseUnits(length: LengthUnit.Centimeter, time: DurationUnit.Hour));
                 yield return new (SpeedUnit.CentimeterPerMinute, "CentimeterPerMinute", "CentimetersPerMinute", new BaseUnits(length: LengthUnit.Centimeter, time: DurationUnit.Minute));
@@ -164,7 +164,7 @@ namespace UnitsNet
 
         static Speed()
         {
-            Info = SpeedInfo.CreateDefault();
+            Info = SpeedInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="StandardVolumeFlow"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class StandardVolumeFlowInfo: QuantityInfo<StandardVolumeFlow, StandardVolumeFlowUnit>
+        private static class StandardVolumeFlowInfo
         {
-            /// <inheritdoc />
-            public StandardVolumeFlowInfo(string name, StandardVolumeFlowUnit baseUnit, IEnumerable<IUnitDefinition<StandardVolumeFlowUnit>> unitMappings, StandardVolumeFlow zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<StandardVolumeFlow, StandardVolumeFlowUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, StandardVolumeFlow.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public StandardVolumeFlowInfo(string name, StandardVolumeFlowUnit baseUnit, IEnumerable<IUnitDefinition<StandardVolumeFlowUnit>> unitMappings, StandardVolumeFlow zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, StandardVolumeFlow.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.StandardVolumeFlow", typeof(StandardVolumeFlow).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="StandardVolumeFlowInfo"/> class with the default settings for the StandardVolumeFlow quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="StandardVolumeFlowInfo"/> class with the default settings.</returns>
-            public static StandardVolumeFlowInfo CreateDefault()
-            {
-                return new StandardVolumeFlowInfo(nameof(StandardVolumeFlow), DefaultBaseUnit, GetDefaultMappings(), new StandardVolumeFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="StandardVolumeFlowInfo"/> class with the default settings for the StandardVolumeFlow quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="StandardVolumeFlowInfo"/> class with the default settings.
             /// </returns>
-            public static StandardVolumeFlowInfo CreateDefault(Func<IEnumerable<UnitDefinition<StandardVolumeFlowUnit>>, IEnumerable<IUnitDefinition<StandardVolumeFlowUnit>>> customizeUnits)
+            private static QuantityInfo<StandardVolumeFlow, StandardVolumeFlowUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<StandardVolumeFlowUnit>>, IEnumerable<IUnitDefinition<StandardVolumeFlowUnit>>>? customizeUnits = null)
             {
-                return new StandardVolumeFlowInfo(nameof(StandardVolumeFlow), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new StandardVolumeFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<StandardVolumeFlowUnit>> unitMappings = StandardVolumeFlowInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<StandardVolumeFlow, StandardVolumeFlowUnit>(
+                    name: nameof(StandardVolumeFlow),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new StandardVolumeFlow(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="StandardVolumeFlow"/> is [T^-1][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 1, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of StandardVolumeFlow is StandardCubicMeterPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static StandardVolumeFlowUnit DefaultBaseUnit { get; } = StandardVolumeFlowUnit.StandardCubicMeterPerSecond;
+            private static StandardVolumeFlowUnit DefaultBaseUnit { get; } = StandardVolumeFlowUnit.StandardCubicMeterPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the StandardVolumeFlow quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.StandardVolumeFlow", typeof(StandardVolumeFlow).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="StandardVolumeFlowUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{StandardVolumeFlowUnit}"/> representing the default unit mappings for StandardVolumeFlow.</returns>
-            public static IEnumerable<UnitDefinition<StandardVolumeFlowUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<StandardVolumeFlowUnit>> GetDefaultMappings()
             {
                 yield return new (StandardVolumeFlowUnit.StandardCubicCentimeterPerMinute, "StandardCubicCentimeterPerMinute", "StandardCubicCentimetersPerMinute", new BaseUnits(length: LengthUnit.Centimeter, time: DurationUnit.Minute));
                 yield return new (StandardVolumeFlowUnit.StandardCubicFootPerHour, "StandardCubicFootPerHour", "StandardCubicFeetPerHour", new BaseUnits(length: LengthUnit.Foot, time: DurationUnit.Hour));
@@ -130,7 +130,7 @@ namespace UnitsNet
 
         static StandardVolumeFlow()
         {
-            Info = StandardVolumeFlowInfo.CreateDefault();
+            Info = StandardVolumeFlowInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Temperature"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class TemperatureInfo: QuantityInfo<Temperature, TemperatureUnit>
+        private static class TemperatureInfo
         {
-            /// <inheritdoc />
-            public TemperatureInfo(string name, TemperatureUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureUnit>> unitMappings, Temperature zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Temperature, TemperatureUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Temperature.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public TemperatureInfo(string name, TemperatureUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureUnit>> unitMappings, Temperature zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Temperature.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Temperature", typeof(Temperature).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="TemperatureInfo"/> class with the default settings for the Temperature quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="TemperatureInfo"/> class with the default settings.</returns>
-            public static TemperatureInfo CreateDefault()
-            {
-                return new TemperatureInfo(nameof(Temperature), DefaultBaseUnit, GetDefaultMappings(), new Temperature(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="TemperatureInfo"/> class with the default settings for the Temperature quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="TemperatureInfo"/> class with the default settings.
             /// </returns>
-            public static TemperatureInfo CreateDefault(Func<IEnumerable<UnitDefinition<TemperatureUnit>>, IEnumerable<IUnitDefinition<TemperatureUnit>>> customizeUnits)
+            private static QuantityInfo<Temperature, TemperatureUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<TemperatureUnit>>, IEnumerable<IUnitDefinition<TemperatureUnit>>>? customizeUnits = null)
             {
-                return new TemperatureInfo(nameof(Temperature), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Temperature(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<TemperatureUnit>> unitMappings = TemperatureInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Temperature, TemperatureUnit>(
+                    name: nameof(Temperature),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Temperature(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Temperature"/> is [Θ].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
 
             /// <summary>
             ///     The default base unit of Temperature is Kelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static TemperatureUnit DefaultBaseUnit { get; } = TemperatureUnit.Kelvin;
+            private static TemperatureUnit DefaultBaseUnit { get; } = TemperatureUnit.Kelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Temperature quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Temperature", typeof(Temperature).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="TemperatureUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{TemperatureUnit}"/> representing the default unit mappings for Temperature.</returns>
-            public static IEnumerable<UnitDefinition<TemperatureUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<TemperatureUnit>> GetDefaultMappings()
             {
                 yield return new (TemperatureUnit.DegreeCelsius, "DegreeCelsius", "DegreesCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius));
                 yield return new (TemperatureUnit.DegreeDelisle, "DegreeDelisle", "DegreesDelisle", new BaseUnits(temperature: TemperatureUnit.DegreeDelisle));
@@ -131,7 +131,7 @@ namespace UnitsNet
 
         static Temperature()
         {
-            Info = TemperatureInfo.CreateDefault();
+            Info = TemperatureInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="TemperatureChangeRate"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class TemperatureChangeRateInfo: QuantityInfo<TemperatureChangeRate, TemperatureChangeRateUnit>
+        private static class TemperatureChangeRateInfo
         {
-            /// <inheritdoc />
-            public TemperatureChangeRateInfo(string name, TemperatureChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureChangeRateUnit>> unitMappings, TemperatureChangeRate zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<TemperatureChangeRate, TemperatureChangeRateUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, TemperatureChangeRate.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public TemperatureChangeRateInfo(string name, TemperatureChangeRateUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureChangeRateUnit>> unitMappings, TemperatureChangeRate zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, TemperatureChangeRate.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.TemperatureChangeRate", typeof(TemperatureChangeRate).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="TemperatureChangeRateInfo"/> class with the default settings for the TemperatureChangeRate quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="TemperatureChangeRateInfo"/> class with the default settings.</returns>
-            public static TemperatureChangeRateInfo CreateDefault()
-            {
-                return new TemperatureChangeRateInfo(nameof(TemperatureChangeRate), DefaultBaseUnit, GetDefaultMappings(), new TemperatureChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="TemperatureChangeRateInfo"/> class with the default settings for the TemperatureChangeRate quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="TemperatureChangeRateInfo"/> class with the default settings.
             /// </returns>
-            public static TemperatureChangeRateInfo CreateDefault(Func<IEnumerable<UnitDefinition<TemperatureChangeRateUnit>>, IEnumerable<IUnitDefinition<TemperatureChangeRateUnit>>> customizeUnits)
+            private static QuantityInfo<TemperatureChangeRate, TemperatureChangeRateUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<TemperatureChangeRateUnit>>, IEnumerable<IUnitDefinition<TemperatureChangeRateUnit>>>? customizeUnits = null)
             {
-                return new TemperatureChangeRateInfo(nameof(TemperatureChangeRate), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new TemperatureChangeRate(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<TemperatureChangeRateUnit>> unitMappings = TemperatureChangeRateInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<TemperatureChangeRate, TemperatureChangeRateUnit>(
+                    name: nameof(TemperatureChangeRate),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new TemperatureChangeRate(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="TemperatureChangeRate"/> is [T^-1][Θ].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, -1, 0, 1, 0, 0);
 
             /// <summary>
             ///     The default base unit of TemperatureChangeRate is DegreeCelsiusPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static TemperatureChangeRateUnit DefaultBaseUnit { get; } = TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
+            private static TemperatureChangeRateUnit DefaultBaseUnit { get; } = TemperatureChangeRateUnit.DegreeCelsiusPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the TemperatureChangeRate quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.TemperatureChangeRate", typeof(TemperatureChangeRate).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="TemperatureChangeRateUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{TemperatureChangeRateUnit}"/> representing the default unit mappings for TemperatureChangeRate.</returns>
-            public static IEnumerable<UnitDefinition<TemperatureChangeRateUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<TemperatureChangeRateUnit>> GetDefaultMappings()
             {
                 yield return new (TemperatureChangeRateUnit.CentidegreeCelsiusPerSecond, "CentidegreeCelsiusPerSecond", "CentidegreesCelsiusPerSecond", BaseUnits.Undefined);
                 yield return new (TemperatureChangeRateUnit.DecadegreeCelsiusPerSecond, "DecadegreeCelsiusPerSecond", "DecadegreesCelsiusPerSecond", BaseUnits.Undefined);
@@ -141,7 +141,7 @@ namespace UnitsNet
 
         static TemperatureChangeRate()
         {
-            Info = TemperatureChangeRateInfo.CreateDefault();
+            Info = TemperatureChangeRateInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -71,59 +71,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="TemperatureDelta"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class TemperatureDeltaInfo: QuantityInfo<TemperatureDelta, TemperatureDeltaUnit>
+        private static class TemperatureDeltaInfo
         {
-            /// <inheritdoc />
-            public TemperatureDeltaInfo(string name, TemperatureDeltaUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureDeltaUnit>> unitMappings, TemperatureDelta zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<TemperatureDelta, TemperatureDeltaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, TemperatureDelta.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public TemperatureDeltaInfo(string name, TemperatureDeltaUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureDeltaUnit>> unitMappings, TemperatureDelta zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, TemperatureDelta.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.TemperatureDelta", typeof(TemperatureDelta).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="TemperatureDeltaInfo"/> class with the default settings for the TemperatureDelta quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="TemperatureDeltaInfo"/> class with the default settings.</returns>
-            public static TemperatureDeltaInfo CreateDefault()
-            {
-                return new TemperatureDeltaInfo(nameof(TemperatureDelta), DefaultBaseUnit, GetDefaultMappings(), new TemperatureDelta(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="TemperatureDeltaInfo"/> class with the default settings for the TemperatureDelta quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="TemperatureDeltaInfo"/> class with the default settings.
             /// </returns>
-            public static TemperatureDeltaInfo CreateDefault(Func<IEnumerable<UnitDefinition<TemperatureDeltaUnit>>, IEnumerable<IUnitDefinition<TemperatureDeltaUnit>>> customizeUnits)
+            private static QuantityInfo<TemperatureDelta, TemperatureDeltaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<TemperatureDeltaUnit>>, IEnumerable<IUnitDefinition<TemperatureDeltaUnit>>>? customizeUnits = null)
             {
-                return new TemperatureDeltaInfo(nameof(TemperatureDelta), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new TemperatureDelta(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<TemperatureDeltaUnit>> unitMappings = TemperatureDeltaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<TemperatureDelta, TemperatureDeltaUnit>(
+                    name: nameof(TemperatureDelta),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new TemperatureDelta(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="TemperatureDelta"/> is [Θ].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, 0, 0, 0, 1, 0, 0);
 
             /// <summary>
             ///     The default base unit of TemperatureDelta is Kelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static TemperatureDeltaUnit DefaultBaseUnit { get; } = TemperatureDeltaUnit.Kelvin;
+            private static TemperatureDeltaUnit DefaultBaseUnit { get; } = TemperatureDeltaUnit.Kelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the TemperatureDelta quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.TemperatureDelta", typeof(TemperatureDelta).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="TemperatureDeltaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{TemperatureDeltaUnit}"/> representing the default unit mappings for TemperatureDelta.</returns>
-            public static IEnumerable<UnitDefinition<TemperatureDeltaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<TemperatureDeltaUnit>> GetDefaultMappings()
             {
                 yield return new (TemperatureDeltaUnit.DegreeCelsius, "DegreeCelsius", "DegreesCelsius", new BaseUnits(temperature: TemperatureUnit.DegreeCelsius));
                 yield return new (TemperatureDeltaUnit.DegreeDelisle, "DegreeDelisle", "DegreesDelisle", new BaseUnits(temperature: TemperatureUnit.DegreeDelisle));
@@ -139,7 +139,7 @@ namespace UnitsNet
 
         static TemperatureDelta()
         {
-            Info = TemperatureDeltaInfo.CreateDefault();
+            Info = TemperatureDeltaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="TemperatureGradient"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class TemperatureGradientInfo: QuantityInfo<TemperatureGradient, TemperatureGradientUnit>
+        private static class TemperatureGradientInfo
         {
-            /// <inheritdoc />
-            public TemperatureGradientInfo(string name, TemperatureGradientUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureGradientUnit>> unitMappings, TemperatureGradient zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<TemperatureGradient, TemperatureGradientUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, TemperatureGradient.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public TemperatureGradientInfo(string name, TemperatureGradientUnit baseUnit, IEnumerable<IUnitDefinition<TemperatureGradientUnit>> unitMappings, TemperatureGradient zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, TemperatureGradient.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.TemperatureGradient", typeof(TemperatureGradient).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="TemperatureGradientInfo"/> class with the default settings for the TemperatureGradient quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="TemperatureGradientInfo"/> class with the default settings.</returns>
-            public static TemperatureGradientInfo CreateDefault()
-            {
-                return new TemperatureGradientInfo(nameof(TemperatureGradient), DefaultBaseUnit, GetDefaultMappings(), new TemperatureGradient(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="TemperatureGradientInfo"/> class with the default settings for the TemperatureGradient quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="TemperatureGradientInfo"/> class with the default settings.
             /// </returns>
-            public static TemperatureGradientInfo CreateDefault(Func<IEnumerable<UnitDefinition<TemperatureGradientUnit>>, IEnumerable<IUnitDefinition<TemperatureGradientUnit>>> customizeUnits)
+            private static QuantityInfo<TemperatureGradient, TemperatureGradientUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<TemperatureGradientUnit>>, IEnumerable<IUnitDefinition<TemperatureGradientUnit>>>? customizeUnits = null)
             {
-                return new TemperatureGradientInfo(nameof(TemperatureGradient), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new TemperatureGradient(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<TemperatureGradientUnit>> unitMappings = TemperatureGradientInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<TemperatureGradient, TemperatureGradientUnit>(
+                    name: nameof(TemperatureGradient),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new TemperatureGradient(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="TemperatureGradient"/> is [L^-1][Θ].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 0, 0, 0, 1, 0, 0);
 
             /// <summary>
             ///     The default base unit of TemperatureGradient is KelvinPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static TemperatureGradientUnit DefaultBaseUnit { get; } = TemperatureGradientUnit.KelvinPerMeter;
+            private static TemperatureGradientUnit DefaultBaseUnit { get; } = TemperatureGradientUnit.KelvinPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the TemperatureGradient quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.TemperatureGradient", typeof(TemperatureGradient).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="TemperatureGradientUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{TemperatureGradientUnit}"/> representing the default unit mappings for TemperatureGradient.</returns>
-            public static IEnumerable<UnitDefinition<TemperatureGradientUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<TemperatureGradientUnit>> GetDefaultMappings()
             {
                 yield return new (TemperatureGradientUnit.DegreeCelsiusPerKilometer, "DegreeCelsiusPerKilometer", "DegreesCelsiusPerKilometer", new BaseUnits(length: LengthUnit.Kilometer, temperature: TemperatureUnit.DegreeCelsius));
                 yield return new (TemperatureGradientUnit.DegreeCelsiusPerMeter, "DegreeCelsiusPerMeter", "DegreesCelsiusPerMeter", new BaseUnits(length: LengthUnit.Meter, temperature: TemperatureUnit.DegreeCelsius));
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static TemperatureGradient()
         {
-            Info = TemperatureGradientInfo.CreateDefault();
+            Info = TemperatureGradientInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ThermalConductivity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ThermalConductivityInfo: QuantityInfo<ThermalConductivity, ThermalConductivityUnit>
+        private static class ThermalConductivityInfo
         {
-            /// <inheritdoc />
-            public ThermalConductivityInfo(string name, ThermalConductivityUnit baseUnit, IEnumerable<IUnitDefinition<ThermalConductivityUnit>> unitMappings, ThermalConductivity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ThermalConductivity, ThermalConductivityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ThermalConductivity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ThermalConductivityInfo(string name, ThermalConductivityUnit baseUnit, IEnumerable<IUnitDefinition<ThermalConductivityUnit>> unitMappings, ThermalConductivity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ThermalConductivity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ThermalConductivity", typeof(ThermalConductivity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ThermalConductivityInfo"/> class with the default settings for the ThermalConductivity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ThermalConductivityInfo"/> class with the default settings.</returns>
-            public static ThermalConductivityInfo CreateDefault()
-            {
-                return new ThermalConductivityInfo(nameof(ThermalConductivity), DefaultBaseUnit, GetDefaultMappings(), new ThermalConductivity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ThermalConductivityInfo"/> class with the default settings for the ThermalConductivity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ThermalConductivityInfo"/> class with the default settings.
             /// </returns>
-            public static ThermalConductivityInfo CreateDefault(Func<IEnumerable<UnitDefinition<ThermalConductivityUnit>>, IEnumerable<IUnitDefinition<ThermalConductivityUnit>>> customizeUnits)
+            private static QuantityInfo<ThermalConductivity, ThermalConductivityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ThermalConductivityUnit>>, IEnumerable<IUnitDefinition<ThermalConductivityUnit>>>? customizeUnits = null)
             {
-                return new ThermalConductivityInfo(nameof(ThermalConductivity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ThermalConductivity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ThermalConductivityUnit>> unitMappings = ThermalConductivityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ThermalConductivity, ThermalConductivityUnit>(
+                    name: nameof(ThermalConductivity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ThermalConductivity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ThermalConductivity"/> is [T^-3][L][M][Θ^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, 0, -1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 1, -3, 0, -1, 0, 0);
 
             /// <summary>
             ///     The default base unit of ThermalConductivity is WattPerMeterKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ThermalConductivityUnit DefaultBaseUnit { get; } = ThermalConductivityUnit.WattPerMeterKelvin;
+            private static ThermalConductivityUnit DefaultBaseUnit { get; } = ThermalConductivityUnit.WattPerMeterKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ThermalConductivity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ThermalConductivity", typeof(ThermalConductivity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ThermalConductivityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ThermalConductivityUnit}"/> representing the default unit mappings for ThermalConductivity.</returns>
-            public static IEnumerable<UnitDefinition<ThermalConductivityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ThermalConductivityUnit>> GetDefaultMappings()
             {
                 yield return new (ThermalConductivityUnit.BtuPerHourFootFahrenheit, "BtuPerHourFootFahrenheit", "BtusPerHourFootFahrenheit", BaseUnits.Undefined);
                 yield return new (ThermalConductivityUnit.WattPerMeterKelvin, "WattPerMeterKelvin", "WattsPerMeterKelvin", new BaseUnits(length: LengthUnit.Meter, mass: MassUnit.Kilogram, time: DurationUnit.Second, temperature: TemperatureUnit.Kelvin));
@@ -126,7 +126,7 @@ namespace UnitsNet
 
         static ThermalConductivity()
         {
-            Info = ThermalConductivityInfo.CreateDefault();
+            Info = ThermalConductivityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ThermalInsulance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalInsulance.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="ThermalInsulance"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class ThermalInsulanceInfo: QuantityInfo<ThermalInsulance, ThermalInsulanceUnit>
+        private static class ThermalInsulanceInfo
         {
-            /// <inheritdoc />
-            public ThermalInsulanceInfo(string name, ThermalInsulanceUnit baseUnit, IEnumerable<IUnitDefinition<ThermalInsulanceUnit>> unitMappings, ThermalInsulance zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<ThermalInsulance, ThermalInsulanceUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, ThermalInsulance.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public ThermalInsulanceInfo(string name, ThermalInsulanceUnit baseUnit, IEnumerable<IUnitDefinition<ThermalInsulanceUnit>> unitMappings, ThermalInsulance zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, ThermalInsulance.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.ThermalInsulance", typeof(ThermalInsulance).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="ThermalInsulanceInfo"/> class with the default settings for the ThermalInsulance quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="ThermalInsulanceInfo"/> class with the default settings.</returns>
-            public static ThermalInsulanceInfo CreateDefault()
-            {
-                return new ThermalInsulanceInfo(nameof(ThermalInsulance), DefaultBaseUnit, GetDefaultMappings(), new ThermalInsulance(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="ThermalInsulanceInfo"/> class with the default settings for the ThermalInsulance quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="ThermalInsulanceInfo"/> class with the default settings.
             /// </returns>
-            public static ThermalInsulanceInfo CreateDefault(Func<IEnumerable<UnitDefinition<ThermalInsulanceUnit>>, IEnumerable<IUnitDefinition<ThermalInsulanceUnit>>> customizeUnits)
+            private static QuantityInfo<ThermalInsulance, ThermalInsulanceUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<ThermalInsulanceUnit>>, IEnumerable<IUnitDefinition<ThermalInsulanceUnit>>>? customizeUnits = null)
             {
-                return new ThermalInsulanceInfo(nameof(ThermalInsulance), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new ThermalInsulance(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<ThermalInsulanceUnit>> unitMappings = ThermalInsulanceInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<ThermalInsulance, ThermalInsulanceUnit>(
+                    name: nameof(ThermalInsulance),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new ThermalInsulance(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="ThermalInsulance"/> is [T^3][M^-1][Θ].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, -1, 3, 0, 1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(0, -1, 3, 0, 1, 0, 0);
 
             /// <summary>
             ///     The default base unit of ThermalInsulance is SquareMeterKelvinPerKilowatt. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static ThermalInsulanceUnit DefaultBaseUnit { get; } = ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt;
+            private static ThermalInsulanceUnit DefaultBaseUnit { get; } = ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the ThermalInsulance quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.ThermalInsulance", typeof(ThermalInsulance).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="ThermalInsulanceUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{ThermalInsulanceUnit}"/> representing the default unit mappings for ThermalInsulance.</returns>
-            public static IEnumerable<UnitDefinition<ThermalInsulanceUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<ThermalInsulanceUnit>> GetDefaultMappings()
             {
                 yield return new (ThermalInsulanceUnit.HourSquareFeetDegreeFahrenheitPerBtu, "HourSquareFeetDegreeFahrenheitPerBtu", "HourSquareFeetDegreesFahrenheitPerBtu", BaseUnits.Undefined);
                 yield return new (ThermalInsulanceUnit.SquareCentimeterHourDegreeCelsiusPerKilocalorie, "SquareCentimeterHourDegreeCelsiusPerKilocalorie", "SquareCentimeterHourDegreesCelsiusPerKilocalorie", BaseUnits.Undefined);
@@ -128,7 +128,7 @@ namespace UnitsNet
 
         static ThermalInsulance()
         {
-            Info = ThermalInsulanceInfo.CreateDefault();
+            Info = ThermalInsulanceInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -71,59 +71,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Torque"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class TorqueInfo: QuantityInfo<Torque, TorqueUnit>
+        private static class TorqueInfo
         {
-            /// <inheritdoc />
-            public TorqueInfo(string name, TorqueUnit baseUnit, IEnumerable<IUnitDefinition<TorqueUnit>> unitMappings, Torque zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Torque, TorqueUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Torque.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public TorqueInfo(string name, TorqueUnit baseUnit, IEnumerable<IUnitDefinition<TorqueUnit>> unitMappings, Torque zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Torque.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Torque", typeof(Torque).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="TorqueInfo"/> class with the default settings for the Torque quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="TorqueInfo"/> class with the default settings.</returns>
-            public static TorqueInfo CreateDefault()
-            {
-                return new TorqueInfo(nameof(Torque), DefaultBaseUnit, GetDefaultMappings(), new Torque(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="TorqueInfo"/> class with the default settings for the Torque quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="TorqueInfo"/> class with the default settings.
             /// </returns>
-            public static TorqueInfo CreateDefault(Func<IEnumerable<UnitDefinition<TorqueUnit>>, IEnumerable<IUnitDefinition<TorqueUnit>>> customizeUnits)
+            private static QuantityInfo<Torque, TorqueUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<TorqueUnit>>, IEnumerable<IUnitDefinition<TorqueUnit>>>? customizeUnits = null)
             {
-                return new TorqueInfo(nameof(Torque), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Torque(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<TorqueUnit>> unitMappings = TorqueInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Torque, TorqueUnit>(
+                    name: nameof(Torque),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Torque(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Torque"/> is [T^-2][L^2][M].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 1, -2, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Torque is NewtonMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static TorqueUnit DefaultBaseUnit { get; } = TorqueUnit.NewtonMeter;
+            private static TorqueUnit DefaultBaseUnit { get; } = TorqueUnit.NewtonMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Torque quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Torque", typeof(Torque).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="TorqueUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{TorqueUnit}"/> representing the default unit mappings for Torque.</returns>
-            public static IEnumerable<UnitDefinition<TorqueUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<TorqueUnit>> GetDefaultMappings()
             {
                 yield return new (TorqueUnit.GramForceCentimeter, "GramForceCentimeter", "GramForceCentimeters", BaseUnits.Undefined);
                 yield return new (TorqueUnit.GramForceMeter, "GramForceMeter", "GramForceMeters", BaseUnits.Undefined);
@@ -155,7 +155,7 @@ namespace UnitsNet
 
         static Torque()
         {
-            Info = TorqueInfo.CreateDefault();
+            Info = TorqueInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Turbidity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class TurbidityInfo: QuantityInfo<Turbidity, TurbidityUnit>
+        private static class TurbidityInfo
         {
-            /// <inheritdoc />
-            public TurbidityInfo(string name, TurbidityUnit baseUnit, IEnumerable<IUnitDefinition<TurbidityUnit>> unitMappings, Turbidity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Turbidity, TurbidityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Turbidity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public TurbidityInfo(string name, TurbidityUnit baseUnit, IEnumerable<IUnitDefinition<TurbidityUnit>> unitMappings, Turbidity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Turbidity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Turbidity", typeof(Turbidity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="TurbidityInfo"/> class with the default settings for the Turbidity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="TurbidityInfo"/> class with the default settings.</returns>
-            public static TurbidityInfo CreateDefault()
-            {
-                return new TurbidityInfo(nameof(Turbidity), DefaultBaseUnit, GetDefaultMappings(), new Turbidity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="TurbidityInfo"/> class with the default settings for the Turbidity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="TurbidityInfo"/> class with the default settings.
             /// </returns>
-            public static TurbidityInfo CreateDefault(Func<IEnumerable<UnitDefinition<TurbidityUnit>>, IEnumerable<IUnitDefinition<TurbidityUnit>>> customizeUnits)
+            private static QuantityInfo<Turbidity, TurbidityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<TurbidityUnit>>, IEnumerable<IUnitDefinition<TurbidityUnit>>>? customizeUnits = null)
             {
-                return new TurbidityInfo(nameof(Turbidity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Turbidity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<TurbidityUnit>> unitMappings = TurbidityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Turbidity, TurbidityUnit>(
+                    name: nameof(Turbidity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Turbidity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Turbidity"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of Turbidity is NTU. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static TurbidityUnit DefaultBaseUnit { get; } = TurbidityUnit.NTU;
+            private static TurbidityUnit DefaultBaseUnit { get; } = TurbidityUnit.NTU;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Turbidity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Turbidity", typeof(Turbidity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="TurbidityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{TurbidityUnit}"/> representing the default unit mappings for Turbidity.</returns>
-            public static IEnumerable<UnitDefinition<TurbidityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<TurbidityUnit>> GetDefaultMappings()
             {
                 yield return new (TurbidityUnit.NTU, "NTU", "NTU", BaseUnits.Undefined);
             }
@@ -125,7 +125,7 @@ namespace UnitsNet
 
         static Turbidity()
         {
-            Info = TurbidityInfo.CreateDefault();
+            Info = TurbidityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="VitaminA"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VitaminAInfo: QuantityInfo<VitaminA, VitaminAUnit>
+        private static class VitaminAInfo
         {
-            /// <inheritdoc />
-            public VitaminAInfo(string name, VitaminAUnit baseUnit, IEnumerable<IUnitDefinition<VitaminAUnit>> unitMappings, VitaminA zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<VitaminA, VitaminAUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, VitaminA.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VitaminAInfo(string name, VitaminAUnit baseUnit, IEnumerable<IUnitDefinition<VitaminAUnit>> unitMappings, VitaminA zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, VitaminA.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.VitaminA", typeof(VitaminA).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VitaminAInfo"/> class with the default settings for the VitaminA quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VitaminAInfo"/> class with the default settings.</returns>
-            public static VitaminAInfo CreateDefault()
-            {
-                return new VitaminAInfo(nameof(VitaminA), DefaultBaseUnit, GetDefaultMappings(), new VitaminA(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VitaminAInfo"/> class with the default settings for the VitaminA quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VitaminAInfo"/> class with the default settings.
             /// </returns>
-            public static VitaminAInfo CreateDefault(Func<IEnumerable<UnitDefinition<VitaminAUnit>>, IEnumerable<IUnitDefinition<VitaminAUnit>>> customizeUnits)
+            private static QuantityInfo<VitaminA, VitaminAUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VitaminAUnit>>, IEnumerable<IUnitDefinition<VitaminAUnit>>>? customizeUnits = null)
             {
-                return new VitaminAInfo(nameof(VitaminA), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new VitaminA(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VitaminAUnit>> unitMappings = VitaminAInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<VitaminA, VitaminAUnit>(
+                    name: nameof(VitaminA),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new VitaminA(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="VitaminA"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of VitaminA is InternationalUnit. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VitaminAUnit DefaultBaseUnit { get; } = VitaminAUnit.InternationalUnit;
+            private static VitaminAUnit DefaultBaseUnit { get; } = VitaminAUnit.InternationalUnit;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the VitaminA quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.VitaminA", typeof(VitaminA).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VitaminAUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VitaminAUnit}"/> representing the default unit mappings for VitaminA.</returns>
-            public static IEnumerable<UnitDefinition<VitaminAUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VitaminAUnit>> GetDefaultMappings()
             {
                 yield return new (VitaminAUnit.InternationalUnit, "InternationalUnit", "InternationalUnits", BaseUnits.Undefined);
             }
@@ -122,7 +122,7 @@ namespace UnitsNet
 
         static VitaminA()
         {
-            Info = VitaminAInfo.CreateDefault();
+            Info = VitaminAInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -77,59 +77,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="Volume"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VolumeInfo: QuantityInfo<Volume, VolumeUnit>
+        private static class VolumeInfo
         {
-            /// <inheritdoc />
-            public VolumeInfo(string name, VolumeUnit baseUnit, IEnumerable<IUnitDefinition<VolumeUnit>> unitMappings, Volume zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<Volume, VolumeUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, Volume.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VolumeInfo(string name, VolumeUnit baseUnit, IEnumerable<IUnitDefinition<VolumeUnit>> unitMappings, Volume zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, Volume.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.Volume", typeof(Volume).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VolumeInfo"/> class with the default settings for the Volume quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VolumeInfo"/> class with the default settings.</returns>
-            public static VolumeInfo CreateDefault()
-            {
-                return new VolumeInfo(nameof(Volume), DefaultBaseUnit, GetDefaultMappings(), new Volume(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VolumeInfo"/> class with the default settings for the Volume quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VolumeInfo"/> class with the default settings.
             /// </returns>
-            public static VolumeInfo CreateDefault(Func<IEnumerable<UnitDefinition<VolumeUnit>>, IEnumerable<IUnitDefinition<VolumeUnit>>> customizeUnits)
+            private static QuantityInfo<Volume, VolumeUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VolumeUnit>>, IEnumerable<IUnitDefinition<VolumeUnit>>>? customizeUnits = null)
             {
-                return new VolumeInfo(nameof(Volume), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new Volume(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VolumeUnit>> unitMappings = VolumeInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<Volume, VolumeUnit>(
+                    name: nameof(Volume),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new Volume(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="Volume"/> is [L^3].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of Volume is CubicMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VolumeUnit DefaultBaseUnit { get; } = VolumeUnit.CubicMeter;
+            private static VolumeUnit DefaultBaseUnit { get; } = VolumeUnit.CubicMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the Volume quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.Volume", typeof(Volume).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VolumeUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VolumeUnit}"/> representing the default unit mappings for Volume.</returns>
-            public static IEnumerable<UnitDefinition<VolumeUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VolumeUnit>> GetDefaultMappings()
             {
                 yield return new (VolumeUnit.AcreFoot, "AcreFoot", "AcreFeet", BaseUnits.Undefined);
                 yield return new (VolumeUnit.AuTablespoon, "AuTablespoon", "AuTablespoons", BaseUnits.Undefined);
@@ -190,7 +190,7 @@ namespace UnitsNet
 
         static Volume()
         {
-            Info = VolumeInfo.CreateDefault();
+            Info = VolumeInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
@@ -69,59 +69,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="VolumeConcentration"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VolumeConcentrationInfo: QuantityInfo<VolumeConcentration, VolumeConcentrationUnit>
+        private static class VolumeConcentrationInfo
         {
-            /// <inheritdoc />
-            public VolumeConcentrationInfo(string name, VolumeConcentrationUnit baseUnit, IEnumerable<IUnitDefinition<VolumeConcentrationUnit>> unitMappings, VolumeConcentration zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<VolumeConcentration, VolumeConcentrationUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, VolumeConcentration.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VolumeConcentrationInfo(string name, VolumeConcentrationUnit baseUnit, IEnumerable<IUnitDefinition<VolumeConcentrationUnit>> unitMappings, VolumeConcentration zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, VolumeConcentration.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.VolumeConcentration", typeof(VolumeConcentration).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VolumeConcentrationInfo"/> class with the default settings for the VolumeConcentration quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VolumeConcentrationInfo"/> class with the default settings.</returns>
-            public static VolumeConcentrationInfo CreateDefault()
-            {
-                return new VolumeConcentrationInfo(nameof(VolumeConcentration), DefaultBaseUnit, GetDefaultMappings(), new VolumeConcentration(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VolumeConcentrationInfo"/> class with the default settings for the VolumeConcentration quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VolumeConcentrationInfo"/> class with the default settings.
             /// </returns>
-            public static VolumeConcentrationInfo CreateDefault(Func<IEnumerable<UnitDefinition<VolumeConcentrationUnit>>, IEnumerable<IUnitDefinition<VolumeConcentrationUnit>>> customizeUnits)
+            private static QuantityInfo<VolumeConcentration, VolumeConcentrationUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VolumeConcentrationUnit>>, IEnumerable<IUnitDefinition<VolumeConcentrationUnit>>>? customizeUnits = null)
             {
-                return new VolumeConcentrationInfo(nameof(VolumeConcentration), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new VolumeConcentration(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VolumeConcentrationUnit>> unitMappings = VolumeConcentrationInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<VolumeConcentration, VolumeConcentrationUnit>(
+                    name: nameof(VolumeConcentration),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new VolumeConcentration(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="VolumeConcentration"/> is .
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
+            private static BaseDimensions DefaultBaseDimensions { get; } = BaseDimensions.Dimensionless;
 
             /// <summary>
             ///     The default base unit of VolumeConcentration is DecimalFraction. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VolumeConcentrationUnit DefaultBaseUnit { get; } = VolumeConcentrationUnit.DecimalFraction;
+            private static VolumeConcentrationUnit DefaultBaseUnit { get; } = VolumeConcentrationUnit.DecimalFraction;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the VolumeConcentration quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.VolumeConcentration", typeof(VolumeConcentration).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VolumeConcentrationUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VolumeConcentrationUnit}"/> representing the default unit mappings for VolumeConcentration.</returns>
-            public static IEnumerable<UnitDefinition<VolumeConcentrationUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VolumeConcentrationUnit>> GetDefaultMappings()
             {
                 yield return new (VolumeConcentrationUnit.CentiliterPerLiter, "CentiliterPerLiter", "CentilitersPerLiter", BaseUnits.Undefined);
                 yield return new (VolumeConcentrationUnit.CentiliterPerMilliliter, "CentiliterPerMilliliter", "CentilitersPerMilliliter", BaseUnits.Undefined);
@@ -148,7 +148,7 @@ namespace UnitsNet
 
         static VolumeConcentration()
         {
-            Info = VolumeConcentrationInfo.CreateDefault();
+            Info = VolumeConcentrationInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -69,59 +69,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="VolumeFlow"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VolumeFlowInfo: QuantityInfo<VolumeFlow, VolumeFlowUnit>
+        private static class VolumeFlowInfo
         {
-            /// <inheritdoc />
-            public VolumeFlowInfo(string name, VolumeFlowUnit baseUnit, IEnumerable<IUnitDefinition<VolumeFlowUnit>> unitMappings, VolumeFlow zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<VolumeFlow, VolumeFlowUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, VolumeFlow.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VolumeFlowInfo(string name, VolumeFlowUnit baseUnit, IEnumerable<IUnitDefinition<VolumeFlowUnit>> unitMappings, VolumeFlow zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, VolumeFlow.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.VolumeFlow", typeof(VolumeFlow).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VolumeFlowInfo"/> class with the default settings for the VolumeFlow quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VolumeFlowInfo"/> class with the default settings.</returns>
-            public static VolumeFlowInfo CreateDefault()
-            {
-                return new VolumeFlowInfo(nameof(VolumeFlow), DefaultBaseUnit, GetDefaultMappings(), new VolumeFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VolumeFlowInfo"/> class with the default settings for the VolumeFlow quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VolumeFlowInfo"/> class with the default settings.
             /// </returns>
-            public static VolumeFlowInfo CreateDefault(Func<IEnumerable<UnitDefinition<VolumeFlowUnit>>, IEnumerable<IUnitDefinition<VolumeFlowUnit>>> customizeUnits)
+            private static QuantityInfo<VolumeFlow, VolumeFlowUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VolumeFlowUnit>>, IEnumerable<IUnitDefinition<VolumeFlowUnit>>>? customizeUnits = null)
             {
-                return new VolumeFlowInfo(nameof(VolumeFlow), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new VolumeFlow(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VolumeFlowUnit>> unitMappings = VolumeFlowInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<VolumeFlow, VolumeFlowUnit>(
+                    name: nameof(VolumeFlow),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new VolumeFlow(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="VolumeFlow"/> is [T^-1][L^3].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(3, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of VolumeFlow is CubicMeterPerSecond. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VolumeFlowUnit DefaultBaseUnit { get; } = VolumeFlowUnit.CubicMeterPerSecond;
+            private static VolumeFlowUnit DefaultBaseUnit { get; } = VolumeFlowUnit.CubicMeterPerSecond;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the VolumeFlow quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.VolumeFlow", typeof(VolumeFlow).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VolumeFlowUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VolumeFlowUnit}"/> representing the default unit mappings for VolumeFlow.</returns>
-            public static IEnumerable<UnitDefinition<VolumeFlowUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VolumeFlowUnit>> GetDefaultMappings()
             {
                 yield return new (VolumeFlowUnit.AcreFootPerDay, "AcreFootPerDay", "AcreFeetPerDay", BaseUnits.Undefined);
                 yield return new (VolumeFlowUnit.AcreFootPerHour, "AcreFootPerHour", "AcreFeetPerHour", BaseUnits.Undefined);
@@ -203,7 +203,7 @@ namespace UnitsNet
 
         static VolumeFlow()
         {
-            Info = VolumeFlowInfo.CreateDefault();
+            Info = VolumeFlowInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="VolumeFlowPerArea"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VolumeFlowPerAreaInfo: QuantityInfo<VolumeFlowPerArea, VolumeFlowPerAreaUnit>
+        private static class VolumeFlowPerAreaInfo
         {
-            /// <inheritdoc />
-            public VolumeFlowPerAreaInfo(string name, VolumeFlowPerAreaUnit baseUnit, IEnumerable<IUnitDefinition<VolumeFlowPerAreaUnit>> unitMappings, VolumeFlowPerArea zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<VolumeFlowPerArea, VolumeFlowPerAreaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, VolumeFlowPerArea.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VolumeFlowPerAreaInfo(string name, VolumeFlowPerAreaUnit baseUnit, IEnumerable<IUnitDefinition<VolumeFlowPerAreaUnit>> unitMappings, VolumeFlowPerArea zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, VolumeFlowPerArea.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.VolumeFlowPerArea", typeof(VolumeFlowPerArea).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VolumeFlowPerAreaInfo"/> class with the default settings for the VolumeFlowPerArea quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VolumeFlowPerAreaInfo"/> class with the default settings.</returns>
-            public static VolumeFlowPerAreaInfo CreateDefault()
-            {
-                return new VolumeFlowPerAreaInfo(nameof(VolumeFlowPerArea), DefaultBaseUnit, GetDefaultMappings(), new VolumeFlowPerArea(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VolumeFlowPerAreaInfo"/> class with the default settings for the VolumeFlowPerArea quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VolumeFlowPerAreaInfo"/> class with the default settings.
             /// </returns>
-            public static VolumeFlowPerAreaInfo CreateDefault(Func<IEnumerable<UnitDefinition<VolumeFlowPerAreaUnit>>, IEnumerable<IUnitDefinition<VolumeFlowPerAreaUnit>>> customizeUnits)
+            private static QuantityInfo<VolumeFlowPerArea, VolumeFlowPerAreaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VolumeFlowPerAreaUnit>>, IEnumerable<IUnitDefinition<VolumeFlowPerAreaUnit>>>? customizeUnits = null)
             {
-                return new VolumeFlowPerAreaInfo(nameof(VolumeFlowPerArea), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new VolumeFlowPerArea(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VolumeFlowPerAreaUnit>> unitMappings = VolumeFlowPerAreaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<VolumeFlowPerArea, VolumeFlowPerAreaUnit>(
+                    name: nameof(VolumeFlowPerArea),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new VolumeFlowPerArea(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="VolumeFlowPerArea"/> is [T^-1][L].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(1, 0, -1, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of VolumeFlowPerArea is CubicMeterPerSecondPerSquareMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VolumeFlowPerAreaUnit DefaultBaseUnit { get; } = VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter;
+            private static VolumeFlowPerAreaUnit DefaultBaseUnit { get; } = VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the VolumeFlowPerArea quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.VolumeFlowPerArea", typeof(VolumeFlowPerArea).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VolumeFlowPerAreaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VolumeFlowPerAreaUnit}"/> representing the default unit mappings for VolumeFlowPerArea.</returns>
-            public static IEnumerable<UnitDefinition<VolumeFlowPerAreaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VolumeFlowPerAreaUnit>> GetDefaultMappings()
             {
                 yield return new (VolumeFlowPerAreaUnit.CubicFootPerMinutePerSquareFoot, "CubicFootPerMinutePerSquareFoot", "CubicFeetPerMinutePerSquareFoot", new BaseUnits(length: LengthUnit.Foot, time: DurationUnit.Minute));
                 yield return new (VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter, "CubicMeterPerSecondPerSquareMeter", "CubicMetersPerSecondPerSquareMeter", new BaseUnits(length: LengthUnit.Meter, time: DurationUnit.Second));
@@ -123,7 +123,7 @@ namespace UnitsNet
 
         static VolumeFlowPerArea()
         {
-            Info = VolumeFlowPerAreaInfo.CreateDefault();
+            Info = VolumeFlowPerAreaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="VolumePerLength"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VolumePerLengthInfo: QuantityInfo<VolumePerLength, VolumePerLengthUnit>
+        private static class VolumePerLengthInfo
         {
-            /// <inheritdoc />
-            public VolumePerLengthInfo(string name, VolumePerLengthUnit baseUnit, IEnumerable<IUnitDefinition<VolumePerLengthUnit>> unitMappings, VolumePerLength zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<VolumePerLength, VolumePerLengthUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, VolumePerLength.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VolumePerLengthInfo(string name, VolumePerLengthUnit baseUnit, IEnumerable<IUnitDefinition<VolumePerLengthUnit>> unitMappings, VolumePerLength zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, VolumePerLength.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.VolumePerLength", typeof(VolumePerLength).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VolumePerLengthInfo"/> class with the default settings for the VolumePerLength quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VolumePerLengthInfo"/> class with the default settings.</returns>
-            public static VolumePerLengthInfo CreateDefault()
-            {
-                return new VolumePerLengthInfo(nameof(VolumePerLength), DefaultBaseUnit, GetDefaultMappings(), new VolumePerLength(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VolumePerLengthInfo"/> class with the default settings for the VolumePerLength quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VolumePerLengthInfo"/> class with the default settings.
             /// </returns>
-            public static VolumePerLengthInfo CreateDefault(Func<IEnumerable<UnitDefinition<VolumePerLengthUnit>>, IEnumerable<IUnitDefinition<VolumePerLengthUnit>>> customizeUnits)
+            private static QuantityInfo<VolumePerLength, VolumePerLengthUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VolumePerLengthUnit>>, IEnumerable<IUnitDefinition<VolumePerLengthUnit>>>? customizeUnits = null)
             {
-                return new VolumePerLengthInfo(nameof(VolumePerLength), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new VolumePerLength(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VolumePerLengthUnit>> unitMappings = VolumePerLengthInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<VolumePerLength, VolumePerLengthUnit>(
+                    name: nameof(VolumePerLength),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new VolumePerLength(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="VolumePerLength"/> is [L^2].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(2, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of VolumePerLength is CubicMeterPerMeter. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VolumePerLengthUnit DefaultBaseUnit { get; } = VolumePerLengthUnit.CubicMeterPerMeter;
+            private static VolumePerLengthUnit DefaultBaseUnit { get; } = VolumePerLengthUnit.CubicMeterPerMeter;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the VolumePerLength quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.VolumePerLength", typeof(VolumePerLength).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VolumePerLengthUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VolumePerLengthUnit}"/> representing the default unit mappings for VolumePerLength.</returns>
-            public static IEnumerable<UnitDefinition<VolumePerLengthUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VolumePerLengthUnit>> GetDefaultMappings()
             {
                 yield return new (VolumePerLengthUnit.CubicMeterPerMeter, "CubicMeterPerMeter", "CubicMetersPerMeter", new BaseUnits(length: LengthUnit.Meter));
                 yield return new (VolumePerLengthUnit.CubicYardPerFoot, "CubicYardPerFoot", "CubicYardsPerFoot", BaseUnits.Undefined);
@@ -130,7 +130,7 @@ namespace UnitsNet
 
         static VolumePerLength()
         {
-            Info = VolumePerLengthInfo.CreateDefault();
+            Info = VolumePerLengthInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -65,59 +65,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="VolumetricHeatCapacity"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class VolumetricHeatCapacityInfo: QuantityInfo<VolumetricHeatCapacity, VolumetricHeatCapacityUnit>
+        private static class VolumetricHeatCapacityInfo
         {
-            /// <inheritdoc />
-            public VolumetricHeatCapacityInfo(string name, VolumetricHeatCapacityUnit baseUnit, IEnumerable<IUnitDefinition<VolumetricHeatCapacityUnit>> unitMappings, VolumetricHeatCapacity zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<VolumetricHeatCapacity, VolumetricHeatCapacityUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, VolumetricHeatCapacity.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public VolumetricHeatCapacityInfo(string name, VolumetricHeatCapacityUnit baseUnit, IEnumerable<IUnitDefinition<VolumetricHeatCapacityUnit>> unitMappings, VolumetricHeatCapacity zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, VolumetricHeatCapacity.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.VolumetricHeatCapacity", typeof(VolumetricHeatCapacity).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="VolumetricHeatCapacityInfo"/> class with the default settings for the VolumetricHeatCapacity quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="VolumetricHeatCapacityInfo"/> class with the default settings.</returns>
-            public static VolumetricHeatCapacityInfo CreateDefault()
-            {
-                return new VolumetricHeatCapacityInfo(nameof(VolumetricHeatCapacity), DefaultBaseUnit, GetDefaultMappings(), new VolumetricHeatCapacity(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="VolumetricHeatCapacityInfo"/> class with the default settings for the VolumetricHeatCapacity quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="VolumetricHeatCapacityInfo"/> class with the default settings.
             /// </returns>
-            public static VolumetricHeatCapacityInfo CreateDefault(Func<IEnumerable<UnitDefinition<VolumetricHeatCapacityUnit>>, IEnumerable<IUnitDefinition<VolumetricHeatCapacityUnit>>> customizeUnits)
+            private static QuantityInfo<VolumetricHeatCapacity, VolumetricHeatCapacityUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<VolumetricHeatCapacityUnit>>, IEnumerable<IUnitDefinition<VolumetricHeatCapacityUnit>>>? customizeUnits = null)
             {
-                return new VolumetricHeatCapacityInfo(nameof(VolumetricHeatCapacity), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new VolumetricHeatCapacity(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<VolumetricHeatCapacityUnit>> unitMappings = VolumetricHeatCapacityInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<VolumetricHeatCapacity, VolumetricHeatCapacityUnit>(
+                    name: nameof(VolumetricHeatCapacity),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new VolumetricHeatCapacity(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="VolumetricHeatCapacity"/> is [T^-2][L^-1][M][Θ^-1].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -2, 0, -1, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(-1, 1, -2, 0, -1, 0, 0);
 
             /// <summary>
             ///     The default base unit of VolumetricHeatCapacity is JoulePerCubicMeterKelvin. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static VolumetricHeatCapacityUnit DefaultBaseUnit { get; } = VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin;
+            private static VolumetricHeatCapacityUnit DefaultBaseUnit { get; } = VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the VolumetricHeatCapacity quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.VolumetricHeatCapacity", typeof(VolumetricHeatCapacity).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="VolumetricHeatCapacityUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{VolumetricHeatCapacityUnit}"/> representing the default unit mappings for VolumetricHeatCapacity.</returns>
-            public static IEnumerable<UnitDefinition<VolumetricHeatCapacityUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<VolumetricHeatCapacityUnit>> GetDefaultMappings()
             {
                 yield return new (VolumetricHeatCapacityUnit.BtuPerCubicFootDegreeFahrenheit, "BtuPerCubicFootDegreeFahrenheit", "BtusPerCubicFootDegreeFahrenheit", BaseUnits.Undefined);
                 yield return new (VolumetricHeatCapacityUnit.CaloriePerCubicCentimeterDegreeCelsius, "CaloriePerCubicCentimeterDegreeCelsius", "CaloriesPerCubicCentimeterDegreeCelsius", BaseUnits.Undefined);
@@ -133,7 +133,7 @@ namespace UnitsNet
 
         static VolumetricHeatCapacity()
         {
-            Info = VolumetricHeatCapacityInfo.CreateDefault();
+            Info = VolumetricHeatCapacityInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -62,59 +62,59 @@ namespace UnitsNet
         /// <summary>
         ///     Provides detailed information about the <see cref="WarpingMomentOfInertia"/> quantity, including its name, base unit, unit mappings, base dimensions, and conversion functions.
         /// </summary>
-        public sealed class WarpingMomentOfInertiaInfo: QuantityInfo<WarpingMomentOfInertia, WarpingMomentOfInertiaUnit>
+        private static class WarpingMomentOfInertiaInfo
         {
-            /// <inheritdoc />
-            public WarpingMomentOfInertiaInfo(string name, WarpingMomentOfInertiaUnit baseUnit, IEnumerable<IUnitDefinition<WarpingMomentOfInertiaUnit>> unitMappings, WarpingMomentOfInertia zero, BaseDimensions baseDimensions,
-                QuantityFromDelegate<WarpingMomentOfInertia, WarpingMomentOfInertiaUnit> fromDelegate, ResourceManager? unitAbbreviations)
-                : base(name, baseUnit, unitMappings, zero, baseDimensions, fromDelegate, WarpingMomentOfInertia.RegisterDefaultConversions, unitAbbreviations)
-            {
-            }
-
-            /// <inheritdoc />
-            public WarpingMomentOfInertiaInfo(string name, WarpingMomentOfInertiaUnit baseUnit, IEnumerable<IUnitDefinition<WarpingMomentOfInertiaUnit>> unitMappings, WarpingMomentOfInertia zero, BaseDimensions baseDimensions)
-                : this(name, baseUnit, unitMappings, zero, baseDimensions, WarpingMomentOfInertia.From, new ResourceManager("UnitsNet.GeneratedCode.Resources.WarpingMomentOfInertia", typeof(WarpingMomentOfInertia).Assembly))
-            {
-            }
-
-            /// <summary>
-            ///     Creates a new instance of the <see cref="WarpingMomentOfInertiaInfo"/> class with the default settings for the WarpingMomentOfInertia quantity.
-            /// </summary>
-            /// <returns>A new instance of the <see cref="WarpingMomentOfInertiaInfo"/> class with the default settings.</returns>
-            public static WarpingMomentOfInertiaInfo CreateDefault()
-            {
-                return new WarpingMomentOfInertiaInfo(nameof(WarpingMomentOfInertia), DefaultBaseUnit, GetDefaultMappings(), new WarpingMomentOfInertia(0, DefaultBaseUnit), DefaultBaseDimensions);
-            }
-
             /// <summary>
             ///     Creates a new instance of the <see cref="WarpingMomentOfInertiaInfo"/> class with the default settings for the WarpingMomentOfInertia quantity and a callback for customizing the default unit mappings.
             /// </summary>
+            /// <param name="unitAbbreviations">
+            ///     When provided, the resource manager used for localizing the quantity's unit abbreviations. Defaults to the built-in abbreviations.
+            /// </param>
             /// <param name="customizeUnits">
-            ///     A callback function for customizing the default unit mappings.
+            ///     Optionally add, replace or remove unit definitions from the default set of units.
             /// </param>
             /// <returns>
             ///     A new instance of the <see cref="WarpingMomentOfInertiaInfo"/> class with the default settings.
             /// </returns>
-            public static WarpingMomentOfInertiaInfo CreateDefault(Func<IEnumerable<UnitDefinition<WarpingMomentOfInertiaUnit>>, IEnumerable<IUnitDefinition<WarpingMomentOfInertiaUnit>>> customizeUnits)
+            private static QuantityInfo<WarpingMomentOfInertia, WarpingMomentOfInertiaUnit> Create(
+                ResourceManager? unitAbbreviations = null,
+                Func<IEnumerable<IUnitDefinition<WarpingMomentOfInertiaUnit>>, IEnumerable<IUnitDefinition<WarpingMomentOfInertiaUnit>>>? customizeUnits = null)
             {
-                return new WarpingMomentOfInertiaInfo(nameof(WarpingMomentOfInertia), DefaultBaseUnit, customizeUnits(GetDefaultMappings()), new WarpingMomentOfInertia(0, DefaultBaseUnit), DefaultBaseDimensions);
+                IEnumerable<IUnitDefinition<WarpingMomentOfInertiaUnit>> unitMappings = WarpingMomentOfInertiaInfo.GetDefaultMappings();
+                if (customizeUnits != null)
+                    unitMappings = customizeUnits(unitMappings);
+
+                return new QuantityInfo<WarpingMomentOfInertia, WarpingMomentOfInertiaUnit>(
+                    name: nameof(WarpingMomentOfInertia),
+                    baseUnit: DefaultBaseUnit,
+                    unitMappings: unitMappings,
+                    zero: new WarpingMomentOfInertia(0, DefaultBaseUnit),
+                    baseDimensions: DefaultBaseDimensions,
+                    fromDelegate: From,
+                    registerUnitConversions: RegisterDefaultConversions,
+                    unitAbbreviations ?? DefaultUnitAbbreviations);
             }
 
             /// <summary>
             ///     The <see cref="BaseDimensions" /> for <see cref="WarpingMomentOfInertia"/> is [L^6].
             /// </summary>
-            public static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(6, 0, 0, 0, 0, 0, 0);
+            private static BaseDimensions DefaultBaseDimensions { get; } = new BaseDimensions(6, 0, 0, 0, 0, 0, 0);
 
             /// <summary>
             ///     The default base unit of WarpingMomentOfInertia is MeterToTheSixth. All conversions, as defined in the <see cref="GetDefaultMappings"/>, go via this value.
             /// </summary>
-            public static WarpingMomentOfInertiaUnit DefaultBaseUnit { get; } = WarpingMomentOfInertiaUnit.MeterToTheSixth;
+            private static WarpingMomentOfInertiaUnit DefaultBaseUnit { get; } = WarpingMomentOfInertiaUnit.MeterToTheSixth;
+
+            /// <summary>
+            ///     The default resource manager for unit abbreviations of the WarpingMomentOfInertia quantity.
+            /// </summary>
+            private static ResourceManager DefaultUnitAbbreviations { get; } = new("UnitsNet.GeneratedCode.Resources.WarpingMomentOfInertia", typeof(WarpingMomentOfInertia).Assembly);
 
             /// <summary>
             ///     Retrieves the default mappings for <see cref="WarpingMomentOfInertiaUnit"/>.
             /// </summary>
             /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="UnitDefinition{WarpingMomentOfInertiaUnit}"/> representing the default unit mappings for WarpingMomentOfInertia.</returns>
-            public static IEnumerable<UnitDefinition<WarpingMomentOfInertiaUnit>> GetDefaultMappings()
+            private static IEnumerable<UnitDefinition<WarpingMomentOfInertiaUnit>> GetDefaultMappings()
             {
                 yield return new (WarpingMomentOfInertiaUnit.CentimeterToTheSixth, "CentimeterToTheSixth", "CentimetersToTheSixth", new BaseUnits(length: LengthUnit.Centimeter));
                 yield return new (WarpingMomentOfInertiaUnit.DecimeterToTheSixth, "DecimeterToTheSixth", "DecimetersToTheSixth", new BaseUnits(length: LengthUnit.Decimeter));
@@ -127,7 +127,7 @@ namespace UnitsNet
 
         static WarpingMomentOfInertia()
         {
-            Info = WarpingMomentOfInertiaInfo.CreateDefault();
+            Info = WarpingMomentOfInertiaInfo.Create();
             DefaultConversionFunctions = new UnitConverter();
             RegisterDefaultConversions(DefaultConversionFunctions);
         }


### PR DESCRIPTION
We already have generic support for quantity info, so adding concrete types for 100+ quantities seems a bit redundant and only used internally.

- Change from concrete types to static factory classes, holding constant values and unit mappings as before
- Merge method overloads, fall back to built-in resource manager if null is given
- Change factory classes from `public` to `private`