### PR TITLE
Deprecating the Dimensions property in favor of QuantityInfo.BaseDimensions (v5)

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -286,9 +286,8 @@ namespace UnitsNet
         /// <inheritdoc cref=""IQuantity.QuantityInfo""/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref=""BaseDimensions"" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete(""This property will be removed in the next major release. Consider using {_quantity.Name}.BaseDimensions instead."")]
         public BaseDimensions Dimensions => {_quantity.Name}.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
@@ -180,9 +180,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using AbsorbedDoseOfIonizingRadiation.BaseDimensions instead.")]
         public BaseDimensions Dimensions => AbsorbedDoseOfIonizingRadiation.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -175,9 +175,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Acceleration.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Acceleration.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -178,9 +178,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using AmountOfSubstance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => AmountOfSubstance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using AmplitudeRatio.BaseDimensions instead.")]
         public BaseDimensions Dimensions => AmplitudeRatio.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -177,9 +177,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Angle.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Angle.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentEnergy.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ApparentEnergy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ApparentEnergy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ApparentPower.g.cs
@@ -171,9 +171,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ApparentPower.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ApparentPower.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -175,9 +175,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Area.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Area.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using AreaDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => AreaDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using AreaMomentOfInertia.BaseDimensions instead.")]
         public BaseDimensions Dimensions => AreaMomentOfInertia.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -191,9 +191,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using BitRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => BitRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using BrakeSpecificFuelConsumption.BaseDimensions instead.")]
         public BaseDimensions Dimensions => BrakeSpecificFuelConsumption.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Capacitance.g.cs
@@ -172,9 +172,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Capacitance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Capacitance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using CoefficientOfThermalExpansion.BaseDimensions instead.")]
         public BaseDimensions Dimensions => CoefficientOfThermalExpansion.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Compressibility.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Compressibility.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -220,9 +220,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Density.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Density.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
@@ -184,9 +184,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using DoseAreaProduct.BaseDimensions instead.")]
         public BaseDimensions Dimensions => DoseAreaProduct.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Duration.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Duration.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using DynamicViscosity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => DynamicViscosity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -181,9 +181,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricAdmittance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricAdmittance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricApparentEnergy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricApparentEnergy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricApparentPower.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricApparentPower.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
@@ -171,9 +171,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricCapacitance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricCapacitance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -175,9 +175,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricCharge.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricCharge.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricChargeDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricChargeDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -180,9 +180,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricConductance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricConductance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricConductivity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricConductivity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricCurrent.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricCurrent.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricCurrentDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricCurrentDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricCurrentGradient.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricCurrentGradient.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricField.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricField.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricImpedance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricImpedance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -169,9 +169,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricInductance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricInductance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricPotential.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricPotential.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialAc.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricPotentialAc.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricPotentialAc.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -181,9 +181,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricPotentialChangeRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricPotentialChangeRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialDc.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricPotentialDc.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricPotentialDc.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
@@ -172,9 +172,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricReactance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricReactance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricReactiveEnergy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricReactiveEnergy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricReactivePower.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricReactivePower.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -172,9 +172,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricResistance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricResistance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -178,9 +178,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricResistivity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricResistivity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricSurfaceChargeDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricSurfaceChargeDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
@@ -180,9 +180,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ElectricSusceptance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ElectricSusceptance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -201,9 +201,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Energy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Energy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using EnergyDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => EnergyDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Entropy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Entropy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
@@ -183,9 +183,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using FluidResistance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => FluidResistance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -176,9 +176,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Force.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Force.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -176,9 +176,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ForceChangeRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ForceChangeRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -199,9 +199,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ForcePerLength.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ForcePerLength.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Frequency.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Frequency.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using FuelEfficiency.BaseDimensions instead.")]
         public BaseDimensions Dimensions => FuelEfficiency.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -179,9 +179,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using HeatFlux.BaseDimensions instead.")]
         public BaseDimensions Dimensions => HeatFlux.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using HeatTransferCoefficient.BaseDimensions instead.")]
         public BaseDimensions Dimensions => HeatTransferCoefficient.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Illuminance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Illuminance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Impulse.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Impulse.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -188,9 +188,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Information.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Information.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -175,9 +175,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Irradiance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Irradiance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Irradiation.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Irradiation.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
@@ -172,9 +172,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Jerk.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Jerk.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using KinematicViscosity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => KinematicViscosity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using LeakRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => LeakRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -203,9 +203,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Length.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Length.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -163,9 +163,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Level.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Level.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -182,9 +182,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using LinearDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => LinearDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -189,9 +189,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using LinearPowerDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => LinearPowerDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Luminance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Luminance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -178,9 +178,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Luminosity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Luminosity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using LuminousFlux.BaseDimensions instead.")]
         public BaseDimensions Dimensions => LuminousFlux.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using LuminousIntensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => LuminousIntensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MagneticField.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MagneticField.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MagneticFlux.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MagneticFlux.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Magnetization.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Magnetization.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -188,9 +188,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Mass.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Mass.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -213,9 +213,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MassConcentration.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MassConcentration.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -194,9 +194,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MassFlow.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MassFlow.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MassFlux.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MassFlux.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
@@ -188,9 +188,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MassFraction.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MassFraction.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -189,9 +189,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MassMomentOfInertia.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MassMomentOfInertia.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Molality.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Molality.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MolarEnergy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MolarEnergy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MolarEntropy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MolarEntropy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MolarFlow.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MolarFlow.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using MolarMass.BaseDimensions instead.")]
         public BaseDimensions Dimensions => MolarMass.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -175,9 +175,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Molarity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Molarity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Permeability.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Permeability.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Permittivity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Permittivity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
