### PR TITLE
Identify UnitsNet.Modular specs by semantic ID

### DIFF
--- a/UnitsNet.Modular/ARCHITECTURE.md
+++ b/UnitsNet.Modular/ARCHITECTURE.md
@@ -46,7 +46,9 @@ source emitted during post-initialization.
 
 Authoring types use role-specific suffixes: quantity recipes are `*Spec`, reusable unit filters are
 `*UnitSet`, and reusable selection groups are `*Profile`. This keeps an input such as `LengthSpec`
-visually distinct from the generated `Length` quantity and `LengthUnit` enum.
+visually distinct from the generated `Length` quantity and `LengthUnit` enum. Each built-in or
+custom spec identifies its definition through `[QuantityDefinition]`; the generator does not infer
+identity from the spec's namespace or type name.
 
 Select every unit for a built-in quantity by inheriting `IInclude<TQuantitySpec>`:
 

--- a/UnitsNet.Modular/README.md
+++ b/UnitsNet.Modular/README.md
@@ -343,7 +343,9 @@ IInclude<UnitsNet.Modular.BuiltIns.LengthSpec, MetricLengthUnitSet>
 Built-in spec names add the `Spec` suffix to quantity definition names in the UnitsNet catalog, so
 the `Length` recipe is selected with `UnitsNet.Modular.BuiltIns.LengthSpec`. The specs are generated
 by the analyzer in `UnitsNet.Modular.BuiltIns`; generated quantities retain their familiar names,
-such as `Length` and `LengthUnit`.
+such as `Length` and `LengthUnit`. Built-in and custom specs both declare their stable semantic ID
+with `[QuantityDefinition]`; the namespace and `Spec` suffix are naming conventions, not lookup
+rules.
 
 ### Use profiles
 

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/QuantityFacadeGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/QuantityFacadeGeneratorTests.cs
@@ -44,6 +44,29 @@ public sealed class QuantityFacadeGeneratorTests
     }
 
     [Fact]
