### PR TITLE
Fix Mass.json JSON structure validity

### DIFF
--- a/Common/UnitDefinitions/Mass.json
+++ b/Common/UnitDefinitions/Mass.json
@@ -281,7 +281,7 @@
       "XmlDocSummary": "The Dalton or unified atomic mass unit (abbreviation Da or u) is a unit of mass defined as 1/12 of the mass of an unbound neutral atom of carbon-12 in its nuclear and electronic ground state and at rest.",
       "XmlDocRemarks": "https://en.wikipedia.org/wiki/Dalton_(unit)",
       "FromUnitToBaseFunc": "{x} *  1.66053906660e-27",
-      "FromBaseToUnitFunc": "{x} /  1.66053906660e-27",      
+      "FromBaseToUnitFunc": "{x} /  1.66053906660e-27",
       "Prefixes": [ "Kilo", "Mega" , "Giga" ],
       "Localization": [
         {
@@ -289,6 +289,6 @@
           "Abbreviations": [ "Da", "u" ]
         }
       ]
-    },
+    }
   ]
 }


### PR DESCRIPTION
The  https://github.com/angularsen/UnitsNet/pull/1634 PR merged a corrupt Mass.json, which caused the JS flavor to skip  Mass in the generated code see https://github.com/haimkastner/unitsnet-js/issues/60