### PR TITLE
Add IQuantity.UnitInfo convenience property

### DIFF
--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -60,6 +60,28 @@ public partial class IQuantityTests
     }
 
     [Fact]
+    public void UnitInfo_ReturnsUnitInfoForQuantityUnit()
+    {
+        var length = new Length(3.0, LengthUnit.Centimeter);
+        IQuantity quantity = length;
+
+        UnitInfo unitInfo = quantity.UnitInfo;
+
+        Assert.Equal(nameof(LengthUnit.Centimeter), unitInfo.Name);
+        Assert.Equal(quantity.UnitKey, unitInfo.UnitKey);
+    }
+
+    [Fact]
+    public void UnitInfo_ReturnsBaseUnitInfo_WhenDefaultConstructed()
+    {
+        IQuantity quantity = new Length(1.0, Length.BaseUnit);
+
+        UnitInfo unitInfo = quantity.UnitInfo;
+
+        Assert.Equal(Length.Info.BaseUnitInfo.UnitKey, unitInfo.UnitKey);
+    }
+
+    [Fact]
     public void ToUnit_UnitSystem_ThrowsArgumentExceptionIfNotSupported()
     {
         var unsupportedUnitSystem = new UnitSystem(new BaseUnits(

--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -82,6 +82,26 @@ public partial class IQuantityTests
     }
 
     [Fact]
+    public void UnitInfo_TypedQuantity_ReturnsTypedUnitInfo()
+    {
+        IQuantity<LengthUnit> quantity = new Length(3.0, LengthUnit.Centimeter);
+
+        UnitInfo<LengthUnit> unitInfo = quantity.UnitInfo;
+
+        Assert.Equal(LengthUnit.Centimeter, unitInfo.Value);
+        Assert.Equal(nameof(LengthUnit.Centimeter), unitInfo.Name);
+    }
+
+    [Fact]
+    public void UnitInfo_MatchesUnit()
+    {
+        Assert.All(Quantity.Infos.Select(x => x.Zero), quantity =>
+        {
+            Assert.Equal(quantity.Unit, quantity.UnitInfo.Value);
+        });
+    }
+
+    [Fact]
     public void ToUnit_UnitSystem_ThrowsArgumentExceptionIfNotSupported()
     {
         var unsupportedUnitSystem = new UnitSystem(new BaseUnits(

--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -72,9 +72,9 @@ public partial class IQuantityTests
     }
 
     [Fact]
-    public void UnitInfo_ReturnsBaseUnitInfo_WhenDefaultConstructed()
+    public void UnitInfo_Zero_ReturnsBaseUnitInfo()
     {
-        IQuantity quantity = new Length(1.0, Length.BaseUnit);
+        IQuantity quantity = Length.Info.Zero;
 
         UnitInfo unitInfo = quantity.UnitInfo;
 

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -17,6 +17,10 @@ public static class QuantityExtensions
     /// </summary>
     /// <param name="quantity">The quantity.</param>
     /// <returns>The <see cref="UnitInfo"/> for the quantity's unit.</returns>
+    /// <remarks>
+    ///     On .NET 5+ targets, this is available as a default interface member property
+    ///     <c>IQuantity.UnitInfo</c> instead.
+    /// </remarks>
     public static UnitInfo GetUnitInfo(this IQuantity quantity)
     {
         return quantity.QuantityInfo[quantity.UnitKey];

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -11,6 +11,18 @@ namespace UnitsNet;
 /// </summary>
 public static class QuantityExtensions
 {
+#if !NET
+    /// <summary>
+    ///     Gets the <see cref="UnitInfo"/> for the unit this quantity was constructed with.
+    /// </summary>
+    /// <param name="quantity">The quantity.</param>
+    /// <returns>The <see cref="UnitInfo"/> for the quantity's unit.</returns>
+    public static UnitInfo GetUnitInfo(this IQuantity quantity)
+    {
+        return quantity.QuantityInfo[quantity.UnitKey];
+    }
+#endif
+
     /// <inheritdoc cref="IQuantity.As(UnitKey)" />
     /// <remarks>This should be using UnitConverter.Default.ConvertValue(quantity, toUnit) </remarks>
     internal static double GetValue<TQuantity>(this TQuantity quantity, UnitKey toUnit)

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -25,6 +25,22 @@ public static class QuantityExtensions
     {
         return quantity.QuantityInfo[quantity.UnitKey];
     }
+
+    /// <summary>
+    ///     Gets the <see cref="UnitInfo{TUnit}"/> for the unit this quantity was constructed with.
+    /// </summary>
+    /// <typeparam name="TUnit">The unit enum type.</typeparam>
+    /// <param name="quantity">The quantity.</param>
+    /// <returns>The <see cref="UnitInfo{TUnit}"/> for the quantity's unit.</returns>
+    /// <remarks>
+    ///     On .NET 5+ targets, this is available as a default interface member property
+    ///     <c>IQuantity&lt;TUnitType&gt;.UnitInfo</c> instead.
+    /// </remarks>
+    public static UnitInfo<TUnit> GetUnitInfo<TUnit>(this IQuantity<TUnit> quantity)
+        where TUnit : struct, Enum
+    {
+        return quantity.QuantityInfo[quantity.Unit];
+    }
 #endif
 
     /// <inheritdoc cref="IQuantity.As(UnitKey)" />

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -63,6 +63,10 @@ namespace UnitsNet
         /// <summary>
         ///     Gets the <see cref="UnitsNet.UnitInfo"/> for the unit this quantity was constructed with.
         /// </summary>
+        /// <remarks>
+        ///     On targets that do not support default interface members (e.g. netstandard2.0),
+        ///     use the <c>GetUnitInfo()</c> extension method from <see cref="QuantityExtensions"/> instead.
+        /// </remarks>
         UnitInfo UnitInfo => QuantityInfo[UnitKey];
 #endif
     }
@@ -101,7 +105,12 @@ namespace UnitsNet
 
 #if NET
 
+        /// <inheritdoc cref="IQuantity.UnitInfo"/>
+        new UnitInfo<TUnitType> UnitInfo => QuantityInfo[Unit];
+
         #region Implementation of IQuantity
+
+        UnitInfo IQuantity.UnitInfo => UnitInfo;
 
         QuantityInfo IQuantity.QuantityInfo
         {

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -58,6 +58,13 @@ namespace UnitsNet
         ///     as it avoids the boxing that would normally occur when casting the enum to <see cref="Enum" />.
         /// </remarks>
         UnitKey UnitKey { get; }
+
+#if NET
+        /// <summary>
+        ///     Gets the <see cref="UnitsNet.UnitInfo"/> for the unit this quantity was constructed with.
+        /// </summary>
+        UnitInfo UnitInfo => QuantityInfo[UnitKey];
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Adds `IQuantity.UnitInfo` default interface member on .NET 5+ targets, so consumers can write `quantity.UnitInfo` instead of `quantity.QuantityInfo[quantity.UnitKey]`
- Adds typed `IQuantity<TUnitType>.UnitInfo` returning `UnitInfo<TUnitType>` on .NET 5+
- Adds `GetUnitInfo()` and `GetUnitInfo<TUnit>()` extension methods on `netstandard2.0` for the same functionality

## Motivation
Getting `UnitInfo` from a quantity instance currently requires the verbose `quantity.QuantityInfo[quantity.UnitKey]`. This is a common operation, especially when chaining with APIs like `UnitAbbreviationsCache` that benefit from having `UnitInfo` directly (see #1067).

## Design decisions

### TFM fragmentation
The extension methods are gated behind `#if !NET` so that .NET 5+ consumers only see the cleaner property syntax in IntelliSense. Library authors who multi-target can use `quantity.QuantityInfo[quantity.UnitKey]` which works on all targets, or write a one-line wrapper. If this turns out to be a real pain point, removing the `#if` guard is a non-breaking one-line change.

### Extension method tests
The test project targets `net8.0;net9.0;net10.0` only, so `#if !NET` code is never compiled in tests. The extension methods are trivial one-liner wrappers over the same indexer call that the default interface members use, so they are effectively covered by the property tests.

## Test plan
- [x] `dotnet build UnitsNet/UnitsNet.csproj` — 0 errors across all 4 target frameworks
- [x] New tests pass on net8.0, net9.0, net10.0:
  - `UnitInfo_ReturnsUnitInfoForQuantityUnit` — non-base unit via `IQuantity`
  - `UnitInfo_Zero_ReturnsBaseUnitInfo` — `.Zero` instance
  - `UnitInfo_TypedQuantity_ReturnsTypedUnitInfo` — typed `IQuantity<LengthUnit>`
  - `UnitInfo_MatchesUnit` — `Assert.All` across all quantities

🤖 Generated with [Claude Code](https://claude.com/claude-code)