### PR TITLE
Update NuGet packages to latest stable

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,10 +5,10 @@
   <ItemGroup>
     <PackageVersion Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageVersion Include="NuGet.Protocol" Version="7.0.1" />
-    <PackageVersion Include="Serilog" Version="4.3.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.3.1" />
+    <PackageVersion Include="Serilog" Version="4.3.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageVersion Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Summary

Bumps centrally-managed NuGet package versions in [Directory.Packages.props](Directory.Packages.props) to the latest stable release.

| Package | From | To |
|---------|------|----|
| Microsoft.NET.Test.Sdk | 18.0.1 | 18.5.1 |
| NuGet.Protocol | 7.0.1 | 7.3.1 |
| Serilog | 4.3.0 | 4.3.1 |

`NuGet.Protocol` 7.3.1 clears the low-severity NU1901 advisories that triggered the original CI failure on #1657. As a result this PR makes #1660 unnecessary as a build-unblocker, though the comment-and-policy clean-up there still has independent value.

`System.CommandLine.DragonFruit` is left at the existing `0.4.0-alpha.22272.1`; no newer stable version is published to the configured sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)