### PR TITLE
Describe UnitsNet.Modular numeric format strings

### DIFF
--- a/UnitsNet.Modular/UnitsNet.Modular.Generator/QuantityEmitter.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Generator/QuantityEmitter.cs
@@ -10,6 +10,10 @@ namespace UnitsNet.Modular.Generator;
 
 internal static class QuantityEmitter
 {
+    private const string NumericFormatStringSyntaxAttribute =
+        "global::System.Diagnostics.CodeAnalysis.StringSyntax(" +
+        "global::System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.NumericFormat)";
+
     public static string Emit(
         QuantitySelection selection,
         IReadOnlyList<EmittedQuantityRelation> relationships,
@@ -222,8 +226,13 @@ internal static class QuantityEmitter
         writer.AppendLine("    public override int GetHashCode() => BaseValue.GetHashCode();");
         writer.AppendLine("    public override string ToString() => ToString(null, null);");
         writer.AppendLine("    public string ToString(global::System.IFormatProvider? formatProvider) => ToString(null, formatProvider);");
-        writer.AppendLine("    public string ToString(string? format) => ToString(format, null);");
-        writer.AppendLine("    public string ToString(string? format, global::System.IFormatProvider? formatProvider) =>");
+        writer.AppendLine("    public string ToString(");
+        writer.Append("        [").Append(NumericFormatStringSyntaxAttribute).AppendLine("]");
+        writer.AppendLine("        string? format) => ToString(format, null);");
+        writer.AppendLine("    public string ToString(");
+        writer.Append("        [").Append(NumericFormatStringSyntaxAttribute).AppendLine("]");
+        writer.AppendLine("        string? format,");
+        writer.AppendLine("        global::System.IFormatProvider? formatProvider) =>");
         writer.AppendLine("        global::UnitsNet.Modular.SourceGen.QuantityOperations.Format(_value, Unit, format, formatProvider, Metadata);");
         writer.AppendLine();
         if (quantity.IsLogarithmic)

--- a/UnitsNet.Modular/UnitsNet.Modular.Tests/GeneratedQuantityTests.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular.Tests/GeneratedQuantityTests.cs
@@ -1,5 +1,7 @@
 // Licensed under MIT No Attribution, see LICENSE file at the root.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.Json;
 using Fictional.Measurements;
 using UnitsNet;
@@ -10,6 +12,23 @@ namespace UnitsNet.Modular.Tests;
 
 public sealed class GeneratedQuantityTests
 {
+    [Fact]
+    public void FormattingApis_IdentifyNumericFormatSyntax()
+    {
+        MethodInfo quantityToString = typeof(Length).GetMethod(nameof(Length.ToString), [typeof(string)])!;
+        StringSyntaxAttribute? quantitySyntax = quantityToString
+            .GetParameters()[0]
+            .GetCustomAttribute<StringSyntaxAttribute>();
+
+        MethodInfo descriptorFormat = typeof(IQuantityDescriptor).GetMethod(nameof(IQuantityDescriptor.Format))!;
+        StringSyntaxAttribute? descriptorSyntax = descriptorFormat
+            .GetParameters()[1]
+            .GetCustomAttribute<StringSyntaxAttribute>();
+
+        Assert.Equal(StringSyntaxAttribute.NumericFormat, quantitySyntax?.Syntax);
+        Assert.Equal(StringSyntaxAttribute.NumericFormat, descriptorSyntax?.Syntax);
+    }
+
     [Fact]
     public void GeneratedRegistry_SystemTextJsonRoundTripsBuiltInAndCustomQuantities()
     {

--- a/UnitsNet.Modular/UnitsNet.Modular/Metadata/QuantityDescriptor.cs
+++ b/UnitsNet.Modular/UnitsNet.Modular/Metadata/QuantityDescriptor.cs
@@ -89,6 +89,7 @@ public interface IQuantityDescriptor
     /// <summary>Formats a generated quantity after validating its concrete type.</summary>
     string Format(
         IQuantity<double> quantity,
+        [System.Diagnostics.CodeAnalysis.StringSyntax(System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.NumericFormat)]
         string? format = null,
         IFormatProvider? formatProvider = null);
 }


### PR DESCRIPTION
## Motivation

UnitsNet.Modular forwards quantity format strings such as `F1` to the stored numeric value, but its public APIs do not currently identify those parameters as numeric format strings to IDE tooling.

## Changes

- annotate generated quantity `ToString(string)` overloads with `StringSyntaxAttribute.NumericFormat`
- annotate the type-erased `IQuantityDescriptor.Format` format parameter
- verify the annotations are present in emitted consumer-visible metadata

This improves validation and completion for direct format-string arguments where supported by the IDE. Interpolation clauses such as `$"{speed:F1}"` continue to work, but their completion behavior remains controlled by the IDE's interpolated-string support.

## Validation

- `dotnet test UnitsNet.Modular/UnitsNet.Modular.slnx --no-restore -m:1 -p:UnitsNetModularSampleUpdateLocalPackagesOnBuild=false`
- 115 tests passed
- Modular runtime built for .NET 8, .NET 9, and .NET 10