### PR TITLE
Remove JetBrains annotations dependency

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,5 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
   </ItemGroup>
 </Project>

--- a/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
+++ b/UnitsNet.Serialization.JsonNet.Tests/UnitsNet.Serialization.JsonNet.Tests.csproj
@@ -16,7 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/UnitsNet.Serialization.JsonNet.Tests/Value/QuantityValueFractionalNotationConverterTests.cs
+++ b/UnitsNet.Serialization.JsonNet.Tests/Value/QuantityValueFractionalNotationConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
-using JetBrains.Annotations;
 using Newtonsoft.Json;
 using UnitsNet.Serialization.JsonNet.Value;
 using Xunit;
 
 namespace UnitsNet.Serialization.JsonNet.Tests.Value;
-
-[TestSubject(typeof(QuantityValueFractionalNotationConverter))]
 public class QuantityValueFractionalNotationConverterTests
 {
     private static JsonSerializerSettings CreateDefaultOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedInterfaceQuantityConverterWithValueConverterTest.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedInterfaceQuantityConverterWithValueConverterTest.cs
@@ -1,15 +1,12 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests;
-
-[TestSubject(typeof(AbbreviatedInterfaceQuantityWithValueConverter))]
 public class AbbreviatedInterfaceQuantityConverterWithValueConverterTest
 {
     [Fact]

--- a/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedInterfaceQuantityWithAvailableValueConverterTest.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedInterfaceQuantityWithAvailableValueConverterTest.cs
@@ -1,15 +1,12 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests;
-
-[TestSubject(typeof(AbbreviatedInterfaceQuantityWithAvailableValueConverter))]
 public class AbbreviatedInterfaceQuantityWithAvailableValueConverterTest
 {
     [Fact]

--- a/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedQuantityConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedQuantityConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests;
-
-[TestSubject(typeof(AbbreviatedQuantityConverter))]
 public class AbbreviatedQuantityConverterTests
 {
     [Fact]

--- a/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedQuantityGenericConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/AbbreviatedQuantityGenericConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests;
-
-[TestSubject(typeof(AbbreviatedQuantityConverter<,>))]
 public class AbbreviatedQuantityGenericConverterTests
 {
     [Fact]

--- a/UnitsNet.Serialization.SystemTextJson.Tests/JsonQuantityConverterFactoryTest.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/JsonQuantityConverterFactoryTest.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests;
-
-[TestSubject(typeof(JsonQuantityConverter))]
 public class JsonQuantityConverterFactoryTest
 {
     [Theory]

--- a/UnitsNet.Serialization.SystemTextJson.Tests/JsonQuantityConverterTest.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/JsonQuantityConverterTest.cs
@@ -1,9 +1,8 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Unit;
 using UnitsNet.Serialization.SystemTextJson.Value;
 using UnitsNet.Units;
@@ -14,8 +13,6 @@ public sealed class TestObject
     public Mass? NullableMass { get; set; }
     public Mass NonNullableMass { get; set; }
 }
-
-[TestSubject(typeof(JsonQuantityConverter<,>))]
 public class JsonQuantityConverterTest
 {
     [Fact]

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Unit/AbbreviatedUnitConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Unit/AbbreviatedUnitConverterTests.cs
@@ -1,15 +1,12 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Globalization;
 using System.Text.Json;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Unit;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Unit;
-
-[TestSubject(typeof(AbbreviatedUnitConverter))]
 public class AbbreviatedUnitConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Unit/UnitTypeAndNameConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Unit/UnitTypeAndNameConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Unit;
 using UnitsNet.Units;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Unit;
-
-[TestSubject(typeof(UnitTypeAndNameConverter<>))]
 public class UnitTypeAndNameConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/UnitsNet.Serialization.SystemTextJson.Tests.csproj
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/UnitsNet.Serialization.SystemTextJson.Tests.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Annotations" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Value/BigIntegerConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Value/BigIntegerConverterTests.cs
@@ -1,13 +1,10 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Value;
-
-[TestSubject(typeof(BigIntegerConverter))]
 public class BigIntegerConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueDecimalConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueDecimalConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Value;
-
-[TestSubject(typeof(QuantityValueDecimalConverter))]
 public class QuantityValueDecimalConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueDecimalNotationConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueDecimalNotationConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Value;
-
-[TestSubject(typeof(QuantityValueDecimalNotationConverter))]
 public class QuantityValueDecimalNotationConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueDoubleConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueDoubleConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Value;
-
-[TestSubject(typeof(QuantityValueDoubleConverter))]
 public class QuantityValueDoubleConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueFractionalNotationConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueFractionalNotationConverterTests.cs
@@ -1,14 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Value;
-
-[TestSubject(typeof(QuantityValueFractionalNotationConverter))]
 public class QuantityValueFractionalNotationConverterTests
 {
     private static JsonSerializerOptions CreateDefaultOptions()

--- a/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueMixedNotationConverterTests.cs
+++ b/UnitsNet.Serialization.SystemTextJson.Tests/Value/QuantityValueMixedNotationConverterTests.cs
@@ -1,15 +1,12 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Numerics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using JetBrains.Annotations;
 using UnitsNet.Serialization.SystemTextJson.Value;
 
 namespace UnitsNet.Serialization.SystemTextJson.Tests.Value;
-
-[TestSubject(typeof(QuantityValueMixedNotationConverter))]
 public class QuantityValueMixedNotationConverterTests
 {
     private static JsonSerializerOptions CreateOptions()

--- a/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.DebugView.cs
+++ b/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.DebugView.cs
@@ -1,11 +1,9 @@
-﻿using System.Numerics;
-using JetBrains.Annotations;
+using System.Numerics;
 
 namespace UnitsNet.Tests;
 
 public partial class QuantityValueTests
 {
-    [TestSubject(typeof(QuantityValue.QuantityValueDebugView))]
     public class DebugViewTests
     {
         [Theory]

--- a/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.Extensions.cs
+++ b/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.Extensions.cs
@@ -1,10 +1,8 @@
-﻿using JetBrains.Annotations;
 
 namespace UnitsNet.Tests;
 
 public partial class QuantityValueTests
 {
-    [TestSubject(typeof(QuantityValueExtensions))]
     public class ExtensionTests
     {
         [Fact]

--- a/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.QuantityValueTypeConverter.cs
+++ b/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.QuantityValueTypeConverter.cs
@@ -1,12 +1,10 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Numerics;
-using JetBrains.Annotations;
 
 namespace UnitsNet.Tests;
 
 public partial class QuantityValueTests
 {
-    [TestSubject(typeof(QuantityValueTypeConverter))]
     public class TypeConverterTests
     {
         [Theory]

--- a/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.cs
+++ b/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.cs
@@ -1,15 +1,12 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Numerics;
-using JetBrains.Annotations;
 using Xunit.Abstractions;
 
 namespace UnitsNet.Tests;
-
-[TestSubject(typeof(QuantityValue))]
 public static partial class QuantityValueTests
 {
     public class QuantityValueData : IXunitSerializable

--- a/UnitsNet.Tests/UnitsNet.Tests.csproj
+++ b/UnitsNet.Tests/UnitsNet.Tests.csproj
@@ -33,7 +33,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>		
-    <PackageReference Include="JetBrains.Annotations" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Motivation
I don't think we should take a `JetBrains.Annotations` dependency just for test metadata.

The current usage is only `[TestSubject(...)]` hints in test projects. These are useful for ReSharper/Rider, but they are not needed by the compiler, runtime, or xUnit. For nullable flow analysis, we already use `System.Diagnostics.CodeAnalysis` attributes and keep local polyfills for older target frameworks.

## Changes
- Remove the `JetBrains.Annotations` package version and test project references.
- Remove `using JetBrains.Annotations;` and `[TestSubject(...)]` from the affected tests.
- Leave the built-in nullable annotations unchanged.

## Validation
- `dotnet build UnitsNet.Tests\UnitsNet.Tests.csproj`
- `dotnet build UnitsNet.Serialization.JsonNet.Tests\UnitsNet.Serialization.JsonNet.Tests.csproj`
- `dotnet build UnitsNet.Serialization.SystemTextJson.Tests\UnitsNet.Serialization.SystemTextJson.Tests.csproj`
- `dotnet test UnitsNet.Tests\UnitsNet.Tests.csproj --no-build --filter "FullyQualifiedName~QuantityValueTests"`
- `dotnet test UnitsNet.Serialization.JsonNet.Tests\UnitsNet.Serialization.JsonNet.Tests.csproj --no-build --filter "FullyQualifiedName~QuantityValueFractionalNotationConverterTests"`
- `dotnet test UnitsNet.Serialization.SystemTextJson.Tests\UnitsNet.Serialization.SystemTextJson.Tests.csproj --no-build --filter "FullyQualifiedName~BigIntegerConverterTests|FullyQualifiedName~QuantityValueMixedNotationConverterTests|FullyQualifiedName~QuantityValueFractionalNotationConverterTests|FullyQualifiedName~QuantityValueDoubleConverterTests|FullyQualifiedName~QuantityValueDecimalNotationConverterTests|FullyQualifiedName~QuantityValueDecimalConverterTests|FullyQualifiedName~JsonQuantityConverterTest|FullyQualifiedName~AbbreviatedQuantityGenericConverterTests|FullyQualifiedName~JsonQuantityConverterFactoryTest|FullyQualifiedName~AbbreviatedQuantityConverterTests|FullyQualifiedName~AbbreviatedUnitConverterTests|FullyQualifiedName~UnitTypeAndNameConverterTests|FullyQualifiedName~AbbreviatedInterfaceQuantityWithAvailableValueConverterTest|FullyQualifiedName~AbbreviatedInterfaceQuantityConverterWithValueConverterTest"`
