### PR TITLE
Revert IQuantity.UnitInfo DIM, expose GetUnitInfo() extension on all TFMs

### DIFF
--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -60,44 +60,44 @@ public partial class IQuantityTests
     }
 
     [Fact]
-    public void UnitInfo_ReturnsUnitInfoForQuantityUnit()
+    public void GetUnitInfo_ReturnsUnitInfoForQuantityUnit()
     {
         var length = new Length(3.0, LengthUnit.Centimeter);
         IQuantity quantity = length;
 
-        UnitInfo unitInfo = quantity.UnitInfo;
+        UnitInfo unitInfo = quantity.GetUnitInfo();
 
         Assert.Equal(nameof(LengthUnit.Centimeter), unitInfo.Name);
         Assert.Equal(quantity.UnitKey, unitInfo.UnitKey);
     }
 
     [Fact]
-    public void UnitInfo_Zero_ReturnsBaseUnitInfo()
+    public void GetUnitInfo_Zero_ReturnsBaseUnitInfo()
     {
         IQuantity quantity = Length.Info.Zero;
 
-        UnitInfo unitInfo = quantity.UnitInfo;
+        UnitInfo unitInfo = quantity.GetUnitInfo();
 
         Assert.Equal(Length.Info.BaseUnitInfo.UnitKey, unitInfo.UnitKey);
     }
 
     [Fact]
-    public void UnitInfo_TypedQuantity_ReturnsTypedUnitInfo()
+    public void GetUnitInfo_TypedQuantity_ReturnsTypedUnitInfo()
     {
         IQuantity<LengthUnit> quantity = new Length(3.0, LengthUnit.Centimeter);
 
-        UnitInfo<LengthUnit> unitInfo = quantity.UnitInfo;
+        UnitInfo<LengthUnit> unitInfo = quantity.GetUnitInfo();
 
         Assert.Equal(LengthUnit.Centimeter, unitInfo.Value);
         Assert.Equal(nameof(LengthUnit.Centimeter), unitInfo.Name);
     }
 
     [Fact]
-    public void UnitInfo_MatchesUnit()
+    public void GetUnitInfo_MatchesUnit()
     {
         Assert.All(Quantity.Infos.Select(x => x.Zero), quantity =>
         {
-            Assert.Equal(quantity.Unit, quantity.UnitInfo.Value);
+            Assert.Equal(quantity.Unit, quantity.GetUnitInfo().Value);
         });
     }
 

--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -82,13 +82,28 @@ public partial class IQuantityTests
     }
 
     [Fact]
-    public void GetUnitInfo_TypedQuantity_ReturnsTypedUnitInfo()
+    public void GetUnitInfo_ConcreteQuantity_ReturnsFullyTypedUnitInfo()
+    {
+        var quantity = new Length(3.0, LengthUnit.Centimeter);
+
+        // Overload resolution picks GetUnitInfo<TQuantity, TUnit> for the concrete struct receiver,
+        // returning the most specific UnitInfo<Length, LengthUnit>.
+        UnitInfo<Length, LengthUnit> unitInfo = quantity.GetUnitInfo();
+
+        Assert.Equal(LengthUnit.Centimeter, unitInfo.Value);
+        Assert.Equal(nameof(LengthUnit.Centimeter), unitInfo.Name);
+    }
+
+    [Fact]
+    public void GetUnitInfo_TypedQuantityReference_FallsBackToNonGeneric()
     {
         IQuantity<LengthUnit> quantity = new Length(3.0, LengthUnit.Centimeter);
 
-        UnitInfo<LengthUnit> unitInfo = quantity.GetUnitInfo();
+        // The IQuantity<TUnit> reference does not satisfy the IQuantity<TSelf, TUnit> constraint
+        // (TSelf would be IQuantity<MassUnit>), so resolution falls back to GetUnitInfo(IQuantity).
+        UnitInfo unitInfo = quantity.GetUnitInfo();
 
-        Assert.Equal(LengthUnit.Centimeter, unitInfo.Value);
+        Assert.Equal(LengthUnit.Centimeter, ((UnitInfo<LengthUnit>)unitInfo).Value);
         Assert.Equal(nameof(LengthUnit.Centimeter), unitInfo.Name);
     }
 

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -14,6 +14,12 @@ public static class QuantityExtensions
     /// <summary>
     ///     Gets the <see cref="UnitInfo"/> for the unit this quantity was constructed with.
     /// </summary>
