### PR TITLE
Add quantity selection factories

### DIFF
--- a/UnitsNet.Tests/CustomCode/QuantityInfos/Builder/QuantitiesSelectorTests.cs
+++ b/UnitsNet.Tests/CustomCode/QuantityInfos/Builder/QuantitiesSelectorTests.cs
@@ -1,0 +1,33 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+namespace UnitsNet.Tests.QuantityInfos.Builder;
+
+public class QuantitiesSelectorTests
+{
+    [Fact]
+    public void GetQuantityInfos_WithoutAdditions_ReturnsBaseSelection()
+    {
+        var selector = new QuantitiesSelector(() => [Length.Info]);
+
+        Assert.Equal([Length.Info], selector.GetQuantityInfos());
+    }
+
+    [Fact]
+    public void WithAdditionalQuantities_AppendsAllSelectionsInOrder()
+    {
+        QuantitiesSelector selector = new QuantitiesSelector(() => [Length.Info])
+            .WithAdditionalQuantities([Mass.Info])
+            .WithAdditionalQuantities([Duration.Info]);
+
+        Assert.Equal([Length.Info, Mass.Info, Duration.Info], selector.GetQuantityInfos());
+    }
+
+    [Fact]
+    public void WithAdditionalQuantities_WithNull_ThrowsArgumentNullException()
+    {
+        var selector = new QuantitiesSelector(() => [Length.Info]);
+
+        Assert.Throws<ArgumentNullException>(() => selector.WithAdditionalQuantities(null!));
+    }
+}

--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -70,6 +70,20 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void FactoryMethods_WithNullArguments_ThrowArgumentNullException()
+        {
+            Assert.Multiple(checks:
+            [
+                () => Assert.Equal("configureQuantities",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.CreateDefault(null!)).ParamName),
+                () => Assert.Equal("defaultQuantities",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.Create(null!, _ => { })).ParamName),
+                () => Assert.Equal("configureQuantities",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.Create([Mass.Info], null!)).ParamName)
+            ]);
+        }
+
+        [Fact]
         public void UnitAbbreviationsCache_Default_ReturnsInstanceFromUnitsNetSetup()
         {
             Assert.Equal(UnitsNetSetup.Default.UnitAbbreviations, UnitAbbreviationsCache.Default);

--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -50,6 +50,26 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void CreateDefault_WithAdditionalQuantity_ReturnsCacheWithExtendedQuantityInfoLookup()
+        {
+            var unitAbbreviationCache = UnitAbbreviationsCache.CreateDefault(selector => selector.WithAdditionalQuantities([HowMuch.Info]));
+
+            Assert.NotEqual(UnitsNetSetup.Default.Quantities, unitAbbreviationCache.Quantities);
+            Assert.Equal("g", unitAbbreviationCache.GetUnitAbbreviations(MassUnit.Gram, AmericanCulture)[0]);
+            Assert.Empty(unitAbbreviationCache.GetUnitAbbreviations(HowMuchUnit.Some, AmericanCulture));
+        }
+
+        [Fact]
+        public void Create_WithBaseAndAdditionalQuantities_ReturnsConfiguredCache()
+        {
+            var unitAbbreviationCache = UnitAbbreviationsCache.Create([Mass.Info],
+                selector => selector.WithAdditionalQuantities([HowMuch.Info]));
+
+            Assert.Equal([Mass.Info, HowMuch.Info], unitAbbreviationCache.Quantities.Infos);
+            Assert.Throws<UnitNotFoundException>(() => unitAbbreviationCache.GetUnitAbbreviations(LengthUnit.Meter));
+        }
+
+        [Fact]
         public void UnitAbbreviationsCache_Default_ReturnsInstanceFromUnitsNetSetup()
         {
             Assert.Equal(UnitsNetSetup.Default.UnitAbbreviations, UnitAbbreviationsCache.Default);

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -35,6 +35,23 @@ public class UnitParserTests
         Assert.NotEqual(UnitAbbreviationsCache.Default, unitParser.Abbreviations);
         Assert.Equal(UnitsNetSetup.Default.Quantities, unitParser.Quantities);
     }
+
+    [Fact]
+    public void CreateDefault_WithAdditionalQuantity_CreatesParserWithExtendedCatalog()
+    {
+        var unitParser = UnitParser.CreateDefault(selector => selector.WithAdditionalQuantities([HowMuch.Info]));
+
+        Assert.Contains(HowMuch.Info, unitParser.Quantities.Infos);
+    }
+
+    [Fact]
+    public void Create_WithConfiguredAbbreviation_ParsesExternalQuantityUnit()
+    {
+        var unitParser = UnitParser.Create([HowMuch.Info], _ => { },
+            abbreviations => abbreviations.MapUnitToAbbreviation(HowMuchUnit.Some, "some"));
+
+        Assert.Equal(HowMuchUnit.Some, unitParser.Parse<HowMuchUnit>("some"));
+    }
         
     [Theory]
     [InlineData("m^^2", AreaUnit.SquareMeter)]

--- a/UnitsNet.Tests/UnitParserTests.cs
+++ b/UnitsNet.Tests/UnitParserTests.cs
@@ -45,12 +45,49 @@ public class UnitParserTests
     }
 
     [Fact]
