### PR TITLE
Updates on nanoFramework build components

### DIFF
--- a/Build/build-functions.psm1
+++ b/Build/build-functions.psm1
@@ -51,19 +51,6 @@ function Start-Build {
 function Start-BuildNanoFramework {
   write-host -foreground blue "Start-BuildNanoFramework (MSBuild)...`n---"
 
-  # Check prerequisites
-  if (-not $msbuildx64 -or -not (Test-Path $msbuildx64)) {
-    write-host -foreground red "ERROR: Cannot build .NET nanoFramework - MSBuild not found."
-    write-host -foreground yellow "Install Visual Studio with .NET desktop development workload to build NanoFramework projects."
-    exit 1
-  }
-
-  if (-not (Test-Path $nuget)) {
-    write-host -foreground red "ERROR: NuGet.exe not found at $nuget"
-    write-host -foreground yellow "Run init.ps1 to download required tools."
-    exit 1
-  }
-
   write-host -foreground green "Building .NET nanoFramework projects..."
   $fileLoggerArg = "/logger:FileLogger,Microsoft.Build;logfile=$logsDir\UnitsNet.NanoFramework.msbuild.log"
 

--- a/Build/build-pack-nano-nugets.psm1
+++ b/Build/build-pack-nano-nugets.psm1
@@ -1,13 +1,11 @@
 ﻿$root = (Resolve-Path "$PSScriptRoot\..").Path
 $nugetOutDir = "$root\Artifacts\NuGet"
-$toolsDir = "$root\.tools"
-$nuget = "$toolsDir\NuGet.exe"
 $nugetsToProcess = (Get-ChildItem -Path "$root\UnitsNet.NanoFramework\GeneratedCode\" -Filter *.nuspec -r | % { echo $_.FullName });
 
 function Invoke-BuildNanoNugets {
 Foreach ($nuspecFile in $nugetsToProcess)
   {
-    & $nuget pack "$nuspecFile" -Verbosity detailed -OutputDirectory "$nugetOutDir"
+    & nuget pack "$nuspecFile" -Verbosity detailed -OutputDirectory "$nugetOutDir"
   }
 }
 

--- a/Build/init.ps1
+++ b/Build/init.ps1
@@ -17,105 +17,10 @@ if (-not (Test-Path "$root/.tools/reportgenerator.exe")) {
   Write-Host -Foreground Green "✅ Installed dotnet-reportgenerator-globaltool"
 }
 
-# NuGet.exe for non-SDK style projects, like UnitsNet.nanoFramework.
-if (-not (Test-Path "$nugetPath")) {
-  Write-Host -Foreground Blue "Downloading NuGet.exe..."
-  Invoke-WebRequest -Uri https://dist.nuget.org/win-x86-commandline/latest/nuget.exe -OutFile $nugetPath
-  Write-Host -Foreground Green "✅ Downloaded NuGet.exe: $nugetPath"
-}
-
-###################################################
-## TODO: OK to remove after moving to AZDO pipeline
-$VsWherePath = "${env:PROGRAMFILES(X86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-
-# Check if Visual Studio is installed
-if (Test-Path $VsWherePath) {
-  $VsPath = $(&$VsWherePath -latest -property installationPath 2>$null)
-  if ($VsPath) {
-    $msbuildPath = Join-Path -Path $VsPath -ChildPath "\MSBuild"
-    Write-Host -Foreground Green "Visual Studio found at: $VsPath"
-  } else {
-    Write-Host -Foreground Yellow "Visual Studio not found via vswhere, NanoFramework builds will be skipped"
-    $VsPath = $null
-    $msbuildPath = $null
-  }
-} else {
-  Write-Host -Foreground Yellow "Visual Studio not installed - NanoFramework builds will be skipped"
-  $VsPath = $null
-  $msbuildPath = $null
-}
-
 # Install dotnet CLI tools declared in /.config/dotnet-tools.json
 pushd $root
 dotnet tool restore
 popd
-
-# Install .NET nanoFramework build components
-if ($msbuildPath -and !(Test-Path "$msbuildPath/nanoFramework")) {
-  Write-Host "Installing .NET nanoFramework VS extension..."
-
-  [System.Net.WebClient]$webClient = New-Object System.Net.WebClient
-  $webClient.Headers.Add("User-Agent", "request")
-  $webClient.Headers.Add("Accept", "application/vnd.github.v3+json")
-
-  $releaseList = $webClient.DownloadString('https://api.github.com/repos/nanoframework/nf-Visual-Studio-extension/releases?per_page=100')
-
-  if($releaseList -match '\"(?<VS2022_version>v2022\.\d+\.\d+\.\d+)\"')
-  {
-      $vs2022Tag =  $Matches.VS2022_version
-  }
-
-  if($releaseList -match '\"(?<VS2019_version>v2019\.\d+\.\d+\.\d+)\"')
-  {
-      $vs2019Tag =  $Matches.VS2019_version
-  }
-
-  # Find which VS version is installed
-  $VsWherePath = "${env:PROGRAMFILES(X86)}\Microsoft Visual Studio\Installer\vswhere.exe"
-
-  Write-Output "VsWherePath is: $VsWherePath"
-
-  $VsInstance = $(&$VSWherePath -latest -property displayName 2>$null)
-
-  Write-Output "Latest VS is: $VsInstance"
-
-  # Get extension details according to VS version, starting from VS2022 down to VS2019
-  # TODO check if the extension for VS2022 is compatible it VS2026
-  if($vsInstance.Contains('2026') -or $vsInstance.Contains('2022'))
-  {
-      $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2022Tag/nanoFramework.Tools.VS2022.Extension.vsix"
-      $vsixPath = Join-Path  $tempDir "nanoFramework.Tools.VS2022.Extension.zip"
-      $extensionVersion = $vs2022Tag
-  }
-  elseif($vsInstance.Contains('2019'))
-  {
-      $extensionUrl = "https://github.com/nanoframework/nf-Visual-Studio-extension/releases/download/$vs2019Tag/nanoFramework.Tools.VS2019.Extension.vsix"
-      $vsixPath = Join-Path  $tempDir "nanoFramework.Tools.VS2019.Extension.zip"
-      $extensionVersion = $vs2019Tag
-  }
-
-  Write-Output "Downloading visx..."
-
-  # download VS extension
-  Write-Host "Download VSIX file from $extensionUrl to $vsixPath"
-  $webClient.DownloadFile($extensionUrl, $vsixPath)
-
-  $outputPath = "$tempDir\nf-extension"
-
-  $vsixPath = Join-Path -Path $tempDir -ChildPath "nf-extension.zip"
-  $webClient.DownloadFile($extensionUrl, $vsixPath)
-
-  Write-Host "Extract VSIX file to $outputPath"
-  Expand-Archive -LiteralPath $vsixPath -DestinationPath $outputPath -Force | Write-Host
-
-  $copyFrom = "$outputPath\`$MSBuild\nanoFramework"
-
-  Write-Host "Copy from $copyFrom to $msbuildPath"
-  Copy-Item -Path "$copyFrom" -Destination $msbuildPath -Recurse
-
-  Write-Host "Installed VS extension $extensionVersion"
-}
-###################################################
 
 # Cleanup
 [system.io.Directory]::Delete($tempDir, $true) | out-null

--- a/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGen/NuspecGenerator.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using CodeGen.JsonTypes;
 
 namespace CodeGen.Generators.NanoFrameworkGen
@@ -52,7 +52,7 @@ namespace CodeGen.Generators.NanoFrameworkGen
     </dependencies>
   </metadata>
   <files>
-    <file src=""..\..\..\Artifacts\UnitsNet.NanoFramework\{_quantity.Name}\UnitsNet.*"" target=""lib"" />
+    <file src=""..\..\..\Artifacts\UnitsNet.NanoFramework\{_quantity.Name}\UnitsNet.*"" target=""lib\netnano1.0"" />
   </files>
 </package>");
 

--- a/CodeGen/Generators/NanoFrameworkGen/ProjectGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGen/ProjectGenerator.cs
@@ -46,7 +46,6 @@ namespace CodeGen.Generators.NanoFrameworkGen
     <Reference Include=""mscorlib, Version={_versions.MscorlibVersion}, Culture=neutral, PublicKeyToken=c07d481e9758c731"">
       <HintPath>..\packages\nanoFramework.CoreLibrary.{_versions.MscorlibNugetVersion}\lib\mscorlib.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>");
 
     if (NanoFrameworkGenerator.ProjectsRequiringMath.Contains(_quantity.Name))
@@ -55,7 +54,6 @@ namespace CodeGen.Generators.NanoFrameworkGen
     <Reference Include=""System.Math, Version={_versions.MathVersion}, Culture=neutral, PublicKeyToken=c07d481e9758c731"">
       <HintPath>..\packages\nanoFramework.System.Math.{_versions.MathNugetVersion}\lib\System.Math.dll</HintPath>
       <Private>True</Private>
-      <SpecificVersion>True</SpecificVersion>
     </Reference>");
     }
 

--- a/CodeGen/Generators/NanoFrameworkGen/PropertyGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGen/PropertyGenerator.cs
@@ -45,10 +45,6 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion(""{_version}"")]
 [assembly: AssemblyFileVersion(""{_version}"")]
 
-//////////////////////////////////////////////////
-// This assembly doens't require native support //
-[assembly: AssemblyNativeVersion(""0.0.0.0"")]
-//////////////////////////////////////////////////
 ");
             return Writer.ToString();
         }

