### PR TITLE
Clean-up some commented-out bits from QuantityInfo and IQuantityInfo

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
@@ -178,6 +178,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -299,15 +300,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void {_quantity.Name}_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {{
+            {_unitEnumName}[] unitsOrderedByName = EnumHelper.GetValues<{_unitEnumName}>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new {_quantity.Name}(1, {_baseUnitFullName});
 
-            QuantityInfo<{_unitEnumName}> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<{_quantity.Name}, {_unitEnumName}> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal({_quantity.Name}.Zero, quantityInfo.Zero);
             Assert.Equal(""{_quantity.Name}"", quantityInfo.Name);
-
-            var units = Enum.GetValues<{_unitEnumName}>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal({_quantity.Name}.Zero, quantityInfo.Zero);
+            Assert.Equal({_quantity.Name}.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal({_quantity.Name}.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<{_unitEnumName}>)quantity).QuantityInfo);
         }}
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AbsorbedDoseOfIonizingRadiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AbsorbedDoseOfIonizingRadiationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -173,15 +174,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void AbsorbedDoseOfIonizingRadiation_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AbsorbedDoseOfIonizingRadiationUnit[] unitsOrderedByName = EnumHelper.GetValues<AbsorbedDoseOfIonizingRadiationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new AbsorbedDoseOfIonizingRadiation(1, AbsorbedDoseOfIonizingRadiationUnit.Gray);
 
-            QuantityInfo<AbsorbedDoseOfIonizingRadiationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(AbsorbedDoseOfIonizingRadiation.Zero, quantityInfo.Zero);
             Assert.Equal("AbsorbedDoseOfIonizingRadiation", quantityInfo.Name);
