### PR TITLE
Exposing the operator IDivisionOperators<TSelf, TSelf, double>

### DIFF
--- a/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct AbsorbedDoseOfIonizingRadiation :
         IArithmeticQuantity<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiation, double>,
         IComparisonOperators<AbsorbedDoseOfIonizingRadiation, AbsorbedDoseOfIonizingRadiation, bool>,
         IParsable<AbsorbedDoseOfIonizingRadiation>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -39,13 +39,12 @@ namespace UnitsNet
     public readonly partial struct Acceleration :
         IArithmeticQuantity<Acceleration, AccelerationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Acceleration, Acceleration, double>,
         IDivisionOperators<Acceleration, Jerk, Duration>,
         IMultiplyOperators<Acceleration, Mass, Force>,
         IDivisionOperators<Acceleration, Duration, Jerk>,
         IMultiplyOperators<Acceleration, Density, SpecificWeight>,
         IMultiplyOperators<Acceleration, Duration, Speed>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Acceleration, Acceleration, bool>,
         IParsable<Acceleration>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -39,14 +39,13 @@ namespace UnitsNet
     public readonly partial struct AmountOfSubstance :
         IArithmeticQuantity<AmountOfSubstance, AmountOfSubstanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<AmountOfSubstance, AmountOfSubstance, double>,
         IDivisionOperators<AmountOfSubstance, MolarFlow, Duration>,
         IMultiplyOperators<AmountOfSubstance, MolarEnergy, Energy>,
         IMultiplyOperators<AmountOfSubstance, MolarMass, Mass>,
         IDivisionOperators<AmountOfSubstance, Duration, MolarFlow>,
         IDivisionOperators<AmountOfSubstance, Volume, Molarity>,
         IDivisionOperators<AmountOfSubstance, Molarity, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<AmountOfSubstance, AmountOfSubstance, bool>,
         IParsable<AmountOfSubstance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct AmplitudeRatio :
         ILogarithmicQuantity<AmplitudeRatio, AmplitudeRatioUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<AmplitudeRatio, AmplitudeRatio, double>,
         IComparisonOperators<AmplitudeRatio, AmplitudeRatio, bool>,
         IParsable<AmplitudeRatio>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -39,11 +39,10 @@ namespace UnitsNet
     public readonly partial struct Angle :
         IArithmeticQuantity<Angle, AngleUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Angle, Angle, double>,
         IDivisionOperators<Angle, RotationalSpeed, Duration>,
         IDivisionOperators<Angle, Duration, RotationalSpeed>,
         IMultiplyOperators<Angle, RotationalStiffness, Torque>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Angle, Angle, bool>,
         IParsable<Angle>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Area :
         IArithmeticQuantity<Area, AreaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Area, Area, double>,
         IMultiplyOperators<Area, Pressure, Force>,
         IMultiplyOperators<Area, SpecificWeight, ForcePerLength>,
         IMultiplyOperators<Area, ReciprocalLength, Length>,
@@ -55,8 +56,6 @@ namespace UnitsNet
         IMultiplyOperators<Area, Length, Volume>,
         IDivisionOperators<Area, ReciprocalLength, Volume>,
         IMultiplyOperators<Area, Speed, VolumeFlow>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Area, Area, bool>,
         IParsable<Area>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct AreaDensity :
         IArithmeticQuantity<AreaDensity, AreaDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<AreaDensity, AreaDensity, double>,
         IMultiplyOperators<AreaDensity, Area, Mass>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<AreaDensity, AreaDensity, bool>,
         IParsable<AreaDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -39,10 +39,9 @@ namespace UnitsNet
     public readonly partial struct AreaMomentOfInertia :
         IArithmeticQuantity<AreaMomentOfInertia, AreaMomentOfInertiaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<AreaMomentOfInertia, AreaMomentOfInertia, double>,
         IDivisionOperators<AreaMomentOfInertia, Volume, Length>,
         IDivisionOperators<AreaMomentOfInertia, Length, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<AreaMomentOfInertia, AreaMomentOfInertia, bool>,
         IParsable<AreaMomentOfInertia>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct BitRate :
         IArithmeticQuantity<BitRate, BitRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<BitRate, BitRate, double>,
         IComparisonOperators<BitRate, BitRate, bool>,
         IParsable<BitRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -39,10 +39,9 @@ namespace UnitsNet
     public readonly partial struct BrakeSpecificFuelConsumption :
         IArithmeticQuantity<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumptionUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumption, double>,
         IMultiplyOperators<BrakeSpecificFuelConsumption, Power, MassFlow>,
         IMultiplyOperators<BrakeSpecificFuelConsumption, SpecificEnergy, double>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<BrakeSpecificFuelConsumption, BrakeSpecificFuelConsumption, bool>,
         IParsable<BrakeSpecificFuelConsumption>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct CoefficientOfThermalExpansion :
         IArithmeticQuantity<CoefficientOfThermalExpansion, CoefficientOfThermalExpansionUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<CoefficientOfThermalExpansion, CoefficientOfThermalExpansion, double>,
         IMultiplyOperators<CoefficientOfThermalExpansion, TemperatureDelta, Ratio>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<CoefficientOfThermalExpansion, CoefficientOfThermalExpansion, bool>,
         IParsable<CoefficientOfThermalExpansion>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Compressibility :
         IArithmeticQuantity<Compressibility, CompressibilityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Compressibility, Compressibility, double>,
         IComparisonOperators<Compressibility, Compressibility, bool>,
         IParsable<Compressibility>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Density :
         IArithmeticQuantity<Density, DensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Density, Density, double>,
         IMultiplyOperators<Density, KinematicViscosity, DynamicViscosity>,
         IMultiplyOperators<Density, Area, LinearDensity>,
         IMultiplyOperators<Density, Volume, Mass>,
@@ -49,8 +50,6 @@ namespace UnitsNet
         IMultiplyOperators<Density, VolumeFlow, MassFlow>,
         IMultiplyOperators<Density, Speed, MassFlux>,
         IMultiplyOperators<Density, Acceleration, SpecificWeight>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Density, Density, bool>,
         IParsable<Density>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct DoseAreaProduct :
         IArithmeticQuantity<DoseAreaProduct, DoseAreaProductUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<DoseAreaProduct, DoseAreaProduct, double>,
         IComparisonOperators<DoseAreaProduct, DoseAreaProduct, bool>,
         IParsable<DoseAreaProduct>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Duration :
         IArithmeticQuantity<Duration, DurationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Duration, Duration, double>,
         IMultiplyOperators<Duration, Jerk, Acceleration>,
         IMultiplyOperators<Duration, MolarFlow, AmountOfSubstance>,
         IMultiplyOperators<Duration, RotationalSpeed, Angle>,