--- a/CodeGen/Generators/NanoFrameworkGenerator.cs
+++ b/CodeGen/Generators/NanoFrameworkGenerator.cs
@@ -108,9 +108,11 @@ namespace CodeGen.Generators
         /// </summary>
         /// <param name="rootDir">The root directory</param>
         /// <param name="quantities">The quantities to update nuspec files</param>
+        /// <param name="usePreview">Use nanoFramework preview builds? Defaults to false.</param>
         public static bool UpdateNanoFrameworkDependencies(
             string rootDir,
-            Quantity[] quantities)
+            Quantity[] quantities,
+            bool usePreview)
         {
             // working path
             var path = Path.Combine(rootDir, "UnitsNet.NanoFramework\\GeneratedCode");
@@ -175,7 +177,7 @@ namespace CodeGen.Generators
                 StartInfo = new ProcessStartInfo
                 {
                     FileName = Path.Combine(rootDir, ".tools/NuGet.exe"),
-                    Arguments = $"update {path}\\UnitsNet.nanoFramework.sln -PreRelease",
+                    Arguments = $"update {path}\\UnitsNet.nanoFramework.sln {(usePreview ? "-PreRelease" : "")}",
                     UseShellExecute = false,
                     CreateNoWindow = true,
                     RedirectStandardError = true
@@ -266,9 +268,9 @@ namespace CodeGen.Generators
                 new Regex(@"<Reference Include=""mscorlib,\s*Version=(?<version>[\d\.]+),.*"">", RegexOptions.IgnoreCase),
                 "mscorlib assembly version");
 
-            // <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\mscorlib.dll</HintPath>
+            // <HintPath>..\packages\nanoFramework.CoreLibrary.1.10.5-preview.18\lib\netnano1.0\mscorlib.dll</HintPath>
             var mscorlibNuGetVersion = ParseVersion(projectFileContent,
-                new Regex(@"<HintPath>.*[\\\/]nanoFramework\.CoreLibrary\.(?<version>.*?)[\\\/]lib[\\\/]mscorlib.dll<", RegexOptions.IgnoreCase),
+                new Regex(@"<HintPath>.*[\\\/]nanoFramework\.CoreLibrary\.(?<version>.*?)[\\\/]lib[\\\/](?:netnano[\d\.]+[\\\/])?mscorlib\.dll<", RegexOptions.IgnoreCase),
                 "nanoFramework.CoreLibrary nuget version");
 
             // <Reference Include="System.Math, Version=1.4.1.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
@@ -276,9 +278,9 @@ namespace CodeGen.Generators
                 new Regex(@"<Reference Include=""System.Math,\s*Version=(?<version>[\d\.]+),.*"">", RegexOptions.IgnoreCase),
                 "System.Math assembly version");
 
