### PR TITLE
Cover all packages in version bump scripts

### DIFF
--- a/Build/bump-version-UnitsNet.Modular.ps1
+++ b/Build/bump-version-UnitsNet.Modular.ps1
@@ -1,0 +1,81 @@
+<# .SYNOPSIS
+  Creates an annotated UnitsNet.Modular release tag with a bumped version.
+.DESCRIPTION
+  Finds the nearest reachable UnitsNet.Modular/* tag, bumps its minor, patch, or prerelease suffix,
+  and creates an annotated tag on HEAD. MinVer uses that tag to version both UnitsNet.Modular and
+  UnitsNet.Core.
+
+  Minor and patch bumps remove any prerelease suffix, matching the existing UnitsNet version scripts.
+  A suffix bump increments the final numeric prerelease identifier, for example alpha.1 to alpha.2.
+  After a stable tag, a suffix bump starts the next patch prerelease at alpha.1, matching MinVer's
+  post-release version range.
+.PARAMETER Bump
+  The semantic version component to bump: minor, patch, or suffix.
+.EXAMPLE
+  ./Build/bump-version-UnitsNet.Modular.ps1 -Bump suffix
+.EXAMPLE
+  ./Build/bump-version-UnitsNet.Modular.ps1 -Bump minor -WhatIf
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+Param(
+  [Parameter(Mandatory = $true, Position = 0)]
+  [ValidateSet("minor", "patch", "suffix")]
+  [string] $Bump
+)
+
+$ErrorActionPreference = "Stop"
+$tagPrefix = "UnitsNet.Modular/"
+$repositoryRoot = Resolve-Path "$PSScriptRoot\.."
+
+Remove-Module set-version -ErrorAction Ignore
+Import-Module "$PSScriptRoot\set-version.psm1"
+
+function Invoke-Git([string[]] $Arguments) {
+  $output = & git -C $repositoryRoot @Arguments 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "git $([string]::Join(' ', $Arguments)) failed:`n$([string]::Join([Environment]::NewLine, $output))"
+  }
+
+  return $output
+}
+
+$status = Invoke-Git @("status", "--porcelain", "--untracked-files=normal")
+if ($status) {
+  throw "The working tree must be clean before tagging a release."
+}
+
+$latestTag = [string](Invoke-Git @(
+  "describe",
+  "--tags",
+  "--abbrev=0",
+  "--match",
+  "$tagPrefix*",
+  "HEAD"
+))
+$latestTag = $latestTag.Trim()
+
+if (!$latestTag.StartsWith($tagPrefix, [StringComparison]::OrdinalIgnoreCase)) {
+  throw "Latest tag '$latestTag' does not start with '$tagPrefix'."
+}
+
+$currentVersion = $latestTag.Substring($tagPrefix.Length)
+if ($Bump -eq "suffix" -and !$currentVersion.Contains("-")) {
+  $nextPatchVersion = Get-BumpedSemanticVersion $currentVersion "patch"
+  $newVersion = Get-BumpedSemanticVersion "$nextPatchVersion-alpha.0" "suffix" "alpha.0"
+}
+else {
+  $newVersion = Get-BumpedSemanticVersion $currentVersion $Bump "alpha.0"
+}
+$newTag = "$tagPrefix$newVersion"
+
+& git -C $repositoryRoot rev-parse --verify --quiet "refs/tags/$newTag" *> $null
+if ($LASTEXITCODE -eq 0) {
+  throw "Tag '$newTag' already exists."
+}
+
+$message = "UnitsNet.Modular $newVersion"
+if ($PSCmdlet.ShouldProcess("HEAD", "Create annotated tag '$newTag'")) {
+  Invoke-Git @("tag", "--annotate", $newTag, "--message", $message, "HEAD") | Out-Null
+  Write-Host "Created annotated tag $newTag"
+  Write-Host "Push it with: git push origin $newTag"
+}

--- a/Build/bump-version-json.bat
+++ b/Build/bump-version-json.bat
@@ -1,10 +1,10 @@
 @echo off
-rem This scripts increases the version of nugets: UnitsNet.Serialization.JsonNet.
+rem This script increases the version of both UnitsNet serialization packages.
 rem The change is committed and tagged locally, but must be pushed to origin/master to take effect.
 rem Only contributors with write access can perform this directly to master, others must perform via pull request.
 
 SET scriptdir=%~dp0
-echo Bump version UnitsNet.Serialization.JsonNet nuget:
+echo Bump version UnitsNet serialization packages:
 echo.
 echo 1:   minor    4.90.0 to 4.91.0
 echo 2:   patch    4.90.0 to 4.90.1

--- a/Build/bump-version-json.sh
+++ b/Build/bump-version-json.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Increments version of nuget UnitNets.Serialization.JsonNet.
+# Increments the version of both UnitsNet serialization packages.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set_version_script="$script_dir/set-version-UnitsNet.Serialization.JsonNet.ps1"
 

--- a/Build/bump-version.bat
+++ b/Build/bump-version.bat
@@ -1,10 +1,10 @@
 @echo off
-rem This scripts increases the version of nugets: UnitsNet, UnitsNet.NumberExtensions.
+rem This script increases the version of UnitsNet and both UnitsNet.NumberExtensions packages.
 rem The change is committed and tagged locally, but must be pushed to origin/master to take effect.
 rem Only contributors with write access can perform this directly to master, others must perform via pull request.
 
 SET scriptdir=%~dp0
-echo Bump version UnitsNet and UnitsNet.NumberExtensions:
+echo Bump version UnitsNet and both UnitsNet.NumberExtensions packages:
 echo.
 echo 1:   minor    4.90.0 to 4.91.0
 echo 2:   patch    4.90.0 to 4.90.1

--- a/Build/bump-version.sh
+++ b/Build/bump-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Increments version of nugets UnitNets, UnitsNet.NumberExtensions.
+# Increments version of UnitsNet and both UnitsNet.NumberExtensions packages.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set_version_script="$script_dir/set-version-UnitsNet.ps1"
 

--- a/Build/set-version-UnitsNet.Serialization.JsonNet.ps1
+++ b/Build/set-version-UnitsNet.Serialization.JsonNet.ps1
@@ -1,5 +1,5 @@
 <# .SYNOPSIS
-  Updates the version of all UnitsNet.Serialiation.JsonNet projects.
+  Updates the version of all UnitsNet serialization projects.
 .DESCRIPTION
   Updates the <Version> property of the .csproj project files.
 .PARAMETER set
@@ -48,11 +48,25 @@ Import-Module "$PSScriptRoot\set-version.psm1"
 
 $root = Resolve-Path "$PSScriptRoot\.."
 $paramSet = $PsCmdlet.ParameterSetName
-$projFile = "$root\UnitsNet.Serialization.JsonNet\UnitsNet.Serialization.JsonNet.csproj"
+$projectFiles = @(
+  "$root\UnitsNet.Serialization.JsonNet\UnitsNet.Serialization.JsonNet.csproj",
+  "$root\UnitsNet.Serialization.SystemTextJson\UnitsNet.Serialization.SystemTextJson.csproj"
+)
 
 # Use project version as base when bumping major/minor/patch
-$newVersion = Get-NewProjectVersion $projFile $paramSet $setVersion $bumpVersion
+$newVersion = Get-NewProjectVersion $projectFiles[0] $paramSet $setVersion $bumpVersion
 
-Set-ProjectVersion $projFile $newVersion
+# Reset and stash any other local changes.
+$didStash = Invoke-StashPush
+
+foreach ($projectFile in $projectFiles) {
+  Set-ProjectVersion $projectFile $newVersion
+}
+
 Invoke-CommitVersionBump "JsonNet" $newVersion
 Invoke-TagVersionBump "JsonNet" $newVersion
+
+# Restore any local changes.
+if ($didStash) {
+  Invoke-StashPop
+}

--- a/Build/set-version-UnitsNet.ps1
+++ b/Build/set-version-UnitsNet.ps1
@@ -51,18 +51,22 @@ Import-Module "$PSScriptRoot\set-version.psm1"
 
 $root = Resolve-Path "$PSScriptRoot\.."
 $paramSet = $PsCmdlet.ParameterSetName
-$projFile = "$root\UnitsNet\UnitsNet.csproj"
-$numberExtensionsProjFile = "$root\UnitsNet.NumberExtensions\UnitsNet.NumberExtensions.csproj"
+$projectFiles = @(
+  "$root\UnitsNet\UnitsNet.csproj",
+  "$root\UnitsNet.NumberExtensions\UnitsNet.NumberExtensions.csproj",
+  "$root\UnitsNet.NumberExtensions.CS14\UnitsNet.NumberExtensions.CS14.csproj"
+)
 
-# Use UnitsNet.Common.props version as base if bumping major/minor/patch
-$newVersion = Get-NewProjectVersion $projFile $paramSet $setVersion $bumpVersion
+# Use UnitsNet version as base if bumping major/minor/patch
+$newVersion = Get-NewProjectVersion $projectFiles[0] $paramSet $setVersion $bumpVersion
 
 # Reset and stash any other local changes.
 $didStash = Invoke-StashPush
 
 # Update project files
-Set-ProjectVersion $projFile $newVersion
-Set-ProjectVersion $numberExtensionsProjFile $newVersion
+foreach ($projectFile in $projectFiles) {
+  Set-ProjectVersion $projectFile $newVersion
+}
 
 # Git commit and tag
 Invoke-CommitVersionBump @("UnitsNet") $newVersion

--- a/Build/set-version-json.sh
+++ b/Build/set-version-json.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Sets version of nuget UnitNets.Serialization.JsonNet.
+# Sets the version of both UnitsNet serialization packages.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set_version_script="$script_dir/set-version-UnitsNet.Serialization.JsonNet.ps1"
 

--- a/Build/set-version.psm1
+++ b/Build/set-version.psm1
@@ -71,85 +71,86 @@ function Set-NuspecVersion([string] $file, [string] $version) {
 function Get-BumpedProjectVersion([string] $projectPath, [string] $bumpVersion) {
   [xml]$projectXml = Get-Content -Path $projectPath
 
-  $old = Get-ProjectVersionAndSuffix $projectXml
+  $oldSemVer = [string]($projectXml.Project.PropertyGroup.Version)[0]
+
+  return Get-BumpedSemanticVersion $oldSemVer $bumpVersion
+}
+
+function Get-BumpedSemanticVersion(
+  [string] $semanticVersion,
+  [string] $bumpVersion,
+  [string] $defaultPreReleaseIdentifiers = "alpha000") {
+  $match = [regex]::Match(
+    $semanticVersion,
+    '^(?<major>0|[1-9][0-9]*)\.(?<minor>0|[1-9][0-9]*)\.(?<patch>0|[1-9][0-9]*)(?:-(?<prerelease>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+(?<metadata>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$')
+
+  if (!$match.Success) {
+    throw "Unable to parse semantic version '$semanticVersion'."
+  }
+
+  $preRelease = $match.Groups["prerelease"].Value
+  foreach ($identifier in $preRelease.Split(".", [StringSplitOptions]::RemoveEmptyEntries)) {
+    if ($identifier -match '^[0-9]+$' -and $identifier.Length -gt 1 -and $identifier.StartsWith("0")) {
+      throw "Numeric prerelease identifier '$identifier' in '$semanticVersion' must not contain leading zeroes."
+    }
+  }
+
+  $major = [long]$match.Groups["major"].Value
+  $minor = [long]$match.Groups["minor"].Value
+  $patch = [long]$match.Groups["patch"].Value
 
   switch ($bumpVersion) {
     "major" {
-      $newVersion = BumpMajor $old.Version
-      $newSuffix = ""
+      return "$($major + 1).0.0"
     }
     "minor" {
-      $newVersion = BumpMinor $old.Version
-      $newSuffix = ""
+      return "$major.$($minor + 1).0"
     }
     "patch" {
-      $newVersion = BumpPatch $old.Version
-      $newSuffix = ""
+      return "$major.$minor.$($patch + 1)"
     }
     "suffix" {
-      $newVersion = $old.Version
-      $newSuffix = BumpSuffix $old.Suffix
+      $newSuffix = BumpSuffix $(if ($preRelease) { "-$preRelease" } else { "" }) $defaultPreReleaseIdentifiers
+      return "$major.$minor.$patch$newSuffix"
     }
     default {
       throw "Unrecognized 'bumpVersion' argument: $bumpVersion"
     }
   }
-
-  $newSemVer = $newVersion.ToString() + $newSuffix
-  return $newSemVer
 }
 
-function BumpMajor ([Version] $oldVersion) {
-  return New-Object System.Version -ArgumentList ($oldVersion.Major+1), 0, 0
-}
-
-function BumpMinor([Version] $oldVersion) {
-  return New-Object System.Version -ArgumentList $oldVersion.Major, ($oldVersion.Minor+1), 0
-}
-
-function BumpPatch([Version] $oldVersion) {
-  return New-Object System.Version -ArgumentList $oldVersion.Major, $oldVersion.Minor, ($oldVersion.Build+1);
-}
-
-function BumpSuffix([string] $oldSuffix) {
+function BumpSuffix(
+  [string] $oldSuffix,
+  [string] $defaultPreReleaseIdentifiers = "alpha000") {
   $oldSuffix = $oldSuffix.Trim()
 
-  # A suffix is a dash '-', then a sequcence of word characters followed by an optional number
-  # Example:
-  # ""      => "-alpha001"
-  # "-beta" => "-beta001"
-  # "-beta1"=> "-beta002"
-  $match = [regex]::Match($oldSuffix, '^-([a-zA-Z]+)(\d+)?$');
-  $oldSuffix = $match.Groups[1].Value
-  if (!$oldSuffix) {
-    $oldSuffix = "alpha"
+  $preRelease = $oldSuffix.TrimStart("-")
+  if (!$preRelease) {
+    $preRelease = $defaultPreReleaseIdentifiers
   }
 
-  $numberGroup = $match.Groups[2]
+  $identifiers = [Collections.Generic.List[string]]::new()
+  $identifiers.AddRange([string[]]$preRelease.Split("."))
+  $lastIdentifierIndex = $identifiers.Count - 1
+  $lastIdentifier = $identifiers[$lastIdentifierIndex]
 
-  $number = if ($numberGroup.Success) { 1+$match.Groups[2].Value } else { 1 }
-
-  # Use 3 digits for the number "-alpha003", for 999 releases lexically sorted.
-  return [string]::Format("-{0}{1:D3}", $oldSuffix, $number)
-}
-
-# Returns object with properties: Version, Suffix
-function Get-ProjectVersionAndSuffix([xml] $projectXml) {
-
-  # Split "1.2.3-alpha" into ["1.2.3", "alpha"]
-  # Split "1.2.3" into ["1.2.3"]
-  $oldSemVer = $($projectXml.Project.PropertyGroup.Version)[0]
-
-  $oldSemVerParts = $oldSemVer.Split('-')
-  $oldVersion = $null
-  if (-not [Version]::TryParse($oldSemVerParts[0], [ref] $oldVersion)) { throw "Unable to parse old version." }
-
-  $oldSuffix = if ($oldSemVerParts.Length -eq 2) { "-" + $oldSemVerParts[1]} else { "" }
-  return [PSCustomObject]@{
-    PSTypeName = "VersionAndSuffix"
-    Version = $oldVersion
-    Suffix = $oldSuffix
+  if ($lastIdentifier -match '^[0-9]+$') {
+    $identifiers[$lastIdentifierIndex] = ([long]$lastIdentifier + 1).ToString()
   }
+  elseif ($lastIdentifier -match '^(?<prefix>.*?)(?<number>[0-9]+)$') {
+    $numberWidth = $Matches["number"].Length
+    $number = [long]$Matches["number"] + 1
+    $identifiers[$lastIdentifierIndex] = $Matches["prefix"] + $number.ToString("D$numberWidth")
+  }
+  elseif ($identifiers.Count -eq 1) {
+    # Preserve the repository's existing alpha001/beta001 suffix convention.
+    $identifiers[0] += "001"
+  }
+  else {
+    $identifiers.Add("1")
+  }
+
+  return "-" + [string]::Join(".", $identifiers)
 }
 
 function Resolve-Error ($ErrorRecord=$Error[0])
@@ -169,6 +170,7 @@ function Resolve-Error ($ErrorRecord=$Error[0])
 }
 
 export-modulemember -function Get-NewProjectVersion,
+  Get-BumpedSemanticVersion,
   Invoke-CommitVersionBump,
   Invoke-TagVersionBump,
   Set-ProjectVersion,

--- a/Build/set-version.sh
+++ b/Build/set-version.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Increments version of nugets UnitNets, UnitsNet.NumberExtensions.
+# Sets the version of UnitsNet and both UnitsNet.NumberExtensions packages.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 set_version_script="$script_dir/set-version-UnitsNet.ps1"
 

--- a/UnitsNet.Modular/ARCHITECTURE.md
+++ b/UnitsNet.Modular/ARCHITECTURE.md
@@ -380,12 +380,18 @@ generation they belong to. UnitsNet retains its existing explicitly controlled v
 UnitsNet.Modular and UnitsNet.Core advance together. Third-party definition packages have independent
 versions; the fictional sample remains at 1.x when packed directly.
 
-Create an annotated release tag on a green `master` commit and push it:
+Create an annotated release tag on a green `master` commit with the Modular bump script, then push
+the tag:
 
 ```powershell
-git tag -a UnitsNet.Modular/6.0.0-alpha.1 -m "UnitsNet.Modular 6.0.0-alpha.1"
-git push origin UnitsNet.Modular/6.0.0-alpha.1
+pwsh Build/bump-version-UnitsNet.Modular.ps1 -Bump suffix
+git push origin UnitsNet.Modular/6.0.0-alpha.2
 ```
+
+Use `minor` or `patch` instead of `suffix` to bump that numeric component and remove the prerelease
+suffix, matching the existing UnitsNet release scripts. After a stable release, `suffix` starts the
+next patch prerelease at `alpha.1`, matching MinVer's post-release version range. Pass `-WhatIf` to
+preview the tag without creating it.
 
 This single tag versions and publishes both packages. Do not create `UnitsNet.Core/*` release tags.
 


### PR DESCRIPTION
## Motivation

The version bump scripts only updated a subset of the packages they release. In particular, `UnitsNet.NumberExtensions.CS14` and `UnitsNet.Serialization.SystemTextJson` could be left on the previous version. UnitsNet.Modular also had no equivalent bump command for its MinVer tag stream.

## Changes

- Update the UnitsNet script to version UnitsNet and both NumberExtensions packages.
- Update the JSON script to version both serialization packages and preserve unrelated working changes.
- Add a MinVer-aware UnitsNet.Modular script for minor, patch, and prerelease suffix tags.
- Document the Modular release command and update the wrapper descriptions.

## Validation

- Parsed the PowerShell scripts in Windows PowerShell and PowerShell 7.
- Checked the shell wrappers with Git Bash.
- Ran both explicit-version scripts in an isolated clone and verified all five project versions, commits, and annotated tags.
- Verified the Modular tag flow and MinVer version resolution in an isolated clone.
- Ran `git diff --check`.
