### PR TITLE
Add static abstract Info and obsolete instance QuantityInfo on .NET 5+

### DIFF
--- a/Samples/MvvmSample.Wpf/MvvmSample.Wpf/Converters/UnitToStringConverter.cs
+++ b/Samples/MvvmSample.Wpf/MvvmSample.Wpf/Converters/UnitToStringConverter.cs
@@ -31,7 +31,7 @@ namespace WpfMVVMSample.Converters
             if (!(value is IQuantity quantity))
                 throw new ArgumentException("Expected value of type UnitsNet.IQuantity.", nameof(value));
 
-            Enum unitEnumValue = _settings.GetDefaultUnit(quantity.QuantityInfo.UnitType);
+            Enum unitEnumValue = _settings.GetDefaultUnit(quantity.GetQuantityInfo().UnitType);
             int significantDigits = _settings.SignificantDigits;
 
             IQuantity quantityInUnit = quantity.ToUnit(unitEnumValue);

--- a/UnitsNet.Benchmark/Conversions/ToUnit/QuantityConversionBenchmarks.cs
+++ b/UnitsNet.Benchmark/Conversions/ToUnit/QuantityConversionBenchmarks.cs
@@ -19,7 +19,7 @@ public class QuantityConversionBenchmarks
         double result = 0;
         foreach (IQuantity quantity in Quantities)
         {
-            foreach (UnitInfo unitInfo in quantity.QuantityInfo.UnitInfos)
+            foreach (UnitInfo unitInfo in quantity.GetQuantityInfo().UnitInfos)
             {
                 result = quantity.As(unitInfo.Value);
             }

--- a/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/AbbreviatedUnitsConverter.cs
@@ -99,7 +99,9 @@ namespace UnitsNet.Serialization.JsonNet
         /// <returns>The string representation associated with the given quantity</returns>
         protected string GetQuantityType(IQuantity quantity)
         {
+#pragma warning disable CS0618 // IQuantity.QuantityInfo: serialization must work for custom quantities not registered in UnitsNetSetup.Default.
             return _quantities[quantity.QuantityInfo.Name].Name;
+#pragma warning restore CS0618
         }
 
         /// <inheritdoc />

--- a/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
+++ b/UnitsNet.Serialization.JsonNet/UnitsNetBaseJsonConverter.cs
@@ -164,7 +164,9 @@ namespace UnitsNet.Serialization.JsonNet
         {
             quantity = quantity ?? throw new ArgumentNullException(nameof(quantity));
 
+#pragma warning disable CS0618 // IQuantity.QuantityInfo: serialization must work for custom quantities not registered in UnitsNetSetup.Default.
             return new ValueUnit {Value = (double)quantity.Value, Unit = $"{quantity.QuantityInfo.UnitType.Name}.{quantity.Unit}"};
+#pragma warning restore CS0618
         }
 
         /// <summary>

--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -117,6 +117,58 @@ public partial class IQuantityTests
     }
 
     [Fact]