+    public void CreateDefault_WithConfiguredQuantityAndAbbreviation_ParsesExternalQuantityUnit()
+    {
+        var unitParser = UnitParser.CreateDefault(
+            selector => selector.WithAdditionalQuantities([HowMuch.Info]),
+            abbreviations => abbreviations.MapUnitToAbbreviation(HowMuchUnit.Some, "some"));
+
+        Assert.Equal(HowMuchUnit.Some, unitParser.Parse<HowMuchUnit>("some"));
+    }
+
+    [Fact]
+    public void Create_WithBaseAndAdditionalQuantities_CreatesParserWithSelectedCatalog()
+    {
+        var unitParser = UnitParser.Create([Mass.Info],
+            selector => selector.WithAdditionalQuantities([HowMuch.Info]));
+
+        Assert.Equal([Mass.Info, HowMuch.Info], unitParser.Quantities.Infos);
+    }
+
+    [Fact]
     public void Create_WithConfiguredAbbreviation_ParsesExternalQuantityUnit()
     {
         var unitParser = UnitParser.Create([HowMuch.Info], _ => { },
             abbreviations => abbreviations.MapUnitToAbbreviation(HowMuchUnit.Some, "some"));
 
         Assert.Equal(HowMuchUnit.Some, unitParser.Parse<HowMuchUnit>("some"));
+    }
+
+    [Fact]
+    public void FactoryMethods_WithNullArguments_ThrowArgumentNullException()
+    {
+        Assert.Multiple(checks:
+        [
+            () => Assert.Equal("configureQuantities",
+                Assert.Throws<ArgumentNullException>(() => UnitParser.CreateDefault((Action<QuantitiesSelector>)null!)).ParamName),
+            () => Assert.Equal("configureAbbreviations",
+                Assert.Throws<ArgumentNullException>(() => UnitParser.CreateDefault(_ => { }, null!)).ParamName),
+            () => Assert.Equal("defaultQuantities",
+                Assert.Throws<ArgumentNullException>(() => UnitParser.Create(null!, _ => { })).ParamName),
+            () => Assert.Equal("configureQuantities",
+                Assert.Throws<ArgumentNullException>(() => UnitParser.Create([Mass.Info], null!)).ParamName),
+            () => Assert.Equal("configureAbbreviations",
+                Assert.Throws<ArgumentNullException>(() => UnitParser.Create([Mass.Info], _ => { }, null!)).ParamName)
+        ]);
     }
         
     [Theory]

--- a/UnitsNet.Tests/UnitsNetSetupTests.cs
+++ b/UnitsNet.Tests/UnitsNetSetupTests.cs
@@ -31,6 +31,35 @@ public class UnitsNetSetupTests
     }
 
     [Fact]