-            //   <HintPath>..\packages\nanoFramework.System.Math.1.4.1-preview.7\lib\System.Math.dll</HintPath>
+            //   <HintPath>..\packages\nanoFramework.System.Math.1.4.1-preview.7\lib\netnano1.0\System.Math.dll</HintPath>
             var mathNuGetVersion = ParseVersion(projectFileContent,
-                new Regex(@"<HintPath>.*[\\\/]nanoFramework\.System\.Math\.(?<version>.*?)[\\\/]lib[\\\/]System.Math.dll<", RegexOptions.IgnoreCase),
+                new Regex(@"<HintPath>.*[\\\/]nanoFramework\.System\.Math\.(?<version>.*?)[\\\/]lib[\\\/](?:netnano[\d\.]+[\\\/])?System\.Math\.dll<", RegexOptions.IgnoreCase),
                 "nanoFramework.System.Math nuget version");
 
             return new NanoFrameworkVersions(mscorlibVersion, mscorlibNuGetVersion, mathVersion, mathNuGetVersion);

--- a/CodeGen/Program.cs
+++ b/CodeGen/Program.cs
@@ -45,7 +45,8 @@ namespace CodeGen
         /// <param name="repositoryRoot">The repository root directory, defaults to searching parent directories for UnitsNet.sln.</param>
         /// <param name="skipNanoFramework">Skip generate nanoFramework Units? Defaults to false</param>
         /// <param name="updateNanoFrameworkDependencies">Update nanoFramework nuget dependencies? Defaults to false.</param>