@@ -169,9 +169,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using PorousMediumPermeability.BaseDimensions instead.")]
         public BaseDimensions Dimensions => PorousMediumPermeability.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -189,9 +189,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Power.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Power.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -205,9 +205,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using PowerDensity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => PowerDensity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -163,9 +163,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using PowerRatio.BaseDimensions instead.")]
         public BaseDimensions Dimensions => PowerRatio.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -210,9 +210,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Pressure.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Pressure.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -179,9 +179,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using PressureChangeRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => PressureChangeRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RadiationEquivalentDose.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RadiationEquivalentDose.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
@@ -171,9 +171,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RadiationEquivalentDoseRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RadiationEquivalentDoseRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
@@ -169,9 +169,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RadiationExposure.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RadiationExposure.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
@@ -190,9 +190,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Radioactivity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Radioactivity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Ratio.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Ratio.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
@@ -163,9 +163,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RatioChangeRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RatioChangeRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactiveEnergy.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ReactiveEnergy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ReactiveEnergy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReactivePower.g.cs
@@ -169,9 +169,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ReactivePower.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ReactivePower.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -175,9 +175,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ReciprocalArea.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ReciprocalArea.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ReciprocalLength.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ReciprocalLength.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
@@ -162,9 +162,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RelativeHumidity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RelativeHumidity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RotationalAcceleration.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RotationalAcceleration.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -174,9 +174,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RotationalSpeed.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RotationalSpeed.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -194,9 +194,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RotationalStiffness.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RotationalStiffness.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -166,9 +166,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using RotationalStiffnessPerLength.BaseDimensions instead.")]
         public BaseDimensions Dimensions => RotationalStiffnessPerLength.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -162,9 +162,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Scalar.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Scalar.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using SolidAngle.BaseDimensions instead.")]
         public BaseDimensions Dimensions => SolidAngle.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -194,9 +194,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using SpecificEnergy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => SpecificEnergy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using SpecificEntropy.BaseDimensions instead.")]
         public BaseDimensions Dimensions => SpecificEntropy.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using SpecificFuelConsumption.BaseDimensions instead.")]
         public BaseDimensions Dimensions => SpecificFuelConsumption.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -164,9 +164,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using SpecificVolume.BaseDimensions instead.")]
         public BaseDimensions Dimensions => SpecificVolume.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -181,9 +181,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using SpecificWeight.BaseDimensions instead.")]
         public BaseDimensions Dimensions => SpecificWeight.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -194,9 +194,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Speed.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Speed.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using StandardVolumeFlow.BaseDimensions instead.")]
         public BaseDimensions Dimensions => StandardVolumeFlow.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -168,9 +168,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Temperature.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Temperature.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -178,9 +178,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using TemperatureChangeRate.BaseDimensions instead.")]
         public BaseDimensions Dimensions => TemperatureChangeRate.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using TemperatureDelta.BaseDimensions instead.")]
         public BaseDimensions Dimensions => TemperatureDelta.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using TemperatureGradient.BaseDimensions instead.")]
         public BaseDimensions Dimensions => TemperatureGradient.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -166,9 +166,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ThermalConductivity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ThermalConductivity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using ThermalResistance.BaseDimensions instead.")]
         public BaseDimensions Dimensions => ThermalResistance.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -186,9 +186,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Torque.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Torque.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TorquePerLength.g.cs
@@ -182,9 +182,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using TorquePerLength.BaseDimensions instead.")]
         public BaseDimensions Dimensions => TorquePerLength.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
@@ -165,9 +165,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Turbidity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Turbidity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -162,9 +162,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using VitaminA.BaseDimensions instead.")]
         public BaseDimensions Dimensions => VitaminA.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -215,9 +215,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using Volume.BaseDimensions instead.")]
         public BaseDimensions Dimensions => Volume.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
@@ -184,9 +184,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using VolumeConcentration.BaseDimensions instead.")]
         public BaseDimensions Dimensions => VolumeConcentration.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -236,9 +236,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using VolumeFlow.BaseDimensions instead.")]
         public BaseDimensions Dimensions => VolumeFlow.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
@@ -163,9 +163,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using VolumeFlowPerArea.BaseDimensions instead.")]
         public BaseDimensions Dimensions => VolumeFlowPerArea.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -170,9 +170,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using VolumePerLength.BaseDimensions instead.")]
         public BaseDimensions Dimensions => VolumePerLength.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -173,9 +173,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using VolumetricHeatCapacity.BaseDimensions instead.")]
         public BaseDimensions Dimensions => VolumetricHeatCapacity.BaseDimensions;
 
         #endregion

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -167,9 +167,8 @@ namespace UnitsNet
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
         QuantityInfo IQuantity.QuantityInfo => Info;
 
-        /// <summary>
-        ///     The <see cref="BaseDimensions" /> of this quantity.
-        /// </summary>
+        /// <inheritdoc />
+        [Obsolete("This property will be removed in the next major release. Consider using WarpingMomentOfInertia.BaseDimensions instead.")]
         public BaseDimensions Dimensions => WarpingMomentOfInertia.BaseDimensions;
 
         #endregion

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -18,6 +18,7 @@ namespace UnitsNet
         /// <summary>
         ///     The <see cref="BaseDimensions" /> of this quantity.
         /// </summary>
+        [Obsolete("This property will be removed in the next major release. Consider using QuantityInfo.BaseDimensions instead.")]
         BaseDimensions Dimensions { get; }
 
         /// <summary>


### PR DESCRIPTION
- `IQuantity`: deprecating the `Dimensions` property in favor of `QuantityInfo.BaseDimensions`
- `TQuantity`: deprecating the `Dimensions` property in favor of `TQuantity.BaseDimensions`