+    public void GetQuantityInfo_NonGeneric_ReturnsRegisteredQuantityInfo()
+    {
+        IQuantity quantity = new Mass(1.0, MassUnit.Kilogram);
+
+        QuantityInfo info = quantity.GetQuantityInfo();
+
+        Assert.Same(Mass.Info, info);
+    }
+
+    [Fact]
+    public void GetQuantityInfo_Typed_ReturnsRegisteredQuantityInfo()
+    {
+        IQuantity<MassUnit> quantity = new Mass(1.0, MassUnit.Kilogram);
+
+        QuantityInfo<MassUnit> info = quantity.GetQuantityInfo();
+
+        Assert.Same(Mass.Info, info);
+    }
+
+    [Fact]
+    public void StaticAbstract_Info_ReturnsSameAsTypedInfo()
+    {
+        // Calls IQuantity<TSelf, TUnitType>.Info via the static abstract member.
+        QuantityInfo<Mass, MassUnit> typedInfo = Mass.Info;
+        QuantityInfo<Mass, MassUnit> viaStaticAbstract = StaticAbstractAccess<Mass, MassUnit>();
+
+        Assert.Same(typedInfo, viaStaticAbstract);
+
+        static QuantityInfo<TSelf, TUnit> StaticAbstractAccess<TSelf, TUnit>()
+            where TSelf : IQuantity<TSelf, TUnit>
+            where TUnit : struct, Enum
+        {
+            return TSelf.Info;
+        }
+    }
+
+    [Fact]
+    public void StaticAbstract_Info_NonGeneric_ReturnsSameAsTypedInfo()
+    {
+        // Calls IQuantityOfType<TQuantity>.Info via the static abstract member.
+        QuantityInfo info = StaticAbstractAccess<Mass>();
+
+        Assert.Same((QuantityInfo)Mass.Info, info);
+
+        static QuantityInfo StaticAbstractAccess<TQuantity>()
+            where TQuantity : IQuantityOfType<TQuantity>
+        {
+            return TQuantity.Info;
+        }
+    }
+
+    [Fact]
     public void ToUnit_UnitSystem_ThrowsArgumentExceptionIfNotSupported()
     {
         var unsupportedUnitSystem = new UnitSystem(new BaseUnits(

--- a/UnitsNet.Tests/CustomQuantities/HowMuch.cs
+++ b/UnitsNet.Tests/CustomQuantities/HowMuch.cs
@@ -31,7 +31,7 @@ namespace UnitsNet.Tests.CustomQuantities
 
         #region IQuantity
         
-        public static readonly QuantityInfo<HowMuch, HowMuchUnit> Info = new(
+        public static QuantityInfo<HowMuch, HowMuchUnit> Info { get; } = new(
             nameof(HowMuch),
             HowMuchUnit.Some,
             new UnitDefinition<HowMuchUnit>[]

--- a/UnitsNet/Extensions/LinearQuantityExtensions.cs
+++ b/UnitsNet/Extensions/LinearQuantityExtensions.cs
@@ -162,7 +162,11 @@ public static class LinearQuantityExtensions
             resultValue += enumerator.Current!.GetValue(unitKey);
         }
 
+#if NET
+        return TQuantity.From(resultValue, unit);
+#else
         return firstQuantity.QuantityInfo.From(resultValue, unit);
+#endif
     }
 
     /// <summary>

--- a/UnitsNet/Extensions/LogarithmicQuantityExtensions.cs
+++ b/UnitsNet/Extensions/LogarithmicQuantityExtensions.cs
@@ -203,7 +203,11 @@ public static class LogarithmicQuantityExtensions
             sumInLinearSpace += enumerator.Current!.GetValue(unitKey).ToLinearSpace(logarithmicScalingFactor);
         }
 
+#if NET
+        return TQuantity.From(sumInLinearSpace.ToLogSpace(logarithmicScalingFactor), targetUnit);
+#else
         return firstQuantity.QuantityInfo.From(sumInLinearSpace.ToLogSpace(logarithmicScalingFactor), targetUnit);
+#endif
     }
 
     /// <summary>
@@ -342,7 +346,11 @@ public static class LogarithmicQuantityExtensions
         }
 
         var avgInLinearSpace = sumInLinearSpace / nbQuantities;
+#if NET
+        return TQuantity.From(avgInLinearSpace.ToLogSpace(logarithmicScalingFactor), unit);
+#else
         return firstQuantity.QuantityInfo.From(avgInLinearSpace.ToLogSpace(logarithmicScalingFactor), unit);
+#endif
     }
 
     /// <summary>
@@ -473,7 +481,11 @@ public static class LogarithmicQuantityExtensions
         }
 
         var geometricMean = RootN(sumInLogSpace, nbQuantities);
+#if NET
+        return TQuantity.From(geometricMean, unitKey.ToUnit<TUnit>());
+#else
         return firstQuantity.QuantityInfo.From(geometricMean, unitKey.ToUnit<TUnit>());
