### PR TITLE
UnitsNetBaseJsonConverter minor bug fix for compatibility with UnitsNet 6.0.0-pre017

### DIFF
--- a/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
@@ -96,7 +96,12 @@ namespace UnitsNet.Serialization.JsonNet
 
             if (registeredQuantity is not null)
             {
-                return (IQuantity)Activator.CreateInstance(registeredQuantity, valueUnit.Value, unit)!;
+                IQuantity? instance = (IQuantity?)Activator.CreateInstance(registeredQuantity, valueUnit.Value, unit);
+                if (instance is null)
+                {
+                    throw new Exception("Unable to convert value unit, instance is null.");
+                }
+                return instance;
             }
 
             return Quantity.From(valueUnit.Value, unit);


### PR DESCRIPTION
- Simple bug fix to make UnitsNet.Serialization.JsonNet compatible with the newest prerelease version of UnitsNet (6.0.0-pre017)

The fix simply replaces a null forgiving operator with an actual null-check and return. It will throw an exception if it fails the null check. 