### PR TITLE
Allow configuring global default quantities

### DIFF
--- a/.github/workflows/net48-compatibility.yml
+++ b/.github/workflows/net48-compatibility.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
         $testProjects = @(
           'UnitsNet.Tests/UnitsNet.Tests.csproj',
+          'UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj',
           'UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj',
           'UnitsNet.NumberExtensions.CS14.Tests/UnitsNet.NumberExtensions.CS14.Tests.csproj',
           'UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj'

--- a/.github/workflows/net48-compatibility.yml
+++ b/.github/workflows/net48-compatibility.yml
@@ -52,6 +52,7 @@ jobs:
       run: |
         $testProjects = @(
           'UnitsNet.Tests/UnitsNet.Tests.csproj',
+          'UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNet.GlobalSetup.DefaultFirst.Tests.csproj',
           'UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj',
           'UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj',
           'UnitsNet.NumberExtensions.CS14.Tests/UnitsNet.NumberExtensions.CS14.Tests.csproj',

--- a/Build/build-functions.psm1
+++ b/Build/build-functions.psm1
@@ -40,6 +40,8 @@ function Start-Tests {
 
   $projectPaths = @(
     "UnitsNet.Tests/UnitsNet.Tests.csproj",
+    "UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNet.GlobalSetup.DefaultFirst.Tests.csproj",
+    "UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj",
     "UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj",
     "UnitsNet.NumberExtensions.CS14.Tests/UnitsNet.NumberExtensions.CS14.Tests.csproj",
     "UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj"

--- a/UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNet.GlobalSetup.DefaultFirst.Tests.csproj
+++ b/UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNet.GlobalSetup.DefaultFirst.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <TestFramework>xunit</TestFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>../UnitsNet.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../UnitsNet/UnitsNet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNetSetupDefaultFirstTests.cs
+++ b/UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNetSetupDefaultFirstTests.cs
@@ -5,7 +5,12 @@ using Xunit;
 
 namespace UnitsNet.GlobalSetup.DefaultFirst.Tests;
 
-// This assembly intentionally contains a single test because UnitsNetSetup.Default is process-wide and cannot be reset.
+/// <summary>
+///     Tests configuring the process-wide default setup after first use.
+/// </summary>
+/// <remarks>
+///     This assembly intentionally contains a single test because <see cref="UnitsNetSetup.Default" /> cannot be reset.
+/// </remarks>
 public class UnitsNetSetupDefaultFirstTests
 {
     [Fact]

--- a/UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNetSetupDefaultFirstTests.cs
+++ b/UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNetSetupDefaultFirstTests.cs
@@ -1,0 +1,22 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using Xunit;
+
+namespace UnitsNet.GlobalSetup.DefaultFirst.Tests;
+
+// This assembly intentionally contains a single test because UnitsNetSetup.Default is process-wide and cannot be reset.
+public class UnitsNetSetupDefaultFirstTests
+{
+    [Fact]
+    public void ConfigureDefaults_AfterDefaultIsCreated_ThrowsInvalidOperationException()
+    {
+        UnitsNetSetup originalDefault = UnitsNetSetup.Default;
+        bool configurationInvoked = false;
+
+        Assert.Throws<InvalidOperationException>(() => UnitsNetSetup.ConfigureDefaults(_ => configurationInvoked = true));
+
+        Assert.False(configurationInvoked);
+        Assert.Same(originalDefault, UnitsNetSetup.Default);
+    }
+}

--- a/UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj
+++ b/UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(TargetFrameworks);net48</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsTestProject>true</IsTestProject>
+    <Nullable>enable</Nullable>
+    <TestFramework>xunit</TestFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <AssemblyOriginatorKeyFile>../UnitsNet.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <SignAssembly>true</SignAssembly>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../UnitsNet/UnitsNet.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
+++ b/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
@@ -6,8 +6,13 @@ using Xunit;
 
 namespace UnitsNet.GlobalSetup.Tests;
 
-// This assembly intentionally contains a single test because UnitsNetSetup.Default is process-wide and cannot be reset.
-// Keep additional global-configuration scenarios isolated in separate test processes.
+/// <summary>
+///     Tests configuring the process-wide default setup before first use.
+/// </summary>
+/// <remarks>
+///     This assembly intentionally contains a single test because <see cref="UnitsNetSetup.Default" /> cannot be reset.
+///     Keep additional global-configuration scenarios isolated in separate test processes.
+/// </remarks>
 public class UnitsNetSetupGlobalConfigurationTests
 {
     [Fact]

--- a/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
+++ b/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
@@ -6,6 +6,8 @@ using Xunit;
 
 namespace UnitsNet.GlobalSetup.Tests;
 
+// This assembly intentionally contains a single test because UnitsNetSetup.Default is process-wide and cannot be reset.
+// Keep additional global-configuration scenarios isolated in separate test processes.
 public class UnitsNetSetupGlobalConfigurationTests
 {
     [Fact]

--- a/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
+++ b/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
@@ -1,0 +1,23 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using UnitsNet.Units;
+using Xunit;
+
+namespace UnitsNet.GlobalSetup.Tests;
+
+public class UnitsNetSetupGlobalConfigurationTests
+{
+    [Fact]
+    public void ConfigureDefaults_BeforeFirstUse_ConfiguresAndFreezesDefaultSetup()
+    {
+        UnitsNetSetup configured = UnitsNetSetup.ConfigureDefaults(builder => builder.WithQuantities([Mass.Info]));
+
+        Assert.Same(configured, UnitsNetSetup.Default);
+        Assert.Same(configured.UnitAbbreviations, UnitAbbreviationsCache.Default);
+        Assert.Same(configured.UnitParser, UnitParser.Default);
+        Assert.Equal([Mass.Info], configured.Quantities.Infos);
+        Assert.Throws<UnitNotFoundException>(() => configured.UnitParser.Parse<LengthUnit>("m"));
+        Assert.Throws<InvalidOperationException>(() => UnitsNetSetup.ConfigureDefaults(_ => { }));
+    }
+}

--- a/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
+++ b/UnitsNet.GlobalSetup.Tests/UnitsNetSetupGlobalConfigurationTests.cs
@@ -18,6 +18,9 @@ public class UnitsNetSetupGlobalConfigurationTests
     [Fact]
     public void ConfigureDefaults_BeforeFirstUse_ConfiguresAndFreezesDefaultSetup()
     {
+        Assert.Equal("configuration",
+            Assert.Throws<ArgumentNullException>(() => UnitsNetSetup.ConfigureDefaults(null!)).ParamName);
+
         UnitsNetSetup configured = UnitsNetSetup.ConfigureDefaults(builder => builder.WithQuantities([Mass.Info]));
 
         Assert.Same(configured, UnitsNetSetup.Default);

--- a/UnitsNet.slnx
+++ b/UnitsNet.slnx
@@ -43,6 +43,7 @@
   </Folder>
   <Project Path="CodeGen/CodeGen.csproj" />
   <Project Path="UnitsNet.Benchmark/UnitsNet.Benchmark.csproj" />
+  <Project Path="UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj" />
   <Project Path="UnitsNet.NumberExtensions.CS14.Tests\UnitsNet.NumberExtensions.CS14.Tests.csproj" Type="Classic C#" />
   <Project Path="UnitsNet.NumberExtensions.CS14\UnitsNet.NumberExtensions.CS14.csproj" Type="Classic C#" />
   <Project Path="UnitsNet.NumberExtensions.Tests/UnitsNet.NumberExtensions.Tests.csproj" />

--- a/UnitsNet.slnx
+++ b/UnitsNet.slnx
@@ -43,6 +43,7 @@
   </Folder>
   <Project Path="CodeGen/CodeGen.csproj" />
   <Project Path="UnitsNet.Benchmark/UnitsNet.Benchmark.csproj" />
+  <Project Path="UnitsNet.GlobalSetup.DefaultFirst.Tests/UnitsNet.GlobalSetup.DefaultFirst.Tests.csproj" />
   <Project Path="UnitsNet.GlobalSetup.Tests/UnitsNet.GlobalSetup.Tests.csproj" />
   <Project Path="UnitsNet.NumberExtensions.CS14.Tests\UnitsNet.NumberExtensions.CS14.Tests.csproj" Type="Classic C#" />
   <Project Path="UnitsNet.NumberExtensions.CS14\UnitsNet.NumberExtensions.CS14.csproj" Type="Classic C#" />

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -14,7 +14,9 @@ namespace UnitsNet;
 /// </summary>
 public sealed class UnitsNetSetup
 {
-    // Lazy<T> synchronizes value creation; this lock also makes the builder swap and creation checks atomic with it.
+    /// <summary>
+    ///     Synchronizes the default builder swap and creation checks with the value creation already synchronized by <see cref="Lazy{T}" />.
+    /// </summary>
     private static readonly object DefaultConfigurationLock = new();
     private static DefaultConfigurationBuilder _defaultConfigurationBuilder = new();
     private static readonly Lazy<UnitsNetSetup> DefaultConfiguration = new(BuildDefault);

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -14,6 +14,7 @@ namespace UnitsNet;
 /// </summary>
 public sealed class UnitsNetSetup
 {
+    // Lazy<T> synchronizes value creation; this lock also makes the builder swap and creation checks atomic with it.
     private static readonly object DefaultConfigurationLock = new();
     private static DefaultConfigurationBuilder _defaultConfigurationBuilder = new();
     private static readonly Lazy<UnitsNetSetup> DefaultConfiguration = new(BuildDefault);
@@ -124,6 +125,7 @@ public sealed class UnitsNetSetup
     /// <param name="configuration">Configures the quantities included in the default setup.</param>
     /// <returns>The configured global default setup.</returns>
     /// <exception cref="InvalidOperationException">The default setup has already been created.</exception>
+    /// <seealso cref="Default" />
     public static UnitsNetSetup ConfigureDefaults(Action<DefaultConfigurationBuilder> configuration)
     {
         if (configuration is null) throw new ArgumentNullException(nameof(configuration));
@@ -172,10 +174,13 @@ public sealed class UnitsNetSetup
     ///     provided.
     /// </summary>
     /// <remarks>
+    ///     Call <see cref="ConfigureDefaults" /> before first accessing this property to select a different quantity catalog.<br />
+    ///     <br />
     ///     Manipulating this instance, such as adding new units or changing default unit abbreviations, will affect most
     ///     usages of UnitsNet in the
     ///     current AppDomain since the typical use is via static members and not providing a setup instance.
     /// </remarks>
+    /// <seealso cref="ConfigureDefaults" />
     public static UnitsNetSetup Default => DefaultConfiguration.Value;
 
     /// <summary>

--- a/UnitsNet/CustomCode/UnitsNetSetup.cs
+++ b/UnitsNet/CustomCode/UnitsNetSetup.cs
@@ -14,6 +14,10 @@ namespace UnitsNet;
 /// </summary>
 public sealed class UnitsNetSetup
 {
+    private static readonly object DefaultConfigurationLock = new();
+    private static DefaultConfigurationBuilder _defaultConfigurationBuilder = new();
+    private static readonly Lazy<UnitsNetSetup> DefaultConfiguration = new(BuildDefault);
+
     /// <summary>
     ///     Builds a UnitsNet setup by selecting built-in or external quantity definitions.
     /// </summary>
@@ -92,14 +96,12 @@ public sealed class UnitsNetSetup
         }
     }
 
-    static UnitsNetSetup()
+    private static UnitsNetSetup BuildDefault()
     {
-        IReadOnlyCollection<QuantityInfo> quantityInfos = Quantity.DefaultProvider.Quantities;
-
-        // note: in order to support the ConvertByAbbreviation, the unit converter should require a UnitParser in the constructor
-        var unitConverter = UnitConverter.CreateDefault();
-
-        Default = new UnitsNetSetup(quantityInfos, unitConverter);
+        lock (DefaultConfigurationLock)
+        {
+            return _defaultConfigurationBuilder.Build();
+        }
     }
 
     /// <summary>
@@ -114,6 +116,36 @@ public sealed class UnitsNetSetup
         var builder = new DefaultConfigurationBuilder();
         configuration(builder);
         return builder.Build();
+    }
+
+    /// <summary>
+    ///     Configures and creates the global default setup before its first use.
+    /// </summary>
+    /// <param name="configuration">Configures the quantities included in the default setup.</param>
+    /// <returns>The configured global default setup.</returns>
+    /// <exception cref="InvalidOperationException">The default setup has already been created.</exception>
+    public static UnitsNetSetup ConfigureDefaults(Action<DefaultConfigurationBuilder> configuration)
+    {
+        if (configuration is null) throw new ArgumentNullException(nameof(configuration));
+
+        lock (DefaultConfigurationLock)
+        {
+            if (DefaultConfiguration.IsValueCreated)
+            {
+                throw new InvalidOperationException("The default configuration cannot be changed after it has been created.");
+            }
+
+            var builder = new DefaultConfigurationBuilder();
+            configuration(builder);
+
+            if (DefaultConfiguration.IsValueCreated)
+            {
+                throw new InvalidOperationException("The default configuration was created while it was being configured.");
+            }
+
+            _defaultConfigurationBuilder = builder;
+            return DefaultConfiguration.Value;
+        }
     }
 
     /// <summary>
@@ -144,7 +176,7 @@ public sealed class UnitsNetSetup
     ///     usages of UnitsNet in the
     ///     current AppDomain since the typical use is via static members and not providing a setup instance.
     /// </remarks>
-    public static UnitsNetSetup Default { get; }
+    public static UnitsNetSetup Default => DefaultConfiguration.Value;
 
     /// <summary>
     ///     Converts between units of a quantity, such as from meters to centimeters of a given length.


### PR DESCRIPTION
Extracted from #1544 because choosing the global quantity catalog is an independent setup capability, not a requirement of fractional QuantityValue. Keeping it separate makes the singleton initialization and compatibility implications explicit and allows this commit to be deferred without blocking the isolated factory APIs.

Changes:
- Lazily create UnitsNetSetup.Default from the existing setup builder.
- Add ConfigureDefaults for selecting the global catalog before first use.
- Synchronize configuration and creation so concurrent first access cannot observe a partially configured builder.
- Reject configuration after the singleton has been created.

Tests:
- Add a dedicated test assembly so global singleton state is isolated from the existing suite.
- Verify configured catalog selection, default cache/parser wiring, excluded units, and rejection of reconfiguration.