@@ -54,8 +55,6 @@ namespace UnitsNet
         IMultiplyOperators<Duration, Acceleration, Speed>,
         IMultiplyOperators<Duration, TemperatureChangeRate, TemperatureDelta>,
         IMultiplyOperators<Duration, VolumeFlow, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Duration, Duration, bool>,
         IParsable<Duration>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -42,10 +42,9 @@ namespace UnitsNet
     public readonly partial struct DynamicViscosity :
         IArithmeticQuantity<DynamicViscosity, DynamicViscosityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<DynamicViscosity, DynamicViscosity, double>,
         IDivisionOperators<DynamicViscosity, KinematicViscosity, Density>,
         IDivisionOperators<DynamicViscosity, Density, KinematicViscosity>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<DynamicViscosity, DynamicViscosity, bool>,
         IParsable<DynamicViscosity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -43,6 +43,7 @@ namespace UnitsNet
     public readonly partial struct ElectricAdmittance :
         IArithmeticQuantity<ElectricAdmittance, ElectricAdmittanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricAdmittance, ElectricAdmittance, double>,
         IComparisonOperators<ElectricAdmittance, ElectricAdmittance, bool>,
         IParsable<ElectricAdmittance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct ElectricApparentEnergy :
         IArithmeticQuantity<ElectricApparentEnergy, ElectricApparentEnergyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricApparentEnergy, ElectricApparentEnergy, double>,
         IComparisonOperators<ElectricApparentEnergy, ElectricApparentEnergy, bool>,
         IParsable<ElectricApparentEnergy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricApparentPower :
         IArithmeticQuantity<ElectricApparentPower, ElectricApparentPowerUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricApparentPower, ElectricApparentPower, double>,
         IComparisonOperators<ElectricApparentPower, ElectricApparentPower, bool>,
         IParsable<ElectricApparentPower>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricCapacitance :
         IArithmeticQuantity<ElectricCapacitance, ElectricCapacitanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricCapacitance, ElectricCapacitance, double>,
         IComparisonOperators<ElectricCapacitance, ElectricCapacitance, bool>,
         IParsable<ElectricCapacitance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -42,11 +42,10 @@ namespace UnitsNet
     public readonly partial struct ElectricCharge :
         IArithmeticQuantity<ElectricCharge, ElectricChargeUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricCharge, ElectricCharge, double>,
         IDivisionOperators<ElectricCharge, ElectricCurrent, Duration>,
         IDivisionOperators<ElectricCharge, Duration, ElectricCurrent>,
         IMultiplyOperators<ElectricCharge, ElectricPotential, Energy>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ElectricCharge, ElectricCharge, bool>,
         IParsable<ElectricCharge>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricChargeDensity :
         IArithmeticQuantity<ElectricChargeDensity, ElectricChargeDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricChargeDensity, ElectricChargeDensity, double>,
         IComparisonOperators<ElectricChargeDensity, ElectricChargeDensity, bool>,
         IParsable<ElectricChargeDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricConductance :
         IArithmeticQuantity<ElectricConductance, ElectricConductanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricConductance, ElectricConductance, double>,
         IComparisonOperators<ElectricConductance, ElectricConductance, bool>,
         IParsable<ElectricConductance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricConductivity :
         IArithmeticQuantity<ElectricConductivity, ElectricConductivityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricConductivity, ElectricConductivity, double>,
         IComparisonOperators<ElectricConductivity, ElectricConductivity, bool>,
         IParsable<ElectricConductivity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -42,13 +42,12 @@ namespace UnitsNet
     public readonly partial struct ElectricCurrent :
         IArithmeticQuantity<ElectricCurrent, ElectricCurrentUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricCurrent, ElectricCurrent, double>,
         IDivisionOperators<ElectricCurrent, ElectricCurrentGradient, Duration>,
         IMultiplyOperators<ElectricCurrent, Duration, ElectricCharge>,
         IDivisionOperators<ElectricCurrent, Duration, ElectricCurrentGradient>,
         IMultiplyOperators<ElectricCurrent, ElectricResistance, ElectricPotential>,
         IMultiplyOperators<ElectricCurrent, ElectricPotential, Power>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ElectricCurrent, ElectricCurrent, bool>,
         IParsable<ElectricCurrent>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricCurrentDensity :
         IArithmeticQuantity<ElectricCurrentDensity, ElectricCurrentDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricCurrentDensity, ElectricCurrentDensity, double>,
         IComparisonOperators<ElectricCurrentDensity, ElectricCurrentDensity, bool>,
         IParsable<ElectricCurrentDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct ElectricCurrentGradient :
         IArithmeticQuantity<ElectricCurrentGradient, ElectricCurrentGradientUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricCurrentGradient, ElectricCurrentGradient, double>,
         IMultiplyOperators<ElectricCurrentGradient, Duration, ElectricCurrent>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ElectricCurrentGradient, ElectricCurrentGradient, bool>,
         IParsable<ElectricCurrentGradient>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricField :
         IArithmeticQuantity<ElectricField, ElectricFieldUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricField, ElectricField, double>,
         IComparisonOperators<ElectricField, ElectricField, bool>,
         IParsable<ElectricField>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
