### PR TITLE
ToUnit overload to preserve concrete quantity type

### DIFF
--- a/UnitsNet.Tests/CustomCode/IQuantityTests.cs
+++ b/UnitsNet.Tests/CustomCode/IQuantityTests.cs
@@ -169,6 +169,24 @@ public partial class IQuantityTests
     }
 
     [Fact]
+    public void ToUnit_SelfTypedGenericConstraint_ReturnsConcreteQuantity()
+    {
+        var length = Length.FromKilometers(1.5);
+
+        Length converted = ConvertToUnit<Length, LengthUnit>(length, LengthUnit.Meter);
+
+        Assert.Equal(1500, converted.Value);
+        Assert.Equal(LengthUnit.Meter, converted.Unit);
+
+        static TQuantity ConvertToUnit<TQuantity, TUnit>(TQuantity quantity, TUnit unit)
+            where TQuantity : IQuantity<TQuantity, TUnit>
+            where TUnit : struct, Enum
+        {
+            return quantity.ToUnit(unit);
+        }
+    }
+
+    [Fact]
     public void ToUnit_UnitSystem_ThrowsArgumentExceptionIfNotSupported()
     {
         var unsupportedUnitSystem = new UnitSystem(new BaseUnits(

--- a/UnitsNet/IQuantity.cs
+++ b/UnitsNet/IQuantity.cs
@@ -183,6 +183,16 @@ namespace UnitsNet
         /// <returns>An instance of the quantity with the specified value and unit.</returns>
         static abstract TSelf From(double value, TUnitType unit);
 
+        /// <summary>
+        ///     Converts this quantity to the specified unit while preserving its concrete quantity type.
+        /// </summary>
+        /// <param name="unit">The unit value.</param>
+        /// <returns>A new <typeparamref name="TSelf" /> in the specified unit.</returns>
+        new TSelf ToUnit(TUnitType unit)
+        {
+            return TSelf.From(As(unit), unit);
+        }
+
         static TSelf IQuantityOfType<TSelf>.Create(double value, UnitKey unit) => TSelf.From(value, unit.ToUnit<TUnitType>());
 
         static QuantityInfo IQuantityOfType<TSelf>.Info => TSelf.Info;
@@ -196,7 +206,7 @@ namespace UnitsNet
 
         IQuantity<TUnitType> IQuantity<TUnitType>.ToUnit(TUnitType unit)
         {
-            return TSelf.From(As(unit), unit);
+            return ToUnit(unit);
         }
 #endif
 


### PR DESCRIPTION
> [!NOTE]
> While v6 is still prerelease, we may instead move the complete `ToUnit` API—including the base
> member and typed overloads—to extension methods. Moving them together avoids member shadowing and
> further reduces the burden on custom quantities.

## Motivation

`IQuantity<TSelf, TUnitType>` preserves the concrete quantity type for static factories and generic
quantity metadata, but inherited `ToUnit(TUnitType)` currently returns the weaker
`IQuantity<TUnitType>` contract. Generic callers therefore lose `TSelf` and must cast or reconstruct
the concrete quantity after a unit conversion.

For example, this cannot currently return `TQuantity` without a cast:

```csharp
static TQuantity ConvertToUnit<TQuantity, TUnit>(TQuantity quantity, TUnit unit)
    where TQuantity : IQuantity<TQuantity, TUnit>
    where TUnit : struct, Enum
{
    return quantity.ToUnit(unit);
}
```

## Changes

- Add a default, self-typed `ToUnit(TUnitType)` member to `IQuantity<TSelf, TUnitType>` on modern .NET
  targets.
- Implement it through the existing `TSelf.From()` and `As()` contracts.
- Delegate the inherited `IQuantity<TUnitType>.ToUnit()` implementation to the strongly typed member.
- Add a generic test demonstrating that conversion returns `Length` directly without boxing or an
  explicit cast.

The default implementation means existing third-party quantity implementations do not need to add a
new member. The `netstandard2.0` contract is unchanged, following the interface's existing
modern-target pattern for static abstract members.

## Validation

- `dotnet build UnitsNet/UnitsNet.csproj --no-restore --verbosity minimal`
  - Builds `netstandard2.0`, `net8.0`, `net9.0`, and `net10.0`.
- `dotnet test UnitsNet.Tests/UnitsNet.Tests.csproj --no-build --verbosity minimal`
  - 42,703 passed and 20 existing skips on each of .NET 8, 9, and 10.
