### PR TITLE
Add name-based unit abbreviation lookup overloads

### DIFF
--- a/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
+++ b/UnitsNet.Tests/UnitAbbreviationsCacheTests.cs
@@ -131,6 +131,79 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
+        public void GetDefaultAbbreviation_WithQuantityAndUnitNames_ReturnsTheExpectedAbbreviation()
+        {
+            var unitAbbreviationCache = new UnitAbbreviationsCache([Length.Info]);
+
+            string abbreviation = unitAbbreviationCache.GetDefaultAbbreviation("Length", "Millimeter", AmericanCulture);
+
+            Assert.Equal("mm", abbreviation);
+        }
+
+        [Fact]
+        public void GetUnitAbbreviations_WithQuantityAndUnitNames_ReturnsTheExpectedAbbreviations()
+        {
+            var unitAbbreviationCache = new UnitAbbreviationsCache([Area.Info]);
+
+            var abbreviations = unitAbbreviationCache.GetUnitAbbreviations("Area", "SquareMeter", AmericanCulture);
+
+            Assert.Contains("m²", abbreviations);
+        }
+
+        [Fact]
+        public void QuantityAndUnitNameOverloads_AreCaseInsensitive()
+        {
+            var unitAbbreviationCache = new UnitAbbreviationsCache([Length.Info]);
+
+            string abbreviation = unitAbbreviationCache.GetDefaultAbbreviation("length", "millimeter", AmericanCulture);
+
+            Assert.Equal("mm", abbreviation);
+        }
+
+        [Fact]
+        public void QuantityAndUnitNameOverloads_UseConfiguredQuantityLookup()
+        {
+            var unitAbbreviationCache = new UnitAbbreviationsCache([Mass.Info]);
+
+            Assert.Multiple(checks:
+            [
+                () => Assert.Equal("g", unitAbbreviationCache.GetDefaultAbbreviation("Mass", "Gram", AmericanCulture)),
+                () => Assert.Throws<QuantityNotFoundException>(() => unitAbbreviationCache.GetDefaultAbbreviation("Length", "Meter", AmericanCulture)),
+                () => Assert.Throws<QuantityNotFoundException>(() => unitAbbreviationCache.GetUnitAbbreviations("Length", "Meter", AmericanCulture))
+            ]);
+        }
+
+        [Fact]
+        public void QuantityAndUnitNameOverloads_WithInvalidNames_ThrowExpectedExceptions()
+        {
+            var unitAbbreviationCache = new UnitAbbreviationsCache([Length.Info]);
+
+            Assert.Multiple(checks:
+            [
+                () => Assert.Throws<QuantityNotFoundException>(() => unitAbbreviationCache.GetDefaultAbbreviation("InvalidQuantity", "Meter", AmericanCulture)),
+                () => Assert.Throws<UnitNotFoundException>(() => unitAbbreviationCache.GetDefaultAbbreviation("Length", "InvalidUnit", AmericanCulture)),
+                () => Assert.Throws<QuantityNotFoundException>(() => unitAbbreviationCache.GetUnitAbbreviations("InvalidQuantity", "Meter", AmericanCulture)),
+                () => Assert.Throws<UnitNotFoundException>(() => unitAbbreviationCache.GetUnitAbbreviations("Length", "InvalidUnit", AmericanCulture))
+            ]);
+        }
+
+        [Fact]
+        public void QuantityAndUnitNameOverloads_WithNullNames_ThrowArgumentNullException()
+        {
+            Assert.Multiple(checks:
+            [
+                () => Assert.Equal("quantityName",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.Default.GetDefaultAbbreviation(null!, "Meter")).ParamName),
+                () => Assert.Equal("unitName",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.Default.GetDefaultAbbreviation("Length", null!)).ParamName),
+                () => Assert.Equal("quantityName",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.Default.GetUnitAbbreviations(null!, "Meter")).ParamName),
+                () => Assert.Equal("unitName",
+                    Assert.Throws<ArgumentNullException>(() => UnitAbbreviationsCache.Default.GetUnitAbbreviations("Length", null!)).ParamName)
+            ]);
+        }
+
+        [Fact]
         public void GetDefaultAbbreviationReturnsTheExpectedAbbreviationWhenConstructedWithTheSpecificQuantityInfo()
         {
             Assert.Multiple(checks:

--- a/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
+++ b/UnitsNet/CustomCode/UnitAbbreviationsCache.cs
@@ -320,6 +320,29 @@ namespace UnitsNet
         }
 
         /// <inheritdoc cref="GetDefaultAbbreviation{TUnitType}" />
+        /// <param name="quantityName">The invariant quantity name, such as "Length". This parameter does not support localization.</param>
+        /// <param name="unitName">The invariant unit name, such as "Meter". This parameter does not support localization.</param>
+        /// <param name="formatProvider">The format provider to use for lookup. Defaults to <see cref="CultureInfo.CurrentCulture" /> if null.</param>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when <paramref name="quantityName" /> or <paramref name="unitName" /> is null.
+        /// </exception>
+        /// <exception cref="QuantityNotFoundException">
+        ///     Thrown when no quantity information is found for the specified
+        ///     <paramref name="quantityName" />.
+        /// </exception>
+        /// <exception cref="UnitNotFoundException">
+        ///     Thrown when no unit information is found for the specified
+        ///     <paramref name="quantityName" /> and <paramref name="unitName" />.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        ///     Thrown when no abbreviations are mapped for the specified unit.
+        /// </exception>
+        public string GetDefaultAbbreviation(string quantityName, string unitName, IFormatProvider? formatProvider = null)
+        {
+            return GetDefaultAbbreviation(GetConfiguredUnitInfo(quantityName, unitName), formatProvider);
+        }
+
+        /// <inheritdoc cref="GetDefaultAbbreviation{TUnitType}" />
         /// <param name="unitInfo">The info representing the unit.</param>
         /// <param name="formatProvider">The format provider to use for lookup. Defaults to <see cref="CultureInfo.CurrentCulture" /> if null.</param>
         /// <exception cref="UnitNotFoundException">
@@ -393,6 +416,29 @@ namespace UnitsNet
         public IReadOnlyList<string> GetUnitAbbreviations(UnitKey unitKey, IFormatProvider? formatProvider = null)
         {
             return GetUnitAbbreviations(Quantities.GetUnitInfo(unitKey), formatProvider);
+        }
+
+        /// <summary>
+        /// Retrieves the unit abbreviations for a specified quantity and unit name with an optional format provider.
+        /// </summary>
+        /// <param name="quantityName">The invariant quantity name, such as "Length". This parameter does not support localization.</param>
+        /// <param name="unitName">The invariant unit name, such as "Meter". This parameter does not support localization.</param>
+        /// <param name="formatProvider">The format provider to use for lookup. Defaults to <see cref="CultureInfo.CurrentCulture" /> if null.</param>
+        /// <returns>A read-only collection of unit abbreviation strings.</returns>
+        /// <exception cref="ArgumentNullException">
+        ///     Thrown when <paramref name="quantityName" /> or <paramref name="unitName" /> is null.
+        /// </exception>
+        /// <exception cref="QuantityNotFoundException">
+        ///     Thrown when no quantity information is found for the specified
+        ///     <paramref name="quantityName" />.
+        /// </exception>
+        /// <exception cref="UnitNotFoundException">
+        ///     Thrown when no unit information is found for the specified
+        ///     <paramref name="quantityName" /> and <paramref name="unitName" />.
+        /// </exception>
+        public IReadOnlyList<string> GetUnitAbbreviations(string quantityName, string unitName, IFormatProvider? formatProvider = null)
+        {
+            return GetUnitAbbreviations(GetConfiguredUnitInfo(quantityName, unitName), formatProvider);
         }
 
         /// <summary>
@@ -470,6 +516,14 @@ namespace UnitsNet
         {
             if (unitInfo is null) throw new ArgumentNullException(nameof(unitInfo));
             return Quantities.GetUnitInfo(unitInfo.UnitKey);
+        }
+
+        private UnitInfo GetConfiguredUnitInfo(string quantityName, string unitName)
+        {
+            if (quantityName is null) throw new ArgumentNullException(nameof(quantityName));
+            if (unitName is null) throw new ArgumentNullException(nameof(unitName));
+
+            return Quantities.GetUnitByName(quantityName, unitName);
         }
 
         /// <summary>


### PR DESCRIPTION
## Motivation

`#1067` asks for looking up unit abbreviations by quantity and unit names instead of requiring unit enum values. The parser side and `UnitInfo` overloads already exist, but the direct `UnitAbbreviationsCache.Default.GetDefaultAbbreviation("Length", "Millimeter")` shape was still missing.

Closes #1067.

## Changes

- Added `UnitAbbreviationsCache.GetDefaultAbbreviation(string quantityName, string unitName, IFormatProvider? formatProvider = null)`.
- Added `UnitAbbreviationsCache.GetUnitAbbreviations(string quantityName, string unitName, IFormatProvider? formatProvider = null)` for the same lookup shape.
- Added tests for valid lookups, case-insensitive names, configured quantity lookups, and invalid/null inputs.

## Validation

- `dotnet test UnitsNet.Tests --filter "FullyQualifiedName~UnitAbbreviationsCacheTests"`
- `dotnet test UnitsNet.Tests --no-build --filter "FullyQualifiedName~UnitAbbreviationsCacheTests"`