@@ -43,6 +43,7 @@ namespace UnitsNet
     public readonly partial struct ElectricImpedance :
         IArithmeticQuantity<ElectricImpedance, ElectricImpedanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricImpedance, ElectricImpedance, double>,
         IComparisonOperators<ElectricImpedance, ElectricImpedance, bool>,
         IParsable<ElectricImpedance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricInductance :
         IArithmeticQuantity<ElectricInductance, ElectricInductanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricInductance, ElectricInductance, double>,
         IComparisonOperators<ElectricInductance, ElectricInductance, bool>,
         IParsable<ElectricInductance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -42,12 +42,11 @@ namespace UnitsNet
     public readonly partial struct ElectricPotential :
         IArithmeticQuantity<ElectricPotential, ElectricPotentialUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricPotential, ElectricPotential, double>,
         IDivisionOperators<ElectricPotential, ElectricResistance, ElectricCurrent>,
         IDivisionOperators<ElectricPotential, ElectricCurrent, ElectricResistance>,
         IMultiplyOperators<ElectricPotential, ElectricCharge, Energy>,
         IMultiplyOperators<ElectricPotential, ElectricCurrent, Power>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ElectricPotential, ElectricPotential, bool>,
         IParsable<ElectricPotential>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct ElectricPotentialChangeRate :
         IArithmeticQuantity<ElectricPotentialChangeRate, ElectricPotentialChangeRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricPotentialChangeRate, ElectricPotentialChangeRate, double>,
         IComparisonOperators<ElectricPotentialChangeRate, ElectricPotentialChangeRate, bool>,
         IParsable<ElectricPotentialChangeRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricReactance :
         IArithmeticQuantity<ElectricReactance, ElectricReactanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricReactance, ElectricReactance, double>,
         IComparisonOperators<ElectricReactance, ElectricReactance, bool>,
         IParsable<ElectricReactance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct ElectricReactiveEnergy :
         IArithmeticQuantity<ElectricReactiveEnergy, ElectricReactiveEnergyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricReactiveEnergy, ElectricReactiveEnergy, double>,
         IComparisonOperators<ElectricReactiveEnergy, ElectricReactiveEnergy, bool>,
         IParsable<ElectricReactiveEnergy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricReactivePower :
         IArithmeticQuantity<ElectricReactivePower, ElectricReactivePowerUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricReactivePower, ElectricReactivePower, double>,
         IComparisonOperators<ElectricReactivePower, ElectricReactivePower, bool>,
         IParsable<ElectricReactivePower>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -42,9 +42,8 @@ namespace UnitsNet
     public readonly partial struct ElectricResistance :
         IArithmeticQuantity<ElectricResistance, ElectricResistanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricResistance, ElectricResistance, double>,
         IMultiplyOperators<ElectricResistance, ElectricCurrent, ElectricPotential>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ElectricResistance, ElectricResistance, bool>,
         IParsable<ElectricResistance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricResistivity :
         IArithmeticQuantity<ElectricResistivity, ElectricResistivityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricResistivity, ElectricResistivity, double>,
         IComparisonOperators<ElectricResistivity, ElectricResistivity, bool>,
         IParsable<ElectricResistivity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricSurfaceChargeDensity :
         IArithmeticQuantity<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensity, double>,
         IComparisonOperators<ElectricSurfaceChargeDensity, ElectricSurfaceChargeDensity, bool>,
         IParsable<ElectricSurfaceChargeDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ElectricSusceptance :
         IArithmeticQuantity<ElectricSusceptance, ElectricSusceptanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ElectricSusceptance, ElectricSusceptance, double>,
         IComparisonOperators<ElectricSusceptance, ElectricSusceptance, bool>,
         IParsable<ElectricSusceptance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Energy :
         IArithmeticQuantity<Energy, EnergyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Energy, Energy, double>,
         IDivisionOperators<Energy, MolarEnergy, AmountOfSubstance>,
         IDivisionOperators<Energy, Power, Duration>,
         IDivisionOperators<Energy, ElectricPotential, ElectricCharge>,
@@ -52,8 +53,6 @@ namespace UnitsNet
         IDivisionOperators<Energy, Mass, SpecificEnergy>,
         IDivisionOperators<Energy, Entropy, TemperatureDelta>,
         IDivisionOperators<Energy, EnergyDensity, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Energy, Energy, bool>,
         IParsable<Energy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct EnergyDensity :
         IArithmeticQuantity<EnergyDensity, EnergyDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<EnergyDensity, EnergyDensity, double>,
         IMultiplyOperators<EnergyDensity, Volume, Energy>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<EnergyDensity, EnergyDensity, bool>,
         IParsable<EnergyDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -39,11 +39,10 @@ namespace UnitsNet
     public readonly partial struct Entropy :
         IArithmeticQuantity<Entropy, EntropyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Entropy, Entropy, double>,
         IMultiplyOperators<Entropy, TemperatureDelta, Energy>,
         IDivisionOperators<Entropy, SpecificEntropy, Mass>,
         IDivisionOperators<Entropy, Mass, SpecificEntropy>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Entropy, Entropy, bool>,
         IParsable<Entropy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct FluidResistance :
         IArithmeticQuantity<FluidResistance, FluidResistanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<FluidResistance, FluidResistance, double>,
         IComparisonOperators<FluidResistance, FluidResistance, bool>,
         IParsable<FluidResistance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Force :
         IArithmeticQuantity<Force, ForceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Force, Force, double>,
         IDivisionOperators<Force, Mass, Acceleration>,
         IDivisionOperators<Force, Pressure, Area>,
         IDivisionOperators<Force, ForceChangeRate, Duration>,
@@ -51,8 +52,6 @@ namespace UnitsNet
         IMultiplyOperators<Force, ReciprocalArea, Pressure>,
         IDivisionOperators<Force, Area, Pressure>,
         IMultiplyOperators<Force, Length, Torque>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Force, Force, bool>,
         IParsable<Force>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct ForceChangeRate :
         IArithmeticQuantity<ForceChangeRate, ForceChangeRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ForceChangeRate, ForceChangeRate, double>,
         IMultiplyOperators<ForceChangeRate, Duration, Force>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ForceChangeRate, ForceChangeRate, bool>,
         IParsable<ForceChangeRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct ForcePerLength :
         IArithmeticQuantity<ForcePerLength, ForcePerLengthUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ForcePerLength, ForcePerLength, double>,
         IDivisionOperators<ForcePerLength, SpecificWeight, Area>,
         IMultiplyOperators<ForcePerLength, Length, Force>,
         IDivisionOperators<ForcePerLength, ReciprocalLength, Force>,