+    /// <remarks>
+    ///     Picked by overload resolution for callers that only have an <see cref="IQuantity"/> reference.
+    ///     Concretely-typed callers (e.g. a <c>Mass</c> receiver) bind to the
+    ///     <see cref="GetUnitInfo{TQuantity,TUnit}(IQuantity{TQuantity,TUnit})"/> overload and get the
+    ///     more specific <see cref="UnitInfo{TQuantity,TUnit}"/> return.
+    /// </remarks>
     /// <param name="quantity">The quantity.</param>
     /// <returns>The <see cref="UnitInfo"/> for the quantity's unit.</returns>
     public static UnitInfo GetUnitInfo(this IQuantity quantity)
@@ -22,12 +28,20 @@ public static class QuantityExtensions
     }
 
     /// <summary>
-    ///     Gets the <see cref="UnitInfo{TUnit}"/> for the unit this quantity was constructed with.
+    ///     Gets the <see cref="UnitInfo{TQuantity,TUnit}"/> for the unit this quantity was constructed with.
     /// </summary>
+    /// <remarks>
+    ///     Picked by overload resolution for concretely-typed receivers (e.g. <c>Mass</c>) where C# can
+    ///     infer both <typeparamref name="TQuantity"/> and <typeparamref name="TUnit"/> from the receiver's
+    ///     <see cref="IQuantity{TSelf,TUnit}"/> implementation. Callers with only an <see cref="IQuantity"/>
+    ///     reference fall back to the non-generic <see cref="GetUnitInfo(IQuantity)"/> overload.
+    /// </remarks>
+    /// <typeparam name="TQuantity">The quantity type.</typeparam>
     /// <typeparam name="TUnit">The unit enum type.</typeparam>
     /// <param name="quantity">The quantity.</param>