-
-            var units = Enum.GetValues<AbsorbedDoseOfIonizingRadiationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(AbsorbedDoseOfIonizingRadiation.Zero, quantityInfo.Zero);
+            Assert.Equal(AbsorbedDoseOfIonizingRadiation.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(AbsorbedDoseOfIonizingRadiation.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AbsorbedDoseOfIonizingRadiationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AccelerationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -161,15 +162,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Acceleration_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AccelerationUnit[] unitsOrderedByName = EnumHelper.GetValues<AccelerationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Acceleration(1, AccelerationUnit.MeterPerSecondSquared);
 
-            QuantityInfo<AccelerationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Acceleration, AccelerationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Acceleration.Zero, quantityInfo.Zero);
             Assert.Equal("Acceleration", quantityInfo.Name);
-
-            var units = Enum.GetValues<AccelerationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Acceleration.Zero, quantityInfo.Zero);
+            Assert.Equal(Acceleration.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Acceleration.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AccelerationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AmountOfSubstanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AmountOfSubstanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -173,15 +174,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void AmountOfSubstance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AmountOfSubstanceUnit[] unitsOrderedByName = EnumHelper.GetValues<AmountOfSubstanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new AmountOfSubstance(1, AmountOfSubstanceUnit.Mole);
 
-            QuantityInfo<AmountOfSubstanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<AmountOfSubstance, AmountOfSubstanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(AmountOfSubstance.Zero, quantityInfo.Zero);
             Assert.Equal("AmountOfSubstance", quantityInfo.Name);
-
-            var units = Enum.GetValues<AmountOfSubstanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(AmountOfSubstance.Zero, quantityInfo.Zero);
+            Assert.Equal(AmountOfSubstance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(AmountOfSubstance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AmountOfSubstanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AmplitudeRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AmplitudeRatioTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -100,15 +101,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void AmplitudeRatio_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AmplitudeRatioUnit[] unitsOrderedByName = EnumHelper.GetValues<AmplitudeRatioUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new AmplitudeRatio(1, AmplitudeRatioUnit.DecibelVolt);
 
-            QuantityInfo<AmplitudeRatioUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<AmplitudeRatio, AmplitudeRatioUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(AmplitudeRatio.Zero, quantityInfo.Zero);
             Assert.Equal("AmplitudeRatio", quantityInfo.Name);
-
-            var units = Enum.GetValues<AmplitudeRatioUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(AmplitudeRatio.Zero, quantityInfo.Zero);
+            Assert.Equal(AmplitudeRatio.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(AmplitudeRatio.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AmplitudeRatioUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -144,15 +145,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Angle_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AngleUnit[] unitsOrderedByName = EnumHelper.GetValues<AngleUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Angle(1, AngleUnit.Radian);
 
-            QuantityInfo<AngleUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Angle, AngleUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Angle.Zero, quantityInfo.Zero);
             Assert.Equal("Angle", quantityInfo.Name);
-
-            var units = Enum.GetValues<AngleUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Angle.Zero, quantityInfo.Zero);
+            Assert.Equal(Angle.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Angle.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AngleUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void AreaDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AreaDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<AreaDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new AreaDensity(1, AreaDensityUnit.KilogramPerSquareMeter);
 
-            QuantityInfo<AreaDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<AreaDensity, AreaDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(AreaDensity.Zero, quantityInfo.Zero);
             Assert.Equal("AreaDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<AreaDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(AreaDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(AreaDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(AreaDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AreaDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaMomentOfInertiaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void AreaMomentOfInertia_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AreaMomentOfInertiaUnit[] unitsOrderedByName = EnumHelper.GetValues<AreaMomentOfInertiaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new AreaMomentOfInertia(1, AreaMomentOfInertiaUnit.MeterToTheFourth);
 
-            QuantityInfo<AreaMomentOfInertiaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<AreaMomentOfInertia, AreaMomentOfInertiaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(AreaMomentOfInertia.Zero, quantityInfo.Zero);
             Assert.Equal("AreaMomentOfInertia", quantityInfo.Name);
-
-            var units = Enum.GetValues<AreaMomentOfInertiaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(AreaMomentOfInertia.Zero, quantityInfo.Zero);
+            Assert.Equal(AreaMomentOfInertia.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(AreaMomentOfInertia.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AreaMomentOfInertiaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -161,15 +162,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Area_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            AreaUnit[] unitsOrderedByName = EnumHelper.GetValues<AreaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Area(1, AreaUnit.SquareMeter);
 
-            QuantityInfo<AreaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Area, AreaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Area.Zero, quantityInfo.Zero);
             Assert.Equal("Area", quantityInfo.Name);
-
-            var units = Enum.GetValues<AreaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Area.Zero, quantityInfo.Zero);
+            Assert.Equal(Area.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Area.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<AreaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/BitRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/BitRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -261,15 +262,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void BitRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            BitRateUnit[] unitsOrderedByName = EnumHelper.GetValues<BitRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new BitRate(1, BitRateUnit.BitPerSecond);
 
-            QuantityInfo<BitRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<BitRate, BitRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(BitRate.Zero, quantityInfo.Zero);
             Assert.Equal("BitRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<BitRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(BitRate.Zero, quantityInfo.Zero);
+            Assert.Equal(BitRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(BitRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<BitRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/BrakeSpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/BrakeSpecificFuelConsumptionTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void BrakeSpecificFuelConsumption_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            BrakeSpecificFuelConsumptionUnit[] unitsOrderedByName = EnumHelper.GetValues<BrakeSpecificFuelConsumptionUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new BrakeSpecificFuelConsumption(1, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule);
 
-            QuantityInfo<BrakeSpecificFuelConsumptionUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumptionUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(BrakeSpecificFuelConsumption.Zero, quantityInfo.Zero);
             Assert.Equal("BrakeSpecificFuelConsumption", quantityInfo.Name);
-
-            var units = Enum.GetValues<BrakeSpecificFuelConsumptionUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(BrakeSpecificFuelConsumption.Zero, quantityInfo.Zero);
+            Assert.Equal(BrakeSpecificFuelConsumption.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(BrakeSpecificFuelConsumption.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<BrakeSpecificFuelConsumptionUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void CoefficientOfThermalExpansion_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            CoefficientOfThermalExpansionUnit[] unitsOrderedByName = EnumHelper.GetValues<CoefficientOfThermalExpansionUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PerKelvin);
 
-            QuantityInfo<CoefficientOfThermalExpansionUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<CoefficientOfThermalExpansion, CoefficientOfThermalExpansionUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(CoefficientOfThermalExpansion.Zero, quantityInfo.Zero);
             Assert.Equal("CoefficientOfThermalExpansion", quantityInfo.Name);
-
-            var units = Enum.GetValues<CoefficientOfThermalExpansionUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(CoefficientOfThermalExpansion.Zero, quantityInfo.Zero);
+            Assert.Equal(CoefficientOfThermalExpansion.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(CoefficientOfThermalExpansion.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<CoefficientOfThermalExpansionUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CompressibilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CompressibilityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -133,15 +134,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Compressibility_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            CompressibilityUnit[] unitsOrderedByName = EnumHelper.GetValues<CompressibilityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Compressibility(1, CompressibilityUnit.InversePascal);
 
-            QuantityInfo<CompressibilityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Compressibility, CompressibilityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Compressibility.Zero, quantityInfo.Zero);
             Assert.Equal("Compressibility", quantityInfo.Name);
-
-            var units = Enum.GetValues<CompressibilityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Compressibility.Zero, quantityInfo.Zero);
+            Assert.Equal(Compressibility.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Compressibility.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<CompressibilityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -329,15 +330,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Density_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            DensityUnit[] unitsOrderedByName = EnumHelper.GetValues<DensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Density(1, DensityUnit.KilogramPerCubicMeter);
 
-            QuantityInfo<DensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Density, DensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Density.Zero, quantityInfo.Zero);
             Assert.Equal("Density", quantityInfo.Name);
-
-            var units = Enum.GetValues<DensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Density.Zero, quantityInfo.Zero);
+            Assert.Equal(Density.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Density.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<DensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DoseAreaProductTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DoseAreaProductTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -205,15 +206,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void DoseAreaProduct_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            DoseAreaProductUnit[] unitsOrderedByName = EnumHelper.GetValues<DoseAreaProductUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new DoseAreaProduct(1, DoseAreaProductUnit.GraySquareMeter);
 
-            QuantityInfo<DoseAreaProductUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<DoseAreaProduct, DoseAreaProductUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(DoseAreaProduct.Zero, quantityInfo.Zero);
             Assert.Equal("DoseAreaProduct", quantityInfo.Name);
-
-            var units = Enum.GetValues<DoseAreaProductUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(DoseAreaProduct.Zero, quantityInfo.Zero);
+            Assert.Equal(DoseAreaProduct.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(DoseAreaProduct.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<DoseAreaProductUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -157,15 +158,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Duration_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            DurationUnit[] unitsOrderedByName = EnumHelper.GetValues<DurationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Duration(1, DurationUnit.Second);
 
-            QuantityInfo<DurationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Duration, DurationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Duration.Zero, quantityInfo.Zero);
             Assert.Equal("Duration", quantityInfo.Name);
-
-            var units = Enum.GetValues<DurationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Duration.Zero, quantityInfo.Zero);
+            Assert.Equal(Duration.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Duration.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<DurationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -145,15 +146,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void DynamicViscosity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            DynamicViscosityUnit[] unitsOrderedByName = EnumHelper.GetValues<DynamicViscosityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new DynamicViscosity(1, DynamicViscosityUnit.NewtonSecondPerMeterSquared);
 
-            QuantityInfo<DynamicViscosityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<DynamicViscosity, DynamicViscosityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(DynamicViscosity.Zero, quantityInfo.Zero);
             Assert.Equal("DynamicViscosity", quantityInfo.Name);
-
-            var units = Enum.GetValues<DynamicViscosityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(DynamicViscosity.Zero, quantityInfo.Zero);
+            Assert.Equal(DynamicViscosity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(DynamicViscosity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<DynamicViscosityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricAdmittanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricAdmittanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -169,15 +170,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricAdmittance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricAdmittanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricAdmittanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricAdmittance(1, ElectricAdmittanceUnit.Siemens);
 
-            QuantityInfo<ElectricAdmittanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricAdmittance, ElectricAdmittanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricAdmittance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricAdmittance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricAdmittanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricAdmittance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricAdmittance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricAdmittance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricAdmittanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentEnergyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricApparentEnergy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricApparentEnergyUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricApparentEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricApparentEnergy(1, ElectricApparentEnergyUnit.VoltampereHour);
 
-            QuantityInfo<ElectricApparentEnergyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricApparentEnergy, ElectricApparentEnergyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricApparentEnergy.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricApparentEnergy", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricApparentEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricApparentEnergy.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricApparentEnergy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricApparentEnergy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricApparentEnergyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentPowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentPowerTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricApparentPower_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricApparentPowerUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricApparentPowerUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricApparentPower(1, ElectricApparentPowerUnit.Voltampere);
 
-            QuantityInfo<ElectricApparentPowerUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricApparentPower, ElectricApparentPowerUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricApparentPower.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricApparentPower", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricApparentPowerUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricApparentPower.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricApparentPower.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricApparentPower.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricApparentPowerUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCapacitanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCapacitanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -133,15 +134,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricCapacitance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricCapacitanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricCapacitanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricCapacitance(1, ElectricCapacitanceUnit.Farad);
 
-            QuantityInfo<ElectricCapacitanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricCapacitance, ElectricCapacitanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricCapacitance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricCapacitance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricCapacitanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricCapacitance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricCapacitance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricCapacitance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricCapacitanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricChargeDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricChargeDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricChargeDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricChargeDensity(1, ElectricChargeDensityUnit.CoulombPerCubicMeter);
 
-            QuantityInfo<ElectricChargeDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricChargeDensity, ElectricChargeDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricChargeDensity.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricChargeDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricChargeDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricChargeDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricChargeDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricChargeDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricChargeDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -149,15 +150,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricCharge_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricChargeUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricChargeUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricCharge(1, ElectricChargeUnit.Coulomb);
 
-            QuantityInfo<ElectricChargeUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricCharge, ElectricChargeUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricCharge.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricCharge", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricChargeUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricCharge.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricCharge.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricCharge.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricChargeUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -169,15 +170,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricConductance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricConductanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricConductanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricConductance(1, ElectricConductanceUnit.Siemens);
 
-            QuantityInfo<ElectricConductanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricConductance, ElectricConductanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricConductance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricConductance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricConductanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricConductance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricConductance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricConductance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricConductanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricConductivity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricConductivityUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricConductivityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerMeter);
 
-            QuantityInfo<ElectricConductivityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricConductivity, ElectricConductivityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricConductivity.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricConductivity", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricConductivityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricConductivity.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricConductivity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricConductivity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricConductivityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricCurrentDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricCurrentDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricCurrentDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricCurrentDensity(1, ElectricCurrentDensityUnit.AmperePerSquareMeter);
 
-            QuantityInfo<ElectricCurrentDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricCurrentDensity, ElectricCurrentDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricCurrentDensity.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricCurrentDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricCurrentDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricCurrentDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricCurrentDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricCurrentDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricCurrentDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -133,15 +134,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricCurrentGradient_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricCurrentGradientUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricCurrentGradientUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.AmperePerSecond);
 
-            QuantityInfo<ElectricCurrentGradientUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricCurrentGradient, ElectricCurrentGradientUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricCurrentGradient.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricCurrentGradient", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricCurrentGradientUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricCurrentGradient.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricCurrentGradient.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricCurrentGradient.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricCurrentGradientUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricCurrent_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricCurrentUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricCurrentUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricCurrent(1, ElectricCurrentUnit.Ampere);
 
-            QuantityInfo<ElectricCurrentUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricCurrent, ElectricCurrentUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricCurrent.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricCurrent", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricCurrentUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricCurrent.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricCurrent.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricCurrent.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricCurrentUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricFieldTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricField_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricFieldUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricFieldUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricField(1, ElectricFieldUnit.VoltPerMeter);
 
-            QuantityInfo<ElectricFieldUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricField, ElectricFieldUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricField.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricField", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricFieldUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricField.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricField.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricField.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricFieldUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricImpedanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricImpedanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -137,15 +138,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricImpedance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricImpedanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricImpedanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricImpedance(1, ElectricImpedanceUnit.Ohm);
 
-            QuantityInfo<ElectricImpedanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricImpedance, ElectricImpedanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricImpedance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricImpedance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricImpedanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricImpedance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricImpedance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricImpedance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricImpedanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricInductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricInductanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -125,15 +126,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricInductance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricInductanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricInductanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricInductance(1, ElectricInductanceUnit.Henry);
 
-            QuantityInfo<ElectricInductanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricInductance, ElectricInductanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricInductance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricInductance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricInductanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricInductance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricInductance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricInductance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricInductanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialChangeRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -185,15 +186,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricPotentialChangeRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricPotentialChangeRateUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricPotentialChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricPotentialChangeRate(1, ElectricPotentialChangeRateUnit.VoltPerSecond);
 
-            QuantityInfo<ElectricPotentialChangeRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricPotentialChangeRate, ElectricPotentialChangeRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricPotentialChangeRate.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricPotentialChangeRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricPotentialChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricPotentialChangeRate.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricPotentialChangeRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricPotentialChangeRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricPotentialChangeRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricPotential_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricPotentialUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricPotentialUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricPotential(1, ElectricPotentialUnit.Volt);
 
-            QuantityInfo<ElectricPotentialUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricPotential, ElectricPotentialUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricPotential.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricPotential", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricPotentialUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricPotential.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricPotential.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricPotential.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricPotentialUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -137,15 +138,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricReactance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricReactanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricReactanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricReactance(1, ElectricReactanceUnit.Ohm);
 
-            QuantityInfo<ElectricReactanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricReactance, ElectricReactanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricReactance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricReactance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricReactanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricReactance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricReactance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricReactance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricReactanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactiveEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactiveEnergyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricReactiveEnergy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricReactiveEnergyUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricReactiveEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricReactiveEnergy(1, ElectricReactiveEnergyUnit.VoltampereReactiveHour);
 
-            QuantityInfo<ElectricReactiveEnergyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricReactiveEnergy, ElectricReactiveEnergyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricReactiveEnergy.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricReactiveEnergy", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricReactiveEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricReactiveEnergy.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricReactiveEnergy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricReactiveEnergy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricReactiveEnergyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactivePowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactivePowerTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricReactivePower_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricReactivePowerUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricReactivePowerUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricReactivePower(1, ElectricReactivePowerUnit.VoltampereReactive);
 
-            QuantityInfo<ElectricReactivePowerUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricReactivePower, ElectricReactivePowerUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricReactivePower.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricReactivePower", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricReactivePowerUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricReactivePower.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricReactivePower.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricReactivePower.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricReactivePowerUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -137,15 +138,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricResistance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricResistanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricResistanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricResistance(1, ElectricResistanceUnit.Ohm);
 
-            QuantityInfo<ElectricResistanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricResistance, ElectricResistanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricResistance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricResistance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricResistanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricResistance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricResistance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricResistance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricResistanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistivityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -161,15 +162,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricResistivity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricResistivityUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricResistivityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricResistivity(1, ElectricResistivityUnit.OhmMeter);
 
-            QuantityInfo<ElectricResistivityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricResistivity, ElectricResistivityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricResistivity.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricResistivity", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricResistivityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricResistivity.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricResistivity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricResistivity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricResistivityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSurfaceChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSurfaceChargeDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricSurfaceChargeDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricSurfaceChargeDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricSurfaceChargeDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricSurfaceChargeDensity(1, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter);
 
-            QuantityInfo<ElectricSurfaceChargeDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricSurfaceChargeDensity.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricSurfaceChargeDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricSurfaceChargeDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricSurfaceChargeDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricSurfaceChargeDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricSurfaceChargeDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricSurfaceChargeDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSusceptanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSusceptanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -169,15 +170,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ElectricSusceptance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ElectricSusceptanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ElectricSusceptanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ElectricSusceptance(1, ElectricSusceptanceUnit.Siemens);
 
-            QuantityInfo<ElectricSusceptanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ElectricSusceptance, ElectricSusceptanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ElectricSusceptance.Zero, quantityInfo.Zero);
             Assert.Equal("ElectricSusceptance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ElectricSusceptanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ElectricSusceptance.Zero, quantityInfo.Zero);
+            Assert.Equal(ElectricSusceptance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ElectricSusceptance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ElectricSusceptanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -153,15 +154,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void EnergyDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            EnergyDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<EnergyDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new EnergyDensity(1, EnergyDensityUnit.JoulePerCubicMeter);
 
-            QuantityInfo<EnergyDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<EnergyDensity, EnergyDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(EnergyDensity.Zero, quantityInfo.Zero);
             Assert.Equal("EnergyDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<EnergyDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(EnergyDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(EnergyDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(EnergyDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<EnergyDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -265,15 +266,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Energy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            EnergyUnit[] unitsOrderedByName = EnumHelper.GetValues<EnergyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Energy(1, EnergyUnit.Joule);
 
-            QuantityInfo<EnergyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Energy, EnergyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Energy.Zero, quantityInfo.Zero);
             Assert.Equal("Energy", quantityInfo.Name);
-
-            var units = Enum.GetValues<EnergyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Energy.Zero, quantityInfo.Zero);
+            Assert.Equal(Energy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Energy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<EnergyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EntropyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -133,15 +134,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Entropy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            EntropyUnit[] unitsOrderedByName = EnumHelper.GetValues<EntropyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Entropy(1, EntropyUnit.JoulePerKelvin);
 
-            QuantityInfo<EntropyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Entropy, EntropyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Entropy.Zero, quantityInfo.Zero);
             Assert.Equal("Entropy", quantityInfo.Name);
-
-            var units = Enum.GetValues<EntropyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Entropy.Zero, quantityInfo.Zero);
+            Assert.Equal(Entropy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Entropy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<EntropyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FluidResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FluidResistanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -181,15 +182,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void FluidResistance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            FluidResistanceUnit[] unitsOrderedByName = EnumHelper.GetValues<FluidResistanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new FluidResistance(1, FluidResistanceUnit.PascalSecondPerCubicMeter);
 
-            QuantityInfo<FluidResistanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<FluidResistance, FluidResistanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(FluidResistance.Zero, quantityInfo.Zero);
             Assert.Equal("FluidResistance", quantityInfo.Name);
-
-            var units = Enum.GetValues<FluidResistanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(FluidResistance.Zero, quantityInfo.Zero);
+            Assert.Equal(FluidResistance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(FluidResistance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<FluidResistanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceChangeRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -165,15 +166,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ForceChangeRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ForceChangeRateUnit[] unitsOrderedByName = EnumHelper.GetValues<ForceChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ForceChangeRate(1, ForceChangeRateUnit.NewtonPerSecond);
 
-            QuantityInfo<ForceChangeRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ForceChangeRate, ForceChangeRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ForceChangeRate.Zero, quantityInfo.Zero);
             Assert.Equal("ForceChangeRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<ForceChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ForceChangeRate.Zero, quantityInfo.Zero);
+            Assert.Equal(ForceChangeRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ForceChangeRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ForceChangeRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForcePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForcePerLengthTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -257,15 +258,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ForcePerLength_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ForcePerLengthUnit[] unitsOrderedByName = EnumHelper.GetValues<ForcePerLengthUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ForcePerLength(1, ForcePerLengthUnit.NewtonPerMeter);
 
-            QuantityInfo<ForcePerLengthUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ForcePerLength, ForcePerLengthUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ForcePerLength.Zero, quantityInfo.Zero);
             Assert.Equal("ForcePerLength", quantityInfo.Name);
-
-            var units = Enum.GetValues<ForcePerLengthUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ForcePerLength.Zero, quantityInfo.Zero);
+            Assert.Equal(ForcePerLength.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ForcePerLength.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ForcePerLengthUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -165,15 +166,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Force_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ForceUnit[] unitsOrderedByName = EnumHelper.GetValues<ForceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Force(1, ForceUnit.Newton);
 
-            QuantityInfo<ForceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Force, ForceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Force.Zero, quantityInfo.Zero);
             Assert.Equal("Force", quantityInfo.Name);
-
-            var units = Enum.GetValues<ForceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Force.Zero, quantityInfo.Zero);
+            Assert.Equal(Force.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Force.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ForceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -153,15 +154,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Frequency_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            FrequencyUnit[] unitsOrderedByName = EnumHelper.GetValues<FrequencyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Frequency(1, FrequencyUnit.Hertz);
 
-            QuantityInfo<FrequencyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Frequency, FrequencyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Frequency.Zero, quantityInfo.Zero);
             Assert.Equal("Frequency", quantityInfo.Name);
-
-            var units = Enum.GetValues<FrequencyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Frequency.Zero, quantityInfo.Zero);
+            Assert.Equal(Frequency.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Frequency.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<FrequencyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FuelEfficiencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FuelEfficiencyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void FuelEfficiency_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            FuelEfficiencyUnit[] unitsOrderedByName = EnumHelper.GetValues<FuelEfficiencyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new FuelEfficiency(1, FuelEfficiencyUnit.KilometerPerLiter);
 
-            QuantityInfo<FuelEfficiencyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<FuelEfficiency, FuelEfficiencyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(FuelEfficiency.Zero, quantityInfo.Zero);
             Assert.Equal("FuelEfficiency", quantityInfo.Name);
-
-            var units = Enum.GetValues<FuelEfficiencyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(FuelEfficiency.Zero, quantityInfo.Zero);
+            Assert.Equal(FuelEfficiency.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(FuelEfficiency.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<FuelEfficiencyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/HeatFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/HeatFluxTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -177,15 +178,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void HeatFlux_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            HeatFluxUnit[] unitsOrderedByName = EnumHelper.GetValues<HeatFluxUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new HeatFlux(1, HeatFluxUnit.WattPerSquareMeter);
 
-            QuantityInfo<HeatFluxUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<HeatFlux, HeatFluxUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(HeatFlux.Zero, quantityInfo.Zero);
             Assert.Equal("HeatFlux", quantityInfo.Name);
-
-            var units = Enum.GetValues<HeatFluxUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(HeatFlux.Zero, quantityInfo.Zero);
+            Assert.Equal(HeatFlux.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(HeatFlux.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<HeatFluxUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/HeatTransferCoefficientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/HeatTransferCoefficientTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -125,15 +126,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void HeatTransferCoefficient_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            HeatTransferCoefficientUnit[] unitsOrderedByName = EnumHelper.GetValues<HeatTransferCoefficientUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new HeatTransferCoefficient(1, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin);
 
-            QuantityInfo<HeatTransferCoefficientUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<HeatTransferCoefficient, HeatTransferCoefficientUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(HeatTransferCoefficient.Zero, quantityInfo.Zero);
             Assert.Equal("HeatTransferCoefficient", quantityInfo.Name);
-
-            var units = Enum.GetValues<HeatTransferCoefficientUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(HeatTransferCoefficient.Zero, quantityInfo.Zero);
+            Assert.Equal(HeatTransferCoefficient.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(HeatTransferCoefficient.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<HeatTransferCoefficientUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IlluminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IlluminanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Illuminance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            IlluminanceUnit[] unitsOrderedByName = EnumHelper.GetValues<IlluminanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Illuminance(1, IlluminanceUnit.Lux);
 
-            QuantityInfo<IlluminanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Illuminance, IlluminanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Illuminance.Zero, quantityInfo.Zero);
             Assert.Equal("Illuminance", quantityInfo.Name);
-
-            var units = Enum.GetValues<IlluminanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Illuminance.Zero, quantityInfo.Zero);
+            Assert.Equal(Illuminance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Illuminance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<IlluminanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ImpulseTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ImpulseTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -157,15 +158,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Impulse_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ImpulseUnit[] unitsOrderedByName = EnumHelper.GetValues<ImpulseUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Impulse(1, ImpulseUnit.NewtonSecond);
 
-            QuantityInfo<ImpulseUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Impulse, ImpulseUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Impulse.Zero, quantityInfo.Zero);
             Assert.Equal("Impulse", quantityInfo.Name);
-
-            var units = Enum.GetValues<ImpulseUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Impulse.Zero, quantityInfo.Zero);
+            Assert.Equal(Impulse.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Impulse.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ImpulseUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/InformationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/InformationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -240,15 +241,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Information_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            InformationUnit[] unitsOrderedByName = EnumHelper.GetValues<InformationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Information(1, InformationUnit.Bit);
 
-            QuantityInfo<InformationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Information, InformationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Information.Zero, quantityInfo.Zero);
             Assert.Equal("Information", quantityInfo.Name);
-
-            var units = Enum.GetValues<InformationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Information.Zero, quantityInfo.Zero);
+            Assert.Equal(Information.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Information.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<InformationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IrradianceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IrradianceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -161,15 +162,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Irradiance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            IrradianceUnit[] unitsOrderedByName = EnumHelper.GetValues<IrradianceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Irradiance(1, IrradianceUnit.WattPerSquareMeter);
 
-            QuantityInfo<IrradianceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Irradiance, IrradianceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Irradiance.Zero, quantityInfo.Zero);
             Assert.Equal("Irradiance", quantityInfo.Name);
-
-            var units = Enum.GetValues<IrradianceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Irradiance.Zero, quantityInfo.Zero);
+            Assert.Equal(Irradiance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Irradiance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<IrradianceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IrradiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IrradiationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Irradiation_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            IrradiationUnit[] unitsOrderedByName = EnumHelper.GetValues<IrradiationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Irradiation(1, IrradiationUnit.JoulePerSquareMeter);
 
-            QuantityInfo<IrradiationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Irradiation, IrradiationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Irradiation.Zero, quantityInfo.Zero);
             Assert.Equal("Irradiation", quantityInfo.Name);
-
-            var units = Enum.GetValues<IrradiationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Irradiation.Zero, quantityInfo.Zero);
+            Assert.Equal(Irradiation.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Irradiation.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<IrradiationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/JerkTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/JerkTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -149,15 +150,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Jerk_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            JerkUnit[] unitsOrderedByName = EnumHelper.GetValues<JerkUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Jerk(1, JerkUnit.MeterPerSecondCubed);
 
-            QuantityInfo<JerkUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Jerk, JerkUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Jerk.Zero, quantityInfo.Zero);
             Assert.Equal("Jerk", quantityInfo.Name);
-
-            var units = Enum.GetValues<JerkUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Jerk.Zero, quantityInfo.Zero);
+            Assert.Equal(Jerk.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Jerk.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<JerkUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/KinematicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/KinematicViscosityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void KinematicViscosity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            KinematicViscosityUnit[] unitsOrderedByName = EnumHelper.GetValues<KinematicViscosityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new KinematicViscosity(1, KinematicViscosityUnit.SquareMeterPerSecond);
 
-            QuantityInfo<KinematicViscosityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<KinematicViscosity, KinematicViscosityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(KinematicViscosity.Zero, quantityInfo.Zero);
             Assert.Equal("KinematicViscosity", quantityInfo.Name);
-
-            var units = Enum.GetValues<KinematicViscosityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(KinematicViscosity.Zero, quantityInfo.Zero);
+            Assert.Equal(KinematicViscosity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(KinematicViscosity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<KinematicViscosityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LeakRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LeakRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void LeakRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LeakRateUnit[] unitsOrderedByName = EnumHelper.GetValues<LeakRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new LeakRate(1, LeakRateUnit.PascalCubicMeterPerSecond);
 
-            QuantityInfo<LeakRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<LeakRate, LeakRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(LeakRate.Zero, quantityInfo.Zero);
             Assert.Equal("LeakRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<LeakRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(LeakRate.Zero, quantityInfo.Zero);
+            Assert.Equal(LeakRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(LeakRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LeakRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -273,15 +274,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Length_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LengthUnit[] unitsOrderedByName = EnumHelper.GetValues<LengthUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Length(1, LengthUnit.Meter);
 
-            QuantityInfo<LengthUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Length, LengthUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Length.Zero, quantityInfo.Zero);
             Assert.Equal("Length", quantityInfo.Name);
-
-            var units = Enum.GetValues<LengthUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Length.Zero, quantityInfo.Zero);
+            Assert.Equal(Length.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Length.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LengthUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LevelTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LevelTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -92,15 +93,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Level_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LevelUnit[] unitsOrderedByName = EnumHelper.GetValues<LevelUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Level(1, LevelUnit.Decibel);
 
-            QuantityInfo<LevelUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Level, LevelUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Level.Zero, quantityInfo.Zero);
             Assert.Equal("Level", quantityInfo.Name);
-
-            var units = Enum.GetValues<LevelUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Level.Zero, quantityInfo.Zero);
+            Assert.Equal(Level.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Level.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LevelUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LinearDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LinearDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -177,15 +178,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void LinearDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LinearDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<LinearDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new LinearDensity(1, LinearDensityUnit.KilogramPerMeter);
 
-            QuantityInfo<LinearDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<LinearDensity, LinearDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(LinearDensity.Zero, quantityInfo.Zero);
             Assert.Equal("LinearDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<LinearDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(LinearDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(LinearDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(LinearDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LinearDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LinearPowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LinearPowerDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -205,15 +206,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void LinearPowerDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LinearPowerDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<LinearPowerDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new LinearPowerDensity(1, LinearPowerDensityUnit.WattPerMeter);
 
-            QuantityInfo<LinearPowerDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<LinearPowerDensity, LinearPowerDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(LinearPowerDensity.Zero, quantityInfo.Zero);
             Assert.Equal("LinearPowerDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<LinearPowerDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(LinearPowerDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(LinearPowerDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(LinearPowerDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LinearPowerDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -145,15 +146,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Luminance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LuminanceUnit[] unitsOrderedByName = EnumHelper.GetValues<LuminanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Luminance(1, LuminanceUnit.CandelaPerSquareMeter);
 
-            QuantityInfo<LuminanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Luminance, LuminanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Luminance.Zero, quantityInfo.Zero);
             Assert.Equal("Luminance", quantityInfo.Name);
-
-            var units = Enum.GetValues<LuminanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Luminance.Zero, quantityInfo.Zero);
+            Assert.Equal(Luminance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Luminance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LuminanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminosityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -161,15 +162,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Luminosity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LuminosityUnit[] unitsOrderedByName = EnumHelper.GetValues<LuminosityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Luminosity(1, LuminosityUnit.Watt);
 
-            QuantityInfo<LuminosityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Luminosity, LuminosityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Luminosity.Zero, quantityInfo.Zero);
             Assert.Equal("Luminosity", quantityInfo.Name);
-
-            var units = Enum.GetValues<LuminosityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Luminosity.Zero, quantityInfo.Zero);
+            Assert.Equal(Luminosity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Luminosity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LuminosityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousFluxTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void LuminousFlux_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LuminousFluxUnit[] unitsOrderedByName = EnumHelper.GetValues<LuminousFluxUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new LuminousFlux(1, LuminousFluxUnit.Lumen);
 
-            QuantityInfo<LuminousFluxUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<LuminousFlux, LuminousFluxUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(LuminousFlux.Zero, quantityInfo.Zero);
             Assert.Equal("LuminousFlux", quantityInfo.Name);
-
-            var units = Enum.GetValues<LuminousFluxUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(LuminousFlux.Zero, quantityInfo.Zero);
+            Assert.Equal(LuminousFlux.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(LuminousFlux.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LuminousFluxUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousIntensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousIntensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void LuminousIntensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            LuminousIntensityUnit[] unitsOrderedByName = EnumHelper.GetValues<LuminousIntensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new LuminousIntensity(1, LuminousIntensityUnit.Candela);
 
-            QuantityInfo<LuminousIntensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<LuminousIntensity, LuminousIntensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(LuminousIntensity.Zero, quantityInfo.Zero);
             Assert.Equal("LuminousIntensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<LuminousIntensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(LuminousIntensity.Zero, quantityInfo.Zero);
+            Assert.Equal(LuminousIntensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(LuminousIntensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<LuminousIntensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFieldTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MagneticField_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MagneticFieldUnit[] unitsOrderedByName = EnumHelper.GetValues<MagneticFieldUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MagneticField(1, MagneticFieldUnit.Tesla);
 
-            QuantityInfo<MagneticFieldUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MagneticField, MagneticFieldUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MagneticField.Zero, quantityInfo.Zero);
             Assert.Equal("MagneticField", quantityInfo.Name);
-
-            var units = Enum.GetValues<MagneticFieldUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MagneticField.Zero, quantityInfo.Zero);
+            Assert.Equal(MagneticField.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MagneticField.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MagneticFieldUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFluxTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MagneticFlux_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MagneticFluxUnit[] unitsOrderedByName = EnumHelper.GetValues<MagneticFluxUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MagneticFlux(1, MagneticFluxUnit.Weber);
 
-            QuantityInfo<MagneticFluxUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MagneticFlux, MagneticFluxUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MagneticFlux.Zero, quantityInfo.Zero);
             Assert.Equal("MagneticFlux", quantityInfo.Name);
-
-            var units = Enum.GetValues<MagneticFluxUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MagneticFlux.Zero, quantityInfo.Zero);
+            Assert.Equal(MagneticFlux.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MagneticFlux.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MagneticFluxUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagnetizationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagnetizationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Magnetization_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MagnetizationUnit[] unitsOrderedByName = EnumHelper.GetValues<MagnetizationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Magnetization(1, MagnetizationUnit.AmperePerMeter);
 
-            QuantityInfo<MagnetizationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Magnetization, MagnetizationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Magnetization.Zero, quantityInfo.Zero);
             Assert.Equal("Magnetization", quantityInfo.Name);
-
-            var units = Enum.GetValues<MagnetizationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Magnetization.Zero, quantityInfo.Zero);
+            Assert.Equal(Magnetization.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Magnetization.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MagnetizationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassConcentrationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -301,15 +302,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MassConcentration_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MassConcentrationUnit[] unitsOrderedByName = EnumHelper.GetValues<MassConcentrationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MassConcentration(1, MassConcentrationUnit.KilogramPerCubicMeter);
 
-            QuantityInfo<MassConcentrationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MassConcentration, MassConcentrationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MassConcentration.Zero, quantityInfo.Zero);
             Assert.Equal("MassConcentration", quantityInfo.Name);
-
-            var units = Enum.GetValues<MassConcentrationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MassConcentration.Zero, quantityInfo.Zero);
+            Assert.Equal(MassConcentration.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MassConcentration.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MassConcentrationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFlowTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -237,15 +238,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MassFlow_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MassFlowUnit[] unitsOrderedByName = EnumHelper.GetValues<MassFlowUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MassFlow(1, MassFlowUnit.GramPerSecond);
 
-            QuantityInfo<MassFlowUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MassFlow, MassFlowUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MassFlow.Zero, quantityInfo.Zero);
             Assert.Equal("MassFlow", quantityInfo.Name);
-
-            var units = Enum.GetValues<MassFlowUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MassFlow.Zero, quantityInfo.Zero);
+            Assert.Equal(MassFlow.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MassFlow.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MassFlowUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFluxTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -153,15 +154,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MassFlux_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MassFluxUnit[] unitsOrderedByName = EnumHelper.GetValues<MassFluxUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MassFlux(1, MassFluxUnit.KilogramPerSecondPerSquareMeter);
 
-            QuantityInfo<MassFluxUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MassFlux, MassFluxUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MassFlux.Zero, quantityInfo.Zero);
             Assert.Equal("MassFlux", quantityInfo.Name);
-
-            var units = Enum.GetValues<MassFluxUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MassFlux.Zero, quantityInfo.Zero);
+            Assert.Equal(MassFlux.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MassFlux.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MassFluxUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -180,15 +181,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MassFraction_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MassFractionUnit[] unitsOrderedByName = EnumHelper.GetValues<MassFractionUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MassFraction(1, MassFractionUnit.DecimalFraction);
 
-            QuantityInfo<MassFractionUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MassFraction, MassFractionUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MassFraction.Zero, quantityInfo.Zero);
             Assert.Equal("MassFraction", quantityInfo.Name);
-
-            var units = Enum.GetValues<MassFractionUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MassFraction.Zero, quantityInfo.Zero);
+            Assert.Equal(MassFraction.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MassFraction.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MassFractionUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassMomentOfInertiaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -217,15 +218,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MassMomentOfInertia_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MassMomentOfInertiaUnit[] unitsOrderedByName = EnumHelper.GetValues<MassMomentOfInertiaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MassMomentOfInertia(1, MassMomentOfInertiaUnit.KilogramSquareMeter);
 
-            QuantityInfo<MassMomentOfInertiaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MassMomentOfInertia, MassMomentOfInertiaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MassMomentOfInertia.Zero, quantityInfo.Zero);
             Assert.Equal("MassMomentOfInertia", quantityInfo.Name);
-
-            var units = Enum.GetValues<MassMomentOfInertiaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MassMomentOfInertia.Zero, quantityInfo.Zero);
+            Assert.Equal(MassMomentOfInertia.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MassMomentOfInertia.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MassMomentOfInertiaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -213,15 +214,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Mass_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MassUnit[] unitsOrderedByName = EnumHelper.GetValues<MassUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Mass(1, MassUnit.Kilogram);
 
-            QuantityInfo<MassUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Mass, MassUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Mass.Zero, quantityInfo.Zero);
             Assert.Equal("Mass", quantityInfo.Name);
-
-            var units = Enum.GetValues<MassUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Mass.Zero, quantityInfo.Zero);
+            Assert.Equal(Mass.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Mass.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MassUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolalityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolalityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Molality_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MolalityUnit[] unitsOrderedByName = EnumHelper.GetValues<MolalityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Molality(1, MolalityUnit.MolePerKilogram);
 
-            QuantityInfo<MolalityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Molality, MolalityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Molality.Zero, quantityInfo.Zero);
             Assert.Equal("Molality", quantityInfo.Name);
-
-            var units = Enum.GetValues<MolalityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Molality.Zero, quantityInfo.Zero);
+            Assert.Equal(Molality.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Molality.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MolalityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEnergyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MolarEnergy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MolarEnergyUnit[] unitsOrderedByName = EnumHelper.GetValues<MolarEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MolarEnergy(1, MolarEnergyUnit.JoulePerMole);
 
-            QuantityInfo<MolarEnergyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MolarEnergy, MolarEnergyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MolarEnergy.Zero, quantityInfo.Zero);
             Assert.Equal("MolarEnergy", quantityInfo.Name);
-
-            var units = Enum.GetValues<MolarEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MolarEnergy.Zero, quantityInfo.Zero);
+            Assert.Equal(MolarEnergy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MolarEnergy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MolarEnergyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEntropyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MolarEntropy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MolarEntropyUnit[] unitsOrderedByName = EnumHelper.GetValues<MolarEntropyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MolarEntropy(1, MolarEntropyUnit.JoulePerMoleKelvin);
 
-            QuantityInfo<MolarEntropyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MolarEntropy, MolarEntropyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MolarEntropy.Zero, quantityInfo.Zero);
             Assert.Equal("MolarEntropy", quantityInfo.Name);
-
-            var units = Enum.GetValues<MolarEntropyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MolarEntropy.Zero, quantityInfo.Zero);
+            Assert.Equal(MolarEntropy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MolarEntropy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MolarEntropyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MolarFlow_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MolarFlowUnit[] unitsOrderedByName = EnumHelper.GetValues<MolarFlowUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MolarFlow(1, MolarFlowUnit.MolePerSecond);
 
-            QuantityInfo<MolarFlowUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MolarFlow, MolarFlowUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MolarFlow.Zero, quantityInfo.Zero);
             Assert.Equal("MolarFlow", quantityInfo.Name);
-
-            var units = Enum.GetValues<MolarFlowUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MolarFlow.Zero, quantityInfo.Zero);
+            Assert.Equal(MolarFlow.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MolarFlow.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MolarFlowUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarMassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarMassTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -157,15 +158,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void MolarMass_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MolarMassUnit[] unitsOrderedByName = EnumHelper.GetValues<MolarMassUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new MolarMass(1, MolarMassUnit.KilogramPerMole);
 
-            QuantityInfo<MolarMassUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<MolarMass, MolarMassUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(MolarMass.Zero, quantityInfo.Zero);
             Assert.Equal("MolarMass", quantityInfo.Name);
-
-            var units = Enum.GetValues<MolarMassUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(MolarMass.Zero, quantityInfo.Zero);
+            Assert.Equal(MolarMass.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(MolarMass.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MolarMassUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -149,15 +150,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Molarity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            MolarityUnit[] unitsOrderedByName = EnumHelper.GetValues<MolarityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Molarity(1, MolarityUnit.MolePerCubicMeter);
 
-            QuantityInfo<MolarityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Molarity, MolarityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Molarity.Zero, quantityInfo.Zero);
             Assert.Equal("Molarity", quantityInfo.Name);
-
-            var units = Enum.GetValues<MolarityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Molarity.Zero, quantityInfo.Zero);
+            Assert.Equal(Molarity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Molarity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<MolarityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PermeabilityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Permeability_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PermeabilityUnit[] unitsOrderedByName = EnumHelper.GetValues<PermeabilityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Permeability(1, PermeabilityUnit.HenryPerMeter);
 
-            QuantityInfo<PermeabilityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Permeability, PermeabilityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Permeability.Zero, quantityInfo.Zero);
             Assert.Equal("Permeability", quantityInfo.Name);
-
-            var units = Enum.GetValues<PermeabilityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Permeability.Zero, quantityInfo.Zero);
+            Assert.Equal(Permeability.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Permeability.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PermeabilityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PermittivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PermittivityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -109,15 +110,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Permittivity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PermittivityUnit[] unitsOrderedByName = EnumHelper.GetValues<PermittivityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Permittivity(1, PermittivityUnit.FaradPerMeter);
 
-            QuantityInfo<PermittivityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Permittivity, PermittivityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Permittivity.Zero, quantityInfo.Zero);
             Assert.Equal("Permittivity", quantityInfo.Name);
-
-            var units = Enum.GetValues<PermittivityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Permittivity.Zero, quantityInfo.Zero);
+            Assert.Equal(Permittivity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Permittivity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PermittivityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PorousMediumPermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PorousMediumPermeabilityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -125,15 +126,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void PorousMediumPermeability_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PorousMediumPermeabilityUnit[] unitsOrderedByName = EnumHelper.GetValues<PorousMediumPermeabilityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new PorousMediumPermeability(1, PorousMediumPermeabilityUnit.SquareMeter);
 
-            QuantityInfo<PorousMediumPermeabilityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<PorousMediumPermeability, PorousMediumPermeabilityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(PorousMediumPermeability.Zero, quantityInfo.Zero);
             Assert.Equal("PorousMediumPermeability", quantityInfo.Name);
-
-            var units = Enum.GetValues<PorousMediumPermeabilityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(PorousMediumPermeability.Zero, quantityInfo.Zero);
+            Assert.Equal(PorousMediumPermeability.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(PorousMediumPermeability.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PorousMediumPermeabilityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerDensityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -281,15 +282,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void PowerDensity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PowerDensityUnit[] unitsOrderedByName = EnumHelper.GetValues<PowerDensityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new PowerDensity(1, PowerDensityUnit.WattPerCubicMeter);
 
-            QuantityInfo<PowerDensityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<PowerDensity, PowerDensityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(PowerDensity.Zero, quantityInfo.Zero);
             Assert.Equal("PowerDensity", quantityInfo.Name);
-
-            var units = Enum.GetValues<PowerDensityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(PowerDensity.Zero, quantityInfo.Zero);
+            Assert.Equal(PowerDensity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(PowerDensity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PowerDensityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerRatioTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -92,15 +93,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void PowerRatio_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PowerRatioUnit[] unitsOrderedByName = EnumHelper.GetValues<PowerRatioUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new PowerRatio(1, PowerRatioUnit.DecibelWatt);
 
-            QuantityInfo<PowerRatioUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<PowerRatio, PowerRatioUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(PowerRatio.Zero, quantityInfo.Zero);
             Assert.Equal("PowerRatio", quantityInfo.Name);
-
-            var units = Enum.GetValues<PowerRatioUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(PowerRatio.Zero, quantityInfo.Zero);
+            Assert.Equal(PowerRatio.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(PowerRatio.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PowerRatioUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -213,15 +214,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Power_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PowerUnit[] unitsOrderedByName = EnumHelper.GetValues<PowerUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Power(1, PowerUnit.Watt);
 
-            QuantityInfo<PowerUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Power, PowerUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Power.Zero, quantityInfo.Zero);
             Assert.Equal("Power", quantityInfo.Name);
-
-            var units = Enum.GetValues<PowerUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Power.Zero, quantityInfo.Zero);
+            Assert.Equal(Power.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Power.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PowerUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -177,15 +178,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void PressureChangeRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PressureChangeRateUnit[] unitsOrderedByName = EnumHelper.GetValues<PressureChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new PressureChangeRate(1, PressureChangeRateUnit.PascalPerSecond);
 
-            QuantityInfo<PressureChangeRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<PressureChangeRate, PressureChangeRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(PressureChangeRate.Zero, quantityInfo.Zero);
             Assert.Equal("PressureChangeRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<PressureChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(PressureChangeRate.Zero, quantityInfo.Zero);
+            Assert.Equal(PressureChangeRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(PressureChangeRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PressureChangeRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -297,15 +298,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Pressure_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            PressureUnit[] unitsOrderedByName = EnumHelper.GetValues<PressureUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Pressure(1, PressureUnit.Pascal);
 
-            QuantityInfo<PressureUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Pressure, PressureUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Pressure.Zero, quantityInfo.Zero);
             Assert.Equal("Pressure", quantityInfo.Name);
-
-            var units = Enum.GetValues<PressureUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Pressure.Zero, quantityInfo.Zero);
+            Assert.Equal(Pressure.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Pressure.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<PressureUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -145,15 +146,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RadiationEquivalentDoseRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RadiationEquivalentDoseRateUnit[] unitsOrderedByName = EnumHelper.GetValues<RadiationEquivalentDoseRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerSecond);
 
-            QuantityInfo<RadiationEquivalentDoseRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RadiationEquivalentDoseRate, RadiationEquivalentDoseRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RadiationEquivalentDoseRate.Zero, quantityInfo.Zero);
             Assert.Equal("RadiationEquivalentDoseRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<RadiationEquivalentDoseRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RadiationEquivalentDoseRate.Zero, quantityInfo.Zero);
+            Assert.Equal(RadiationEquivalentDoseRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RadiationEquivalentDoseRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RadiationEquivalentDoseRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RadiationEquivalentDose_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RadiationEquivalentDoseUnit[] unitsOrderedByName = EnumHelper.GetValues<RadiationEquivalentDoseUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RadiationEquivalentDose(1, RadiationEquivalentDoseUnit.Sievert);
 
-            QuantityInfo<RadiationEquivalentDoseUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RadiationEquivalentDose, RadiationEquivalentDoseUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RadiationEquivalentDose.Zero, quantityInfo.Zero);
             Assert.Equal("RadiationEquivalentDose", quantityInfo.Name);
-
-            var units = Enum.GetValues<RadiationEquivalentDoseUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RadiationEquivalentDose.Zero, quantityInfo.Zero);
+            Assert.Equal(RadiationEquivalentDose.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RadiationEquivalentDose.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RadiationEquivalentDoseUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationExposureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationExposureTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -137,15 +138,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RadiationExposure_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RadiationExposureUnit[] unitsOrderedByName = EnumHelper.GetValues<RadiationExposureUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RadiationExposure(1, RadiationExposureUnit.CoulombPerKilogram);
 
-            QuantityInfo<RadiationExposureUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RadiationExposure, RadiationExposureUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RadiationExposure.Zero, quantityInfo.Zero);
             Assert.Equal("RadiationExposure", quantityInfo.Name);
-
-            var units = Enum.GetValues<RadiationExposureUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RadiationExposure.Zero, quantityInfo.Zero);
+            Assert.Equal(RadiationExposure.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RadiationExposure.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RadiationExposureUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadioactivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadioactivityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -221,15 +222,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Radioactivity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RadioactivityUnit[] unitsOrderedByName = EnumHelper.GetValues<RadioactivityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Radioactivity(1, RadioactivityUnit.Becquerel);
 
-            QuantityInfo<RadioactivityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Radioactivity, RadioactivityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Radioactivity.Zero, quantityInfo.Zero);
             Assert.Equal("Radioactivity", quantityInfo.Name);
-
-            var units = Enum.GetValues<RadioactivityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Radioactivity.Zero, quantityInfo.Zero);
+            Assert.Equal(Radioactivity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Radioactivity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RadioactivityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioChangeRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -113,15 +114,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RatioChangeRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RatioChangeRateUnit[] unitsOrderedByName = EnumHelper.GetValues<RatioChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RatioChangeRate(1, RatioChangeRateUnit.DecimalFractionPerSecond);
 
-            QuantityInfo<RatioChangeRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RatioChangeRate, RatioChangeRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RatioChangeRate.Zero, quantityInfo.Zero);
             Assert.Equal("RatioChangeRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<RatioChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RatioChangeRate.Zero, quantityInfo.Zero);
+            Assert.Equal(RatioChangeRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RatioChangeRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RatioChangeRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -108,15 +109,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Ratio_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RatioUnit[] unitsOrderedByName = EnumHelper.GetValues<RatioUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Ratio(1, RatioUnit.DecimalFraction);
 
-            QuantityInfo<RatioUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Ratio, RatioUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Ratio.Zero, quantityInfo.Zero);
             Assert.Equal("Ratio", quantityInfo.Name);
-
-            var units = Enum.GetValues<RatioUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Ratio.Zero, quantityInfo.Zero);
+            Assert.Equal(Ratio.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Ratio.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RatioUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalAreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalAreaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -149,15 +150,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ReciprocalArea_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ReciprocalAreaUnit[] unitsOrderedByName = EnumHelper.GetValues<ReciprocalAreaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ReciprocalArea(1, ReciprocalAreaUnit.InverseSquareMeter);
 
-            QuantityInfo<ReciprocalAreaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ReciprocalArea, ReciprocalAreaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ReciprocalArea.Zero, quantityInfo.Zero);
             Assert.Equal("ReciprocalArea", quantityInfo.Name);
-
-            var units = Enum.GetValues<ReciprocalAreaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ReciprocalArea.Zero, quantityInfo.Zero);
+            Assert.Equal(ReciprocalArea.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ReciprocalArea.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ReciprocalAreaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalLengthTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -145,15 +146,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ReciprocalLength_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ReciprocalLengthUnit[] unitsOrderedByName = EnumHelper.GetValues<ReciprocalLengthUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ReciprocalLength(1, ReciprocalLengthUnit.InverseMeter);
 
-            QuantityInfo<ReciprocalLengthUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ReciprocalLength, ReciprocalLengthUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ReciprocalLength.Zero, quantityInfo.Zero);
             Assert.Equal("ReciprocalLength", quantityInfo.Name);
-
-            var units = Enum.GetValues<ReciprocalLengthUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ReciprocalLength.Zero, quantityInfo.Zero);
+            Assert.Equal(ReciprocalLength.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ReciprocalLength.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ReciprocalLengthUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RelativeHumidityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RelativeHumidityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -88,15 +89,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RelativeHumidity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RelativeHumidityUnit[] unitsOrderedByName = EnumHelper.GetValues<RelativeHumidityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RelativeHumidity(1, RelativeHumidityUnit.Percent);
 
-            QuantityInfo<RelativeHumidityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RelativeHumidity, RelativeHumidityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RelativeHumidity.Zero, quantityInfo.Zero);
             Assert.Equal("RelativeHumidity", quantityInfo.Name);
-
-            var units = Enum.GetValues<RelativeHumidityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RelativeHumidity.Zero, quantityInfo.Zero);
+            Assert.Equal(RelativeHumidity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RelativeHumidity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RelativeHumidityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalAccelerationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RotationalAcceleration_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RotationalAccelerationUnit[] unitsOrderedByName = EnumHelper.GetValues<RotationalAccelerationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RotationalAcceleration(1, RotationalAccelerationUnit.RadianPerSecondSquared);
 
-            QuantityInfo<RotationalAccelerationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RotationalAcceleration, RotationalAccelerationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RotationalAcceleration.Zero, quantityInfo.Zero);
             Assert.Equal("RotationalAcceleration", quantityInfo.Name);
-
-            var units = Enum.GetValues<RotationalAccelerationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RotationalAcceleration.Zero, quantityInfo.Zero);
+            Assert.Equal(RotationalAcceleration.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RotationalAcceleration.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RotationalAccelerationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalSpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalSpeedTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -157,15 +158,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RotationalSpeed_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RotationalSpeedUnit[] unitsOrderedByName = EnumHelper.GetValues<RotationalSpeedUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RotationalSpeed(1, RotationalSpeedUnit.RadianPerSecond);
 
-            QuantityInfo<RotationalSpeedUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RotationalSpeed, RotationalSpeedUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RotationalSpeed.Zero, quantityInfo.Zero);
             Assert.Equal("RotationalSpeed", quantityInfo.Name);
-
-            var units = Enum.GetValues<RotationalSpeedUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RotationalSpeed.Zero, quantityInfo.Zero);
+            Assert.Equal(RotationalSpeed.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RotationalSpeed.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RotationalSpeedUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessPerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessPerLengthTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -125,15 +126,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RotationalStiffnessPerLength_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RotationalStiffnessPerLengthUnit[] unitsOrderedByName = EnumHelper.GetValues<RotationalStiffnessPerLengthUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RotationalStiffnessPerLength(1, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter);
 
-            QuantityInfo<RotationalStiffnessPerLengthUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RotationalStiffnessPerLength, RotationalStiffnessPerLengthUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RotationalStiffnessPerLength.Zero, quantityInfo.Zero);
             Assert.Equal("RotationalStiffnessPerLength", quantityInfo.Name);
-
-            var units = Enum.GetValues<RotationalStiffnessPerLengthUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RotationalStiffnessPerLength.Zero, quantityInfo.Zero);
+            Assert.Equal(RotationalStiffnessPerLength.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RotationalStiffnessPerLength.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RotationalStiffnessPerLengthUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -237,15 +238,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void RotationalStiffness_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            RotationalStiffnessUnit[] unitsOrderedByName = EnumHelper.GetValues<RotationalStiffnessUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new RotationalStiffness(1, RotationalStiffnessUnit.NewtonMeterPerRadian);
 
-            QuantityInfo<RotationalStiffnessUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<RotationalStiffness, RotationalStiffnessUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(RotationalStiffness.Zero, quantityInfo.Zero);
             Assert.Equal("RotationalStiffness", quantityInfo.Name);
-
-            var units = Enum.GetValues<RotationalStiffnessUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(RotationalStiffness.Zero, quantityInfo.Zero);
+            Assert.Equal(RotationalStiffness.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(RotationalStiffness.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<RotationalStiffnessUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -88,15 +89,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Scalar_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ScalarUnit[] unitsOrderedByName = EnumHelper.GetValues<ScalarUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Scalar(1, ScalarUnit.Amount);
 
-            QuantityInfo<ScalarUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Scalar, ScalarUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Scalar.Zero, quantityInfo.Zero);
             Assert.Equal("Scalar", quantityInfo.Name);
-
-            var units = Enum.GetValues<ScalarUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Scalar.Zero, quantityInfo.Zero);
+            Assert.Equal(Scalar.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Scalar.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ScalarUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SolidAngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SolidAngleTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -88,15 +89,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void SolidAngle_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SolidAngleUnit[] unitsOrderedByName = EnumHelper.GetValues<SolidAngleUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new SolidAngle(1, SolidAngleUnit.Steradian);
 
-            QuantityInfo<SolidAngleUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<SolidAngle, SolidAngleUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(SolidAngle.Zero, quantityInfo.Zero);
             Assert.Equal("SolidAngle", quantityInfo.Name);
-
-            var units = Enum.GetValues<SolidAngleUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(SolidAngle.Zero, quantityInfo.Zero);
+            Assert.Equal(SolidAngle.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(SolidAngle.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SolidAngleUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEnergyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -225,15 +226,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void SpecificEnergy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SpecificEnergyUnit[] unitsOrderedByName = EnumHelper.GetValues<SpecificEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new SpecificEnergy(1, SpecificEnergyUnit.JoulePerKilogram);
 
-            QuantityInfo<SpecificEnergyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<SpecificEnergy, SpecificEnergyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(SpecificEnergy.Zero, quantityInfo.Zero);
             Assert.Equal("SpecificEnergy", quantityInfo.Name);
-
-            var units = Enum.GetValues<SpecificEnergyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(SpecificEnergy.Zero, quantityInfo.Zero);
+            Assert.Equal(SpecificEnergy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(SpecificEnergy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SpecificEnergyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEntropyTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void SpecificEntropy_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SpecificEntropyUnit[] unitsOrderedByName = EnumHelper.GetValues<SpecificEntropyUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new SpecificEntropy(1, SpecificEntropyUnit.JoulePerKilogramKelvin);
 
-            QuantityInfo<SpecificEntropyUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<SpecificEntropy, SpecificEntropyUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(SpecificEntropy.Zero, quantityInfo.Zero);
             Assert.Equal("SpecificEntropy", quantityInfo.Name);
-
-            var units = Enum.GetValues<SpecificEntropyUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(SpecificEntropy.Zero, quantityInfo.Zero);
+            Assert.Equal(SpecificEntropy.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(SpecificEntropy.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SpecificEntropyUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificFuelConsumptionTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void SpecificFuelConsumption_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SpecificFuelConsumptionUnit[] unitsOrderedByName = EnumHelper.GetValues<SpecificFuelConsumptionUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new SpecificFuelConsumption(1, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond);
 
-            QuantityInfo<SpecificFuelConsumptionUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<SpecificFuelConsumption, SpecificFuelConsumptionUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(SpecificFuelConsumption.Zero, quantityInfo.Zero);
             Assert.Equal("SpecificFuelConsumption", quantityInfo.Name);
-
-            var units = Enum.GetValues<SpecificFuelConsumptionUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(SpecificFuelConsumption.Zero, quantityInfo.Zero);
+            Assert.Equal(SpecificFuelConsumption.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(SpecificFuelConsumption.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SpecificFuelConsumptionUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificVolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificVolumeTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -117,15 +118,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void SpecificVolume_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SpecificVolumeUnit[] unitsOrderedByName = EnumHelper.GetValues<SpecificVolumeUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new SpecificVolume(1, SpecificVolumeUnit.CubicMeterPerKilogram);
 
-            QuantityInfo<SpecificVolumeUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<SpecificVolume, SpecificVolumeUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(SpecificVolume.Zero, quantityInfo.Zero);
             Assert.Equal("SpecificVolume", quantityInfo.Name);
-
-            var units = Enum.GetValues<SpecificVolumeUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(SpecificVolume.Zero, quantityInfo.Zero);
+            Assert.Equal(SpecificVolume.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(SpecificVolume.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SpecificVolumeUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificWeightTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificWeightTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -173,15 +174,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void SpecificWeight_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SpecificWeightUnit[] unitsOrderedByName = EnumHelper.GetValues<SpecificWeightUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new SpecificWeight(1, SpecificWeightUnit.NewtonPerCubicMeter);
 
-            QuantityInfo<SpecificWeightUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<SpecificWeight, SpecificWeightUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(SpecificWeight.Zero, quantityInfo.Zero);
             Assert.Equal("SpecificWeight", quantityInfo.Name);
-
-            var units = Enum.GetValues<SpecificWeightUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(SpecificWeight.Zero, quantityInfo.Zero);
+            Assert.Equal(SpecificWeight.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(SpecificWeight.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SpecificWeightUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpeedTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -237,15 +238,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Speed_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            SpeedUnit[] unitsOrderedByName = EnumHelper.GetValues<SpeedUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Speed(1, SpeedUnit.MeterPerSecond);
 
-            QuantityInfo<SpeedUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Speed, SpeedUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Speed.Zero, quantityInfo.Zero);
             Assert.Equal("Speed", quantityInfo.Name);
-
-            var units = Enum.GetValues<SpeedUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Speed.Zero, quantityInfo.Zero);
+            Assert.Equal(Speed.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Speed.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<SpeedUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void StandardVolumeFlow_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            StandardVolumeFlowUnit[] unitsOrderedByName = EnumHelper.GetValues<StandardVolumeFlowUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new StandardVolumeFlow(1, StandardVolumeFlowUnit.StandardCubicMeterPerSecond);
 
-            QuantityInfo<StandardVolumeFlowUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<StandardVolumeFlow, StandardVolumeFlowUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(StandardVolumeFlow.Zero, quantityInfo.Zero);
             Assert.Equal("StandardVolumeFlow", quantityInfo.Name);
-
-            var units = Enum.GetValues<StandardVolumeFlowUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(StandardVolumeFlow.Zero, quantityInfo.Zero);
+            Assert.Equal(StandardVolumeFlow.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(StandardVolumeFlow.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<StandardVolumeFlowUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureChangeRateTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -173,15 +174,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void TemperatureChangeRate_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            TemperatureChangeRateUnit[] unitsOrderedByName = EnumHelper.GetValues<TemperatureChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new TemperatureChangeRate(1, TemperatureChangeRateUnit.DegreeCelsiusPerSecond);
 
-            QuantityInfo<TemperatureChangeRateUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<TemperatureChangeRate, TemperatureChangeRateUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(TemperatureChangeRate.Zero, quantityInfo.Zero);
             Assert.Equal("TemperatureChangeRate", quantityInfo.Name);
-
-            var units = Enum.GetValues<TemperatureChangeRateUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(TemperatureChangeRate.Zero, quantityInfo.Zero);
+            Assert.Equal(TemperatureChangeRate.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(TemperatureChangeRate.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<TemperatureChangeRateUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureDeltaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureDeltaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void TemperatureDelta_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            TemperatureDeltaUnit[] unitsOrderedByName = EnumHelper.GetValues<TemperatureDeltaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new TemperatureDelta(1, TemperatureDeltaUnit.Kelvin);
 
-            QuantityInfo<TemperatureDeltaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<TemperatureDelta, TemperatureDeltaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(TemperatureDelta.Zero, quantityInfo.Zero);
             Assert.Equal("TemperatureDelta", quantityInfo.Name);
-
-            var units = Enum.GetValues<TemperatureDeltaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(TemperatureDelta.Zero, quantityInfo.Zero);
+            Assert.Equal(TemperatureDelta.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(TemperatureDelta.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<TemperatureDeltaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -121,15 +122,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void TemperatureGradient_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            TemperatureGradientUnit[] unitsOrderedByName = EnumHelper.GetValues<TemperatureGradientUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new TemperatureGradient(1, TemperatureGradientUnit.KelvinPerMeter);
 
-            QuantityInfo<TemperatureGradientUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<TemperatureGradient, TemperatureGradientUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(TemperatureGradient.Zero, quantityInfo.Zero);
             Assert.Equal("TemperatureGradient", quantityInfo.Name);
-
-            var units = Enum.GetValues<TemperatureGradientUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(TemperatureGradient.Zero, quantityInfo.Zero);
+            Assert.Equal(TemperatureGradient.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(TemperatureGradient.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<TemperatureGradientUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -145,15 +146,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Temperature_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            TemperatureUnit[] unitsOrderedByName = EnumHelper.GetValues<TemperatureUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Temperature(1, TemperatureUnit.Kelvin);
 
-            QuantityInfo<TemperatureUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Temperature, TemperatureUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Temperature.Zero, quantityInfo.Zero);
             Assert.Equal("Temperature", quantityInfo.Name);
-
-            var units = Enum.GetValues<TemperatureUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Temperature.Zero, quantityInfo.Zero);
+            Assert.Equal(Temperature.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Temperature.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<TemperatureUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalConductivityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -113,15 +114,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ThermalConductivity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ThermalConductivityUnit[] unitsOrderedByName = EnumHelper.GetValues<ThermalConductivityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ThermalConductivity(1, ThermalConductivityUnit.WattPerMeterKelvin);
 
-            QuantityInfo<ThermalConductivityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ThermalConductivity, ThermalConductivityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ThermalConductivity.Zero, quantityInfo.Zero);
             Assert.Equal("ThermalConductivity", quantityInfo.Name);
-
-            var units = Enum.GetValues<ThermalConductivityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ThermalConductivity.Zero, quantityInfo.Zero);
+            Assert.Equal(ThermalConductivity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ThermalConductivity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ThermalConductivityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalInsulanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalInsulanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -133,15 +134,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ThermalInsulance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ThermalInsulanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ThermalInsulanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ThermalInsulance(1, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt);
 
-            QuantityInfo<ThermalInsulanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ThermalInsulance, ThermalInsulanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ThermalInsulance.Zero, quantityInfo.Zero);
             Assert.Equal("ThermalInsulance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ThermalInsulanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ThermalInsulance.Zero, quantityInfo.Zero);
+            Assert.Equal(ThermalInsulance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ThermalInsulance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ThermalInsulanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -113,15 +114,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void ThermalResistance_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            ThermalResistanceUnit[] unitsOrderedByName = EnumHelper.GetValues<ThermalResistanceUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new ThermalResistance(1, ThermalResistanceUnit.KelvinPerWatt);
 
-            QuantityInfo<ThermalResistanceUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<ThermalResistance, ThermalResistanceUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(ThermalResistance.Zero, quantityInfo.Zero);
             Assert.Equal("ThermalResistance", quantityInfo.Name);
-
-            var units = Enum.GetValues<ThermalResistanceUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(ThermalResistance.Zero, quantityInfo.Zero);
+            Assert.Equal(ThermalResistance.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(ThermalResistance.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<ThermalResistanceUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TorqueTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TorqueTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -205,15 +206,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Torque_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            TorqueUnit[] unitsOrderedByName = EnumHelper.GetValues<TorqueUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Torque(1, TorqueUnit.NewtonMeter);
 
-            QuantityInfo<TorqueUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Torque, TorqueUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Torque.Zero, quantityInfo.Zero);
             Assert.Equal("Torque", quantityInfo.Name);
-
-            var units = Enum.GetValues<TorqueUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Torque.Zero, quantityInfo.Zero);
+            Assert.Equal(Torque.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Torque.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<TorqueUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TurbidityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TurbidityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -88,15 +89,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Turbidity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            TurbidityUnit[] unitsOrderedByName = EnumHelper.GetValues<TurbidityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Turbidity(1, TurbidityUnit.NTU);
 
-            QuantityInfo<TurbidityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Turbidity, TurbidityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Turbidity.Zero, quantityInfo.Zero);
             Assert.Equal("Turbidity", quantityInfo.Name);
-
-            var units = Enum.GetValues<TurbidityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Turbidity.Zero, quantityInfo.Zero);
+            Assert.Equal(Turbidity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Turbidity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<TurbidityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VitaminATestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VitaminATestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -88,15 +89,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void VitaminA_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VitaminAUnit[] unitsOrderedByName = EnumHelper.GetValues<VitaminAUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new VitaminA(1, VitaminAUnit.InternationalUnit);
 
-            QuantityInfo<VitaminAUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<VitaminA, VitaminAUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(VitaminA.Zero, quantityInfo.Zero);
             Assert.Equal("VitaminA", quantityInfo.Name);
-
-            var units = Enum.GetValues<VitaminAUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(VitaminA.Zero, quantityInfo.Zero);
+            Assert.Equal(VitaminA.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(VitaminA.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VitaminAUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -164,15 +165,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void VolumeConcentration_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VolumeConcentrationUnit[] unitsOrderedByName = EnumHelper.GetValues<VolumeConcentrationUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new VolumeConcentration(1, VolumeConcentrationUnit.DecimalFraction);
 
-            QuantityInfo<VolumeConcentrationUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<VolumeConcentration, VolumeConcentrationUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(VolumeConcentration.Zero, quantityInfo.Zero);
             Assert.Equal("VolumeConcentration", quantityInfo.Name);
-
-            var units = Enum.GetValues<VolumeConcentrationUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(VolumeConcentration.Zero, quantityInfo.Zero);
+            Assert.Equal(VolumeConcentration.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(VolumeConcentration.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VolumeConcentrationUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowPerAreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowPerAreaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -113,15 +114,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void VolumeFlowPerArea_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VolumeFlowPerAreaUnit[] unitsOrderedByName = EnumHelper.GetValues<VolumeFlowPerAreaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new VolumeFlowPerArea(1, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter);
 
-            QuantityInfo<VolumeFlowPerAreaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<VolumeFlowPerArea, VolumeFlowPerAreaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(VolumeFlowPerArea.Zero, quantityInfo.Zero);
             Assert.Equal("VolumeFlowPerArea", quantityInfo.Name);
-
-            var units = Enum.GetValues<VolumeFlowPerAreaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(VolumeFlowPerArea.Zero, quantityInfo.Zero);
+            Assert.Equal(VolumeFlowPerArea.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(VolumeFlowPerArea.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VolumeFlowPerAreaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -405,15 +406,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void VolumeFlow_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VolumeFlowUnit[] unitsOrderedByName = EnumHelper.GetValues<VolumeFlowUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new VolumeFlow(1, VolumeFlowUnit.CubicMeterPerSecond);
 
-            QuantityInfo<VolumeFlowUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<VolumeFlow, VolumeFlowUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(VolumeFlow.Zero, quantityInfo.Zero);
             Assert.Equal("VolumeFlow", quantityInfo.Name);
-
-            var units = Enum.GetValues<VolumeFlowUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(VolumeFlow.Zero, quantityInfo.Zero);
+            Assert.Equal(VolumeFlow.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(VolumeFlow.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VolumeFlowUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumePerLengthTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void VolumePerLength_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VolumePerLengthUnit[] unitsOrderedByName = EnumHelper.GetValues<VolumePerLengthUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new VolumePerLength(1, VolumePerLengthUnit.CubicMeterPerMeter);
 
-            QuantityInfo<VolumePerLengthUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<VolumePerLength, VolumePerLengthUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(VolumePerLength.Zero, quantityInfo.Zero);
             Assert.Equal("VolumePerLength", quantityInfo.Name);
-
-            var units = Enum.GetValues<VolumePerLengthUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(VolumePerLength.Zero, quantityInfo.Zero);
+            Assert.Equal(VolumePerLength.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(VolumePerLength.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VolumePerLengthUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -321,15 +322,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void Volume_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VolumeUnit[] unitsOrderedByName = EnumHelper.GetValues<VolumeUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new Volume(1, VolumeUnit.CubicMeter);
 
-            QuantityInfo<VolumeUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<Volume, VolumeUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(Volume.Zero, quantityInfo.Zero);
             Assert.Equal("Volume", quantityInfo.Name);
-
-            var units = Enum.GetValues<VolumeUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(Volume.Zero, quantityInfo.Zero);
+            Assert.Equal(Volume.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(Volume.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VolumeUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumetricHeatCapacityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumetricHeatCapacityTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -141,15 +142,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void VolumetricHeatCapacity_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            VolumetricHeatCapacityUnit[] unitsOrderedByName = EnumHelper.GetValues<VolumetricHeatCapacityUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new VolumetricHeatCapacity(1, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin);
 
-            QuantityInfo<VolumetricHeatCapacityUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<VolumetricHeatCapacity, VolumetricHeatCapacityUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(VolumetricHeatCapacity.Zero, quantityInfo.Zero);
             Assert.Equal("VolumetricHeatCapacity", quantityInfo.Name);
-
-            var units = Enum.GetValues<VolumetricHeatCapacityUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(VolumetricHeatCapacity.Zero, quantityInfo.Zero);
+            Assert.Equal(VolumetricHeatCapacity.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(VolumetricHeatCapacity.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<VolumetricHeatCapacityUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/WarpingMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/WarpingMomentOfInertiaTestsBase.g.cs
@@ -22,6 +22,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using UnitsNet.InternalHelpers;
 using UnitsNet.Tests.Helpers;
 using UnitsNet.Tests.TestsBase;
 using UnitsNet.Units;
@@ -129,15 +130,19 @@ namespace UnitsNet.Tests
         [Fact]
         public void WarpingMomentOfInertia_QuantityInfo_ReturnsQuantityInfoDescribingQuantity()
         {
+            WarpingMomentOfInertiaUnit[] unitsOrderedByName = EnumHelper.GetValues<WarpingMomentOfInertiaUnit>().OrderBy(x => x.ToString()).ToArray();
             var quantity = new WarpingMomentOfInertia(1, WarpingMomentOfInertiaUnit.MeterToTheSixth);
 
-            QuantityInfo<WarpingMomentOfInertiaUnit> quantityInfo = quantity.QuantityInfo;
+            QuantityInfo<WarpingMomentOfInertia, WarpingMomentOfInertiaUnit> quantityInfo = quantity.QuantityInfo;
 
-            Assert.Equal(WarpingMomentOfInertia.Zero, quantityInfo.Zero);
             Assert.Equal("WarpingMomentOfInertia", quantityInfo.Name);
-
-            var units = Enum.GetValues<WarpingMomentOfInertiaUnit>().OrderBy(x => x.ToString()).ToArray();
-            var unitNames = units.Select(x => x.ToString());
+            Assert.Equal(WarpingMomentOfInertia.Zero, quantityInfo.Zero);
+            Assert.Equal(WarpingMomentOfInertia.BaseUnit, quantityInfo.BaseUnitInfo.Value);
+            Assert.Equal(unitsOrderedByName, quantityInfo.Units);
+            Assert.Equal(unitsOrderedByName, quantityInfo.UnitInfos.Select(x => x.Value));
+            Assert.Equal(WarpingMomentOfInertia.Info, quantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity)quantity).QuantityInfo);
+            Assert.Equal(quantityInfo, ((IQuantity<WarpingMomentOfInertiaUnit>)quantity).QuantityInfo);
         }
 
         [Fact]

--- a/UnitsNet/IQuantityInfo.cs
+++ b/UnitsNet/IQuantityInfo.cs
@@ -1,11 +1,7 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
-using System;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Resources;
-using UnitsNet.Units;
 
 namespace UnitsNet;
 
@@ -67,22 +63,10 @@ public interface IQuantityInfo
     /// <returns>The <see cref="UnitInfo" /> associated with the specified unit.</returns>
     /// <exception cref="KeyNotFoundException">Thrown if the specified unit is not found.</exception>
     /// <exception cref="InvalidOperationException">
-    ///     Thrown when the type of <see cref="UnitType"/>> does not match the type of the current <see cref="UnitKey.UnitEnumType" />.
+    ///     Thrown when the type of <see cref="UnitType" />> does not match the type of the current
+    ///     <see cref="UnitKey.UnitEnumType" />.
     /// </exception>
     UnitInfo this[UnitKey unit] { get; }
-
-    // /// <summary>
-    // ///     Attempts to retrieve the unit information for the specified unit.
-    // /// </summary>
-    // /// <param name="unit">The unit for which to retrieve information.</param>
-    // /// <param name="unitInfo">
-    // ///     When this method returns, contains the unit information associated with the specified unit,
-    // ///     if the unit is found; otherwise, <c>null</c>. This parameter is passed uninitialized.
-    // /// </param>
-    // /// <returns>
-    // ///     <c>true</c> if the unit information was found; otherwise, <c>false</c>.
-    // /// </returns>
-    // bool TryGetUnitInfo(UnitKey unit, [NotNullWhen(true)] out UnitInfo? unitInfo);
 
     /// <summary>
     ///     Gets the <see cref="UnitInfo" /> whose <see cref="BaseUnits" /> is a subset of <paramref name="baseUnits" />.
@@ -115,52 +99,7 @@ public interface IQuantityInfo
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="baseUnits" /> is null.</exception>
     IEnumerable<UnitInfo> GetUnitInfosFor(BaseUnits baseUnits);
-
-    // /// <summary>
-    // ///     Creates an instance of <see cref="IQuantity" /> from the specified value and unit.
-    // /// </summary>
-    // /// <param name="value">The numerical value of the quantity.</param>
-    // /// <param name="unit">The unit of the quantity, represented as an enumeration.</param>
-    // /// <returns>An instance of <see cref="IQuantity" /> representing the specified value and unit.</returns>
-    // /// <exception cref="ArgumentNullException">Thrown when <paramref name="unit" /> is null.</exception>
-    // /// <exception cref="ArgumentException">Thrown when <paramref name="unit" /> is not a valid unit for this quantity.</exception>
-    // IQuantity From(QuantityValue value, Enum unit);
 }
-
-// /// <inheritdoc cref="IQuantityInfo" />
-// /// <remarks>
-// ///     This is a specialization of <see cref="IQuantityInfo" />, for when the unit type is known.
-// ///     Typically, you obtain this by looking it up statically from <see cref="Length.Info" /> or
-// ///     <see cref="Length.QuantityInfo" />, or dynamically via <see cref="IQuantity{TUnitType}.QuantityInfo" />.
-// /// </remarks>
-// /// <typeparam name="TUnit">The unit enum type, such as <see cref="LengthUnit" />. </typeparam>
-// public interface IQuantityInfo<TUnit> : IQuantityInfo
-//     where TUnit : struct, Enum
-// {
-//     /// <inheritdoc cref="IQuantityInfo.Zero" />
-//     new IQuantity<TUnit> Zero { get; }
-//
-//     /// <inheritdoc cref="IQuantityInfo.UnitInfos" />
-//     new IReadOnlyCollection<UnitInfo<TUnit>> UnitInfos { get; }
-//
-//     /// <inheritdoc cref="IQuantityInfo.BaseUnitInfo" />
-//     new UnitInfo<TUnit> BaseUnitInfo { get; }
-//     
-//     /// <inheritdoc cref="IQuantityInfo.this" />
-//     UnitInfo<TUnit> this[TUnit unit] { get; }
-//     
-//     /// <inheritdoc cref="IQuantityInfo.TryGetUnitInfo" />
-//     bool TryGetUnitInfo(TUnit unit, [NotNullWhen(true)] out UnitInfo<TUnit>? unitInfo);
-//
-//     /// <inheritdoc cref="IQuantityInfo.GetUnitInfoFor" />
-//     new UnitInfo<TUnit> GetUnitInfoFor(BaseUnits baseUnits);
-//
-//     /// <inheritdoc cref="IQuantityInfo.GetUnitInfosFor" />
-//     new IEnumerable<UnitInfo<TUnit>> GetUnitInfosFor(BaseUnits baseUnits);
-//
-//     /// <inheritdoc cref="IQuantityInfo.From" />
-//     IQuantity<TUnit> From(QuantityValue value, TUnit unit);
-// }
 
 /// <inheritdoc cref="IQuantityInfo" />
 /// <remarks>
@@ -175,43 +114,3 @@ public interface IQuantityInstanceInfo<out TQuantity> : IQuantityInfo
 
     internal TQuantity Create(double value, UnitKey unitKey);
 }
-
-// /// <inheritdoc cref="IQuantityInfo{TUnit}" />
-// public interface IQuantityInfo<TQuantity, TUnit> : IQuantityInfo<TUnit>, IQuantityInstanceInfo<TQuantity>
-//     where TQuantity : IQuantity<TUnit>
-//     where TUnit : struct, Enum
-// {
-//     /// <inheritdoc cref="IQuantityInfo.Zero" />
-//     new TQuantity Zero { get; }
-//
-//     /// <inheritdoc cref="IQuantityInfo.UnitInfos" />
-//     new IReadOnlyCollection<UnitInfo<TQuantity, TUnit>> UnitInfos { get; }
-//
-//     /// <inheritdoc cref="IQuantityInfo.BaseUnitInfo" />
-//     new UnitInfo<TQuantity, TUnit> BaseUnitInfo { get; }
-//
-//     /// <inheritdoc cref="IQuantityInfo.this" />
-//     new UnitInfo<TQuantity, TUnit> this[TUnit unit] { get; }
-//
-//     /// <inheritdoc cref="IQuantityInfo.GetUnitInfoFor" />
-//     new UnitInfo<TQuantity, TUnit> GetUnitInfoFor(BaseUnits baseUnits);
-//
-//     /// <inheritdoc cref="IQuantityInfo.GetUnitInfosFor" />
-//     new IEnumerable<UnitInfo<TQuantity, TUnit>> GetUnitInfosFor(BaseUnits baseUnits);
-//
-//     /// <inheritdoc cref="IQuantityInfo.From" />
-//     new TQuantity From(QuantityValue value, TUnit unit);
-//
-//     // #if NET
-//     //
-//     // #region Implementation of IQuantityInstanceInfo<out TQuantity>
-//     //
-//     // TQuantity IQuantityInstanceInfo<TQuantity>.Create(QuantityValue value, UnitKey unitKey)
-//     // {
-//     //     return From(value, unitKey.ToUnit<TUnit>());
-//     // }
-//     //
-//     // #endregion
-//     //
-//     // #endif
-// }

--- a/UnitsNet/QuantityInfo.cs
+++ b/UnitsNet/QuantityInfo.cs
@@ -31,12 +31,6 @@ public abstract class QuantityInfo : IQuantityInfo
         UnitAbbreviations = unitAbbreviations;
     }
 
-    /// <inheritdoc />
-    public string Name { get; }
-
-    /// <inheritdoc />
-    public Type QuantityType { get; }
-
     /// <inheritdoc cref="QuantityType" />
     [Obsolete("Replaced by the QuantityType property.")]
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -44,6 +38,12 @@ public abstract class QuantityInfo : IQuantityInfo
     {
         get => QuantityType;
     }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public Type QuantityType { get; }
 
     /// <inheritdoc />
     public abstract Type UnitType { get; }
@@ -61,18 +61,12 @@ public abstract class QuantityInfo : IQuantityInfo
         get => GetGenericZero();
     }
 
-    /// <inheritdoc cref="Zero" />
-    protected internal abstract IQuantity GetGenericZero();
-
     /// <inheritdoc />
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     public UnitInfo BaseUnitInfo
     {
         get => GetGenericBaseUnitInfo();
     }
-
-    /// <inheritdoc cref="BaseUnitInfo" />
-    protected internal abstract UnitInfo GetGenericBaseUnitInfo();
 
     /// <inheritdoc />
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -81,14 +75,8 @@ public abstract class QuantityInfo : IQuantityInfo
         get => GetGenericUnitInfos();
     }
 
-    /// <inheritdoc cref="UnitInfos" />
-    protected internal abstract IReadOnlyList<UnitInfo> GetGenericUnitInfos();
-
     /// <inheritdoc />
     public abstract UnitInfo this[UnitKey unit] { get; }
-
-    // /// <inheritdoc />
-    // public abstract bool TryGetUnitInfo(UnitKey unit, [NotNullWhen(true)] out UnitInfo? unitInfo);
 
     /// <inheritdoc />
     public UnitInfo GetUnitInfoFor(BaseUnits baseUnits)
@@ -101,6 +89,15 @@ public abstract class QuantityInfo : IQuantityInfo
     {
         return UnitInfo.GetUnitsWithBase(UnitInfos, baseUnits);
     }
+
+    /// <inheritdoc cref="Zero" />
+    protected internal abstract IQuantity GetGenericZero();
+
+    /// <inheritdoc cref="BaseUnitInfo" />
+    protected internal abstract UnitInfo GetGenericBaseUnitInfo();
+
+    /// <inheritdoc cref="UnitInfos" />
+    protected internal abstract IReadOnlyList<UnitInfo> GetGenericUnitInfos();
 
     /// <summary>
     ///     Creates an instance of <see cref="IQuantity" /> from the specified value and unit.
@@ -126,7 +123,7 @@ public abstract class QuantityInfo : IQuantityInfo
 ///     <see cref="Length.QuantityInfo" />, or dynamically via <see cref="IQuantity{TUnitType}.QuantityInfo" />.
 /// </remarks>
 /// <typeparam name="TUnit">The unit enum type, such as <see cref="LengthUnit" />. </typeparam>
-public abstract class QuantityInfo<TUnit> : QuantityInfo//, IQuantityInfo<TUnit>
+public abstract class QuantityInfo<TUnit> : QuantityInfo
     where TUnit : struct, Enum
 {
     /// <inheritdoc />
@@ -179,9 +176,6 @@ public abstract class QuantityInfo<TUnit> : QuantityInfo//, IQuantityInfo<TUnit>
     /// <returns>An <see cref="UnitInfo{TUnit}" /> instance containing information about the specified unit.</returns>
     /// <exception cref="ArgumentException">Thrown if the specified unit is not valid for this quantity.</exception>
     protected internal abstract UnitInfo<TUnit> GetUnitInfo(TUnit unit);
-
-    //  /// <inheritdoc cref="QuantityInfo.TryGetUnitInfo" />
-    // public abstract bool TryGetUnitInfo(TUnit unit, [NotNullWhen(true)] out UnitInfo<TUnit>? unitInfo);
 
     /// <inheritdoc cref="QuantityInfo.GetUnitInfoFor" />
     public new UnitInfo<TUnit> GetUnitInfoFor(BaseUnits baseUnits)
@@ -237,19 +231,6 @@ public abstract class QuantityInfo<TUnit> : QuantityInfo//, IQuantityInfo<TUnit>
     {
         get => this[unit.ToUnit<TUnit>()];
     }
-
-    // /// <inheritdoc />
-    // public override bool TryGetUnitInfo(UnitKey unit, [NotNullWhen(true)] out UnitInfo? unitInfo)
-    // {
-    //     if (unit.UnitType == typeof(TUnit) && TryGetUnitInfo(unit.ToUnit<TUnit>(), out UnitInfo<TUnit>? unitMapping))
-    //     {
-    //         unitInfo = unitMapping;
-    //         return true;
-    //     }
-    //
-    //     unitInfo = null;
-    //     return false;
-    // }
 
     /// <inheritdoc />
     internal override IQuantity From(double value, UnitKey unitKey)
@@ -361,19 +342,6 @@ public abstract class QuantityInfoBase<TQuantity, TUnit, TUnitInfo> : QuantityIn
         return this[unit];
     }
 
-    // /// <inheritdoc />
-    // public override bool TryGetUnitInfo(TUnit unit, [NotNullWhen(true)] out UnitInfo<TUnit>? unitInfo)
-    // {
-    //     if (TryGetUnitInfo(unit, out TUnitInfo? unitMapping))
-    //     {
-    //         unitInfo = unitMapping;
-    //         return true;
-    //     }
-    //
-    //     unitInfo = null;
-    //     return false;
-    // }
-
     /// <inheritdoc />
     protected internal override IQuantity<TUnit> CreateGenericQuantity(double value, TUnit unit)
     {
@@ -384,20 +352,21 @@ public abstract class QuantityInfoBase<TQuantity, TUnit, TUnitInfo> : QuantityIn
 }
 
 /// <inheritdoc cref="QuantityInfoBase{TQuantity,TUnit,TUnitMapping}" />
-public class QuantityInfo<TQuantity, TUnit> : QuantityInfoBase<TQuantity, TUnit, UnitInfo<TQuantity, TUnit>>//, IQuantityInfo<TQuantity, TUnit>
+public class QuantityInfo<TQuantity, TUnit> : QuantityInfoBase<TQuantity, TUnit, UnitInfo<TQuantity, TUnit>>
     where TQuantity : IQuantity<TQuantity, TUnit>
     where TUnit : struct, Enum
 {
     [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    private readonly Dictionary<TUnit, UnitInfo<TQuantity, TUnit>> _unitMappings;
-
-    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
     private readonly UnitInfo<TQuantity, TUnit>[] _unitInfos;
 
-    #if NET
+    [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+    private readonly Dictionary<TUnit, UnitInfo<TQuantity, TUnit>> _unitMappings;
+
+#if NET
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="QuantityInfo{TQuantity, TUnit}" /> class using the default quantity name.
+    ///     Initializes a new instance of the <see cref="QuantityInfo{TQuantity, TUnit}" /> class using the default quantity
+    ///     name.
     /// </summary>
     /// <param name="unitMappings">A collection of unit mapping configurations.</param>
     /// <param name="baseUnit">The base unit of the quantity.</param>
@@ -409,7 +378,8 @@ public class QuantityInfo<TQuantity, TUnit> : QuantityInfoBase<TQuantity, TUnit,
     /// <exception cref="UnitNotFoundException">
     ///     Thrown when no unit mapping configuration is found for the specified <paramref name="baseUnit" />.
     /// </exception>
-    public QuantityInfo(TUnit baseUnit, IEnumerable<IUnitDefinition<TUnit>> unitMappings, BaseDimensions baseDimensions, ResourceManager? unitAbbreviations = null)
+    public QuantityInfo(TUnit baseUnit, IEnumerable<IUnitDefinition<TUnit>> unitMappings, BaseDimensions baseDimensions,
+        ResourceManager? unitAbbreviations = null)
         : this(typeof(TQuantity).Name, baseUnit, unitMappings, baseDimensions, TQuantity.From, unitAbbreviations)
     {
     }
@@ -428,15 +398,17 @@ public class QuantityInfo<TQuantity, TUnit> : QuantityInfoBase<TQuantity, TUnit,
     /// <exception cref="UnitNotFoundException">
     ///     Thrown when no unit mapping configuration is found for the specified <paramref name="baseUnit" />.
     /// </exception>
-    public QuantityInfo(string name, TUnit baseUnit, IEnumerable<IUnitDefinition<TUnit>> unitMappings, BaseDimensions baseDimensions, ResourceManager? unitAbbreviations = null)
+    public QuantityInfo(string name, TUnit baseUnit, IEnumerable<IUnitDefinition<TUnit>> unitMappings, BaseDimensions baseDimensions,
+        ResourceManager? unitAbbreviations = null)
         : this(name, baseUnit, unitMappings, TQuantity.From(0, baseUnit), baseDimensions, TQuantity.From, unitAbbreviations)
     {
     }
 
-    #endif
+#endif
 
     /// <summary>
-    ///     Initializes a new instance of the <see cref="QuantityInfo{TQuantity, TUnit}" /> class using the default quantity name.
+    ///     Initializes a new instance of the <see cref="QuantityInfo{TQuantity, TUnit}" /> class using the default quantity
+    ///     name.
     /// </summary>
     /// <param name="unitMappings">A collection of unit mapping configurations.</param>
     /// <param name="baseUnit">The base unit of the quantity.</param>
@@ -550,98 +522,6 @@ public class QuantityInfo<TQuantity, TUnit> : QuantityInfoBase<TQuantity, TUnit,
     {
         get => _unitInfos;
     }
-
-    #endregion
-
-    #region Explicit implementation of IQuantityInfo<TUnit>
-
-    // [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    // IReadOnlyCollection<UnitInfo<TUnit>> IQuantityInfo<TUnit>.UnitInfos
-    // {
-    //     get => UnitInfos;
-    // }
-
-    // [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    // UnitInfo<TUnit> IQuantityInfo<TUnit>.BaseUnitInfo
-    // {
-    //     get => BaseUnitInfo;
-    // }
-
-    // IUnitInfo<TUnit> IQuantityInfo<TUnit>.this[TUnit unit]
-    // {
-    //     get => this[unit];
-    // }
-
-    // bool IQuantityInfo<TUnit>.TryGetUnitInfo(TUnit unit, [NotNullWhen(true)] out IUnitInfo<TUnit>? unitInfo)
-    // {
-    //     if (TryGetUnitInfo(unit, out UnitInfo<TQuantity, TUnit>? info))
-    //     {
-    //         unitInfo = info;
-    //         return true;
-    //     }
-    //
-    //     unitInfo = null;
-    //     return false;
-    // }
-
-    // IUnitInfo<TUnit> IQuantityInfo<TUnit>.GetUnitInfoFor(BaseUnits baseUnits)
-    // {
-    //     return GetUnitInfoFor(baseUnits);
-    // }
-
-    // IEnumerable<IUnitInfo<TUnit>> IQuantityInfo<TUnit>.GetUnitInfosFor(BaseUnits baseUnits)
-    // {
-    //     return GetUnitInfosFor(baseUnits);
-    // }
-
-    // IQuantity<TUnit> IQuantityInfo<TUnit>.From(QuantityValue value, TUnit unit)
-    // {
-    //     return From(value, unit);
-    // }
-
-    // [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    // IQuantity<TUnit> IQuantityInfo<TUnit>.Zero
-    // {
-    //     get => Zero;
-    // }
-
-
-    // /// <inheritdoc />
-    // TQuantity IQuantityInstanceInfo<TQuantity>.Create(QuantityValue value, UnitKey unitKey)
-    // {
-    //     return From(value, unitKey.ToUnit<TUnit>());
-    // }
-
-    #endregion
-
-    #region Implementation of IQuantityInfo<TQuantity,TUnit>
-
-    // [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    // IReadOnlyCollection<UnitInfo<TQuantity, TUnit>> IQuantityInfo<TQuantity, TUnit>.UnitInfos
-    // {
-    //     get => UnitInfos;
-    // }
-
-    // [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-    // IUnitInfo<TQuantity, TUnit> IQuantityInfo<TQuantity, TUnit>.BaseUnitInfo
-    // {
-    //     get => BaseUnitInfo;
-    // }
-
-    // UnitInfo<TQuantity, TUnit> IQuantityInfo<TQuantity, TUnit>.this[TUnit unit]
-    // {
-    //     get => this[unit];
-    // }
-
-    // UnitInfo<TQuantity, TUnit> IQuantityInfo<TQuantity, TUnit>.GetUnitInfoFor(BaseUnits baseUnits)
-    // {
-    //     return GetUnitInfoFor(baseUnits);
-    // }
-
-    // IEnumerable<UnitInfo<TQuantity, TUnit>> IQuantityInfo<TQuantity, TUnit>.GetUnitInfosFor(BaseUnits baseUnits)
-    // {
-    //     return GetUnitInfosFor(baseUnits);
-    // }
 
     #endregion
 }


### PR DESCRIPTION
- cleaned up some commented-out bits from `QuantityInfo` and `IQuantityInfo`
- extended the test for `XXX_QuantityInfo_ReturnsQuantityInfoDescribingQuantity` with the checks for the explicit interface implementations