@@ -48,8 +49,6 @@ namespace UnitsNet
         IDivisionOperators<ForcePerLength, Force, ReciprocalLength>,
         IDivisionOperators<ForcePerLength, Area, SpecificWeight>,
         IMultiplyOperators<ForcePerLength, Area, Torque>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ForcePerLength, ForcePerLength, bool>,
         IParsable<ForcePerLength>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct Frequency :
         IArithmeticQuantity<Frequency, FrequencyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Frequency, Frequency, double>,
         IMultiplyOperators<Frequency, Energy, Power>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Frequency, Frequency, bool>,
         IParsable<Frequency>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct FuelEfficiency :
         IArithmeticQuantity<FuelEfficiency, FuelEfficiencyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<FuelEfficiency, FuelEfficiency, double>,
         IComparisonOperators<FuelEfficiency, FuelEfficiency, bool>,
         IParsable<FuelEfficiency>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct HeatFlux :
         IArithmeticQuantity<HeatFlux, HeatFluxUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<HeatFlux, HeatFlux, double>,
         IMultiplyOperators<HeatFlux, Area, Power>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<HeatFlux, HeatFlux, bool>,
         IParsable<HeatFlux>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct HeatTransferCoefficient :
         IArithmeticQuantity<HeatTransferCoefficient, HeatTransferCoefficientUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<HeatTransferCoefficient, HeatTransferCoefficient, double>,
         IComparisonOperators<HeatTransferCoefficient, HeatTransferCoefficient, bool>,
         IParsable<HeatTransferCoefficient>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -42,9 +42,8 @@ namespace UnitsNet
     public readonly partial struct Illuminance :
         IArithmeticQuantity<Illuminance, IlluminanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Illuminance, Illuminance, double>,
         IMultiplyOperators<Illuminance, Area, LuminousFlux>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Illuminance, Illuminance, bool>,
         IParsable<Illuminance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Impulse :
         IArithmeticQuantity<Impulse, ImpulseUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Impulse, Impulse, double>,
         IComparisonOperators<Impulse, Impulse, bool>,
         IParsable<Impulse>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Information :
         IArithmeticQuantity<Information, InformationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Information, Information, double>,
         IComparisonOperators<Information, Information, bool>,
         IParsable<Information>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Irradiance :
         IArithmeticQuantity<Irradiance, IrradianceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Irradiance, Irradiance, double>,
         IComparisonOperators<Irradiance, Irradiance, bool>,
         IParsable<Irradiance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Irradiation :
         IArithmeticQuantity<Irradiation, IrradiationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Irradiation, Irradiation, double>,
         IComparisonOperators<Irradiation, Irradiation, bool>,
         IParsable<Irradiation>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct Jerk :
         IArithmeticQuantity<Jerk, JerkUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Jerk, Jerk, double>,
         IMultiplyOperators<Jerk, Duration, Acceleration>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Jerk, Jerk, bool>,
         IParsable<Jerk>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -42,12 +42,11 @@ namespace UnitsNet
     public readonly partial struct KinematicViscosity :
         IArithmeticQuantity<KinematicViscosity, KinematicViscosityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<KinematicViscosity, KinematicViscosity, double>,
         IMultiplyOperators<KinematicViscosity, Duration, Area>,
         IMultiplyOperators<KinematicViscosity, Density, DynamicViscosity>,
         IDivisionOperators<KinematicViscosity, Speed, Length>,
         IDivisionOperators<KinematicViscosity, Length, Speed>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<KinematicViscosity, KinematicViscosity, bool>,
         IParsable<KinematicViscosity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct LeakRate :
         IArithmeticQuantity<LeakRate, LeakRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<LeakRate, LeakRate, double>,
         IComparisonOperators<LeakRate, LeakRate, bool>,
         IParsable<LeakRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Length :
         IArithmeticQuantity<Length, LengthUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Length, Length, double>,
         IMultiplyOperators<Length, Length, Area>,
         IDivisionOperators<Length, ReciprocalLength, Area>,
         IMultiplyOperators<Length, Volume, AreaMomentOfInertia>,
@@ -57,8 +58,6 @@ namespace UnitsNet
         IMultiplyOperators<Length, Force, Torque>,
         IMultiplyOperators<Length, Area, Volume>,
         IDivisionOperators<Length, ReciprocalArea, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Length, Length, bool>,
         IParsable<Length>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Level :
         ILogarithmicQuantity<Level, LevelUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Level, Level, double>,
         IComparisonOperators<Level, Level, bool>,
         IParsable<Level>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -42,11 +42,10 @@ namespace UnitsNet
     public readonly partial struct LinearDensity :
         IArithmeticQuantity<LinearDensity, LinearDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<LinearDensity, LinearDensity, double>,
         IDivisionOperators<LinearDensity, Density, Area>,
         IDivisionOperators<LinearDensity, Area, Density>,
         IMultiplyOperators<LinearDensity, Length, Mass>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<LinearDensity, LinearDensity, bool>,
         IParsable<LinearDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct LinearPowerDensity :
         IArithmeticQuantity<LinearPowerDensity, LinearPowerDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<LinearPowerDensity, LinearPowerDensity, double>,
         IComparisonOperators<LinearPowerDensity, LinearPowerDensity, bool>,
         IParsable<LinearPowerDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
@@ -42,9 +42,8 @@ namespace UnitsNet
     public readonly partial struct Luminance :
         IArithmeticQuantity<Luminance, LuminanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Luminance, Luminance, double>,
         IMultiplyOperators<Luminance, Area, LuminousIntensity>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Luminance, Luminance, bool>,
         IParsable<Luminance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Luminosity :
         IArithmeticQuantity<Luminosity, LuminosityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Luminosity, Luminosity, double>,
         IComparisonOperators<Luminosity, Luminosity, bool>,
         IParsable<Luminosity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -42,10 +42,9 @@ namespace UnitsNet
     public readonly partial struct LuminousFlux :
         IArithmeticQuantity<LuminousFlux, LuminousFluxUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<LuminousFlux, LuminousFlux, double>,
         IDivisionOperators<LuminousFlux, Illuminance, Area>,
         IDivisionOperators<LuminousFlux, Area, Illuminance>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<LuminousFlux, LuminousFlux, bool>,
         IParsable<LuminousFlux>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -42,10 +42,9 @@ namespace UnitsNet
     public readonly partial struct LuminousIntensity :
         IArithmeticQuantity<LuminousIntensity, LuminousIntensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<LuminousIntensity, LuminousIntensity, double>,
         IDivisionOperators<LuminousIntensity, Luminance, Area>,
         IDivisionOperators<LuminousIntensity, Area, Luminance>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<LuminousIntensity, LuminousIntensity, bool>,
         IParsable<LuminousIntensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct MagneticField :
         IArithmeticQuantity<MagneticField, MagneticFieldUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MagneticField, MagneticField, double>,
         IComparisonOperators<MagneticField, MagneticField, bool>,
         IParsable<MagneticField>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct MagneticFlux :
         IArithmeticQuantity<MagneticFlux, MagneticFluxUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MagneticFlux, MagneticFlux, double>,
         IComparisonOperators<MagneticFlux, MagneticFlux, bool>,
         IParsable<MagneticFlux>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Magnetization :
         IArithmeticQuantity<Magnetization, MagnetizationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Magnetization, Magnetization, double>,
         IComparisonOperators<Magnetization, Magnetization, bool>,
         IParsable<Magnetization>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Mass :
         IArithmeticQuantity<Mass, MassUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Mass, Mass, double>,
         IDivisionOperators<Mass, MolarMass, AmountOfSubstance>,
         IDivisionOperators<Mass, AreaDensity, Area>,
         IDivisionOperators<Mass, Area, AreaDensity>,