-    /// <returns>The <see cref="UnitInfo{TUnit}"/> for the quantity's unit.</returns>
-    public static UnitInfo<TUnit> GetUnitInfo<TUnit>(this IQuantity<TUnit> quantity)
+    /// <returns>The <see cref="UnitInfo{TQuantity,TUnit}"/> for the quantity's unit.</returns>
+    public static UnitInfo<TQuantity, TUnit> GetUnitInfo<TQuantity, TUnit>(this IQuantity<TQuantity, TUnit> quantity)
+        where TQuantity : IQuantity<TQuantity, TUnit>
         where TUnit : struct, Enum
     {
         return quantity.QuantityInfo[quantity.Unit];

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -11,16 +11,11 @@ namespace UnitsNet;
 /// </summary>
 public static class QuantityExtensions
 {
-#if !NET
     /// <summary>
     ///     Gets the <see cref="UnitInfo"/> for the unit this quantity was constructed with.
     /// </summary>
     /// <param name="quantity">The quantity.</param>
     /// <returns>The <see cref="UnitInfo"/> for the quantity's unit.</returns>
-    /// <remarks>
-    ///     On .NET 5+ targets, this is available as a default interface member property
-    ///     <c>IQuantity.UnitInfo</c> instead.
-    /// </remarks>
     public static UnitInfo GetUnitInfo(this IQuantity quantity)
     {
         return quantity.QuantityInfo[quantity.UnitKey];
@@ -32,16 +27,11 @@ public static class QuantityExtensions
     /// <typeparam name="TUnit">The unit enum type.</typeparam>
     /// <param name="quantity">The quantity.</param>
     /// <returns>The <see cref="UnitInfo{TUnit}"/> for the quantity's unit.</returns>
-    /// <remarks>
-    ///     On .NET 5+ targets, this is available as a default interface member property
-    ///     <c>IQuantity&lt;TUnitType&gt;.UnitInfo</c> instead.
-    /// </remarks>
     public static UnitInfo<TUnit> GetUnitInfo<TUnit>(this IQuantity<TUnit> quantity)
         where TUnit : struct, Enum
     {
         return quantity.QuantityInfo[quantity.Unit];
     }
-#endif
 
     /// <inheritdoc cref="IQuantity.As(UnitKey)" />
     /// <remarks>This should be using UnitConverter.Default.ConvertValue(quantity, toUnit) </remarks>

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -58,17 +58,6 @@ namespace UnitsNet
         ///     as it avoids the boxing that would normally occur when casting the enum to <see cref="Enum" />.
         /// </remarks>
         UnitKey UnitKey { get; }
-
-#if NET
-        /// <summary>
-        ///     Gets the <see cref="UnitsNet.UnitInfo"/> for the unit this quantity was constructed with.
-        /// </summary>
-        /// <remarks>
-        ///     On targets that do not support default interface members (e.g. netstandard2.0),
-        ///     use the <c>GetUnitInfo()</c> extension method from <see cref="QuantityExtensions"/> instead.
-        /// </remarks>
-        UnitInfo UnitInfo => QuantityInfo[UnitKey];
-#endif
     }
 
     /// <summary>
@@ -105,12 +94,7 @@ namespace UnitsNet
 
 #if NET
 
-        /// <inheritdoc cref="IQuantity.UnitInfo"/>
-        new UnitInfo<TUnitType> UnitInfo => QuantityInfo[Unit];
-
         #region Implementation of IQuantity
-
-        UnitInfo IQuantity.UnitInfo => UnitInfo;
 
         QuantityInfo IQuantity.QuantityInfo
         {


### PR DESCRIPTION
## Summary

Reverts the default interface members added in #1649 and exposes `GetUnitInfo()` as extension methods on all target frameworks instead. The typed overload returns the most specific `UnitInfo<TQuantity, TUnit>` when overload resolution can infer both type parameters from the receiver.

## Rationale

Per @lipchev's [review feedback on #1649](https://github.com/angularsen/UnitsNet/pull/1649#issuecomment-4236027376):

- **Lean interface.** The DIM is just a getter over `QuantityInfo[UnitKey]` — no new state, sets a precedent for further interface bloat (`Dimensions` etc.).
- **Semantic trap.** A custom `IQuantity` implementor overriding `UnitInfo` would silently diverge from internal lookups (`UnitConverter`, `UnitAbbreviationsCache`, `QuantityFormatter`) which all go through `QuantityInfo`, not the new property.
- **Boxing on structs.** Calling `Mass.Zero.UnitInfo` through `IQuantity` on a struct quantity boxes the receiver per call; concrete quantities don't override the property so the DIM path is the only one available.

The extension method gives the same call-site ergonomics (`quantity.GetUnitInfo()`) on every TFM with none of these issues.

## Overload resolution

| Caller has         | Resolved overload | Return type |
|--------------------|-------------------|-------------|
| `Length q;`           | `GetUnitInfo<TQuantity, TUnit>(IQuantity<TQuantity, TUnit>)` | `UnitInfo<Length, LengthUnit>` |
| `IQuantity q;`        | `GetUnitInfo(IQuantity)` | `UnitInfo` |
| `IQuantity<TUnit> q;` | `GetUnitInfo(IQuantity)` (fallback) | `UnitInfo` |

The `IQuantity<TUnit>` reference case loses its typed return — `IQuantity<TUnit>` does not satisfy the `IQuantity<TQuantity, TUnit>` constraint, so resolution falls back to the non-generic overload. That scenario is uncommon compared to the concretely-typed receiver case, which is now strictly better than before (returns `UnitInfo<TQuantity, TUnit>` instead of `UnitInfo<TUnit>`).

## Follow-up

PR #1658 stacks on top of this branch: adds `static abstract Info` on `IQuantityOfType<T>` / `IQuantity<TSelf, TUnitType>`, obsoletes the instance `QuantityInfo` member, and provides matching `GetQuantityInfo()` extensions. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)