-        public static int Main(bool verbose = false, DirectoryInfo? repositoryRoot = null, bool skipNanoFramework = false, bool updateNanoFrameworkDependencies = false)
+        /// <param name="useNanoPreview">Use nanoFramework preview builds? Defaults to false.</param>
+        public static int Main(bool verbose = false, DirectoryInfo? repositoryRoot = null, bool skipNanoFramework = false, bool updateNanoFrameworkDependencies = false, bool useNanoPreview = false)
         {
             Log.Logger = new LoggerConfiguration()
                 .WriteTo
@@ -77,7 +78,8 @@ namespace CodeGen
                 {
                     if (!NanoFrameworkGenerator.UpdateNanoFrameworkDependencies(
                         rootDir,
-                        quantities))
+                        quantities, 
+                        useNanoPreview))
                     {
                         return 1;
                     }

--- a/azure-pipelines-pr.yml
+++ b/azure-pipelines-pr.yml
@@ -58,6 +58,8 @@ stages:
 
     - task: InstallNanoMSBuildComponents@1
       displayName: Install .NET nanoFramework MSBuild components
+      inputs:
+        usePreview: $(UseNanoPreview)
 
     - task: PowerShell@2
       displayName: 'Build, test, pack'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,8 @@ stages:
 
     - task: InstallNanoMSBuildComponents@1
       displayName: Install .NET nanoFramework MSBuild components
+      inputs:
+        usePreview: $(UseNanoPreview)
 
     - task: PowerShell@2
       displayName: 'Build, test, pack'


### PR DESCRIPTION
- Add optional parameter to choose preview builds (and nuget packages).
- Update nuspec (and code generator) to use offical nano1.0 Target Framework Moniker.
- Remove unnused declaration properties generator.
- Remove unnecessary property in reference project entry.
- Remove all checks and installer for nanoFramework VS extension, as all that is handled in AZDO step.
- Remove pre-check of nuget and msbuild as builds are now running in ADZO which include these in the VM image.
- Add input to install nanoFramework build components to allow specifying preview build. (settable from pipeline var UseNanoPreview)
- Not using nuget from tools folder anymore as ADZO includes this in the VM image.

Addresses  #1643