### PR TITLE
Making the QuantityInfoLookup public

### DIFF
--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -40,7 +40,7 @@ namespace UnitsNet
         ///     information about quantities and their associated units. It is used internally to map units
         ///     to their abbreviations and vice versa.
         /// </remarks>
-        internal QuantityInfoLookup Quantities { get; }
+        public QuantityInfoLookup Quantities { get; }
 
         /// <summary>
         /// Culture name to abbreviations. To add a custom default abbreviation, add to the beginning of the list.

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -61,7 +61,7 @@ public sealed class UnitParser
     ///     This property provides access to the <see cref="QuantityInfoLookup" /> that contains
     ///     information about all quantities and their associated units.
     /// </remarks>
-    internal QuantityInfoLookup Quantities
+    public QuantityInfoLookup Quantities
     {
         get => Abbreviations.Quantities;
     }

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -1,11 +1,6 @@
 ﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using UnitsNet.Units;
-
 namespace UnitsNet;
 
 /// <summary>
@@ -88,8 +83,5 @@ public sealed class UnitsNetSetup
     /// <summary>
     ///     The quantities and units that are loaded.
     /// </summary>
-    /// <remarks>
-    ///     Access type is <c>internal</c> until this class is matured and ready for external use.
-    /// </remarks>
-    internal QuantityInfoLookup QuantityInfoLookup { get; }
+    public QuantityInfoLookup QuantityInfoLookup { get; }
 }

--- a/UnitsNet/QuantityInfoLookup.cs
+++ b/UnitsNet/QuantityInfoLookup.cs
@@ -18,7 +18,7 @@ namespace UnitsNet;
 /// <remarks>
 ///     Access type is <c>internal</c> until this class is matured and ready for external use.
 /// </remarks>
-internal class QuantityInfoLookup
+public class QuantityInfoLookup
 {
     private readonly QuantityInfo[] _quantities;
     private readonly Lazy<QuantityByNameLookupDictionary> _quantitiesByName;


### PR DESCRIPTION
- making the `QuantityInfoLookup` type public
- exposing the `Quantities` associated with a given `UnitParser` and `UnitAbbreviationsCache`
- exposing the `QuantityInfoLookup` property of the `UnitsNetSetup`