### PR TITLE
Use latest UnitsNet NuGet in samples

### DIFF
--- a/Samples/Directory.Packages.props
+++ b/Samples/Directory.Packages.props
@@ -3,7 +3,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="UnitsNet" Version="5.75.0" />
+    <PackageVersion Include="UnitsNet" Version="6.0.0-pre021" />
     <PackageVersion Include="MahApps.Metro" Version="2.4.11" />
     <PackageVersion Include="Prism.Unity" Version="9.0.537" />
     <PackageVersion Include="Prism.Wpf" Version="9.0.537" />

--- a/Samples/MvvmSample.Wpf/MvvmSample.Wpf/MvvmSample.Wpf.csproj
+++ b/Samples/MvvmSample.Wpf/MvvmSample.Wpf/MvvmSample.Wpf.csproj
@@ -21,11 +21,7 @@
     <Reference Include="System.Transactions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Configuration)' != 'Official'">
-    <PackageReference Include="UnitsNet" VersionOverride="6.0.0-pre103" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)' == 'Official'">
+  <ItemGroup>
     <PackageReference Include="UnitsNet" />
   </ItemGroup>
 </Project>

--- a/Samples/UnitConverter.Console/UnitConverter.Console.csproj
+++ b/Samples/UnitConverter.Console/UnitConverter.Console.csproj
@@ -9,11 +9,7 @@
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Configuration)' != 'Official'">
-    <PackageReference Include="UnitsNet" VersionOverride="6.0.0-pre103" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)' == 'Official'">
+  <ItemGroup>
     <PackageReference Include="UnitsNet" />
   </ItemGroup>
 

--- a/Samples/UnitConverter.Wpf/UnitConverter.Wpf/UnitConverter.Wpf.csproj
+++ b/Samples/UnitConverter.Wpf/UnitConverter.Wpf/UnitConverter.Wpf.csproj
@@ -26,11 +26,7 @@
   </ItemGroup>
   
 
-  <ItemGroup Condition="'$(Configuration)' != 'Official'">
-    <PackageReference Include="UnitsNet" VersionOverride="6.0.0-pre103" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)' == 'Official'">
+  <ItemGroup>
     <PackageReference Include="UnitsNet" />
   </ItemGroup>
 

--- a/Samples/UnitsNetSetup.Configuration/ConfigureWithCustomQuantities.cs
+++ b/Samples/UnitsNetSetup.Configuration/ConfigureWithCustomQuantities.cs
@@ -26,7 +26,7 @@ internal static class ConfigureWithCustomQuantities
     [DebuggerDisplay(QuantityDebugProxy.DisplayFormat)]
     [DebuggerTypeProxy(typeof(QuantityDebugProxy))]
     public readonly struct HowMuch(QuantityValue value, HowMuchUnit unit) :
-        IArithmeticQuantity<HowMuch, HowMuchUnit>,
+        ILinearQuantity<HowMuch, HowMuchUnit>,
         IEquatable<HowMuch>, IComparable<HowMuch>, IComparisonOperators<HowMuch, HowMuch, bool>,
         IParsable<HowMuch>
     {

--- a/Samples/UnitsNetSetup.Configuration/UnitsNetSetup.Configuration.csproj
+++ b/Samples/UnitsNetSetup.Configuration/UnitsNetSetup.Configuration.csproj
@@ -9,11 +9,7 @@
     <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(Configuration)' != 'Official'">
-    <PackageReference Include="UnitsNet" VersionOverride="6.0.0-pre103" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(Configuration)' == 'Official'">
+  <ItemGroup>
     <PackageReference Include="UnitsNet" />
   </ItemGroup>
 


### PR DESCRIPTION
## Motivation

PR #1544 left the samples with a development-only package override for normal builds, while only the `Official` configuration used the published NuGet package. That override also pointed to the accidental `pre103` version.

The samples should always exercise the package users install.

## Changes

- Reference `UnitsNet 6.0.0-pre021` centrally for all samples.
- Remove the configuration-specific package overrides.
- Update the custom quantity sample to implement `ILinearQuantity`, matching the current v6 aggregation APIs.

## Validation

- Restored the sample solution with an empty-cache package resolution.
- Built `Samples/Samples.slnx` in Release successfully.
- Verified that no development `VersionOverride` or conditional UnitsNet package references remain.
- Ran `git diff --check`.
