### PR TITLE
Fail codegen for powered unit prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.user
 *.userosscache
 *.sln.docstates
+.temp/
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
+++ b/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
@@ -20,6 +20,17 @@ namespace CodeGen.Helpers.PrefixBuilder;
 /// </remarks>
 internal class UnitPrefixBuilder
 {
+    /// <summary>
+    ///     Matches abbreviations whose leading unit token is raised to the second, third, or fourth power using a
+    ///     superscript or caret, such as <c>m²</c>, <c>ft³/s</c>, or <c>m^4</c>.
+    /// </summary>
+    /// <remarks>
+    ///     This is intentionally not a general unit-expression parser. It does not match a power in a denominator or later
+    ///     compound term (<c>kg/m³</c>, <c>m/s²</c>, or <c>N·m²</c>), a leading numeric scale factor
+    ///     (<c>10³·m³</c>), parenthesized or implicit powers, or powers other than two through four. These cases do not put
+    ///     a metric prefix directly before an explicitly powered leading unit token, or are outside the scope of this
+    ///     heuristic. Unit names starting with <c>Square</c> or <c>Cubic</c> are checked separately.
+    /// </remarks>
     private static readonly Regex LeadingPoweredUnitAbbreviationRegex = new(
         @"^[^\s/·*()\-\d]+(?:[²³⁴]|\^[234])",
         RegexOptions.Compiled | RegexOptions.CultureInvariant);

--- a/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
+++ b/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
@@ -141,7 +141,8 @@ internal class UnitPrefixBuilder
 
     private static bool LooksLikePoweredUnit(Unit unit)
     {
-        // This intentionally checks naming conventions rather than dimensions, since valid derived units can have powered base dimensions.
+        // This intentionally checks naming conventions rather than dimensions, since derived units such as Watt, Joule,
+        // and Ohm have powered base dimensions and safely support prefixes.
         if (unit.SingularName.StartsWith("Square", StringComparison.Ordinal) ||
             unit.SingularName.StartsWith("Cubic", StringComparison.Ordinal))
         {

--- a/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
+++ b/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
@@ -5,6 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Text.RegularExpressions;
+using CodeGen.Exceptions;
 using CodeGen.JsonTypes;
 
 namespace CodeGen.Helpers.PrefixBuilder;
@@ -18,6 +20,10 @@ namespace CodeGen.Helpers.PrefixBuilder;
 /// </remarks>
 internal class UnitPrefixBuilder
 {
+    private static readonly Regex LeadingPoweredUnitAbbreviationRegex = new(
+        @"^[^\s/·*()\-\d]+(?:[²³⁴]|\^[234])",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
     private readonly BaseUnitPrefixes _prefixes;
 
     /// <summary>
@@ -58,6 +64,8 @@ internal class UnitPrefixBuilder
         {
             try
             {
+                ThrowIfPrefixesAreUnsafeForPoweredUnit(quantity, unit);
+
                 PrefixInfo prefixInfo = PrefixInfo.Entries[prefix];
 
                 unitsToAdd.Add(new Unit
@@ -80,6 +88,31 @@ internal class UnitPrefixBuilder
         }
 
         return unitsToAdd;
+    }
+
+    private static void ThrowIfPrefixesAreUnsafeForPoweredUnit(Quantity quantity, Unit unit)
+    {
+        if (!LooksLikePoweredUnit(unit))
+        {
+            return;
+        }
+
+        throw new UnitsNetCodeGenException(
+            $"Prefixes cannot be used on {quantity.Name}.{unit.SingularName} because it looks like a powered unit. " +
+            "Define explicit units instead, such as CubicKilometer for km³ or ThousandCubicMeter for 1000 m³.");
+    }
+
+    private static bool LooksLikePoweredUnit(Unit unit)
+    {
+        if (unit.SingularName.StartsWith("Square", StringComparison.Ordinal) ||
+            unit.SingularName.StartsWith("Cubic", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        return unit.Localization
+            .SelectMany(localization => localization.Abbreviations)
+            .Any(abbreviation => LeadingPoweredUnitAbbreviationRegex.IsMatch(abbreviation));
     }
 
     /// <summary>

--- a/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
+++ b/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
@@ -111,6 +111,22 @@ internal class UnitPrefixBuilder
         return unitsToAdd;
     }
 
+    /// <summary>
+    ///     Prevents automatic prefixes from being applied to units that appear to represent a directly powered unit.
+    /// </summary>
+    /// <param name="quantity">The quantity that defines the unit.</param>
+    /// <param name="unit">The unit configured with one or more automatic prefixes.</param>
+    /// <exception cref="UnitsNetCodeGenException">
+    ///     Thrown when the unit name starts with <c>Square</c> or <c>Cubic</c>, or when one of its abbreviations starts with
+    ///     a unit token raised to the second, third, or fourth power.
+    /// </exception>
+    /// <remarks>
+    ///     Mechanically prefixing a powered unit can produce a misleading abbreviation. For example, prefixing
+    ///     <c>CubicMeter</c> with <c>Kilo</c> produces <c>km³</c>, which means cubic kilometer rather than one thousand
+    ///     cubic meters. This guard uses unit names and <see cref="LeadingPoweredUnitAbbreviationRegex" /> as a focused
+    ///     heuristic. It intentionally does not inspect base dimensions, since valid derived units such as watt and joule
+    ///     have powered dimensions but can safely use automatic prefixes.
+    /// </remarks>
     private static void ThrowIfPrefixesAreUnsafeForPoweredUnit(Quantity quantity, Unit unit)
     {
         if (!LooksLikePoweredUnit(unit))

--- a/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
+++ b/CodeGen/Helpers/PrefixBuilder/UnitPrefixBuilder.cs
@@ -51,6 +51,9 @@ internal class UnitPrefixBuilder
     /// <exception cref="System.Exception">
     ///     Thrown when an error occurs while processing a prefix for a unit, such as an invalid prefix or unit configuration.
     /// </exception>
+    /// <exception cref="UnitsNetCodeGenException">
+    ///     Thrown when prefixes are configured for a unit that looks like a powered unit.
+    /// </exception>
     /// <remarks>
     ///     This method iterates through the existing units of the specified <see cref="Quantity" /> and applies each defined
     ///     prefix to generate new prefixed units. It ensures that the singular and plural names, conversion functions,
@@ -60,30 +63,37 @@ internal class UnitPrefixBuilder
     {
         var unitsToAdd = new List<Unit>();
         foreach (Unit unit in quantity.Units)
-        foreach (Prefix prefix in unit.Prefixes)
         {
-            try
+            if (!unit.Prefixes.Any())
             {
-                ThrowIfPrefixesAreUnsafeForPoweredUnit(quantity, unit);
-
-                PrefixInfo prefixInfo = PrefixInfo.Entries[prefix];
-
-                unitsToAdd.Add(new Unit
-                {
-                    SingularName = $"{prefix}{unit.SingularName.ToCamelCase()}", // "Kilo" + "NewtonPerMeter" => "KilonewtonPerMeter"
-                    PluralName = $"{prefix}{unit.PluralName.ToCamelCase()}", // "Kilo" + "NewtonsPerMeter" => "KilonewtonsPerMeter"
-                    BaseUnits = GetPrefixedBaseUnits(quantity.BaseDimensions, unit.BaseUnits, prefixInfo),
-                    FromBaseToUnitFunc = $"({unit.FromBaseToUnitFunc}) / {prefixInfo.Factor}",
-                    FromUnitToBaseFunc = $"({unit.FromUnitToBaseFunc}) * {prefixInfo.Factor}",
-                    Localization = GetLocalizationForPrefixUnit(unit.Localization, prefixInfo),
-                    ObsoleteText = unit.ObsoleteText,
-                    SkipConversionGeneration = unit.SkipConversionGeneration,
-                    AllowAbbreviationLookup = unit.AllowAbbreviationLookup
-                });
+                continue;
             }
-            catch (Exception e)
+
+            ThrowIfPrefixesAreUnsafeForPoweredUnit(quantity, unit);
+
+            foreach (Prefix prefix in unit.Prefixes)
             {
-                throw new Exception($"Error parsing prefix {prefix} for unit {quantity.Name}.{unit.SingularName}.", e);
+                try
+                {
+                    PrefixInfo prefixInfo = PrefixInfo.Entries[prefix];
+
+                    unitsToAdd.Add(new Unit
+                    {
+                        SingularName = $"{prefix}{unit.SingularName.ToCamelCase()}", // "Kilo" + "NewtonPerMeter" => "KilonewtonPerMeter"
+                        PluralName = $"{prefix}{unit.PluralName.ToCamelCase()}", // "Kilo" + "NewtonsPerMeter" => "KilonewtonsPerMeter"
+                        BaseUnits = GetPrefixedBaseUnits(quantity.BaseDimensions, unit.BaseUnits, prefixInfo),
+                        FromBaseToUnitFunc = $"({unit.FromBaseToUnitFunc}) / {prefixInfo.Factor}",
+                        FromUnitToBaseFunc = $"({unit.FromUnitToBaseFunc}) * {prefixInfo.Factor}",
+                        Localization = GetLocalizationForPrefixUnit(unit.Localization, prefixInfo),
+                        ObsoleteText = unit.ObsoleteText,
+                        SkipConversionGeneration = unit.SkipConversionGeneration,
+                        AllowAbbreviationLookup = unit.AllowAbbreviationLookup
+                    });
+                }
+                catch (Exception e)
+                {
+                    throw new Exception($"Error parsing prefix {prefix} for unit {quantity.Name}.{unit.SingularName}.", e);
+                }
             }
         }
 
@@ -104,6 +114,7 @@ internal class UnitPrefixBuilder
 
     private static bool LooksLikePoweredUnit(Unit unit)
     {
+        // This intentionally checks naming conventions rather than dimensions, since valid derived units can have powered base dimensions.
         if (unit.SingularName.StartsWith("Square", StringComparison.Ordinal) ||
             unit.SingularName.StartsWith("Cubic", StringComparison.Ordinal))
         {

--- a/Docs/quantity-and-unit-definition-schema.md
+++ b/Docs/quantity-and-unit-definition-schema.md
@@ -206,6 +206,9 @@ instead. For example, define `CubicMillimeterPerKilogram` for `mm³/kg` instead 
 `MillicubicMeterPerKilogram`, and define `ThousandCubicMeter` with an abbreviation such as `10³·m³` when the intended
 unit is 1000 cubic meters rather than cubic kilometers.
 
+CodeGen fails when `Prefixes` is used on a unit that looks like the powered unit itself, such as a unit name starting
+with `Square` or `Cubic`, or an abbreviation starting with `m²`, `m³`, `ft³`, or similar powered unit symbols.
+
 ## Localization object
 
 Each `Localization` entry configures abbreviations for one culture.

--- a/Docs/quantity-and-unit-definition-schema.md
+++ b/Docs/quantity-and-unit-definition-schema.md
@@ -207,7 +207,14 @@ instead. For example, define `CubicMillimeterPerKilogram` for `mm³/kg` instead 
 unit is 1000 cubic meters rather than cubic kilometers.
 
 CodeGen fails when `Prefixes` is used on a unit that looks like the powered unit itself, such as a unit name starting
-with `Square` or `Cubic`, or an abbreviation starting with `m²`, `m³`, `ft³`, or similar powered unit symbols.
+with `Square` or `Cubic`, or an abbreviation starting with `m²`, `m³`, `ft³`, or similar powered unit symbols. For
+example, generating `Kilo` from `SquareMeter` would produce `km²`, which means one square kilometer (`1e6 m²`), not
+one thousand square meters. Generating it from `CubicMeter` would produce `km³`, which means one cubic kilometer
+(`1e9 m³`), not one thousand cubic meters.
+
+This is a naming and abbreviation heuristic, not a dimensional-analysis check. Derived units such as `Watt`, `Joule`,
+and `Ohm` have powered SI base dimensions, but can safely use `Prefixes` because their own abbreviations are not
+powered unit symbols. They produce unambiguous units such as `MW`, `MJ`, and `MΩ`.
 
 ## Localization object
 


### PR DESCRIPTION
## Motivation

Follow-up to #1700.

We should fail codegen when `Prefixes` is used on units that look like powered units themselves, such as `SquareMeter`, `CubicMeter`, or abbreviations starting with `m²`, `m³`, `ft³`, and similar symbols.

That avoids reintroducing bugs like `KilocubicMeter` formatting as `km³`, where the generated prefix looks like it applies before the length unit is cubed.

This is intentionally narrower than checking base dimensions. Units like `Megawatt`, `Megajoule`, and `Megaohm` still need to be allowed even though their SI base dimensions contain exponents internally.

## Changes

- Add a CodeGen guard for `Prefixes` on units that look like powered units.
- Keep existing valid derived-unit prefixes working.
- Document that this rule is now enforced by CodeGen.

## Validation

- `dotnet build CodeGen\CodeGen.csproj`
- `generate-code.bat`
- Temporarily added `Prefixes: [ "Kilo" ]` to `Area.SquareMeter` and verified CodeGen fails with the new error, then reverted the temporary edit.