@@ -55,8 +56,6 @@ namespace UnitsNet
         IDivisionOperators<Mass, AmountOfSubstance, MolarMass>,
         IMultiplyOperators<Mass, SpecificVolume, Volume>,
         IDivisionOperators<Mass, Density, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Mass, Mass, bool>,
         IParsable<Mass>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -42,13 +42,12 @@ namespace UnitsNet
     public readonly partial struct MassConcentration :
         IArithmeticQuantity<MassConcentration, MassConcentrationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MassConcentration, MassConcentration, double>,
         IDivisionOperators<MassConcentration, VolumeConcentration, Density>,
         IMultiplyOperators<MassConcentration, Volume, Mass>,
         IDivisionOperators<MassConcentration, Molarity, MolarMass>,
         IDivisionOperators<MassConcentration, MolarMass, Molarity>,
         IDivisionOperators<MassConcentration, Density, VolumeConcentration>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MassConcentration, MassConcentration, bool>,
         IParsable<MassConcentration>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct MassFlow :
         IArithmeticQuantity<MassFlow, MassFlowUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MassFlow, MassFlow, double>,
         IDivisionOperators<MassFlow, MassFlux, Area>,
         IDivisionOperators<MassFlow, Power, BrakeSpecificFuelConsumption>,
         IDivisionOperators<MassFlow, VolumeFlow, Density>,
@@ -49,8 +50,6 @@ namespace UnitsNet
         IMultiplyOperators<MassFlow, SpecificEnergy, Power>,
         IDivisionOperators<MassFlow, BrakeSpecificFuelConsumption, Power>,
         IDivisionOperators<MassFlow, Density, VolumeFlow>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MassFlow, MassFlow, bool>,
         IParsable<MassFlow>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -39,11 +39,10 @@ namespace UnitsNet
     public readonly partial struct MassFlux :
         IArithmeticQuantity<MassFlux, MassFluxUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MassFlux, MassFlux, double>,
         IDivisionOperators<MassFlux, Speed, Density>,
         IMultiplyOperators<MassFlux, Area, MassFlow>,
         IDivisionOperators<MassFlux, Density, Speed>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MassFlux, MassFlux, bool>,
         IParsable<MassFlux>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
@@ -42,9 +42,8 @@ namespace UnitsNet
     public readonly partial struct MassFraction :
         IArithmeticQuantity<MassFraction, MassFractionUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MassFraction, MassFraction, double>,
         IMultiplyOperators<MassFraction, Mass, Mass>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MassFraction, MassFraction, bool>,
         IParsable<MassFraction>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct MassMomentOfInertia :
         IArithmeticQuantity<MassMomentOfInertia, MassMomentOfInertiaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MassMomentOfInertia, MassMomentOfInertia, double>,
         IComparisonOperators<MassMomentOfInertia, MassMomentOfInertia, bool>,
         IParsable<MassMomentOfInertia>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Molality :
         IArithmeticQuantity<Molality, MolalityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Molality, Molality, double>,
         IComparisonOperators<Molality, Molality, bool>,
         IParsable<Molality>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct MolarEnergy :
         IArithmeticQuantity<MolarEnergy, MolarEnergyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MolarEnergy, MolarEnergy, double>,
         IMultiplyOperators<MolarEnergy, AmountOfSubstance, Energy>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MolarEnergy, MolarEnergy, bool>,
         IParsable<MolarEnergy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct MolarEntropy :
         IArithmeticQuantity<MolarEntropy, MolarEntropyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MolarEntropy, MolarEntropy, double>,
         IComparisonOperators<MolarEntropy, MolarEntropy, bool>,
         IParsable<MolarEntropy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
@@ -39,12 +39,11 @@ namespace UnitsNet
     public readonly partial struct MolarFlow :
         IArithmeticQuantity<MolarFlow, MolarFlowUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MolarFlow, MolarFlow, double>,
         IMultiplyOperators<MolarFlow, Duration, AmountOfSubstance>,
         IMultiplyOperators<MolarFlow, MolarMass, MassFlow>,
         IDivisionOperators<MolarFlow, VolumeFlow, Molarity>,
         IDivisionOperators<MolarFlow, Molarity, VolumeFlow>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MolarFlow, MolarFlow, bool>,
         IParsable<MolarFlow>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -39,11 +39,10 @@ namespace UnitsNet
     public readonly partial struct MolarMass :
         IArithmeticQuantity<MolarMass, MolarMassUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<MolarMass, MolarMass, double>,
         IMultiplyOperators<MolarMass, AmountOfSubstance, Mass>,
         IMultiplyOperators<MolarMass, Molarity, MassConcentration>,
         IMultiplyOperators<MolarMass, MolarFlow, MassFlow>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<MolarMass, MolarMass, bool>,
         IParsable<MolarMass>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -42,13 +42,12 @@ namespace UnitsNet
     public readonly partial struct Molarity :
         IArithmeticQuantity<Molarity, MolarityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Molarity, Molarity, double>,
         IMultiplyOperators<Molarity, Volume, AmountOfSubstance>,
         IMultiplyOperators<Molarity, MolarMass, MassConcentration>,
         IMultiplyOperators<Molarity, VolumeFlow, MolarFlow>,
         IMultiplyOperators<Molarity, VolumeConcentration, Molarity>,
         IDivisionOperators<Molarity, VolumeConcentration, Molarity>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Molarity, Molarity, bool>,
         IParsable<Molarity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Permeability :
         IArithmeticQuantity<Permeability, PermeabilityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Permeability, Permeability, double>,
         IComparisonOperators<Permeability, Permeability, bool>,
         IParsable<Permeability>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Permittivity :
         IArithmeticQuantity<Permittivity, PermittivityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Permittivity, Permittivity, double>,
         IComparisonOperators<Permittivity, Permittivity, bool>,
         IParsable<Permittivity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct PorousMediumPermeability :
         IArithmeticQuantity<PorousMediumPermeability, PorousMediumPermeabilityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<PorousMediumPermeability, PorousMediumPermeability, double>,
         IComparisonOperators<PorousMediumPermeability, PorousMediumPermeability, bool>,
         IParsable<PorousMediumPermeability>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Power :
         IArithmeticQuantity<Power, PowerUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Power, Power, double>,
         IDivisionOperators<Power, HeatFlux, Area>,
         IDivisionOperators<Power, ElectricPotential, ElectricCurrent>,
         IDivisionOperators<Power, ElectricCurrent, ElectricPotential>,
