### PR TITLE
Write codegen outputs as explicit UTF-8

### DIFF
--- a/CodeGen/Generators/QuantityJsonFilesParser.cs
+++ b/CodeGen/Generators/QuantityJsonFilesParser.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CodeGen.Exceptions;
+using CodeGen.Helpers;
 using CodeGen.Helpers.PrefixBuilder;
 using CodeGen.JsonTypes;
 using Newtonsoft.Json;
@@ -54,7 +55,7 @@ internal static class QuantityJsonFilesParser
     {
         try
         {
-            return JsonConvert.DeserializeObject<Quantity>(File.ReadAllText(jsonFileName), JsonSerializerSettings)
+            return JsonConvert.DeserializeObject<Quantity>(CodeGenFile.ReadAllText(jsonFileName), JsonSerializerSettings)
                    ?? throw new UnitsNetCodeGenException($"Unable to parse quantity from JSON file: {jsonFileName}");
         }
         catch (Exception e)

--- a/CodeGen/Generators/QuantityRelationsParser.cs
+++ b/CodeGen/Generators/QuantityRelationsParser.cs
@@ -7,6 +7,7 @@ using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using CodeGen.Exceptions;
+using CodeGen.Helpers;
 using CodeGen.JsonTypes;
 using Newtonsoft.Json;
 
@@ -133,7 +134,7 @@ namespace CodeGen.Generators
 
             try
             {
-                var text = File.ReadAllText(relationsFileName);
+                var text = CodeGenFile.ReadAllText(relationsFileName);
 
                 // Explicitly sort to keep the file consistent.
                 var relationStrings = JsonConvert.DeserializeObject<List<string>>(text)
@@ -142,7 +143,7 @@ namespace CodeGen.Generators
                 var parsedRelations = relationStrings.Select(relationString => ParseRelation(relationString, quantities)).ToList();
 
                 // File parsed successfully, save it back to disk in the sorted state.
-                File.WriteAllText(relationsFileName, JsonConvert.SerializeObject(relationStrings, Formatting.Indented));
+                CodeGenFile.WriteAllText(relationsFileName, JsonConvert.SerializeObject(relationStrings, Formatting.Indented));
 
                 return parsedRelations;
             }

--- a/CodeGen/Generators/UnitsNetGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGenerator.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using CodeGen.Generators.UnitsNetGen;
+using CodeGen.Helpers;
 using CodeGen.Helpers.UnitEnumValueAllocation;
 using CodeGen.JsonTypes;
 using Serilog;
@@ -91,63 +92,63 @@ namespace CodeGen.Generators
             if (File.Exists(filePath)) return;
 
             var content = new UnitTestStubGenerator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
             Log.Information("✅ {Quantity} initial test stub", quantity.Name);
         }
 
         private static void GenerateQuantity(Quantity quantity, string filePath)
         {
             var content = new QuantityGenerator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateNumberToExtensions(Quantity quantity, string filePath)
         {
             var content = new NumberExtensionsGenerator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateNumberToExtensionsTestClass(Quantity quantity, string filePath)
         {
             var content = new NumberExtensionsTestClassGenerator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateNumberToExtensionsCS14(Quantity quantity, string filePath)
         {
             var content = new NumberExtensionsCS14Generator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateNumberToExtensionsCS14TestClass(Quantity quantity, string filePath)
         {
             var content = new NumberExtensionsCS14TestClassGenerator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateUnitType(Quantity quantity, string filePath, UnitEnumNameToValue unitEnumValues)
         {
             var content = new UnitTypeGenerator(quantity, unitEnumValues).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateQuantityTestBaseClass(Quantity quantity, string filePath)
         {
             var content = new UnitTestBaseClassGenerator(quantity).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
         }
 
         private static void GenerateIQuantityTests(Quantity[] quantities, string filePath)
         {
             var content = new IQuantityTestClassGenerator(quantities).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
             Log.Information("✅ IQuantityTests.g.cs");
         }
 
         private static void GenerateStaticQuantity(Quantity[] quantities, string filePath)
         {
             var content = new StaticQuantityGenerator(quantities).Generate();
-            File.WriteAllText(filePath, content);
+            CodeGenFile.WriteAllText(filePath, content);
             Log.Information("✅ Quantity.g.cs");
         }
 
@@ -171,7 +172,7 @@ namespace CodeGen.Generators
                         $"{resourcesDirectory}/{quantity.Name}.restext" :
                         $"{resourcesDirectory}/{quantity.Name}.{culture}.restext";
 
-                    using var writer = File.CreateText(fileName);
+                    using var writer = CodeGenFile.CreateText(fileName);
 
                     foreach(Unit unit in quantity.Units)
                     {

--- a/CodeGen/Helpers/CodeGenFile.cs
+++ b/CodeGen/Helpers/CodeGenFile.cs
@@ -6,25 +6,49 @@ using System.Text;
 
 namespace CodeGen.Helpers
 {
+    /// <summary>
+    ///     Provides file I/O helpers for CodeGen files with explicit UTF-8 encoding behavior.
+    /// </summary>
     internal static class CodeGenFile
     {
+        /// <summary>
+        ///     UTF-8 encoding without byte order mark, used for generated and codegen-normalized files.
+        /// </summary>
         internal static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
 
+        /// <summary>
+        ///     Reads all text from a CodeGen input file as UTF-8.
+        /// </summary>
+        /// <remarks>
+        ///     Existing byte order marks are still detected when present.
+        /// </remarks>
         public static string ReadAllText(string path)
         {
             return File.ReadAllText(path, Utf8NoBom);
         }
 
+        /// <summary>
+        ///     Writes all text to a generated or codegen-normalized file as UTF-8 without byte order mark.
+        /// </summary>
         public static void WriteAllText(string path, string contents)
         {
             File.WriteAllText(path, contents, Utf8NoBom);
         }
 
+        /// <summary>
+        ///     Opens a CodeGen input file for text reading as UTF-8.
+        /// </summary>
+        /// <remarks>
+        ///     Existing byte order marks are still detected when present.
+        /// </remarks>
         public static StreamReader OpenText(string path)
         {
             return new StreamReader(path, Utf8NoBom, detectEncodingFromByteOrderMarks: true);
         }
 
+        /// <summary>
+        ///     Creates or overwrites a generated or codegen-normalized text file as UTF-8 without byte order mark.
+        /// </summary>
         public static StreamWriter CreateText(string path)
         {
             return new StreamWriter(path, append: false, Utf8NoBom);

--- a/CodeGen/Helpers/CodeGenFile.cs
+++ b/CodeGen/Helpers/CodeGenFile.cs
@@ -1,0 +1,33 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+using System.IO;
+using System.Text;
+
+namespace CodeGen.Helpers
+{
+    internal static class CodeGenFile
+    {
+        internal static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+        public static string ReadAllText(string path)
+        {
+            return File.ReadAllText(path, Utf8NoBom);
+        }
+
+        public static void WriteAllText(string path, string contents)
+        {
+            File.WriteAllText(path, contents, Utf8NoBom);
+        }
+
+        public static StreamReader OpenText(string path)
+        {
+            return new StreamReader(path, Utf8NoBom, detectEncodingFromByteOrderMarks: true);
+        }
+
+        public static StreamWriter CreateText(string path)
+        {
+            return new StreamWriter(path, append: false, Utf8NoBom);
+        }
+    }
+}

--- a/CodeGen/Helpers/FileInfoExtensions.cs
+++ b/CodeGen/Helpers/FileInfoExtensions.cs
@@ -15,8 +15,8 @@ namespace CodeGen.Helpers
             Dictionary<string, string> replacements)
         {
             var tempFilename = $"{sourceFile.FullName}.edited";
-            using (StreamReader input = sourceFile.OpenText())
-            using (var output = new StreamWriter(tempFilename))
+            using (StreamReader input = CodeGenFile.OpenText(sourceFile.FullName))
+            using (var output = CodeGenFile.CreateText(tempFilename))
             {
                 while (input.ReadLine() is { } line)
                 {

--- a/CodeGen/Helpers/UnitEnumValueAllocation/UnitEnumValueAllocator.cs
+++ b/CodeGen/Helpers/UnitEnumValueAllocation/UnitEnumValueAllocator.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Text.Json;
 using CodeGen.Exceptions;
 using CodeGen.JsonTypes;
+using CodeGen.Helpers;
 using Serilog;
 
 namespace CodeGen.Helpers.UnitEnumValueAllocation
@@ -150,7 +151,7 @@ Conflicts:
 ");
 
             fileContentStringBuilder.AppendLine(JsonSerializer.Serialize(_quantityNameToUnitEnumValues, JsonOptions));
-            File.WriteAllText(_jsonFile, fileContentStringBuilder.ToString());
+            CodeGenFile.WriteAllText(_jsonFile, fileContentStringBuilder.ToString());
         }
 
         /// <summary>
@@ -162,7 +163,7 @@ Conflicts:
         {
             if (File.Exists(jsonFile))
             {
-                return JsonSerializer.Deserialize<QuantityNameToUnitEnumValues>(File.ReadAllText(jsonFile), JsonOptions)
+                return JsonSerializer.Deserialize<QuantityNameToUnitEnumValues>(CodeGenFile.ReadAllText(jsonFile), JsonOptions)
                        ?? throw new InvalidOperationException($"Failed to deserialize file: {jsonFile}");
             }
 


### PR DESCRIPTION
## Motivation

CodeGen currently relies on default file encodings from `File.WriteAllText`, `File.CreateText`, `StreamWriter`, and related read helpers. Those defaults can differ by runtime/API history and make generated output encoding/BOM behavior less obvious than it should be.

We want generated output to be stable across platforms and avoid review noise from UTF-8 BOM differences.

## Changes

- Add a small `CodeGenFile` helper that reads text as UTF-8 and detects an existing BOM, but writes generated/codegen-normalized files as explicit UTF-8 without BOM.
- Use the helper for generated C# files, generated resource text files, normalized relation JSON, unit enum allocation JSON, quantity JSON reads, and codegen edit helpers.

## Validation

- `dotnet build CodeGen\CodeGen.csproj`
- `generate-code.bat`
- Scanned generated/codegen-normalized outputs and found no UTF-8 BOM.
- Running code generation after the change produced no generated-file diffs.
