### PR TITLE
🔧Set assembly file version to match nuget version

### DIFF
--- a/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
+++ b/UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-	<TargetFrameworks>net9.0;net48</TargetFrameworks>
-	<LangVersion>preview</LangVersion>
-    <Version>4.0.0.0</Version>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <TargetFrameworks>net9.0;net48</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+    <Version>6.0.0.0</Version>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>
     <AssemblyTitle>UnitsNet.Benchmark</AssemblyTitle>
     <Product>UnitsNet.Benchmark</Product>
     <RootNamespace>UnitsNet.Benchmark</RootNamespace>

--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -18,7 +18,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Fixed to major version, for strong naming -->
+    <FileVersion>$(Version)</FileVersion>      <!-- Will match NuGet version -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet</RootNamespace>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -20,7 +20,8 @@
 
   <!-- Assembly and msbuild properties -->
   <PropertyGroup>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Should reflect major part of Version -->
+    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Fixed to major version, for strong naming -->
+    <FileVersion>$(Version)</FileVersion>      <!-- Will match NuGet version -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -20,7 +20,8 @@
 
   <!-- Assembly and msbuild properties -->
   <PropertyGroup>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Should reflect major part of Version -->
+    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Fixed to major version, for strong naming -->
+    <FileVersion>$(Version)</FileVersion>      <!-- Will match NuGet version -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet</RootNamespace>


### PR DESCRIPTION
Fixes #1557
Forward port of #1581 

The assembly file version was incorrectly set to the same as `<AssemblyVersion>`, which is fixed to the major version for strong naming.

### Changes
- Explicitly configure `<FileVersion>` to match the nuget package version

(cherry picked from commit 6fe8e42f1452caa4bb70a3753f18049b3ae4813f)

# Conflicts:
#	UnitsNet.Benchmark/UnitsNet.Benchmark.csproj
#	UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj #	UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj #	UnitsNet/UnitsNet.csproj