+    public void AttributedSpecOutsideBuiltInNamespace_ResolvesBuiltInBySemanticId()
+    {
+        GeneratorTestHost.TestRun run = GeneratorTestHost.Run("""
+            using UnitsNet.Modular;
+
+            namespace Application.Units;
+
+            [QuantityDefinition("UnitsNet.Length")]
+            internal interface DistanceRecipe;
+
+            [UnitsNetModule]
+            internal interface Module : IInclude<DistanceRecipe>;
+            """);
+
+        Assert.DoesNotContain(run.Result.Diagnostics, diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(run.Compilation.GetDiagnostics(), diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains(
+            run.Result.Results.SelectMany(result => result.GeneratedSources),
+            source => source.HintName.EndsWith("_Length.g.cs", StringComparison.Ordinal));
+        Assert.Contains("namespace UnitsNet", GetFacade(run), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NamespaceOverride_EmitsQuantityFacadeInRequestedNamespace()
     {
         GeneratorTestHost.TestRun run = GeneratorTestHost.Run("""

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/BootstrapSource.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/BootstrapSource.cs
@@ -32,7 +32,10 @@ internal static class BootstrapSource
         writer.AppendLine("{");
         foreach (string quantityName in BuiltInCatalog.Names)
         {
-            writer.Append("    internal sealed class ").Append(quantityName).AppendLine("Spec { }");
+            writer.Append("    [global::UnitsNet.Modular.QuantityDefinition(\"UnitsNet.")
+                .Append(quantityName)
+                .AppendLine("\")]");
+            writer.Append("    internal interface ").Append(quantityName).AppendLine("Spec { }");
         }
 
         writer.AppendLine("}");

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/BuiltInCatalog.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/BuiltInCatalog.cs
@@ -20,12 +20,19 @@ internal static class BuiltInCatalog
             pair => pair.Key,
             pair => PrefixExpander.Expand(pair.Value, BaseUnitPrefixes),
             StringComparer.Ordinal);
+    private static readonly IReadOnlyDictionary<string, QuantityDefinition> DefinitionsBySemanticId =
+        Definitions.Values.ToDictionary(
+            definition => definition.SemanticId,
+            StringComparer.Ordinal);
 
     public static IReadOnlyList<string> Names { get; } =
         Definitions.Keys.OrderBy(name => name, StringComparer.Ordinal).ToArray();
 
-    public static bool TryGet(string name, out QuantityDefinition definition)
+    public static bool TryGetByName(string name, out QuantityDefinition definition)
         => Definitions.TryGetValue(name, out definition!);
+
+    public static bool TryGetBySemanticId(string semanticId, out QuantityDefinition definition)
+        => DefinitionsBySemanticId.TryGetValue(semanticId, out definition!);
 
     public static PrefixExpander.BaseUnitPrefixCatalog CreateBaseUnitPrefixes(
         IEnumerable<QuantityDefinition> additionalDefinitions) =>

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/ModuleRequest.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/ModuleRequest.cs
@@ -35,7 +35,9 @@ internal sealed class ModuleRequest
     public string FacadeNamespace =>
         !string.IsNullOrWhiteSpace(TargetNamespace)
             ? TargetNamespace!
-            : Selections.Any(selection => selection.BuiltInName is not null)
+            : Selections.Any(
+                selection => selection.SemanticId is not null &&
+                             BuiltInCatalog.TryGetBySemanticId(selection.SemanticId, out _))
                 ? "UnitsNet"
                 : OwnerNamespace;
 
@@ -50,23 +52,20 @@ internal sealed class ModuleSelection
 {
     public ModuleSelection(
         string specName,
-        string? builtInName,
-        string? definitionId,
+        string? semanticId,
         ImmutableArray<string> patterns,
         bool hasUnitSet,
         bool isDirect)
     {
         SpecName = specName;
-        BuiltInName = builtInName;
-        DefinitionId = definitionId;
+        SemanticId = semanticId;
         Patterns = patterns;
         HasUnitSet = hasUnitSet;
         IsDirect = isDirect;
         Fingerprint = string.Join(
             "|",
             specName,
-            builtInName ?? string.Empty,
-            definitionId ?? string.Empty,
+            semanticId ?? string.Empty,
             hasUnitSet,
             isDirect,
             string.Join("\u001f", patterns));
@@ -74,9 +73,7 @@ internal sealed class ModuleSelection
 
     public string SpecName { get; }
 
-    public string? BuiltInName { get; }
-
-    public string? DefinitionId { get; }
+    public string? SemanticId { get; }
 
     public ImmutableArray<string> Patterns { get; }
 
@@ -85,8 +82,6 @@ internal sealed class ModuleSelection
     public bool IsDirect { get; }
 
     public string Fingerprint { get; }
-
-    public string? SemanticId => BuiltInName is null ? DefinitionId : "UnitsNet." + BuiltInName;
 }
 
 internal readonly struct SourceLocation

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/UnitsNetModularGenerator.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/UnitsNetModularGenerator.cs
@@ -18,8 +18,6 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
     private const string UnitSetAttribute = "UnitsNet.Modular.UnitSetAttribute";
     private const string QuantityAttribute = "UnitsNet.Modular.QuantityDefinitionAttribute";
     private const string GenerationNamespace = "UnitsNet.Modular";
-    private const string BuiltInsNamespace = "UnitsNet.Modular.BuiltIns";
-    private const string BuiltInSpecSuffix = "Spec";
     private const string IncludeName = "IInclude";
     private const string IncludeProfileName = "IIncludeProfile";
 
@@ -378,7 +376,7 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
         QuantityDefinition[] knownDefinitions = BuiltInCatalog.Names
             .Select(name =>
             {
-                BuiltInCatalog.TryGet(name, out QuantityDefinition definition);
+                BuiltInCatalog.TryGetByName(name, out QuantityDefinition definition);
                 return definition;
             })
             .Concat(jsonDefinitions.Values)
@@ -522,13 +520,9 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
             return null;
         }
 
-        string? builtInName = spec.ContainingNamespace.ToDisplayString() == BuiltInsNamespace &&
-                              spec.Name.EndsWith(BuiltInSpecSuffix, StringComparison.Ordinal)
-            ? spec.Name.Substring(0, spec.Name.Length - BuiltInSpecSuffix.Length)
-            : null;
         AttributeData? definitionAttribute = spec.GetAttributes()
             .FirstOrDefault(attribute => AttributeName(attribute) == QuantityAttribute);
-        string? definitionId = definitionAttribute?.ConstructorArguments.Length == 1
+        string? semanticId = definitionAttribute?.ConstructorArguments.Length == 1
             ? definitionAttribute.ConstructorArguments[0].Value as string
             : null;
         IReadOnlyList<string>? patterns = arguments.Length == 2
@@ -536,8 +530,7 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
             : Array.Empty<string>();
         return new ModuleSelection(
             spec.ToDisplayString(),
-            builtInName,
-            definitionId,
+            semanticId,
             (patterns ?? Array.Empty<string>()).OrderBy(value => value, StringComparer.Ordinal).ToImmutableArray(),
             arguments.Length == 1 || patterns is not null,
             isDirect);
@@ -599,14 +592,14 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
         ModuleSelection selection,
         IReadOnlyDictionary<string, QuantityDefinition> jsonDefinitions)
     {
-        if (selection.BuiltInName is not null &&
-            BuiltInCatalog.TryGet(selection.BuiltInName, out QuantityDefinition builtIn))
+        if (selection.SemanticId is not null &&
+            BuiltInCatalog.TryGetBySemanticId(selection.SemanticId, out QuantityDefinition builtIn))
         {
             return builtIn;
         }
 
-        return selection.DefinitionId is not null &&
-               jsonDefinitions.TryGetValue(selection.DefinitionId, out QuantityDefinition definition)
+        return selection.SemanticId is not null &&
+               jsonDefinitions.TryGetValue(selection.SemanticId, out QuantityDefinition definition)
             ? definition
             : null;
     }

--- a/UnitsNet.Modular/UnitsNet.Modular/Generation/AuthoringContracts.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular/Generation/AuthoringContracts.cs
@@ -29,11 +29,11 @@ public sealed class UnitSetAttribute : Attribute
     public string[] Patterns { get; }
 }
 
-/// <summary>Binds a public quantity spec from a definition package to a semantic quantity ID.</summary>
+/// <summary>Binds a quantity spec to a stable semantic quantity ID.</summary>
 [AttributeUsage(AttributeTargets.Interface)]
 public sealed class QuantityDefinitionAttribute : Attribute
 {
-    /// <summary>Creates a quantity spec for <paramref name="id" />.</summary>
+    /// <summary>Creates a binding to the semantic quantity ID <paramref name="id" />.</summary>
     public QuantityDefinitionAttribute(string id) => Id = id;
 
     /// <summary>Gets the stable semantic quantity ID.</summary>


### PR DESCRIPTION
## Motivation

Follow-up to #1708. Quantity spec names now have a consistent `*Spec` convention, but the generator
still treated the `UnitsNet.Modular.BuiltIns` namespace and `Spec` suffix as part of its lookup
protocol. That made a developer-facing naming convention responsible for definition identity.

## Changes

- Annotate every generated built-in spec with its stable
  `[QuantityDefinition("UnitsNet.*")]` semantic ID.
- Generate built-in specs as interfaces, matching custom specs and the attribute's supported target.
- Resolve both built-in and custom specs through the same semantic-ID path.
- Remove the built-in namespace/suffix parsing and the separate `BuiltInName` selection state.
- Resolve the default `UnitsNet` facade namespace from catalog identity rather than marker location.
- Add coverage proving an arbitrarily named spec outside the built-in namespace can select
  `UnitsNet.Length`.
- Document that `*Spec` and the built-in namespace are naming conventions, not lookup rules.

This changes only generator authoring internals and bootstrap metadata. Generated quantity names and
behavior remain unchanged.

## Validation

- Refreshed and built the local NuGet package-reference consumer with the newly packed analyzer.
- `dotnet build UnitsNet.Modular/UnitsNet.Modular.slnx --configuration Release --no-restore --no-incremental -p:GenerateDocumentationFile=false`
- `dotnet test UnitsNet.Modular/UnitsNet.Modular.slnx --configuration Release --no-build --no-restore`
- 109 tests passed: 35 runtime, 43 compatibility, and 31 generator tests.
