### PR TITLE
Fix MolarFlow per-hour abbreviations

### DIFF
--- a/Common/UnitDefinitions/MolarFlow.json
+++ b/Common/UnitDefinitions/MolarFlow.json
@@ -54,7 +54,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "kmol/h" ]
+          "Abbreviations": [ "mol/h" ]
         }
       ]
     },

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
@@ -280,10 +280,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "4.2 kkmol/h", MolarFlowUnit.KilomolePerHour, 4.2)]
+        [InlineData("en-US", "4.2 kmol/h", MolarFlowUnit.KilomolePerHour, 4.2)]
         [InlineData("en-US", "4.2 kmol/min", MolarFlowUnit.KilomolePerMinute, 4.2)]
         [InlineData("en-US", "4.2 kmol/s", MolarFlowUnit.KilomolePerSecond, 4.2)]
-        [InlineData("en-US", "4.2 kmol/h", MolarFlowUnit.MolePerHour, 4.2)]
+        [InlineData("en-US", "4.2 mol/h", MolarFlowUnit.MolePerHour, 4.2)]
         [InlineData("en-US", "4.2 mol/min", MolarFlowUnit.MolePerMinute, 4.2)]
         [InlineData("en-US", "4.2 mol/s", MolarFlowUnit.MolePerSecond, 4.2)]
         [InlineData("en-US", "4.2 lbmol/h", MolarFlowUnit.PoundMolePerHour, 4.2)]
@@ -298,10 +298,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "4.2 kkmol/h", MolarFlowUnit.KilomolePerHour, 4.2)]
+        [InlineData("en-US", "4.2 kmol/h", MolarFlowUnit.KilomolePerHour, 4.2)]
         [InlineData("en-US", "4.2 kmol/min", MolarFlowUnit.KilomolePerMinute, 4.2)]
         [InlineData("en-US", "4.2 kmol/s", MolarFlowUnit.KilomolePerSecond, 4.2)]
-        [InlineData("en-US", "4.2 kmol/h", MolarFlowUnit.MolePerHour, 4.2)]
+        [InlineData("en-US", "4.2 mol/h", MolarFlowUnit.MolePerHour, 4.2)]
         [InlineData("en-US", "4.2 mol/min", MolarFlowUnit.MolePerMinute, 4.2)]
         [InlineData("en-US", "4.2 mol/s", MolarFlowUnit.MolePerSecond, 4.2)]
         [InlineData("en-US", "4.2 lbmol/h", MolarFlowUnit.PoundMolePerHour, 4.2)]
