### PR TITLE
Rename QuantityDefinitionAttribute to QuantitySpecAttribute

### DIFF
--- a/UnitsNet.Modular/ARCHITECTURE.md
+++ b/UnitsNet.Modular/ARCHITECTURE.md
@@ -47,7 +47,7 @@ source emitted during post-initialization.
 Authoring types use role-specific suffixes: quantity recipes are `*Spec`, reusable unit filters are
 `*UnitSet`, and reusable selection groups are `*Profile`. This keeps an input such as `LengthSpec`
 visually distinct from the generated `Length` quantity and `LengthUnit` enum. Each built-in or
-custom spec identifies its definition through `[QuantityDefinition]`; the generator does not infer
+custom spec identifies its definition through `[QuantitySpec]`; the generator does not infer
 identity from the spec's namespace or type name.
 
 Select every unit for a built-in quantity by inheriting `IInclude<TQuantitySpec>`:
@@ -149,7 +149,7 @@ namespace Fictional;
 
 using UnitsNet.Modular;
 
-[QuantityDefinition("Fictional.Measurements.HowMuch")]
+[QuantitySpec("Fictional.Measurements.HowMuch")]
 public interface HowMuchSpec;
 
 [UnitsNetModule]

--- a/UnitsNet.Modular/README.md
+++ b/UnitsNet.Modular/README.md
@@ -344,7 +344,7 @@ Built-in spec names add the `Spec` suffix to quantity definition names in the Un
 the `Length` recipe is selected with `UnitsNet.Modular.BuiltIns.LengthSpec`. The specs are generated
 by the analyzer in `UnitsNet.Modular.BuiltIns`; generated quantities retain their familiar names,
 such as `Length` and `LengthUnit`. Built-in and custom specs both declare their stable semantic ID
-with `[QuantityDefinition]`; the namespace and `Spec` suffix are naming conventions, not lookup
+with `[QuantitySpec]`; the namespace and `Spec` suffix are naming conventions, not lookup
 rules.
 
 ### Use profiles
@@ -483,7 +483,7 @@ using UnitsNet.Modular;
 
 namespace Fictional.Measurements.Definitions;
 
-[QuantityDefinition("Fictional.Measurements.HowMuch")]
+[QuantitySpec("Fictional.Measurements.HowMuch")]
 public interface HowMuchSpec;
 ```
 
@@ -721,7 +721,7 @@ The props file contributes those files directly to the referencing consumer's co
 ```
 
 Quantity specs should be public so the consumer can select them. Keep their
-`[QuantityDefinition]` IDs stable once published.
+`[QuantitySpec]` semantic IDs stable once published.
 
 An organization can instead publish one canonical compiled units assembly for several controlled
 applications. That is a deployment choice, not the primary composition model. Independently

--- a/UnitsNet.Modular/Samples/DefinitionPackages/Fictional.Measurements.Definitions/QuantitySpecs.cs
+++ b/UnitsNet.Modular/Samples/DefinitionPackages/Fictional.Measurements.Definitions/QuantitySpecs.cs
@@ -5,9 +5,9 @@ using UnitsNet.Modular;
 namespace Fictional.Measurements.Definitions;
 
 /// <summary>Represents the fictional HowMuch recipe from this definition package.</summary>
-[QuantityDefinition("Fictional.Measurements.HowMuch")]
+[QuantitySpec("Fictional.Measurements.HowMuch")]
 public interface HowMuchSpec;
 
 /// <summary>Represents the fictional HowMuchDistance recipe from this definition package.</summary>
-[QuantityDefinition("Fictional.Measurements.HowMuchDistance")]
+[QuantitySpec("Fictional.Measurements.HowMuchDistance")]
 public interface HowMuchDistanceSpec;

--- a/UnitsNet.Modular/Samples/UnitsNet.Modular.Custom.Sample/Program.cs
+++ b/UnitsNet.Modular/Samples/UnitsNet.Modular.Custom.Sample/Program.cs
@@ -4,7 +4,7 @@ using UnitsNet.Modular;
 
 namespace Fictional.Measurements;
 
-[QuantityDefinition("Fictional.Measurements.HowMuch")]
+[QuantitySpec("Fictional.Measurements.HowMuch")]
 public interface HowMuchSpec
 {
 }

--- a/UnitsNet.Modular/Samples/UnitsNet.Modular.NuGet.Sample/Program.cs
+++ b/UnitsNet.Modular/Samples/UnitsNet.Modular.NuGet.Sample/Program.cs
@@ -8,7 +8,7 @@ using Catalog = UnitsNet.Modular.BuiltIns;
 
 namespace UnitsNet.Modular.NuGet.Sample;
 
