### PR TITLE
Stop failing the build on low/moderate NuGet audit advisories

### DIFF
--- a/CodeGen/CodeGen.csproj
+++ b/CodeGen/CodeGen.csproj
@@ -5,8 +5,18 @@
     <TargetFramework>net10.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
-    <!-- Allow compile with various nullability warnings until fixed. -->
-    <WarningsNotAsErrors>8600,8601,8603,8604,8618,8619,8625</WarningsNotAsErrors>
+    <!--
+      Inherits Directory.Build.props codes and adds nullability warnings the codegen sources
+      have not been annotated for. All stay visible as warnings.
+      CS8600  - null literal to non-nullable
+      CS8601  - possible null reference assignment
+      CS8603  - possible null reference return
+      CS8604  - possible null reference argument
+      CS8618  - non-nullable field uninitialized in ctor
+      CS8619  - nullability mismatch
+      CS8625  - null literal to non-nullable reference
+    -->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);8600;8601;8603;8604;8618;8619;8625</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,8 +17,14 @@
   <PropertyGroup>
     <!-- Warning instead of compile error on obsolete errors.-->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- 612: obsolete, 618: obsolete with message -->
-    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
+    <!--
+      Warnings stay visible but do not fail the build. NU1903 (high) and NU1904 (critical) still fail.
+      CS0612  - obsolete member
+      CS0618  - obsolete member with message
+      NU1901  - NuGet audit: low severity vulnerability
+      NU1902  - NuGet audit: moderate severity vulnerability
+    -->
+    <WarningsNotAsErrors>612;618;NU1901;NU1902</WarningsNotAsErrors>
   </PropertyGroup>
 
   <!-- Build symbol package (.snupkg) to distribute the PDB file for debugging, in addition to Source Link per recommendation: https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/sourcelink -->


### PR DESCRIPTION
## Summary

Stops the build from failing on low/moderate NuGet audit advisories while keeping them visible as warnings.

## Why

PR #1657's CI failed at restore time with:

```
error NU1901: Warning As Error: Package 'NuGet.Packaging' 7.0.1 has a known low severity vulnerability
error NU1901: Warning As Error: Package 'NuGet.Protocol' 7.0.1 has a known low severity vulnerability
```

These are pulled in transitively by build tooling (CodeGen) and cannot be upgraded without breaking other constraints.

## Changes

- Add `NU1901` (low) and `NU1902` (moderate) to `<WarningsNotAsErrors>` in `Directory.Build.props`. They remain visible as warnings but no longer fail the build via `TreatWarningsAsErrors`. `NU1903` (high) and `NU1904` (critical) still fail the build.
- `CodeGen.csproj` had its own `<WarningsNotAsErrors>` that overrode (not appended to) the one in `Directory.Build.props`. Prefix it with `$(WarningsNotAsErrors);` so the project inherits the NU codes (and the obsolete codes) while keeping its nullability suppressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)