### PR TITLE
Support partial unit systems

### DIFF
--- a/UnitsNet.Tests/UnitSystemTests.cs
+++ b/UnitsNet.Tests/UnitSystemTests.cs
@@ -34,11 +34,20 @@ namespace UnitsNet.Tests
         [InlineData(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second, ElectricCurrentUnit.Ampere, null, AmountOfSubstanceUnit.Mole, LuminousIntensityUnit.Candela)]
         [InlineData(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second, ElectricCurrentUnit.Ampere, TemperatureUnit.Kelvin, null, LuminousIntensityUnit.Candela)]
         [InlineData(LengthUnit.Meter, MassUnit.Kilogram, DurationUnit.Second, ElectricCurrentUnit.Ampere, TemperatureUnit.Kelvin, AmountOfSubstanceUnit.Mole, null)]
-        public void ConstructorThrowsArgumentExceptionWithUndefinedUnits(LengthUnit? length, MassUnit? mass, DurationUnit? time, ElectricCurrentUnit? current,
+        [InlineData(LengthUnit.Meter, null, null, null, null, null, null)]
+        public void ConstructorSupportsPartialDimensions(LengthUnit? length, MassUnit? mass, DurationUnit? time, ElectricCurrentUnit? current,
             TemperatureUnit? temperature, AmountOfSubstanceUnit? amount, LuminousIntensityUnit? luminousIntensity)
         {
             var baseUnits = new BaseUnits(length, mass, time, current, temperature, amount, luminousIntensity);
-            Assert.Throws<ArgumentException>(() => new UnitSystem(baseUnits));
+            var unitSystem = new UnitSystem(baseUnits);
+
+            Assert.Equal(baseUnits, unitSystem.BaseUnits);
+        }
+
+        [Fact]
+        public void ConstructorThrowsArgumentExceptionWithUndefinedUnits()
+        {
+            Assert.Throws<ArgumentException>(() => new UnitSystem(BaseUnits.Undefined));
         }
 
         [Fact]

--- a/UnitsNet/UnitSystem.cs
+++ b/UnitsNet/UnitSystem.cs
@@ -16,11 +16,11 @@ namespace UnitsNet
         /// <summary>
         /// Creates an instance of a unit system with the specified base units.
         /// </summary>
-        /// <param name="baseUnits">The base units for the unit system.</param>
+        /// <param name="baseUnits">One or more base units that define the unit system.</param>
         public UnitSystem(BaseUnits baseUnits)
         {
             if (baseUnits is null) throw new ArgumentNullException(nameof(baseUnits));
-            if (!baseUnits.IsFullyDefined) throw new ArgumentException("A unit system must have all base units defined.", nameof(baseUnits));
+            if (baseUnits == BaseUnits.Undefined) throw new ArgumentException("A unit system must define at least one base unit.", nameof(baseUnits));
 
             BaseUnits = baseUnits;
         }


### PR DESCRIPTION
Extracted from #1544 because representing a unit system for only the dimensions an application uses is useful independently of QuantityValue. Moving it out gives the API change focused review and reduces the original PR's scope.

Changes:
- Allow UnitSystem to be constructed from any BaseUnits value defining at least one dimension.
- Continue rejecting null and fully undefined base-unit sets.
- Clarify the constructor documentation and exception message.

Tests:
- Change the seven previously rejected one-dimension-missing cases to assert successful construction.
- Add a single-dimension UnitSystem case.
- Add a dedicated assertion that BaseUnits.Undefined remains invalid.