@@ -316,10 +316,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -334,10 +334,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -352,10 +352,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("en-US", "kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("en-US", "kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("en-US", "kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("en-US", "kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("en-US", "mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("en-US", "mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("en-US", "mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("en-US", "lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -369,10 +369,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("en-US", "kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("en-US", "kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("en-US", "kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("en-US", "kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("en-US", "mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("en-US", "mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("en-US", "mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("en-US", "lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -385,10 +385,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -403,10 +403,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -421,10 +421,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("en-US", "kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("en-US", "kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("en-US", "kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("en-US", "kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("en-US", "mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("en-US", "mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("en-US", "mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("en-US", "lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -438,10 +438,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", "kkmol/h", MolarFlowUnit.KilomolePerHour)]
+        [InlineData("en-US", "kmol/h", MolarFlowUnit.KilomolePerHour)]
         [InlineData("en-US", "kmol/min", MolarFlowUnit.KilomolePerMinute)]
         [InlineData("en-US", "kmol/s", MolarFlowUnit.KilomolePerSecond)]
-        [InlineData("en-US", "kmol/h", MolarFlowUnit.MolePerHour)]
+        [InlineData("en-US", "mol/h", MolarFlowUnit.MolePerHour)]
         [InlineData("en-US", "mol/min", MolarFlowUnit.MolePerMinute)]
         [InlineData("en-US", "mol/s", MolarFlowUnit.MolePerSecond)]
         [InlineData("en-US", "lbmol/h", MolarFlowUnit.PoundMolePerHour)]
@@ -454,10 +454,10 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("en-US", MolarFlowUnit.KilomolePerHour, "kkmol/h")]
+        [InlineData("en-US", MolarFlowUnit.KilomolePerHour, "kmol/h")]
         [InlineData("en-US", MolarFlowUnit.KilomolePerMinute, "kmol/min")]
         [InlineData("en-US", MolarFlowUnit.KilomolePerSecond, "kmol/s")]
-        [InlineData("en-US", MolarFlowUnit.MolePerHour, "kmol/h")]
+        [InlineData("en-US", MolarFlowUnit.MolePerHour, "mol/h")]
         [InlineData("en-US", MolarFlowUnit.MolePerMinute, "mol/min")]
         [InlineData("en-US", MolarFlowUnit.MolePerSecond, "mol/s")]
         [InlineData("en-US", MolarFlowUnit.PoundMolePerHour, "lbmol/h")]
@@ -712,10 +712,10 @@ namespace UnitsNet.Tests
         public void ToString_ReturnsValueAndUnitAbbreviationInCurrentCulture()
         {
             using var _ = new CultureScope("en-US");
-            Assert.Equal("1 kkmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString());
+            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString());
             Assert.Equal("1 kmol/min", new MolarFlow(1, MolarFlowUnit.KilomolePerMinute).ToString());
             Assert.Equal("1 kmol/s", new MolarFlow(1, MolarFlowUnit.KilomolePerSecond).ToString());
-            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString());
+            Assert.Equal("1 mol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString());
             Assert.Equal("1 mol/min", new MolarFlow(1, MolarFlowUnit.MolePerMinute).ToString());
             Assert.Equal("1 mol/s", new MolarFlow(1, MolarFlowUnit.MolePerSecond).ToString());
             Assert.Equal("1 lbmol/h", new MolarFlow(1, MolarFlowUnit.PoundMolePerHour).ToString());
@@ -729,10 +729,10 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
-            Assert.Equal("1 kkmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString(swedishCulture));
+            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString(swedishCulture));
             Assert.Equal("1 kmol/min", new MolarFlow(1, MolarFlowUnit.KilomolePerMinute).ToString(swedishCulture));
             Assert.Equal("1 kmol/s", new MolarFlow(1, MolarFlowUnit.KilomolePerSecond).ToString(swedishCulture));
-            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString(swedishCulture));
+            Assert.Equal("1 mol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString(swedishCulture));
             Assert.Equal("1 mol/min", new MolarFlow(1, MolarFlowUnit.MolePerMinute).ToString(swedishCulture));
             Assert.Equal("1 mol/s", new MolarFlow(1, MolarFlowUnit.MolePerSecond).ToString(swedishCulture));
             Assert.Equal("1 lbmol/h", new MolarFlow(1, MolarFlowUnit.PoundMolePerHour).ToString(swedishCulture));

--- a/UnitsNet/GeneratedCode/Resources/MolarFlow.restext
+++ b/UnitsNet/GeneratedCode/Resources/MolarFlow.restext
@@ -1,7 +1,7 @@
-KilomolesPerHour=kkmol/h
+KilomolesPerHour=kmol/h
 KilomolesPerMinute=kmol/min
 KilomolesPerSecond=kmol/s
-MolesPerHour=kmol/h
+MolesPerHour=mol/h
 MolesPerMinute=mol/min
 MolesPerSecond=mol/s
 PoundMolesPerHour=lbmol/h


### PR DESCRIPTION
## Motivation

Issue #1663 reports that the generated abbreviations for MolarFlow per-hour units are shifted by one kilo prefix:

- `MolarFlowUnit.MolePerHour` formats/parses as `kmol/h`
- `MolarFlowUnit.KilomolePerHour` formats/parses as `kkmol/h`

The root cause is that `MolePerHour` has `Prefixes: [ "Kilo" ]`, but its base abbreviation in `MolarFlow.json` was already written as `kmol/h`. The prefix generator then prepended another `k` for the generated `KilomolePerHour` unit.

## Changes

- Change `MolePerHour` abbreviation from `kmol/h` to `mol/h`.
- Regenerate MolarFlow resources and generated tests.
- Generated abbreviations now match the other molar-flow units:
  - `MolePerHour`: `mol/h`
  - `KilomolePerHour`: `kmol/h`

## Validation

- `generate-code.bat`
- `dotnet test UnitsNet.Tests --filter "FullyQualifiedName~MolarFlowTests"`

Fixes #1663.