### PR TITLE
v5: Mark Scalar obsolete

### DIFF
--- a/Common/UnitDefinitions/Scalar.json
+++ b/Common/UnitDefinitions/Scalar.json
@@ -2,6 +2,7 @@
   "Name": "Scalar",
   "BaseUnit": "Amount",
   "XmlDocSummary": "A way of representing a number of items.",
+  "ObsoleteText": "Scalar is a unitless value wrapper rather than a physical quantity and will be removed in UnitsNet v6. Use a plain numeric value, QuantityValue, or a semantic dimensionless quantity such as Ratio where appropriate.",
   "Units": [
     {
       "SingularName": "Amount",

--- a/UnitsNet.NanoFramework/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet.NanoFramework/GeneratedCode/Quantities/Scalar.g.cs
@@ -26,6 +26,7 @@ namespace UnitsNet
     /// <summary>
     ///     A way of representing a number of items.
     /// </summary>
+    [Obsolete("Scalar is a unitless value wrapper rather than a physical quantity and will be removed in UnitsNet v6. Use a plain numeric value, QuantityValue, or a semantic dimensionless quantity such as Ratio where appropriate.")]
     public struct  Scalar
     {
         /// <summary>

--- a/UnitsNet.NumberExtensions/GeneratedCode/NumberToScalarExtensions.g.cs
+++ b/UnitsNet.NumberExtensions/GeneratedCode/NumberToScalarExtensions.g.cs
@@ -30,9 +30,11 @@ namespace UnitsNet.NumberExtensions.NumberToScalar
     /// <summary>
     /// A number to Scalar Extensions
     /// </summary>
+    [Obsolete("Scalar is a unitless value wrapper rather than a physical quantity and will be removed in UnitsNet v6. Use a plain numeric value, QuantityValue, or a semantic dimensionless quantity such as Ratio where appropriate.")]
     public static class NumberToScalarExtensions
     {
         /// <inheritdoc cref="Scalar.FromAmount(UnitsNet.QuantityValue)" />
+        [Obsolete("Scalar is a unitless value wrapper rather than a physical quantity and will be removed in UnitsNet v6. Use a plain numeric value, QuantityValue, or a semantic dimensionless quantity such as Ratio where appropriate.")]
         public static Scalar Amount<T>(this T value)
             where T : notnull
 #if NET7_0_OR_GREATER

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -36,6 +36,7 @@ namespace UnitsNet
     /// <summary>
     ///     A way of representing a number of items.
     /// </summary>
+    [Obsolete("Scalar is a unitless value wrapper rather than a physical quantity and will be removed in UnitsNet v6. Use a plain numeric value, QuantityValue, or a semantic dimensionless quantity such as Ratio where appropriate.")]
     [DataContract]
     [DebuggerTypeProxy(typeof(QuantityDisplay))]
     public readonly partial struct Scalar :


### PR DESCRIPTION
## Motivation

`Scalar` is planned for removal in v6 because it is a unitless value wrapper rather than a physical quantity. It was originally added in #889 for #849 as a way to put plain counts/values into an `IQuantity` shape, but it has not grown meaningful semantic usage in the codebase.

This v5 PR keeps the API intact while warning callers ahead of the v6 breaking removal in #1680.

## Changes

- Add `ObsoleteText` to `Common/UnitDefinitions/Scalar.json`.
- Regenerate the `Scalar` quantity, nanoFramework quantity, and number extensions so callers see `[Obsolete]` warnings.

## Validation

- `dotnet run --project CodeGen -p:NuGetAudit=false`
- `dotnet build UnitsNet.sln -p:NuGetAudit=false`
- `dotnet test UnitsNet.Tests -f net48 -p:NuGetAudit=false`
- `dotnet test UnitsNet.Tests -f net9.0 -p:NuGetAudit=false`
- `dotnet test UnitsNet.NumberExtensions.Tests -p:NuGetAudit=false`

Note: `generate-code.bat`/plain restore on this maintenance branch is currently blocked by a NuGet audit warning for `NuGet.Protocol` 6.12.1, so validation used `NuGetAudit=false` to avoid changing dependencies in this deprecation PR.

Refs #849, #1200, #1679, #1680.