-[QuantityDefinition("NuGetConsumer.Measurements.HowMuch")]
+[QuantitySpec("NuGetConsumer.Measurements.HowMuch")]
 internal interface HowMuchSpec;
 
 [UnitsNetModule]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/DiagnosticGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/DiagnosticGeneratorTests.cs
@@ -86,10 +86,10 @@ public sealed class DiagnosticGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("First.Widget")]
+            [QuantitySpec("First.Widget")]
             internal interface FirstWidgetSpec;
 
-            [QuantityDefinition("Second.Widget")]
+            [QuantitySpec("Second.Widget")]
             internal interface SecondWidgetSpec;
 
             [UnitsNetModule("Application.Units")]
@@ -111,7 +111,7 @@ public sealed class DiagnosticGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Sample.Widget")]
+            [QuantitySpec("Sample.Widget")]
             internal interface WidgetSpec;
 
             [UnitsNetModule]
@@ -142,7 +142,7 @@ public sealed class DiagnosticGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Sample.Widget")]
+            [QuantitySpec("Sample.Widget")]
             internal interface WidgetSpec;
 
             [UnitsNetModule]
@@ -177,7 +177,7 @@ public sealed class DiagnosticGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Sample.Widget")]
+            [QuantitySpec("Sample.Widget")]
             internal interface WidgetSpec;
 
             [UnitsNetModule]
@@ -209,7 +209,7 @@ public sealed class DiagnosticGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Sample.Bad-Widget")]
+            [QuantitySpec("Sample.Bad-Widget")]
             internal interface WidgetSpec;
 
             [UnitsNetModule]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/IncrementalityGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/IncrementalityGeneratorTests.cs
@@ -12,10 +12,10 @@ public sealed class IncrementalityGeneratorTests
     private const string CustomModule = """
         using UnitsNet.Modular;
 
-        [QuantityDefinition("Sample.Distance")]
+        [QuantitySpec("Sample.Distance")]
         internal interface DistanceSpec;
 
-        [QuantityDefinition("Sample.Weight")]
+        [QuantitySpec("Sample.Weight")]
         internal interface WeightSpec;
 
         [UnitsNetModule]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/PrefixGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/PrefixGeneratorTests.cs
@@ -14,7 +14,7 @@ public sealed class PrefixGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Sample.Widget")]
+            [QuantitySpec("Sample.Widget")]
             internal interface WidgetSpec;
 
             [UnitsNetModule]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/QuantityFacadeGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/QuantityFacadeGeneratorTests.cs
@@ -51,7 +51,7 @@ public sealed class QuantityFacadeGeneratorTests
 
             namespace Application.Units;
 
-            [QuantityDefinition("UnitsNet.Length")]
+            [QuantitySpec("UnitsNet.Length")]
             internal interface DistanceRecipe;
 
             [UnitsNetModule]
@@ -94,7 +94,7 @@ public sealed class QuantityFacadeGeneratorTests
 
             namespace Application.Units;
 
-            [QuantityDefinition("Fictional.Widget")]
+            [QuantitySpec("Fictional.Widget")]
             internal interface WidgetSpec;
 
             [UnitsNetModule]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/RelationshipGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/RelationshipGeneratorTests.cs
@@ -14,7 +14,7 @@ public sealed class RelationshipGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("UnitsNet.ReciprocalLength")]
+            [QuantitySpec("UnitsNet.ReciprocalLength")]
             internal interface ReciprocalLengthSpec;
 
             [UnitsNetModule("UnitsNet.Modular")]
@@ -84,10 +84,10 @@ public sealed class RelationshipGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Fictional.Width")]
+            [QuantitySpec("Fictional.Width")]
             internal interface WidthSpec;
 
-            [QuantityDefinition("Fictional.AreaLike")]
+            [QuantitySpec("Fictional.AreaLike")]
             internal interface AreaLikeSpec;
 
             [UnitSet("Meter")]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/StableEnumGeneratorTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator.Tests/StableEnumGeneratorTests.cs
@@ -34,7 +34,7 @@ public sealed class StableEnumGeneratorTests
             """
             using UnitsNet.Modular;
 