@@ -53,8 +54,6 @@ namespace UnitsNet
         IDivisionOperators<Power, MassFlow, SpecificEnergy>,
         IDivisionOperators<Power, Force, Speed>,
         IDivisionOperators<Power, RotationalSpeed, Torque>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Power, Power, bool>,
         IParsable<Power>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct PowerDensity :
         IArithmeticQuantity<PowerDensity, PowerDensityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<PowerDensity, PowerDensity, double>,
         IComparisonOperators<PowerDensity, PowerDensity, bool>,
         IParsable<PowerDensity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct PowerRatio :
         ILogarithmicQuantity<PowerRatio, PowerRatioUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<PowerRatio, PowerRatio, double>,
         IComparisonOperators<PowerRatio, PowerRatio, bool>,
         IParsable<PowerRatio>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Pressure :
         IArithmeticQuantity<Pressure, PressureUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Pressure, Pressure, double>,
         IDivisionOperators<Pressure, PressureChangeRate, Duration>,
         IDivisionOperators<Pressure, ReciprocalArea, Force>,
         IMultiplyOperators<Pressure, Area, Force>,
@@ -49,8 +50,6 @@ namespace UnitsNet
         IDivisionOperators<Pressure, Force, ReciprocalArea>,
         IDivisionOperators<Pressure, ForcePerLength, ReciprocalLength>,
         IDivisionOperators<Pressure, Length, SpecificWeight>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Pressure, Pressure, bool>,
         IParsable<Pressure>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct PressureChangeRate :
         IArithmeticQuantity<PressureChangeRate, PressureChangeRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<PressureChangeRate, PressureChangeRate, double>,
         IMultiplyOperators<PressureChangeRate, Duration, Pressure>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<PressureChangeRate, PressureChangeRate, bool>,
         IParsable<PressureChangeRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
@@ -39,10 +39,9 @@ namespace UnitsNet
     public readonly partial struct RadiationEquivalentDose :
         IArithmeticQuantity<RadiationEquivalentDose, RadiationEquivalentDoseUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RadiationEquivalentDose, RadiationEquivalentDose, double>,
         IDivisionOperators<RadiationEquivalentDose, RadiationEquivalentDoseRate, Duration>,
         IDivisionOperators<RadiationEquivalentDose, Duration, RadiationEquivalentDoseRate>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<RadiationEquivalentDose, RadiationEquivalentDose, bool>,
         IParsable<RadiationEquivalentDose>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct RadiationEquivalentDoseRate :
         IArithmeticQuantity<RadiationEquivalentDoseRate, RadiationEquivalentDoseRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RadiationEquivalentDoseRate, RadiationEquivalentDoseRate, double>,
         IMultiplyOperators<RadiationEquivalentDoseRate, Duration, RadiationEquivalentDose>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<RadiationEquivalentDoseRate, RadiationEquivalentDoseRate, bool>,
         IParsable<RadiationEquivalentDoseRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct RadiationExposure :
         IArithmeticQuantity<RadiationExposure, RadiationExposureUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RadiationExposure, RadiationExposure, double>,
         IComparisonOperators<RadiationExposure, RadiationExposure, bool>,
         IParsable<RadiationExposure>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Radioactivity :
         IArithmeticQuantity<Radioactivity, RadioactivityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Radioactivity, Radioactivity, double>,
         IComparisonOperators<Radioactivity, Radioactivity, bool>,
         IParsable<Radioactivity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Ratio :
         IArithmeticQuantity<Ratio, RatioUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Ratio, Ratio, double>,
         IComparisonOperators<Ratio, Ratio, bool>,
         IParsable<Ratio>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct RatioChangeRate :
         IArithmeticQuantity<RatioChangeRate, RatioChangeRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RatioChangeRate, RatioChangeRate, double>,
         IComparisonOperators<RatioChangeRate, RatioChangeRate, bool>,
         IParsable<RatioChangeRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -42,13 +42,12 @@ namespace UnitsNet
     public readonly partial struct ReciprocalArea :
         IArithmeticQuantity<ReciprocalArea, ReciprocalAreaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ReciprocalArea, ReciprocalArea, double>,
         IMultiplyOperators<ReciprocalArea, Volume, Length>,
         IMultiplyOperators<ReciprocalArea, Force, Pressure>,
         IMultiplyOperators<ReciprocalArea, Area, Ratio>,
         IMultiplyOperators<ReciprocalArea, Length, ReciprocalLength>,
         IDivisionOperators<ReciprocalArea, ReciprocalLength, ReciprocalLength>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ReciprocalArea, ReciprocalArea, bool>,
         IParsable<ReciprocalArea>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ReciprocalLength :
         IArithmeticQuantity<ReciprocalLength, ReciprocalLengthUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ReciprocalLength, ReciprocalLength, double>,
         IMultiplyOperators<ReciprocalLength, Volume, Area>,
         IMultiplyOperators<ReciprocalLength, Force, ForcePerLength>,
         IMultiplyOperators<ReciprocalLength, Area, Length>,
