### PR TITLE
Publish UnitsNet.Modular packages to NuGet.org

### DIFF
--- a/.github/workflows/unitsnet-modular-ci.yml
+++ b/.github/workflows/unitsnet-modular-ci.yml
@@ -40,13 +40,20 @@ on:
       - 'global.json'
       - '.github/workflows/unitsnet-modular-ci.yml'
   workflow_dispatch:
+    inputs:
+      publish_nuget:
+        description: Publish to nuget.org (master or UnitsNet.Modular/* tag only)
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
 
 concurrency:
   group: unitsnet-modular-ci-${{ github.ref }}
-  cancel-in-progress: true
+  # Never interrupt a master or release-tag run while it may be publishing immutable packages.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/UnitsNet.Modular/') }}
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -107,3 +114,41 @@ jobs:
             Artifacts/UnitsNet.Modular.CI/*.snupkg
           if-no-files-found: error
           retention-days: 14
+
+  publish-nuget:
+    name: Publish NuGet packages
+    needs: build-test-pack
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    if: >-
+      github.repository_owner == 'angularsen' &&
+      (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/UnitsNet.Modular/')) &&
+      (github.event_name == 'push' || inputs.publish_nuget)
+    environment: Publish
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Download NuGet packages
+        uses: actions/download-artifact@v8
+        with:
+          name: unitsnet-modular-packages-${{ github.sha }}
+          path: nugets
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Log in to NuGet with trusted publishing
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: angularsen
+
+      - name: Push to nuget.org
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: dotnet nuget push "**/*.nupkg" --skip-duplicate --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json
+        working-directory: nugets

--- a/.github/workflows/unitsnet-modular-ci.yml
+++ b/.github/workflows/unitsnet-modular-ci.yml
@@ -42,7 +42,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_nuget:
-        description: Publish to nuget.org (master or UnitsNet.Modular/* tag only)
+        description: Publish to nuget.org (UnitsNet.Modular/* tag only)
         required: true
         default: false
         type: boolean
@@ -52,8 +52,8 @@ permissions:
 
 concurrency:
   group: unitsnet-modular-ci-${{ github.ref }}
-  # Never interrupt a master or release-tag run while it may be publishing immutable packages.
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/UnitsNet.Modular/') }}
+  # Never interrupt a release-tag run while it may be publishing immutable packages.
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/UnitsNet.Modular/') }}
 
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: true
@@ -105,6 +105,24 @@ jobs:
       - name: Pack
         run: dotnet pack UnitsNet.Modular/UnitsNet.Modular/UnitsNet.Modular.csproj --configuration Release --no-build --output Artifacts/UnitsNet.Modular.CI -p:UnitsNetModularPackForPublish=true
 
+      - name: Verify tagged package versions
+        if: startsWith(github.ref, 'refs/tags/UnitsNet.Modular/')
+        shell: pwsh
+        run: |
+          $tagRefPrefix = 'refs/tags/UnitsNet.Modular/'
+          if (-not $env:GITHUB_REF.StartsWith($tagRefPrefix, [StringComparison]::Ordinal)) {
+            throw "Expected ref '$env:GITHUB_REF' to start with '$tagRefPrefix'."
+          }
+
+          $expectedVersion = $env:GITHUB_REF.Substring($tagRefPrefix.Length)
+          $packageDirectory = 'Artifacts/UnitsNet.Modular.CI'
+          foreach ($packageId in @('UnitsNet.Modular', 'UnitsNet.Core')) {
+            $packagePath = Join-Path $packageDirectory "$packageId.$expectedVersion.nupkg"
+            if (-not (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+              throw "Expected tagged package was not produced: $packagePath"
+            }
+          }
+
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:
@@ -122,7 +140,7 @@ jobs:
     timeout-minutes: 10
     if: >-
       github.repository_owner == 'angularsen' &&
-      (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/UnitsNet.Modular/')) &&
+      startsWith(github.ref, 'refs/tags/UnitsNet.Modular/') &&
       (github.event_name == 'push' || inputs.publish_nuget)
     environment: Publish
     permissions:

--- a/UnitsNet.Core/UnitsNet.Core.csproj
+++ b/UnitsNet.Core/UnitsNet.Core.csproj
@@ -7,7 +7,8 @@
     <IsAotCompatible>true</IsAotCompatible>
     <RootNamespace>UnitsNet.Core</RootNamespace>
     <AssemblyName>UnitsNet.Core</AssemblyName>
-    <MinVerTagPrefix>UnitsNet.Core/</MinVerTagPrefix>
+    <!-- Core ships as part of Modular and intentionally shares its release tag and package version. -->
+    <MinVerTagPrefix>UnitsNet.Modular/</MinVerTagPrefix>
     <MinVerMinimumMajorMinor>6.0</MinVerMinimumMajorMinor>
     <MinVerDefaultPreReleaseIdentifiers>alpha.0</MinVerDefaultPreReleaseIdentifiers>
     <MinVerVersionOverride Condition="'$(UnitsNetCoreVersionOverride)' != '' and '$(MinVerVersionOverride)' == ''">$(UnitsNetCoreVersionOverride)</MinVerVersionOverride>

--- a/UnitsNet.Modular/ARCHITECTURE.md
+++ b/UnitsNet.Modular/ARCHITECTURE.md
@@ -363,19 +363,29 @@ executing the consumer.
 
 ## Versioning and CI
 
-The combined `UnitsNet.Modular` package uses MinVer with the tag prefix `UnitsNet.Modular/`, a minimum version
-of `6.0`, and `alpha.0` as the default prerelease identifiers. Existing `UnitsNet/*`, `JsonNet/*`,
-and unprefixed tags are ignored. A release tag such as `UnitsNet.Modular/6.0.0-alpha.1` or
-`UnitsNet.Modular/6.0.0` becomes the exact package version. Untagged builds receive a MinVer-generated
-alpha version with commit height. `UnitsNet.Modular.Generator` remains an internal, non-packable project
-because its generated code requires the runtime shipped in the combined package.
+The combined `UnitsNet.Modular` package and its `UnitsNet.Core` dependency share one MinVer release
+stream with the tag prefix `UnitsNet.Modular/`, a minimum version of `6.0`, and `alpha.0` as the
+default prerelease identifiers. Existing `UnitsNet/*`, `JsonNet/*`, and unprefixed tags are ignored.
+A release tag such as `UnitsNet.Modular/6.0.0-alpha.1` or `UnitsNet.Modular/6.0.0` becomes the exact
+version of both packages. Untagged builds give both packages the same MinVer-generated alpha version
+with commit height. Keeping their versions in lockstep makes the package dependency and release
+process explicit while Core is shipped as part of the Modular product. `UnitsNet.Modular.Generator`
+remains an internal, non-packable project because its generated code requires the runtime shipped in
+the combined package.
 
 UnitsNet, UnitsNet.Modular, and UnitsNet.Core share major version 6 to communicate the catalog
-generation they belong to, but their minor and patch versions can advance independently. UnitsNet
-retains its existing explicitly controlled version. UnitsNet.Modular and UnitsNet.Core use the
-independent MinVer tag prefixes `UnitsNet.Modular/` and `UnitsNet.Core/`, respectively. Core advances
-when its shared contracts change. Third-party definition packages have independent versions; the
-fictional sample remains at 1.x when packed directly.
+generation they belong to. UnitsNet retains its existing explicitly controlled version, while
+UnitsNet.Modular and UnitsNet.Core advance together. Third-party definition packages have independent
+versions; the fictional sample remains at 1.x when packed directly.
+
+Create an annotated release tag on a green `master` commit and push it:
+
+```powershell
+git tag -a UnitsNet.Modular/6.0.0-alpha.1 -m "UnitsNet.Modular 6.0.0-alpha.1"
+git push origin UnitsNet.Modular/6.0.0-alpha.1
+```
+
+This single tag versions and publishes both packages. Do not create `UnitsNet.Core/*` release tags.
 
 The local package automation passes a timestamped `MinVerVersionOverride` so repeated packages
 containing uncommitted changes remain unique. The package includes complete NuGet metadata,
@@ -389,11 +399,12 @@ publishing artifacts.
 
 The separate `UnitsNet.Modular CI` workflow uses full Git history, builds and tests `UnitsNet.Modular.slnx`,
 runs the minimal NuGet consumer with an isolated package cache, packs the combined package with its
-MinVer version, and uploads it as a workflow artifact. Upstream pushes to `master` publish the
-MinVer-generated alpha packages to NuGet.org, while `UnitsNet.Modular/*` tag pushes publish the exact
-tagged version. A manual run can opt into publishing when run from either of those refs. NuGet.org
-trusted publishing must authorize the `angularsen/UnitsNet` repository, the
-`unitsnet-modular-ci.yml` workflow, and the `Publish` environment.
+MinVer version, and uploads it as a workflow artifact. Upstream pushes to `master` stop there.
+`UnitsNet.Modular/*` tag pushes additionally publish the exact tagged version to NuGet.org, and a
+manual run from such a tag can opt into publishing for recovery. Before uploading or publishing, CI
+verifies that both package filenames contain the exact version declared by the tag. NuGet.org trusted
+publishing must authorize the `angularsen/UnitsNet` repository, the `unitsnet-modular-ci.yml`
+workflow, and the `Publish` environment.
 
 ## Analyzer dependency plumbing
 

--- a/UnitsNet.Modular/ARCHITECTURE.md
+++ b/UnitsNet.Modular/ARCHITECTURE.md
@@ -389,7 +389,11 @@ publishing artifacts.
 
 The separate `UnitsNet.Modular CI` workflow uses full Git history, builds and tests `UnitsNet.Modular.slnx`,
 runs the minimal NuGet consumer with an isolated package cache, packs the combined package with its
-MinVer version, and uploads it as a workflow artifact. It does not publish to NuGet.org.
+MinVer version, and uploads it as a workflow artifact. Upstream pushes to `master` publish the
+MinVer-generated alpha packages to NuGet.org, while `UnitsNet.Modular/*` tag pushes publish the exact
+tagged version. A manual run can opt into publishing when run from either of those refs. NuGet.org
+trusted publishing must authorize the `angularsen/UnitsNet` repository, the
+`unitsnet-modular-ci.yml` workflow, and the `Publish` environment.
 
 ## Analyzer dependency plumbing
 


### PR DESCRIPTION
## Motivation

The UnitsNet.Modular CI packs `UnitsNet.Modular` and `UnitsNet.Core`, but only keeps the packages as workflow artifacts. Release tags should publish an exact, matching package set to NuGet.org without publishing every `master` build.

## Changes

- keep `master` builds as workflow artifacts only
- publish only `UnitsNet.Modular/*` tag builds, with an opt-in manual retry from a tag
- version `UnitsNet.Modular` and `UnitsNet.Core` in lockstep from the same tag
- verify both package filenames match the tag before publishing
- authenticate through trusted publishing and protect release runs from cancellation
- document tag-driven releases and trusted-policy requirements

## Validation

- `github-actionlint .github/workflows/unitsnet-modular-ci.yml`
- `git diff --check`
- publish-style pack produced matching `6.0.0-alpha.0.2236` Modular and Core packages
- verified the Modular nuspec pins Core to the same version for all target frameworks
- configured the matching NuGet.org trusted-publishing policy for package owner `UnitsNet`