+#endif
     }
 
     /// <summary>

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -12,6 +12,30 @@ namespace UnitsNet;
 public static class QuantityExtensions
 {
     /// <summary>
+    ///     Gets the <see cref="UnitsNet.QuantityInfo"/> for the given quantity instance, looked up via
+    ///     <see cref="UnitsNetSetup.Default"/>.
+    /// </summary>
+    /// <remarks>
+    ///     Use the static <c>TSelf.Info</c> directly when you have a typed quantity reference for the best performance.
+    ///     This extension is convenient when working with an <see cref="IQuantity"/> reference where the concrete
+    ///     type is not known at compile time.
+    /// </remarks>
+    /// <param name="quantity">The quantity instance.</param>
+    /// <returns>The <see cref="UnitsNet.QuantityInfo"/> registered in <see cref="UnitsNetSetup.Default"/> for the quantity's runtime type.</returns>
+    public static QuantityInfo GetQuantityInfo(this IQuantity quantity)
+    {
+        return UnitsNetSetup.Default.Quantities.GetQuantityInfo(quantity.GetType());
+    }
+
+    /// <inheritdoc cref="GetQuantityInfo(IQuantity)"/>
+    /// <typeparam name="TUnit">The unit enum type of the quantity.</typeparam>
+    public static QuantityInfo<TUnit> GetQuantityInfo<TUnit>(this IQuantity<TUnit> quantity)
+        where TUnit : struct, Enum
+    {
+        return (QuantityInfo<TUnit>)UnitsNetSetup.Default.Quantities.GetQuantityInfo(quantity.GetType());
+    }
+
+    /// <summary>
     ///     Gets the <see cref="UnitInfo"/> for the unit this quantity was constructed with.
     /// </summary>
     /// <remarks>
@@ -24,7 +48,7 @@ public static class QuantityExtensions
     /// <returns>The <see cref="UnitInfo"/> for the quantity's unit.</returns>
     public static UnitInfo GetUnitInfo(this IQuantity quantity)
     {
-        return quantity.QuantityInfo[quantity.UnitKey];
+        return quantity.GetQuantityInfo()[quantity.UnitKey];
     }
 
     /// <summary>
@@ -44,10 +68,14 @@ public static class QuantityExtensions
         where TQuantity : IQuantity<TQuantity, TUnit>
         where TUnit : struct, Enum
     {
+#if NET
+        return TQuantity.Info[quantity.Unit];
+#else
         // Azure CI build failed on binding QuantityInfo through IQuantity<TUnit>, so cast to expose the fully typed indexer.
         // This is likely a .NET SDK version compatibility thing, did not bother looking closer at it.
         var quantityInfo = (QuantityInfo<TQuantity, TUnit>)quantity.QuantityInfo;
         return quantityInfo[quantity.Unit];
+#endif
     }
 
     /// <inheritdoc cref="IQuantity.As(UnitKey)" />
@@ -75,7 +103,11 @@ public static class QuantityExtensions
     public static double As<TQuantity>(this TQuantity quantity, UnitSystem unitSystem)
         where TQuantity : IQuantity
     {
+#if NET
+        return quantity.GetValue(quantity.GetQuantityInfo().GetDefaultUnit(unitSystem).UnitKey);
+#else
         return quantity.GetValue(quantity.QuantityInfo.GetDefaultUnit(unitSystem).UnitKey);
+#endif
     }
 
     /// <summary>
@@ -103,7 +135,7 @@ public static class QuantityExtensions
         where TQuantity : IQuantityOfType<TQuantity>
     {
 #if NET
-        QuantityInfo quantityInfo = quantity.QuantityInfo;
+        QuantityInfo quantityInfo = TQuantity.Info;
         UnitKey unitKey = quantityInfo.GetDefaultUnit(unitSystem).UnitKey;
         return TQuantity.Create(quantity.As(unitKey), unitKey);
 #else
@@ -280,6 +312,10 @@ public static class QuantityExtensions
             nbValues++;
         }
 
+#if NET
+        return TQuantity.From(sumOfValues / nbValues, unit);
+#else
         return firstQuantity.QuantityInfo.From(sumOfValues / nbValues, unit);
+#endif
     }
 }

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 namespace UnitsNet
@@ -11,6 +11,13 @@ namespace UnitsNet
         /// <summary>
         ///     Information about the quantity type, such as unit values and names.
         /// </summary>