@@ -49,8 +50,6 @@ namespace UnitsNet
         IMultiplyOperators<ReciprocalLength, ForcePerLength, Pressure>,
         IMultiplyOperators<ReciprocalLength, ReciprocalLength, ReciprocalArea>,
         IDivisionOperators<ReciprocalLength, Length, ReciprocalArea>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<ReciprocalLength, ReciprocalLength, bool>,
         IParsable<ReciprocalLength>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct RelativeHumidity :
         IArithmeticQuantity<RelativeHumidity, RelativeHumidityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RelativeHumidity, RelativeHumidity, double>,
         IComparisonOperators<RelativeHumidity, RelativeHumidity, bool>,
         IParsable<RelativeHumidity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct RotationalAcceleration :
         IArithmeticQuantity<RotationalAcceleration, RotationalAccelerationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RotationalAcceleration, RotationalAcceleration, double>,
         IComparisonOperators<RotationalAcceleration, RotationalAcceleration, bool>,
         IParsable<RotationalAcceleration>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -39,10 +39,9 @@ namespace UnitsNet
     public readonly partial struct RotationalSpeed :
         IArithmeticQuantity<RotationalSpeed, RotationalSpeedUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RotationalSpeed, RotationalSpeed, double>,
         IMultiplyOperators<RotationalSpeed, Duration, Angle>,
         IMultiplyOperators<RotationalSpeed, Torque, Power>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<RotationalSpeed, RotationalSpeed, bool>,
         IParsable<RotationalSpeed>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -39,11 +39,10 @@ namespace UnitsNet
     public readonly partial struct RotationalStiffness :
         IArithmeticQuantity<RotationalStiffness, RotationalStiffnessUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RotationalStiffness, RotationalStiffness, double>,
         IDivisionOperators<RotationalStiffness, RotationalStiffnessPerLength, Length>,
         IDivisionOperators<RotationalStiffness, Length, RotationalStiffnessPerLength>,
         IMultiplyOperators<RotationalStiffness, Angle, Torque>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<RotationalStiffness, RotationalStiffness, bool>,
         IParsable<RotationalStiffness>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct RotationalStiffnessPerLength :
         IArithmeticQuantity<RotationalStiffnessPerLength, RotationalStiffnessPerLengthUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<RotationalStiffnessPerLength, RotationalStiffnessPerLength, double>,
         IMultiplyOperators<RotationalStiffnessPerLength, Length, RotationalStiffness>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<RotationalStiffnessPerLength, RotationalStiffnessPerLength, bool>,
         IParsable<RotationalStiffnessPerLength>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Scalar :
         IArithmeticQuantity<Scalar, ScalarUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Scalar, Scalar, double>,
         IComparisonOperators<Scalar, Scalar, bool>,
         IParsable<Scalar>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct SolidAngle :
         IArithmeticQuantity<SolidAngle, SolidAngleUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<SolidAngle, SolidAngle, double>,
         IComparisonOperators<SolidAngle, SolidAngle, bool>,
         IParsable<SolidAngle>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -42,14 +42,13 @@ namespace UnitsNet
     public readonly partial struct SpecificEnergy :
         IArithmeticQuantity<SpecificEnergy, SpecificEnergyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<SpecificEnergy, SpecificEnergy, double>,
         IMultiplyOperators<SpecificEnergy, Mass, Energy>,
         IMultiplyOperators<SpecificEnergy, MassFlow, Power>,
         IDivisionOperators<SpecificEnergy, TemperatureDelta, SpecificEntropy>,
         IDivisionOperators<SpecificEnergy, Speed, Speed>,
         IDivisionOperators<SpecificEnergy, SpecificEntropy, TemperatureDelta>,
         IMultiplyOperators<SpecificEnergy, BrakeSpecificFuelConsumption, double>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<SpecificEnergy, SpecificEnergy, bool>,
         IParsable<SpecificEnergy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -39,10 +39,9 @@ namespace UnitsNet
     public readonly partial struct SpecificEntropy :
         IArithmeticQuantity<SpecificEntropy, SpecificEntropyUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<SpecificEntropy, SpecificEntropy, double>,
         IMultiplyOperators<SpecificEntropy, Mass, Entropy>,
         IMultiplyOperators<SpecificEntropy, TemperatureDelta, SpecificEnergy>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<SpecificEntropy, SpecificEntropy, bool>,
         IParsable<SpecificEntropy>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct SpecificFuelConsumption :
         IArithmeticQuantity<SpecificFuelConsumption, SpecificFuelConsumptionUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<SpecificFuelConsumption, SpecificFuelConsumption, double>,
         IComparisonOperators<SpecificFuelConsumption, SpecificFuelConsumption, bool>,
         IParsable<SpecificFuelConsumption>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct SpecificVolume :
         IArithmeticQuantity<SpecificVolume, SpecificVolumeUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<SpecificVolume, SpecificVolume, double>,
         IMultiplyOperators<SpecificVolume, Mass, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<SpecificVolume, SpecificVolume, bool>,
         IParsable<SpecificVolume>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -42,12 +42,11 @@ namespace UnitsNet
     public readonly partial struct SpecificWeight :
         IArithmeticQuantity<SpecificWeight, SpecificWeightUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<SpecificWeight, SpecificWeight, double>,
         IDivisionOperators<SpecificWeight, Density, Acceleration>,
         IDivisionOperators<SpecificWeight, Acceleration, Density>,
         IMultiplyOperators<SpecificWeight, Area, ForcePerLength>,
         IMultiplyOperators<SpecificWeight, Length, Pressure>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<SpecificWeight, SpecificWeight, bool>,
         IParsable<SpecificWeight>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Speed :
         IArithmeticQuantity<Speed, SpeedUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Speed, Speed, double>,
         IDivisionOperators<Speed, Duration, Acceleration>,
         IDivisionOperators<Speed, Acceleration, Duration>,
         IMultiplyOperators<Speed, Length, KinematicViscosity>,
@@ -47,8 +48,6 @@ namespace UnitsNet
         IMultiplyOperators<Speed, Force, Power>,
         IMultiplyOperators<Speed, Speed, SpecificEnergy>,
         IMultiplyOperators<Speed, Area, VolumeFlow>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Speed, Speed, bool>,
         IParsable<Speed>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct StandardVolumeFlow :
         IArithmeticQuantity<StandardVolumeFlow, StandardVolumeFlowUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<StandardVolumeFlow, StandardVolumeFlow, double>,
         IComparisonOperators<StandardVolumeFlow, StandardVolumeFlow, bool>,
         IParsable<StandardVolumeFlow>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct TemperatureChangeRate :
         IArithmeticQuantity<TemperatureChangeRate, TemperatureChangeRateUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<TemperatureChangeRate, TemperatureChangeRate, double>,
         IMultiplyOperators<TemperatureChangeRate, Duration, TemperatureDelta>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<TemperatureChangeRate, TemperatureChangeRate, bool>,
         IParsable<TemperatureChangeRate>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct TemperatureDelta :
         IArithmeticQuantity<TemperatureDelta, TemperatureDeltaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<TemperatureDelta, TemperatureDelta, double>,
         IDivisionOperators<TemperatureDelta, TemperatureChangeRate, Duration>,
         IMultiplyOperators<TemperatureDelta, Entropy, Energy>,
         IDivisionOperators<TemperatureDelta, TemperatureGradient, Length>,
