### PR TITLE
Parse quantity format suffixes invariantly

### DIFF
--- a/UnitsNet.Tests/QuantityFormatterTests.cs
+++ b/UnitsNet.Tests/QuantityFormatterTests.cs
@@ -196,5 +196,19 @@ namespace UnitsNet.Tests
             var actual = QuantityFormatter.Format(length, "G");
             Assert.Equal(expected, actual);
         }
+
+        [Theory]
+        [InlineData("A+0", "m")]
+        [InlineData("S+1", "123.3 m")]
+        public void Format_CustomSpecifierSuffix_ParsesUsingInvariantCulture(string format, string expected)
+        {
+            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            culture.NumberFormat.PositiveSign = "!";
+            using var cultureScope = new CultureScope(culture);
+
+            var length = Length.FromMeters(123.321);
+
+            Assert.Equal(expected, QuantityFormatter.Default.Format(length, format));
+        }
     }
 }

--- a/UnitsNet/QuantityFormatter.cs
+++ b/UnitsNet/QuantityFormatter.cs
@@ -144,9 +144,9 @@ public class QuantityFormatter
             switch (format[0])
             {
 #if NET
-                case 'S' or 's' when int.TryParse(format.AsSpan(1), out var precisionSpecifier):
+                case 'S' or 's' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out var precisionSpecifier):
                     return ToStringWithSignificantDigitsAfterRadix(quantity, formatProvider, precisionSpecifier);
-                case 'A' or 'a' when int.TryParse(format.AsSpan(1), out var abbreviationIndex):
+                case 'A' or 'a' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out var abbreviationIndex):
                 {
                     IReadOnlyList<string> abbreviations = _unitAbbreviations.GetUnitAbbreviations(quantity.UnitKey, formatProvider);
 
@@ -157,14 +157,14 @@ public class QuantityFormatter
 
                     return abbreviations[abbreviationIndex];
                 }
-                case 'C' or 'c' when int.TryParse(format.AsSpan(1), out _):
+                case 'C' or 'c' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (currency) format is not supported.");
-                case 'P' or 'p' when int.TryParse(format.AsSpan(1), out _):
+                case 'P' or 'p' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (percent) format is not supported.");
 #else
-                case 'S' or 's' when int.TryParse(format.Substring(1), out var precisionSpecifier):
+                case 'S' or 's' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out var precisionSpecifier):
                     return ToStringWithSignificantDigitsAfterRadix(quantity, formatProvider, precisionSpecifier);
-                case 'A' or 'a' when int.TryParse(format.Substring(1), out var abbreviationIndex):
+                case 'A' or 'a' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out var abbreviationIndex):
                 {
                     IReadOnlyList<string> abbreviations = _unitAbbreviations.GetUnitAbbreviations(quantity.UnitKey, formatProvider);
 
@@ -175,9 +175,9 @@ public class QuantityFormatter
 
                     return abbreviations[abbreviationIndex];
                 }
-                case 'C' or 'c' when int.TryParse(format.Substring(1), out _):
+                case 'C' or 'c' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (currency) format is not supported.");
-                case 'P' or 'p' when int.TryParse(format.Substring(1), out _):
+                case 'P' or 'p' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (percent) format is not supported.");
 #endif
             }


### PR DESCRIPTION
Extracted from #1544 because format-string parsing is unrelated to QuantityValue and is a standalone correctness improvement for the existing formatter. Moving it out keeps the feature PR focused and lets this behavior ship independently.

Changes:
- Parse significant-digit, abbreviation-index, currency, and percent suffixes with invariant culture.
- Apply the same parsing rules to the span-based and .NET Framework-compatible code paths.

Tests:
- Add Format_CustomSpecifierSuffix_ParsesUsingInvariantCulture for abbreviation and significant-digit formats.