### PR TITLE
Make unit relation ordering culture-invariant

### DIFF
--- a/CodeGen/Generators/QuantityRelationsParser.cs
+++ b/CodeGen/Generators/QuantityRelationsParser.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using CodeGen.Exceptions;
@@ -133,7 +134,8 @@ namespace CodeGen.Generators
             try
             {
                 var text = File.ReadAllText(relationsFileName);
-                var relationStrings = JsonConvert.DeserializeObject<SortedSet<string>>(text) ?? [];
+                var relationStrings = JsonConvert.DeserializeObject<List<string>>(text)
+                    ?.ToImmutableSortedSet(StringComparer.OrdinalIgnoreCase) ?? [];
 
                 var parsedRelations = relationStrings.Select(relationString => ParseRelation(relationString, quantities)).ToList();
 


### PR DESCRIPTION
Extracted from #1544 because deterministic code generation is independent of the QuantityValue feature and improves the existing generator on its own. Moving it out reduces the size and conflict surface of the original PR.

Changes:
- Deserialize relation definitions without relying on SortedSet's current-culture comparer.
- Normalize relations with an ordinal, case-insensitive immutable sorted set before parsing and rewriting the file.

Tests:
- No test cases changed; verified by running the full code generator and confirming it produced no unrelated generated-file changes.