### PR TITLE
v5: Fix MolarFlow per-hour abbreviations

### DIFF
--- a/Common/UnitDefinitions/MolarFlow.json
+++ b/Common/UnitDefinitions/MolarFlow.json
@@ -54,7 +54,7 @@
       "Localization": [
         {
           "Culture": "en-US",
-          "Abbreviations": [ "kmol/h" ]
+          "Abbreviations": [ "mol/h" ]
         }
       ]
     },

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
@@ -253,7 +253,7 @@ namespace UnitsNet.Tests
         {
             try
             {
-                var parsed = MolarFlow.Parse("1 kkmol/h", CultureInfo.GetCultureInfo("en-US"));
+                var parsed = MolarFlow.Parse("1 kmol/h", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.KilomolesPerHour, KilomolesPerHourTolerance);
                 Assert.Equal(MolarFlowUnit.KilomolePerHour, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -274,7 +274,7 @@ namespace UnitsNet.Tests
 
             try
             {
-                var parsed = MolarFlow.Parse("1 kmol/h", CultureInfo.GetCultureInfo("en-US"));
+                var parsed = MolarFlow.Parse("1 mol/h", CultureInfo.GetCultureInfo("en-US"));
                 AssertEx.EqualTolerance(1, parsed.MolesPerHour, MolesPerHourTolerance);
                 Assert.Equal(MolarFlowUnit.MolePerHour, parsed.Unit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
@@ -320,7 +320,7 @@ namespace UnitsNet.Tests
         public void TryParse()
         {
             {
-                Assert.True(MolarFlow.TryParse("1 kkmol/h", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                Assert.True(MolarFlow.TryParse("1 kmol/h", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.KilomolesPerHour, KilomolesPerHourTolerance);
                 Assert.Equal(MolarFlowUnit.KilomolePerHour, parsed.Unit);
             }
@@ -338,7 +338,7 @@ namespace UnitsNet.Tests
             }
 
             {
-                Assert.True(MolarFlow.TryParse("1 kmol/h", CultureInfo.GetCultureInfo("en-US"), out var parsed));
+                Assert.True(MolarFlow.TryParse("1 mol/h", CultureInfo.GetCultureInfo("en-US"), out var parsed));
                 AssertEx.EqualTolerance(1, parsed.MolesPerHour, MolesPerHourTolerance);
                 Assert.Equal(MolarFlowUnit.MolePerHour, parsed.Unit);
             }
@@ -380,7 +380,7 @@ namespace UnitsNet.Tests
         {
             try
             {
-                var parsedUnit = MolarFlow.ParseUnit("kkmol/h", CultureInfo.GetCultureInfo("en-US"));
+                var parsedUnit = MolarFlow.ParseUnit("kmol/h", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(MolarFlowUnit.KilomolePerHour, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
@@ -398,7 +398,7 @@ namespace UnitsNet.Tests
 
             try
             {
-                var parsedUnit = MolarFlow.ParseUnit("kmol/h", CultureInfo.GetCultureInfo("en-US"));
+                var parsedUnit = MolarFlow.ParseUnit("mol/h", CultureInfo.GetCultureInfo("en-US"));
                 Assert.Equal(MolarFlowUnit.MolePerHour, parsedUnit);
             } catch (AmbiguousUnitParseException) { /* Some units have the same abbreviations */ }
 
@@ -438,7 +438,7 @@ namespace UnitsNet.Tests
         public void TryParseUnit()
         {
             {
-                Assert.True(MolarFlow.TryParseUnit("kkmol/h", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.True(MolarFlow.TryParseUnit("kmol/h", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(MolarFlowUnit.KilomolePerHour, parsedUnit);
             }
 
@@ -453,7 +453,7 @@ namespace UnitsNet.Tests
             }
 
             {
-                Assert.True(MolarFlow.TryParseUnit("kmol/h", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
+                Assert.True(MolarFlow.TryParseUnit("mol/h", CultureInfo.GetCultureInfo("en-US"), out var parsedUnit));
                 Assert.Equal(MolarFlowUnit.MolePerHour, parsedUnit);
             }
 
@@ -686,10 +686,10 @@ namespace UnitsNet.Tests
         public void ToString_ReturnsValueAndUnitAbbreviationInCurrentCulture()
         {
             using var _ = new CultureScope("en-US");
-            Assert.Equal("1 kkmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString());
+            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString());
             Assert.Equal("1 kmol/min", new MolarFlow(1, MolarFlowUnit.KilomolePerMinute).ToString());
             Assert.Equal("1 kmol/s", new MolarFlow(1, MolarFlowUnit.KilomolePerSecond).ToString());
-            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString());
+            Assert.Equal("1 mol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString());
             Assert.Equal("1 mol/min", new MolarFlow(1, MolarFlowUnit.MolePerMinute).ToString());
             Assert.Equal("1 mol/s", new MolarFlow(1, MolarFlowUnit.MolePerSecond).ToString());
             Assert.Equal("1 lbmol/h", new MolarFlow(1, MolarFlowUnit.PoundMolePerHour).ToString());
@@ -703,10 +703,10 @@ namespace UnitsNet.Tests
             // Chose this culture, because we don't currently have any abbreviations mapped for that culture and we expect the en-US to be used as fallback.
             var swedishCulture = CultureInfo.GetCultureInfo("sv-SE");
 
-            Assert.Equal("1 kkmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString(swedishCulture));
+            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.KilomolePerHour).ToString(swedishCulture));
             Assert.Equal("1 kmol/min", new MolarFlow(1, MolarFlowUnit.KilomolePerMinute).ToString(swedishCulture));
             Assert.Equal("1 kmol/s", new MolarFlow(1, MolarFlowUnit.KilomolePerSecond).ToString(swedishCulture));
-            Assert.Equal("1 kmol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString(swedishCulture));
+            Assert.Equal("1 mol/h", new MolarFlow(1, MolarFlowUnit.MolePerHour).ToString(swedishCulture));
             Assert.Equal("1 mol/min", new MolarFlow(1, MolarFlowUnit.MolePerMinute).ToString(swedishCulture));
             Assert.Equal("1 mol/s", new MolarFlow(1, MolarFlowUnit.MolePerSecond).ToString(swedishCulture));
             Assert.Equal("1 lbmol/h", new MolarFlow(1, MolarFlowUnit.PoundMolePerHour).ToString(swedishCulture));

--- a/UnitsNet/GeneratedCode/Resources/MolarFlow.restext
+++ b/UnitsNet/GeneratedCode/Resources/MolarFlow.restext
@@ -1,7 +1,7 @@
-KilomolesPerHour=kkmol/h
+KilomolesPerHour=kmol/h
 KilomolesPerMinute=kmol/min
 KilomolesPerSecond=kmol/s
-MolesPerHour=kmol/h
+MolesPerHour=mol/h
 MolesPerMinute=mol/min
 MolesPerSecond=mol/s
 PoundMolesPerHour=lbmol/h


### PR DESCRIPTION
## Motivation

Backport of #1682 for the v5 maintenance branch.

Issue #1663 reports that the generated abbreviations for MolarFlow per-hour units are shifted by one kilo prefix:

- `MolarFlowUnit.MolePerHour` formats/parses as `kmol/h`
- `MolarFlowUnit.KilomolePerHour` formats/parses as `kkmol/h`

The root cause is that `MolePerHour` has `Prefixes: [ "Kilo" ]`, but its base abbreviation in `MolarFlow.json` was already written as `kmol/h`. The prefix generator then prepended another `k` for the generated `KilomolePerHour` unit.

## Changes

- Change `MolePerHour` abbreviation from `kmol/h` to `mol/h`.
- Regenerate MolarFlow resources and generated tests.
- Generated abbreviations now match the other molar-flow units:
  - `MolePerHour`: `mol/h`
  - `KilomolePerHour`: `kmol/h`

## Validation

- `dotnet run --project CodeGen -p:NuGetAudit=false`
- `dotnet test UnitsNet.Tests -f net48 --filter "FullyQualifiedName~MolarFlowTests" -p:NuGetAudit=false`
- `dotnet test UnitsNet.Tests -f net9.0 -p:NuGetAudit=false`

Note: plain restore/codegen on this maintenance branch is currently blocked by an unrelated NuGet audit warning for `NuGet.Protocol` 6.12.1, so validation used `NuGetAudit=false` to avoid changing dependencies in this bugfix PR.

Fixes #1663.