@@ -46,8 +47,6 @@ namespace UnitsNet
         IMultiplyOperators<TemperatureDelta, SpecificEntropy, SpecificEnergy>,
         IDivisionOperators<TemperatureDelta, Duration, TemperatureChangeRate>,
         IDivisionOperators<TemperatureDelta, Length, TemperatureGradient>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<TemperatureDelta, TemperatureDelta, bool>,
         IParsable<TemperatureDelta>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -39,9 +39,8 @@ namespace UnitsNet
     public readonly partial struct TemperatureGradient :
         IArithmeticQuantity<TemperatureGradient, TemperatureGradientUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<TemperatureGradient, TemperatureGradient, double>,
         IMultiplyOperators<TemperatureGradient, Length, TemperatureDelta>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<TemperatureGradient, TemperatureGradient, bool>,
         IParsable<TemperatureGradient>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct ThermalConductivity :
         IArithmeticQuantity<ThermalConductivity, ThermalConductivityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ThermalConductivity, ThermalConductivity, double>,
         IComparisonOperators<ThermalConductivity, ThermalConductivity, bool>,
         IParsable<ThermalConductivity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ThermalInsulance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalInsulance.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct ThermalInsulance :
         IArithmeticQuantity<ThermalInsulance, ThermalInsulanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ThermalInsulance, ThermalInsulance, double>,
         IComparisonOperators<ThermalInsulance, ThermalInsulance, bool>,
         IParsable<ThermalInsulance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct ThermalResistance :
         IArithmeticQuantity<ThermalResistance, ThermalResistanceUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<ThermalResistance, ThermalResistance, double>,
         IComparisonOperators<ThermalResistance, ThermalResistance, bool>,
         IParsable<ThermalResistance>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Torque :
         IArithmeticQuantity<Torque, TorqueUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Torque, Torque, double>,
         IDivisionOperators<Torque, RotationalStiffness, Angle>,
         IDivisionOperators<Torque, ForcePerLength, Area>,
         IDivisionOperators<Torque, Length, Force>,
@@ -46,8 +47,6 @@ namespace UnitsNet
         IDivisionOperators<Torque, Force, Length>,
         IMultiplyOperators<Torque, RotationalSpeed, Power>,
         IDivisionOperators<Torque, Angle, RotationalStiffness>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Torque, Torque, bool>,
         IParsable<Torque>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct Turbidity :
         IArithmeticQuantity<Turbidity, TurbidityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Turbidity, Turbidity, double>,
         IComparisonOperators<Turbidity, Turbidity, bool>,
         IParsable<Turbidity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct VitaminA :
         IArithmeticQuantity<VitaminA, VitaminAUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<VitaminA, VitaminA, double>,
         IComparisonOperators<VitaminA, VitaminA, bool>,
         IParsable<VitaminA>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct Volume :
         IArithmeticQuantity<Volume, VolumeUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<Volume, Volume, double>,
         IMultiplyOperators<Volume, Molarity, AmountOfSubstance>,
         IMultiplyOperators<Volume, ReciprocalLength, Area>,
         IDivisionOperators<Volume, Length, Area>,
@@ -52,8 +53,6 @@ namespace UnitsNet
         IDivisionOperators<Volume, SpecificVolume, Mass>,
         IDivisionOperators<Volume, Mass, SpecificVolume>,
         IDivisionOperators<Volume, Duration, VolumeFlow>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<Volume, Volume, bool>,
         IParsable<Volume>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
@@ -42,10 +42,9 @@ namespace UnitsNet
     public readonly partial struct VolumeConcentration :
         IArithmeticQuantity<VolumeConcentration, VolumeConcentrationUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<VolumeConcentration, VolumeConcentration, double>,
         IMultiplyOperators<VolumeConcentration, Density, MassConcentration>,
         IMultiplyOperators<VolumeConcentration, Molarity, Molarity>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<VolumeConcentration, VolumeConcentration, bool>,
         IParsable<VolumeConcentration>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -39,13 +39,12 @@ namespace UnitsNet
     public readonly partial struct VolumeFlow :
         IArithmeticQuantity<VolumeFlow, VolumeFlowUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<VolumeFlow, VolumeFlow, double>,
         IDivisionOperators<VolumeFlow, Speed, Area>,
         IMultiplyOperators<VolumeFlow, Density, MassFlow>,
         IMultiplyOperators<VolumeFlow, Molarity, MolarFlow>,
         IDivisionOperators<VolumeFlow, Area, Speed>,
         IMultiplyOperators<VolumeFlow, Duration, Volume>,
-#endif
-#if NET7_0_OR_GREATER
         IComparisonOperators<VolumeFlow, VolumeFlow, bool>,
         IParsable<VolumeFlow>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct VolumeFlowPerArea :
         IArithmeticQuantity<VolumeFlowPerArea, VolumeFlowPerAreaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<VolumeFlowPerArea, VolumeFlowPerArea, double>,
         IComparisonOperators<VolumeFlowPerArea, VolumeFlowPerArea, bool>,
         IParsable<VolumeFlowPerArea>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct VolumePerLength :
         IArithmeticQuantity<VolumePerLength, VolumePerLengthUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<VolumePerLength, VolumePerLength, double>,
         IComparisonOperators<VolumePerLength, VolumePerLength, bool>,
         IParsable<VolumePerLength>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -42,6 +42,7 @@ namespace UnitsNet
     public readonly partial struct VolumetricHeatCapacity :
         IArithmeticQuantity<VolumetricHeatCapacity, VolumetricHeatCapacityUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<VolumetricHeatCapacity, VolumetricHeatCapacity, double>,
         IComparisonOperators<VolumetricHeatCapacity, VolumetricHeatCapacity, bool>,
         IParsable<VolumetricHeatCapacity>,
 #endif

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -39,6 +39,7 @@ namespace UnitsNet
     public readonly partial struct WarpingMomentOfInertia :
         IArithmeticQuantity<WarpingMomentOfInertia, WarpingMomentOfInertiaUnit>,
 #if NET7_0_OR_GREATER
+        IDivisionOperators<WarpingMomentOfInertia, WarpingMomentOfInertia, double>,
         IComparisonOperators<WarpingMomentOfInertia, WarpingMomentOfInertia, bool>,
         IParsable<WarpingMomentOfInertia>,
 #endif


### PR DESCRIPTION
Exposing the operator `IDivisionOperators<TSelf, TSelf, double>` for all non-affine quantities (which already implement it).

Unfortunately it's not possible for the operator to be part of the `IAritmeticQuantity` interface, as the compiler cannot verify that there isn't a collision with the `IDivisionOperators<TSelf, double, TSelf>`.