### PR TITLE
Fix Compressibility inverse-pressure conversions

### DIFF
--- a/Common/UnitDefinitions/Compressibility.json
+++ b/Common/UnitDefinitions/Compressibility.json
@@ -28,8 +28,8 @@
     {
       "SingularName": "InverseKilopascal",
       "PluralName": "InverseKilopascals",
-      "FromUnitToBaseFunc": "{x} * 1e3",
-      "FromBaseToUnitFunc": "{x} / 1e3",
+      "FromUnitToBaseFunc": "{x} / 1e3",
+      "FromBaseToUnitFunc": "{x} * 1e3",
       "Localization": [
         {
           "Culture": "en-US",
@@ -40,8 +40,8 @@
     {
       "SingularName": "InverseMegapascal",
       "PluralName": "InverseMegapascals",
-      "FromUnitToBaseFunc": "{x} * 1e6",
-      "FromBaseToUnitFunc": "{x} / 1e6",
+      "FromUnitToBaseFunc": "{x} / 1e6",
+      "FromBaseToUnitFunc": "{x} * 1e6",
       "Localization": [
         {
           "Culture": "en-US",
@@ -52,8 +52,8 @@
     {
       "SingularName": "InverseAtmosphere",
       "PluralName": "InverseAtmospheres",
-      "FromUnitToBaseFunc": "{x} * 101325",
-      "FromBaseToUnitFunc": "{x} / 101325",
+      "FromUnitToBaseFunc": "{x} / 101325",
+      "FromBaseToUnitFunc": "{x} * 101325",
       "Localization": [
         {
           "Culture": "en-US",
@@ -64,8 +64,8 @@
     {
       "SingularName": "InverseMillibar",
       "PluralName": "InverseMillibars",
-      "FromUnitToBaseFunc": "{x} * 100",
-      "FromBaseToUnitFunc": "{x} / 100",
+      "FromUnitToBaseFunc": "{x} / 100",
+      "FromBaseToUnitFunc": "{x} * 100",
       "Localization": [
         {
           "Culture": "en-US",
@@ -76,8 +76,8 @@
     {
       "SingularName": "InverseBar",
       "PluralName": "InverseBars",
-      "FromUnitToBaseFunc": "{x} * 1e5",
-      "FromBaseToUnitFunc": "{x} / 1e5",
+      "FromUnitToBaseFunc": "{x} / 1e5",
+      "FromBaseToUnitFunc": "{x} * 1e5",
       "Localization": [
         {
           "Culture": "en-US",
@@ -88,8 +88,8 @@
     {
       "SingularName": "InversePoundForcePerSquareInch",
       "PluralName": "InversePoundsForcePerSquareInch",
-      "FromUnitToBaseFunc": "{x} * 6.894757293168361e3",
-      "FromBaseToUnitFunc": "{x} / 6.894757293168361e3",
+      "FromUnitToBaseFunc": "{x} / 6.894757293168361e3",
+      "FromBaseToUnitFunc": "{x} * 6.894757293168361e3",
       "Localization": [
         {
           "Culture": "en-US",

--- a/UnitsNet.Tests/CustomCode/CompressibilityTests.cs
+++ b/UnitsNet.Tests/CustomCode/CompressibilityTests.cs
@@ -18,19 +18,52 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using UnitsNet.Units;
+using Xunit;
 
 namespace UnitsNet.Tests.CustomCode
 {
     public class CompressibilityTests : CompressibilityTestsBase
     {
-        // Override properties in base class here
-
         protected override double InversePascalsInOneInversePascal => 1;
-        protected override double InverseMillibarsInOneInversePascal => 1e-2;
-        protected override double InverseKilopascalsInOneInversePascal => 1e-3;
-        protected override double InverseMegapascalsInOneInversePascal => 1e-6;
-        protected override double InverseBarsInOneInversePascal => 1e-5;
-        protected override double InversePoundsForcePerSquareInchInOneInversePascal => 1.450377377302092151542e-4;
-        protected override double InverseAtmospheresInOneInversePascal => 9.86923266716013e-6;
+        protected override double InverseMillibarsInOneInversePascal => 100;
+        protected override double InverseKilopascalsInOneInversePascal => 1e3;
+        protected override double InverseMegapascalsInOneInversePascal => 1e6;
+        protected override double InverseBarsInOneInversePascal => 1e5;
+        protected override double InversePoundsForcePerSquareInchInOneInversePascal => 6.894757293168361e3;
+        protected override double InverseAtmospheresInOneInversePascal => 101325;
+
+        [Fact]
+        public void InverseKilopascalToInversePoundForcePerSquareInch()
+        {
+            Compressibility compressibility = Compressibility.FromInverseKilopascals(1);
+
+            // 1 psi = 6.894757293168361 kPa, so 1 kPa^-1 = 6.894757293168361 psi^-1.
+            AssertEx.EqualTolerance(6.894757293168361, compressibility.InversePoundsForcePerSquareInch, 1e-12);
+        }
+
+        [Fact]
+        public void InversePoundForcePerSquareInchToInverseKilopascal()
+        {
+            Compressibility compressibility = Compressibility.FromInversePoundsForcePerSquareInch(1);
+
+            // 1 psi = 6.894757293168361 kPa, so 1 psi^-1 = 0.14503773773020923 kPa^-1.
+            AssertEx.EqualTolerance(0.14503773773020923, compressibility.InverseKilopascals, 1e-12);
+        }
+
+        [Theory]
+        [InlineData(CompressibilityUnit.InverseMillibar, 100)]
+        [InlineData(CompressibilityUnit.InverseKilopascal, 1e3)]
+        [InlineData(CompressibilityUnit.InverseMegapascal, 1e6)]
+        [InlineData(CompressibilityUnit.InverseBar, 1e5)]
+        [InlineData(CompressibilityUnit.InverseAtmosphere, 101325)]
+        [InlineData(CompressibilityUnit.InversePoundForcePerSquareInch, 6.894757293168361e3)]
+        public void OneInversePascalEqualsPressureFactorInInversePressureUnit(CompressibilityUnit unit, double expected)
+        {
+            Compressibility compressibility = Compressibility.FromInversePascals(1);
+
+            // If 1 target pressure unit equals N pascals, then 1 Pa^-1 equals N target-unit^-1.
+            AssertEx.EqualTolerance(expected, compressibility.As(unit), 1e-12);
+        }
     }
 }

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -768,20 +768,20 @@ namespace UnitsNet
             Compressibility? convertedOrNull = (Unit, unit) switch
             {
                 // CompressibilityUnit -> BaseUnit
-                (CompressibilityUnit.InverseAtmosphere, CompressibilityUnit.InversePascal) => new Compressibility(_value * 101325, CompressibilityUnit.InversePascal),
-                (CompressibilityUnit.InverseBar, CompressibilityUnit.InversePascal) => new Compressibility(_value * 1e5, CompressibilityUnit.InversePascal),
-                (CompressibilityUnit.InverseKilopascal, CompressibilityUnit.InversePascal) => new Compressibility(_value * 1e3, CompressibilityUnit.InversePascal),
-                (CompressibilityUnit.InverseMegapascal, CompressibilityUnit.InversePascal) => new Compressibility(_value * 1e6, CompressibilityUnit.InversePascal),
-                (CompressibilityUnit.InverseMillibar, CompressibilityUnit.InversePascal) => new Compressibility(_value * 100, CompressibilityUnit.InversePascal),
-                (CompressibilityUnit.InversePoundForcePerSquareInch, CompressibilityUnit.InversePascal) => new Compressibility(_value * 6.894757293168361e3, CompressibilityUnit.InversePascal),
+                (CompressibilityUnit.InverseAtmosphere, CompressibilityUnit.InversePascal) => new Compressibility(_value / 101325, CompressibilityUnit.InversePascal),
+                (CompressibilityUnit.InverseBar, CompressibilityUnit.InversePascal) => new Compressibility(_value / 1e5, CompressibilityUnit.InversePascal),
+                (CompressibilityUnit.InverseKilopascal, CompressibilityUnit.InversePascal) => new Compressibility(_value / 1e3, CompressibilityUnit.InversePascal),
+                (CompressibilityUnit.InverseMegapascal, CompressibilityUnit.InversePascal) => new Compressibility(_value / 1e6, CompressibilityUnit.InversePascal),
+                (CompressibilityUnit.InverseMillibar, CompressibilityUnit.InversePascal) => new Compressibility(_value / 100, CompressibilityUnit.InversePascal),
+                (CompressibilityUnit.InversePoundForcePerSquareInch, CompressibilityUnit.InversePascal) => new Compressibility(_value / 6.894757293168361e3, CompressibilityUnit.InversePascal),
 
                 // BaseUnit -> CompressibilityUnit
-                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseAtmosphere) => new Compressibility(_value / 101325, CompressibilityUnit.InverseAtmosphere),
-                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseBar) => new Compressibility(_value / 1e5, CompressibilityUnit.InverseBar),
-                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseKilopascal) => new Compressibility(_value / 1e3, CompressibilityUnit.InverseKilopascal),
-                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseMegapascal) => new Compressibility(_value / 1e6, CompressibilityUnit.InverseMegapascal),
-                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseMillibar) => new Compressibility(_value / 100, CompressibilityUnit.InverseMillibar),
-                (CompressibilityUnit.InversePascal, CompressibilityUnit.InversePoundForcePerSquareInch) => new Compressibility(_value / 6.894757293168361e3, CompressibilityUnit.InversePoundForcePerSquareInch),
+                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseAtmosphere) => new Compressibility(_value * 101325, CompressibilityUnit.InverseAtmosphere),
+                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseBar) => new Compressibility(_value * 1e5, CompressibilityUnit.InverseBar),
+                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseKilopascal) => new Compressibility(_value * 1e3, CompressibilityUnit.InverseKilopascal),
+                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseMegapascal) => new Compressibility(_value * 1e6, CompressibilityUnit.InverseMegapascal),
+                (CompressibilityUnit.InversePascal, CompressibilityUnit.InverseMillibar) => new Compressibility(_value * 100, CompressibilityUnit.InverseMillibar),
+                (CompressibilityUnit.InversePascal, CompressibilityUnit.InversePoundForcePerSquareInch) => new Compressibility(_value * 6.894757293168361e3, CompressibilityUnit.InversePoundForcePerSquareInch),
 
                 _ => null
             };


### PR DESCRIPTION
## Motivation

Compressibility is inverse pressure, so conversions need to use the reciprocal of the pressure conversion factor. The existing definitions used the same direction as pressure units, which inverted conversions such as `kPa^-1` to `psi^-1`.

Closes #1667.

## Changes

- Fix all non-base `Compressibility` inverse-pressure conversion functions.
- Regenerate the generated `Compressibility` code.
- Update the expected conversion constants and add focused regression coverage for `kPa^-1` <-> `psi^-1`.

## Validation

- `dotnet test UnitsNet.Tests --filter "FullyQualifiedName~CompressibilityTests"`
- `dotnet test UnitsNet.Tests --filter "FullyQualifiedName~CompressibilityTests|FullyQualifiedName~ReciprocalLengthTests|FullyQualifiedName~ReciprocalAreaTests"`
