### PR TITLE
fixup! 🔧Set assembly file version to match nuget version

### DIFF
--- a/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
+++ b/UnitsNet.NumberExtensions/UnitsNet.NumberExtensions.csproj
@@ -17,9 +17,12 @@
     <PackageTags>UnitsNet Extensions NumberToExtensions NumberToUnitsExtensions NumberExtensions NumberToUnits convert conversion parse</PackageTags>
   </PropertyGroup>
 
+  <!-- Assembly and msbuild properties -->
   <PropertyGroup>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Fixed to major version, for strong naming -->
-    <FileVersion>$(Version)</FileVersion>      <!-- Will match NuGet version -->
+    <!-- Removes any semantic version suffix after the version number and appends ".0", for example "6.0.0-pre014 => "6.0.0.0" -->
+    <VersionNoSuffix>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9.]+')).0</VersionNoSuffix>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>    <!-- Fixed to major version, for strong naming -->
+    <FileVersion>$(VersionNoSuffix)</FileVersion> <!-- Match the NuGet version number, except any suffix in the semantic version. -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet</RootNamespace>

--- a/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
+++ b/UnitsNet.Serialization.JsonNet/UnitsNet.Serialization.JsonNet.csproj
@@ -20,8 +20,10 @@
 
   <!-- Assembly and msbuild properties -->
   <PropertyGroup>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Fixed to major version, for strong naming -->
-    <FileVersion>$(Version)</FileVersion>      <!-- Will match NuGet version -->
+    <!-- Removes any semantic version suffix after the version number and appends ".0", for example "6.0.0-pre014 => "6.0.0.0" -->
+    <VersionNoSuffix>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9.]+')).0</VersionNoSuffix>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>    <!-- Fixed to major version, for strong naming -->
+    <FileVersion>$(VersionNoSuffix)</FileVersion> <!-- Match the NuGet version number, except any suffix in the semantic version. -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet.Serialization.JsonNet</RootNamespace>

--- a/UnitsNet/UnitsNet.csproj
+++ b/UnitsNet/UnitsNet.csproj
@@ -20,8 +20,10 @@
 
   <!-- Assembly and msbuild properties -->
   <PropertyGroup>
-    <AssemblyVersion>6.0.0.0</AssemblyVersion> <!-- Fixed to major version, for strong naming -->
-    <FileVersion>$(Version)</FileVersion>      <!-- Will match NuGet version -->
+    <!-- Removes any semantic version suffix after the version number and appends ".0", for example "6.0.0-pre014 => "6.0.0.0" -->
+    <VersionNoSuffix>$([System.Text.RegularExpressions.Regex]::Match($(Version), '^[0-9.]+')).0</VersionNoSuffix>
+    <AssemblyVersion>6.0.0.0</AssemblyVersion>    <!-- Fixed to major version, for strong naming -->
+    <FileVersion>$(VersionNoSuffix)</FileVersion> <!-- Match the NuGet version number, except any suffix in the semantic version. -->
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <RootNamespace>UnitsNet</RootNamespace>


### PR DESCRIPTION
Fixup of #1582

Remove any semantic version suffix in the file version, it is not allowed and broke the master branch build with pre-release version.