+        /// <remarks>
+        ///     Kept for back-compat with netstandard2.0. On .NET 5+, prefer the static <c>TSelf.Info</c>
+        ///     property or the <c>GetQuantityInfo()</c> extension method on <see cref="QuantityExtensions"/>.
+        /// </remarks>
+#if NET
+        [Obsolete("Kept for back-compat with netstandard2.0. On .NET 5+, use the static TSelf.Info property or the GetQuantityInfo() extension method.")]
+#endif
         QuantityInfo QuantityInfo { get; }
 
         /// <summary>
@@ -82,6 +89,9 @@ namespace UnitsNet
         new TUnitType Unit { get; }
 
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
+#if NET
+        [Obsolete("Kept for back-compat with netstandard2.0. On .NET 5+, use the static TSelf.Info property or the GetQuantityInfo() extension method.")]
+#endif
         new QuantityInfo<TUnitType> QuantityInfo { get; }
 
         /// <summary>
@@ -96,10 +106,12 @@ namespace UnitsNet
 
         #region Implementation of IQuantity
 
+#pragma warning disable CS0618 // Type or member is obsolete
         QuantityInfo IQuantity.QuantityInfo
         {
             get => QuantityInfo;
         }
+#pragma warning restore CS0618
 
         Enum IQuantity.Unit
         {
@@ -121,6 +133,16 @@ namespace UnitsNet
         where TQuantity : IQuantity
     {
 #if NET
+        /// <summary>
+        ///     The static <see cref="UnitsNet.QuantityInfo"/> for this quantity type.
+        /// </summary>
+        /// <remarks>
+        ///     Implemented by every quantity as a public static <c>Info</c> property. Prefer this and the
+        ///     <see cref="QuantityExtensions.GetQuantityInfo(IQuantity)"/> extension method over the
+        ///     obsolete instance <see cref="IQuantity.QuantityInfo"/> property.
+        /// </remarks>
+        public static abstract QuantityInfo Info { get; }
+
         /// <summary>
         ///     Creates an instance of the quantity from a specified value and unit.
         /// </summary>
@@ -144,9 +166,15 @@ namespace UnitsNet
         where TUnitType : struct, Enum
     {
         /// <inheritdoc cref="IQuantity.QuantityInfo"/>
+#if NET
+        [Obsolete("Kept for back-compat with netstandard2.0. On .NET 5+, use the static TSelf.Info property or the GetQuantityInfo() extension method.")]
+#endif
         new QuantityInfo<TSelf, TUnitType> QuantityInfo { get; }
 
 #if NET
+        /// <inheritdoc cref="IQuantityOfType{TQuantity}.Info"/>
+        public new static abstract QuantityInfo<TSelf, TUnitType> Info { get; }
+
         /// <summary>
         ///     Creates an instance of the quantity from a specified value and unit.
         /// </summary>
@@ -157,10 +185,14 @@ namespace UnitsNet
 
         static TSelf IQuantityOfType<TSelf>.Create(double value, UnitKey unit) => TSelf.From(value, unit.ToUnit<TUnitType>());
 
+        static QuantityInfo IQuantityOfType<TSelf>.Info => TSelf.Info;
+
+#pragma warning disable CS0618 // Type or member is obsolete
         QuantityInfo<TUnitType> IQuantity<TUnitType>.QuantityInfo
         {
             get => QuantityInfo;
         }
+#pragma warning restore CS0618
 
         IQuantity<TUnitType> IQuantity<TUnitType>.ToUnit(TUnitType unit)
         {

--- a/UnitsNet/QuantityDisplay.cs
+++ b/UnitsNet/QuantityDisplay.cs
@@ -32,7 +32,9 @@ internal readonly struct QuantityDisplay(IQuantity quantity)
         public AbbreviationDisplay(IQuantity quantity)
         {
             _quantity = quantity;
+#pragma warning disable CS0618 // IQuantity.QuantityInfo: debug proxy must work for custom quantities not registered in UnitsNetSetup.Default.
             QuantityInfo quantityQuantityInfo = quantity.QuantityInfo;
+#pragma warning restore CS0618
             IQuantity baseQuantity = quantity.ToUnit(quantityQuantityInfo.BaseUnitInfo.Value);
             Conversions = quantityQuantityInfo.UnitInfos.Select(x => new ConvertedQuantity(baseQuantity, x)).ToArray();
         }
@@ -70,8 +72,11 @@ internal readonly struct QuantityDisplay(IQuantity quantity)
         public UnitDisplay(IQuantity quantity)
         {
             Unit = quantity.Unit;
-            IQuantity baseQuantity = quantity.ToUnit(quantity.QuantityInfo.BaseUnitInfo.Value);
-            Conversions = quantity.QuantityInfo.UnitInfos.Select(x => new ConvertedQuantity(baseQuantity, x.Value)).ToArray();
+#pragma warning disable CS0618 // IQuantity.QuantityInfo: debug proxy must work for custom quantities not registered in UnitsNetSetup.Default.
+            QuantityInfo info = quantity.QuantityInfo;
+#pragma warning restore CS0618
+            IQuantity baseQuantity = quantity.ToUnit(info.BaseUnitInfo.Value);
+            Conversions = info.UnitInfos.Select(x => new ConvertedQuantity(baseQuantity, x.Value)).ToArray();
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -110,7 +115,9 @@ internal readonly struct QuantityDisplay(IQuantity quantity)
         public QuantityConvertor(IQuantity quantity)
         {
             QuantityToString = new StringFormatsDisplay(quantity);
+#pragma warning disable CS0618 // IQuantity.QuantityInfo: debug proxy must work for custom quantities not registered in UnitsNetSetup.Default.
             QuantityInfo quantityQuantityInfo = quantity.QuantityInfo;
+#pragma warning restore CS0618
             IQuantity baseQuantity = quantity.ToUnit(quantityQuantityInfo.BaseUnitInfo.Value);
             QuantityToUnit = quantityQuantityInfo.UnitInfos.Select(x => new ConvertedQuantity(baseQuantity.ToUnit(x.Value), x)).ToArray();
         }

--- a/UnitsNet/QuantityTypeConverter.cs
+++ b/UnitsNet/QuantityTypeConverter.cs
@@ -153,8 +153,10 @@ namespace UnitsNet
             // Ensure the attribute's unit is compatible with this converter's quantity.
             if (attribute?.UnitType != null)
             {
+#pragma warning disable CS0618 // IQuantity.QuantityInfo is obsolete on .NET 5+; use it here so consumers can author custom quantities (e.g. HowMuch in tests) without registering them in UnitsNetSetup.Default.
                 string converterQuantityName = default(TQuantity).QuantityInfo.Name;
                 string attributeQuantityName = Quantity.From(1, attribute.UnitType).QuantityInfo.Name;
+#pragma warning restore CS0618
                 if (converterQuantityName != attributeQuantityName)
                 {
                     throw new ArgumentException($"The {attribute.GetType()}'s UnitType [{attribute.UnitType}] is not compatible with the converter's quantity [{converterQuantityName}].");


### PR DESCRIPTION
## Summary

Builds on top of #1657 (revert of the `IQuantity.UnitInfo` DIM) with the bigger ergonomics + perf shift @lipchev called for in his review. **Base this PR on #1657 and rebase once it merges.**

- **Adds a static abstract `Info` member** on `IQuantityOfType<TQuantity>` and `IQuantity<TSelf, TUnitType>` (under `#if NET`).
- **Marks the existing instance `QuantityInfo` property as `[Obsolete]`** on .NET 5+ across all three interfaces (`IQuantity`, `IQuantity<TUnitType>`, `IQuantity<TSelf, TUnitType>`). Kept un-obsoleted on netstandard2.0 to preserve back-compat there.
- **Adds `GetQuantityInfo()` extension methods** (non-generic + typed) on `QuantityExtensions` so callers have a single discoverable API on every TFM.
- **Migrates internal callers** of the obsolete instance member to either `TSelf.Info` (where the generic constraint allows) or `quantity.GetQuantityInfo()` (where it doesn't).

## Why

The instance `QuantityInfo` property invariably returns a per-type static value. Exposing it as an instance member:

1. Implies it can vary per instance, which it cannot.
2. Costs interface dispatch and boxes the receiver on struct quantities for every call.
3. Encourages custom `IQuantity` implementors to override it in ways that silently diverge from the rest of the library, which only ever consults `QuantityInfo` indirectly through the static `TSelf.Info` (via UnitsNetSetup, etc.).

The static abstract member lets generic algorithms reach the info with `TSelf.Info` directly — no boxing, no virtual call. The extension method covers the common `IQuantity` / `IQuantity<TUnit>` reference case via a `UnitsNetSetup.Default.Quantities` lookup.

## Implementation notes

- **Generated quantities already expose** `public static QuantityInfo<TSelf, TUnitType> Info { get; }`. This directly satisfies the typed static abstract — no codegen change required.
- **The non-generic `IQuantityOfType<TSelf>.Info`** is satisfied by a default static implementation in the typed interface:
  ```csharp
  static QuantityInfo IQuantityOfType<TSelf>.Info => TSelf.Info;
  ```
- **Bridges** like `QuantityInfo IQuantity.QuantityInfo => QuantityInfo;` inside the interface itself are wrapped in `#pragma warning disable CS0618` so the bridge implementation does not warn about consuming the obsolete member it bridges.
- **Callers that must work for custom quantities not registered in `UnitsNetSetup.Default`** (JsonNet serialization, the debugger proxy, `QuantityTypeConverter`) keep using the instance member with a `#pragma warning disable CS0618` and a comment explaining why. The lookup-based extension method would throw `QuantityNotFoundException` for these scenarios.
- **`HowMuch` test custom quantity** had `public static readonly QuantityInfo Info = ...` (a field). Static abstract property requires a property — changed to `public static QuantityInfo Info { get; }`.

## Migration path

| Caller has | .NET 5+ | netstandard2.0 |
|------------|---------|----------------|
| `IQuantity` | `q.GetQuantityInfo()` | `q.GetQuantityInfo()` (delegates to instance) |
| `IQuantity<TUnit>` | `q.GetQuantityInfo()` (typed return) | `q.GetQuantityInfo()` |
| `TQuantity : IQuantityOfType<T>` | `TQuantity.Info` (no boxing) | `q.GetQuantityInfo()` |
| `TSelf : IQuantity<TSelf, TUnit>` | `TSelf.Info` (typed, no boxing) | `q.QuantityInfo` |

The instance member stays warning-only this release. Promote to error / remove once netstandard2.0 is dropped — possibly backport the obsolete to v5 if we decide to fully remove in v6.

## Tests

- `GetQuantityInfo_NonGeneric_ReturnsRegisteredQuantityInfo` — `Same(Mass.Info, ((IQuantity)mass).GetQuantityInfo())`
- `GetQuantityInfo_Typed_ReturnsRegisteredQuantityInfo` — typed variant returns `QuantityInfo<MassUnit>`
- `StaticAbstract_Info_ReturnsSameAsTypedInfo` — `TSelf.Info` via `IQuantity<TSelf, TUnit>` static abstract
- `StaticAbstract_Info_NonGeneric_ReturnsSameAsTypedInfo` — `TQuantity.Info` via `IQuantityOfType<TQuantity>` static abstract (covariant return through default impl bridge)

## Test plan

- [x] `dotnet build UnitsNet.slnx` — 0 errors across all TFMs
- [x] `dotnet test UnitsNet.Tests -f net8.0` — 42303 passed (4 new), 0 failed
- [x] `dotnet test UnitsNet.Serialization.JsonNet.Tests -f net8.0` — 113 passed, 0 failed
- [x] No `IQuantity.QuantityInfo` CS0618 warnings remain in `UnitsNet/`, `UnitsNet.Serialization.JsonNet/`, `UnitsNet.Benchmark/`, `Samples/` (suppressions are explicit + commented)

## Out of scope

- Migrating the test project `.QuantityInfo` call sites (suppressed at csproj level with `<NoWarn>CS0618</NoWarn>`).
- A struct-friendly `GetQuantityInfo<TSelf, TUnit>(this TSelf q) where TSelf : IQuantity<TSelf, TUnit>` overload that would JIT-specialize per struct. Easy to add later if a perf-sensitive use case shows up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)