-            [QuantityDefinition("Example.Widget")]
+            [QuantitySpec("Example.Widget")]
             internal interface WidgetSpec;
 
             [UnitSet("Base", "Third")]

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/BootstrapSource.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/BootstrapSource.cs
@@ -32,7 +32,7 @@ internal static class BootstrapSource
         writer.AppendLine("{");
         foreach (string quantityName in BuiltInCatalog.Names)
         {
-            writer.Append("    [global::UnitsNet.Modular.QuantityDefinition(\"UnitsNet.")
+            writer.Append("    [global::UnitsNet.Modular.QuantitySpec(\"UnitsNet.")
                 .Append(quantityName)
                 .AppendLine("\")]");
             writer.Append("    internal interface ").Append(quantityName).AppendLine("Spec { }");

--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/UnitsNetModularGenerator.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/UnitsNetModularGenerator.cs
@@ -16,7 +16,7 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
 {
     private const string ModuleAttribute = "UnitsNet.Modular.UnitsNetModuleAttribute";
     private const string UnitSetAttribute = "UnitsNet.Modular.UnitSetAttribute";
-    private const string QuantityAttribute = "UnitsNet.Modular.QuantityDefinitionAttribute";
+    private const string QuantitySpecAttribute = "UnitsNet.Modular.QuantitySpecAttribute";
     private const string GenerationNamespace = "UnitsNet.Modular";
     private const string IncludeName = "IInclude";
     private const string IncludeProfileName = "IIncludeProfile";
@@ -520,10 +520,10 @@ public sealed class UnitsNetModularGenerator : IIncrementalGenerator
             return null;
         }
 
-        AttributeData? definitionAttribute = spec.GetAttributes()
-            .FirstOrDefault(attribute => AttributeName(attribute) == QuantityAttribute);
-        string? semanticId = definitionAttribute?.ConstructorArguments.Length == 1
-            ? definitionAttribute.ConstructorArguments[0].Value as string
+        AttributeData? specAttribute = spec.GetAttributes()
+            .FirstOrDefault(attribute => AttributeName(attribute) == QuantitySpecAttribute);
+        string? semanticId = specAttribute?.ConstructorArguments.Length == 1
+            ? specAttribute.ConstructorArguments[0].Value as string
             : null;
         IReadOnlyList<string>? patterns = arguments.Length == 2
             ? GetUnitSetPatterns(arguments[1])

--- a/UnitsNet.Modular/UnitsNet.Modular.Tests/TestModule.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Tests/TestModule.cs
@@ -10,7 +10,7 @@ internal interface ByteUnitSet
 {
 }
 
-[QuantityDefinition("Fictional.Measurements.HowMuch")]
+[QuantitySpec("Fictional.Measurements.HowMuch")]
 internal interface HowMuchSpec
 {
 }

--- a/UnitsNet.Modular/UnitsNet.Modular/Generation/AuthoringContracts.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular/Generation/AuthoringContracts.cs
@@ -31,13 +31,13 @@ public sealed class UnitSetAttribute : Attribute
 
 /// <summary>Binds a quantity spec to a stable semantic quantity ID.</summary>
 [AttributeUsage(AttributeTargets.Interface)]
-public sealed class QuantityDefinitionAttribute : Attribute
+public sealed class QuantitySpecAttribute : Attribute
 {
-    /// <summary>Creates a binding to the semantic quantity ID <paramref name="id" />.</summary>
-    public QuantityDefinitionAttribute(string id) => Id = id;
+    /// <summary>Creates a binding to the semantic quantity ID <paramref name="semanticId" />.</summary>
+    public QuantitySpecAttribute(string semanticId) => SemanticId = semanticId;
 
     /// <summary>Gets the stable semantic quantity ID.</summary>
-    public string Id { get; }
+    public string SemanticId { get; }
 }
 
 /// <summary>Selects all units from a quantity spec.</summary>


### PR DESCRIPTION
## Motivation

The public authoring vocabulary now calls selectable quantity recipes `*Spec`, but their identifying
attribute is still named `QuantityDefinitionAttribute`. That mixes the selectable spec with the
underlying JSON/catalog definition and makes examples such as `[QuantityDefinition] HowMuchSpec`
needlessly inconsistent.

## Changes

- Rename `QuantityDefinitionAttribute` to `QuantitySpecAttribute` (`[QuantitySpec]` in source).
- Rename the attribute payload property from `Id` to the more precise `SemanticId`.
- Update generated built-in spec metadata and generator attribute discovery.
- Update custom and definition-package samples, generator fixtures, runtime tests, README, and
  architecture documentation.
- Keep internal `QuantityDefinition` model terminology unchanged for actual JSON/catalog
  definitions.

This is an intentional public authoring API rename while UnitsNet.Modular is still alpha. Generated
quantity APIs and definition JSON formats are unchanged.

## Validation

- Repacked the runtime/analyzer and sample definition package, then built the package-reference
  consumer.
- Repacked and built the isolated NuGet consumer.
- `dotnet build UnitsNet.Modular/UnitsNet.Modular.slnx --configuration Release --no-restore --no-incremental -p:GenerateDocumentationFile=false`
- `dotnet test UnitsNet.Modular/UnitsNet.Modular.slnx --configuration Release --no-build --no-restore`
- 109 tests passed: 35 runtime, 43 compatibility, and 31 generator tests.