+    public void Create_WithSelectedAndAdditionalQuantities_AppendsToSelectedCatalog()
+    {
+        UnitsNetSetup setup = UnitsNetSetup.Create(builder => builder.WithQuantities([Mass.Info],
+            selector => selector.WithAdditionalQuantities([HowMuch.Info])));
+
+        Assert.Equal([Mass.Info, HowMuch.Info], setup.Quantities.Infos);
+    }
+
+    [Fact]
+    public void FactoryMethods_WithNullArguments_ThrowArgumentNullException()
+    {
+        var builder = new UnitsNetSetup.DefaultConfigurationBuilder();
+
+        Assert.Multiple(checks:
+        [
+            () => Assert.Equal("configuration",
+                Assert.Throws<ArgumentNullException>(() => UnitsNetSetup.Create(null!)).ParamName),
+            () => Assert.Equal("quantities",
+                Assert.Throws<ArgumentNullException>(() => builder.WithQuantities((IEnumerable<QuantityInfo>)null!)).ParamName),
+            () => Assert.Equal("quantities",
+                Assert.Throws<ArgumentNullException>(() => builder.WithQuantities((Func<IEnumerable<QuantityInfo>>)null!)).ParamName),
+            () => Assert.Equal("quantities",
+                Assert.Throws<ArgumentNullException>(() => builder.WithQuantities((IEnumerable<QuantityInfo>)null!, _ => { })).ParamName),
+            () => Assert.Equal("configureQuantities",
+                Assert.Throws<ArgumentNullException>(() => builder.WithQuantities(() => [Mass.Info], null!)).ParamName)
+        ]);
+    }
+
+    [Fact]
     public void Builder_WithQuantitiesTwice_ThrowsInvalidOperationException()
     {
         Assert.Throws<InvalidOperationException>(() => UnitsNetSetup.Create(builder => builder

--- a/UnitsNet.Tests/UnitsNetSetupTests.cs
+++ b/UnitsNet.Tests/UnitsNetSetupTests.cs
@@ -1,0 +1,40 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using UnitsNet.Tests.CustomQuantities;
+using UnitsNet.Units;
+
+namespace UnitsNet.Tests;
+
+public class UnitsNetSetupTests
+{
+    [Fact]
+    public void Create_WithSelectedQuantities_WiresIsolatedComponentsToSameCatalog()
+    {
+        UnitsNetSetup setup = UnitsNetSetup.Create(builder => builder.WithQuantities([Mass.Info]));
+
+        Assert.Equal([Mass.Info], setup.Quantities.Infos);
+        Assert.Same(setup.Quantities, setup.UnitAbbreviations.Quantities);
+        Assert.Same(setup.UnitAbbreviations, setup.UnitParser.Abbreviations);
+        Assert.NotSame(UnitsNetSetup.Default, setup);
+        Assert.Throws<UnitNotFoundException>(() => setup.Quantities.GetQuantityByUnitType(typeof(LengthUnit)));
+    }
+
+    [Fact]
+    public void Create_WithAdditionalQuantities_AppendsToSelectedCatalog()
+    {
+        UnitsNetSetup setup = UnitsNetSetup.Create(builder => builder
+            .WithQuantities([Mass.Info])
+            .WithAdditionalQuantities([HowMuch.Info]));
+
+        Assert.Equal([Mass.Info, HowMuch.Info], setup.Quantities.Infos);
+    }
+
+    [Fact]
+    public void Builder_WithQuantitiesTwice_ThrowsInvalidOperationException()
+    {
+        Assert.Throws<InvalidOperationException>(() => UnitsNetSetup.Create(builder => builder
+            .WithQuantities([Mass.Info])
+            .WithQuantities([Length.Info])));
+    }
+}

--- a/UnitsNet/CustomCode/QuantityInfo/Builder/QuantitiesSelector.cs
+++ b/UnitsNet/CustomCode/QuantityInfo/Builder/QuantitiesSelector.cs
@@ -1,0 +1,39 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.Linq;
+
+namespace UnitsNet;
+
+/// <summary>
+///     Selects the quantities used to construct an isolated UnitsNet component or setup.
+/// </summary>
+public sealed class QuantitiesSelector
+{
+    private readonly Func<IEnumerable<QuantityInfo>> _defaultQuantities;
+    private IEnumerable<QuantityInfo>? _additionalQuantities;
+
+    internal QuantitiesSelector(Func<IEnumerable<QuantityInfo>> defaultQuantities)
+    {
+        _defaultQuantities = defaultQuantities ?? throw new ArgumentNullException(nameof(defaultQuantities));
+    }
+
+    /// <summary>
+    ///     Appends external quantity definitions to the current selection.
+    /// </summary>
+    /// <param name="quantities">The quantity definitions to append.</param>
+    /// <returns>This selector, for method chaining.</returns>
+    public QuantitiesSelector WithAdditionalQuantities(IEnumerable<QuantityInfo> quantities)
+    {
+        if (quantities is null) throw new ArgumentNullException(nameof(quantities));
+
+        _additionalQuantities = _additionalQuantities?.Concat(quantities) ?? quantities;
+        return this;
+    }
+
+    internal IEnumerable<QuantityInfo> GetQuantityInfos()
+    {
+        IEnumerable<QuantityInfo> quantities = _defaultQuantities();
+        return _additionalQuantities is null ? quantities : quantities.Concat(_additionalQuantities);
+    }
+}

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -85,6 +85,27 @@ namespace UnitsNet
             return new UnitAbbreviationsCache();
         }
 
+        /// <summary>
+        ///     Creates a cache for the built-in quantities and any additions made by <paramref name="configureQuantities" />.
+        /// </summary>
+        /// <param name="configureQuantities">Configures the selected quantities.</param>
+        /// <returns>A cache mapped to the configured quantity selection.</returns>
+        public static UnitAbbreviationsCache CreateDefault(Action<QuantitiesSelector> configureQuantities)
+        {
+            return Create(Quantity.DefaultProvider.Quantities, configureQuantities);
+        }
+
+        /// <summary>
+        ///     Creates a cache for a configured selection based on <paramref name="defaultQuantities" />.
+        /// </summary>
+        /// <param name="defaultQuantities">The initial quantity definitions.</param>
+        /// <param name="configureQuantities">Configures the selected quantities.</param>
+        /// <returns>A cache mapped to the configured quantity selection.</returns>
+        public static UnitAbbreviationsCache Create(IEnumerable<QuantityInfo> defaultQuantities, Action<QuantitiesSelector> configureQuantities)
+        {
+            return new UnitAbbreviationsCache(QuantityInfoLookup.Create(defaultQuantities, configureQuantities));
+        }
+
         #region MapUnitToAbbreviation overloads
 
         /// <summary>

--- a/UnitsNet/CustomCode/UnitParser.cs
+++ b/UnitsNet/CustomCode/UnitParser.cs
@@ -83,6 +83,55 @@ public sealed class UnitParser
     }
 
     /// <summary>
+    ///     Creates a parser for the built-in quantities and any additions made by <paramref name="configureQuantities" />.
+    /// </summary>
+    /// <param name="configureQuantities">Configures the selected quantities.</param>
+    /// <returns>A parser for the configured quantity selection.</returns>
+    public static UnitParser CreateDefault(Action<QuantitiesSelector> configureQuantities)
+    {
+        return new UnitParser(UnitAbbreviationsCache.CreateDefault(configureQuantities));
+    }
+
+    /// <summary>
+    ///     Creates a parser for the built-in quantities, with configurable quantities and abbreviations.
+    /// </summary>
+    /// <param name="configureQuantities">Configures the selected quantities.</param>
+    /// <param name="configureAbbreviations">Configures abbreviations before constructing the parser.</param>
+    /// <returns>A parser for the configured quantities and abbreviations.</returns>
+    public static UnitParser CreateDefault(Action<QuantitiesSelector> configureQuantities, Action<UnitAbbreviationsCache> configureAbbreviations)
+    {
+        return Create(Quantity.DefaultProvider.Quantities, configureQuantities, configureAbbreviations);
+    }
+
+    /// <summary>
+    ///     Creates a parser for a configured selection based on <paramref name="defaultQuantities" />.
+    /// </summary>
+    /// <param name="defaultQuantities">The initial quantity definitions.</param>
+    /// <param name="configureQuantities">Configures the selected quantities.</param>
+    /// <returns>A parser for the configured quantity selection.</returns>
+    public static UnitParser Create(IEnumerable<QuantityInfo> defaultQuantities, Action<QuantitiesSelector> configureQuantities)
+    {
+        return new UnitParser(UnitAbbreviationsCache.Create(defaultQuantities, configureQuantities));
+    }
+
+    /// <summary>
+    ///     Creates a parser for a base catalog, with configurable quantities and abbreviations.
+    /// </summary>
+    /// <param name="defaultQuantities">The initial quantity definitions.</param>
+    /// <param name="configureQuantities">Configures the selected quantities.</param>
+    /// <param name="configureAbbreviations">Configures abbreviations before constructing the parser.</param>
+    /// <returns>A parser for the configured quantities and abbreviations.</returns>
+    public static UnitParser Create(IEnumerable<QuantityInfo> defaultQuantities, Action<QuantitiesSelector> configureQuantities,
+        Action<UnitAbbreviationsCache> configureAbbreviations)
+    {
+        if (configureAbbreviations is null) throw new ArgumentNullException(nameof(configureAbbreviations));
+
+        var unitAbbreviations = UnitAbbreviationsCache.Create(defaultQuantities, configureQuantities);
+        configureAbbreviations(unitAbbreviations);
+        return new UnitParser(unitAbbreviations);
+    }
+
+    /// <summary>
     ///     Parses a unit abbreviation for a given unit enumeration type.
     ///     Example: Parse&lt;LengthUnit&gt;("km") => LengthUnit.Kilometer
     /// </summary>

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -14,6 +14,84 @@ namespace UnitsNet;
 /// </summary>
 public sealed class UnitsNetSetup
 {
+    /// <summary>
+    ///     Builds a UnitsNet setup by selecting built-in or external quantity definitions.
+    /// </summary>
+    public sealed class DefaultConfigurationBuilder
+    {
+        private QuantitiesSelector? _quantitiesSelector;
+
+        /// <summary>
+        ///     Uses the specified quantities as the setup's base catalog.
+        /// </summary>
+        /// <param name="quantities">The quantity definitions to use.</param>
+        /// <returns>This builder, for method chaining.</returns>
+        public DefaultConfigurationBuilder WithQuantities(IEnumerable<QuantityInfo> quantities)
+        {
+            if (quantities is null) throw new ArgumentNullException(nameof(quantities));
+            return WithQuantities(() => quantities);
+        }
+
+        /// <summary>
+        ///     Uses quantities returned by <paramref name="quantities" /> as the setup's base catalog.
+        /// </summary>
+        /// <param name="quantities">Provides the quantity definitions to use.</param>
+        /// <returns>This builder, for method chaining.</returns>
+        public DefaultConfigurationBuilder WithQuantities(Func<IEnumerable<QuantityInfo>> quantities)
+        {
+            if (quantities is null) throw new ArgumentNullException(nameof(quantities));
+            if (_quantitiesSelector is not null) throw new InvalidOperationException("The base quantity selection is already configured.");
+
+            _quantitiesSelector = new QuantitiesSelector(quantities);
+            return this;
+        }
+
+        /// <summary>
+        ///     Uses the specified quantities as the setup's base catalog and configures that selection.
+        /// </summary>
+        /// <param name="quantities">The quantity definitions to use.</param>
+        /// <param name="configureQuantities">Configures the selected quantities.</param>
+        /// <returns>This builder, for method chaining.</returns>
+        public DefaultConfigurationBuilder WithQuantities(IEnumerable<QuantityInfo> quantities, Action<QuantitiesSelector> configureQuantities)
+        {
+            if (quantities is null) throw new ArgumentNullException(nameof(quantities));
+            return WithQuantities(() => quantities, configureQuantities);
+        }
+
+        /// <summary>
+        ///     Uses quantities returned by <paramref name="quantities" /> as the setup's base catalog and configures that selection.
+        /// </summary>
+        /// <param name="quantities">Provides the quantity definitions to use.</param>
+        /// <param name="configureQuantities">Configures the selected quantities.</param>
+        /// <returns>This builder, for method chaining.</returns>
+        public DefaultConfigurationBuilder WithQuantities(Func<IEnumerable<QuantityInfo>> quantities, Action<QuantitiesSelector> configureQuantities)
+        {
+            if (configureQuantities is null) throw new ArgumentNullException(nameof(configureQuantities));
+
+            WithQuantities(quantities);
+            configureQuantities(_quantitiesSelector!);
+            return this;
+        }
+
+        /// <summary>
+        ///     Appends external quantity definitions to the current selection.
+        /// </summary>
+        /// <param name="quantities">The quantity definitions to append.</param>
+        /// <returns>This builder, for method chaining.</returns>
+        public DefaultConfigurationBuilder WithAdditionalQuantities(IEnumerable<QuantityInfo> quantities)
+        {
+            _quantitiesSelector ??= new QuantitiesSelector(() => Quantity.DefaultProvider.Quantities);
+            _quantitiesSelector.WithAdditionalQuantities(quantities);
+            return this;
+        }
+
+        internal UnitsNetSetup Build()
+        {
+            IEnumerable<QuantityInfo> quantities = _quantitiesSelector?.GetQuantityInfos() ?? Quantity.DefaultProvider.Quantities;
+            return new UnitsNetSetup(quantities, UnitConverter.CreateDefault());
+        }
+    }
+
     static UnitsNetSetup()
     {
         IReadOnlyCollection<QuantityInfo> quantityInfos = Quantity.DefaultProvider.Quantities;
@@ -22,6 +100,20 @@ public sealed class UnitsNetSetup
         var unitConverter = UnitConverter.CreateDefault();
 
         Default = new UnitsNetSetup(quantityInfos, unitConverter);
+    }
+
+    /// <summary>
+    ///     Creates an isolated setup without changing <see cref="Default" />.
+    /// </summary>
+    /// <param name="configuration">Configures the quantities included in the setup.</param>
+    /// <returns>A configured UnitsNet setup.</returns>
+    public static UnitsNetSetup Create(Action<DefaultConfigurationBuilder> configuration)
+    {
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+        var builder = new DefaultConfigurationBuilder();
+        configuration(builder);
+        return builder.Build();
     }
 
     /// <summary>

--- a/UnitsNet/QuantityInfoLookup.cs
+++ b/UnitsNet/QuantityInfoLookup.cs
@@ -99,6 +99,16 @@ public class QuantityInfoLookup
     /// </summary>
     public IReadOnlyList<QuantityInfo> Infos => _quantities;
 
+    internal static QuantityInfoLookup Create(IEnumerable<QuantityInfo> defaultQuantities, Action<QuantitiesSelector> configureQuantities)
+    {
+        if (defaultQuantities is null) throw new ArgumentNullException(nameof(defaultQuantities));
+        if (configureQuantities is null) throw new ArgumentNullException(nameof(configureQuantities));
+
+        var selector = new QuantitiesSelector(() => defaultQuantities);
+        configureQuantities(selector);
+        return new QuantityInfoLookup(selector.GetQuantityInfos());
+    }
+
     /// <summary>
     ///     Retrieves the <see cref="QuantityInfo" /> associated with the specified quantity type.
     /// </summary>


### PR DESCRIPTION
Extracted from #1544 because composing an isolated quantity catalog is useful for custom quantities without depending on QuantityValue. Moving this API out gives the catalog design focused review and reduces the feature PR's size and initialization surface.

Changes:
- Add QuantitiesSelector for appending external quantity definitions to a base catalog.
- Add configured factory overloads for QuantityInfoLookup, UnitAbbreviationsCache, and UnitParser.
- Allow parser factories to configure abbreviations before parser construction.
- Add UnitsNetSetup.Create and a selection builder for isolated, consistently wired setups.
- Keep UnitsNetSetup.Default behavior unchanged.

Tests:
- Add QuantitiesSelector coverage for base, chained additions, ordering, and null input.
- Add cache factory coverage for default and custom base catalogs.
- Add parser factory coverage for external quantities and custom abbreviations.
- Add isolated setup coverage for component wiring, catalog selection, additions, and duplicate base selection.