### PR TITLE
Standardize quantity formatting on .NET numeric formats

### DIFF
--- a/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/QuantityGenerator.cs
@@ -1032,7 +1032,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref=""CultureInfo.CurrentCulture"" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {{
             return QuantityFormatter.Default.Format(this, format, provider);
         }}

--- a/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
+++ b/CodeGen/Generators/UnitsNetGen/UnitTestBaseClassGenerator.cs
@@ -1255,26 +1255,6 @@ namespace UnitsNet.Tests
             Writer.WL($@"
         }}
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {{
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal(""0.1{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s1""));
-            Assert.Equal(""0.12{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s2""));
-            Assert.Equal(""0.123{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s3""));
-            Assert.Equal(""0.1235{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s4""));
-        }}
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {{
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal(""0.1{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s1"", culture));
-            Assert.Equal(""0.12{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s2"", culture));
-            Assert.Equal(""0.123{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s3"", culture));
-            Assert.Equal(""0.1235{_baseUnitEnglishAbbreviation}"", new {_quantity.Name}(0.123456, {_baseUnitFullName}).ToString(""s4"", culture));
-        }}
-
         [Theory]
         [InlineData(null)]
         [InlineData(""en-US"")]

--- a/Docs/string-formatting.md
+++ b/Docs/string-formatting.md
@@ -63,19 +63,3 @@ IReadOnlyList<string> abbreviations = UnitsNetSetup.Default.UnitAbbreviations
     .GetUnitAbbreviations(LengthUnit.Foot, CultureInfo.InvariantCulture);
 // "ft", "'", "′"
 ```
-
-## v6 quantity-format cleanup
-
-UnitsNet v6 accepts numeric format strings only. The remaining proprietary quantity formats were
-removed together with the formats already retired during the v6 redesign:
-
-| Removed format | Replacement |
-|---|---|
-| `A`, `A0`, `A1`, ... | `Length.GetAbbreviation(unit)` or `UnitAbbreviationsCache.GetUnitAbbreviations(unit)` |
-| `S`, `S2`, ... | An explicit numeric format such as `G3`, `F2`, `N2`, `E2`, or `0.##` |
-| `U` | The quantity's `Unit` property |
-| `V` | The quantity's `Value` property, optionally formatted separately |
-| `Q` | Static quantity metadata such as `Length.Info.Name` |
-
-This keeps formatting compatible with standard .NET tooling and enables IDE assistance through
-`StringSyntaxAttribute.NumericFormat`.

--- a/Docs/string-formatting.md
+++ b/Docs/string-formatting.md
@@ -1,51 +1,81 @@
-# String Formatting
+# String formatting
 
-## Common examples
+Quantity formatting applies a .NET numeric format string to the value and appends the localized
+abbreviation of the quantity's current unit.
 
-Assuming computer running with US English culture.
-```c#
-var length = Length.FromCentimeters(3.14159265358979);
+```csharp
+Length length = Length.FromCentimeters(Math.PI);
 
-// Typical formats
-length.ToString(); // 3.14 cm
-length.ToString("s4"); // 3.1416 cm
-
-// Localized
-length.ToString(new CultureInfo("nb-NO")); // 3,14 cm
-length.ToString(new CultureInfo("ru-RU")); // 3,14 sm (Cyrillic)
-
-// Converted
-length.As(LengthUnit.Meters).ToString(); // 0.13 m
-
-// Use .NET's built-in formatting methods
-Console.WriteLine("Length is {0:v} {0:a}", l); // "Length is 3.14159265358979 ft"
-string.Format("Length is {0:v} {0:a}", l); // "Length is 3.14159265358979 ft"
-$"Length is {l:v} {l:a}"; // "Length is 3.14159265358979 ft"
+length.ToString();                                      // 3.141592653589793 cm
+length.ToString("F2", CultureInfo.InvariantCulture);   // 3.14 cm
+$"Length: {length:N3}";                                // Length: 3.142 cm with an en-US current culture
 ```
 
-## Standard Quantity Format Strings
+The parameterless overload uses the general (`G`) numeric format. Formatting honors the supplied
+`IFormatProvider`, or `CultureInfo.CurrentCulture` when none is supplied.
 
-| Format specifier | Description | Examples |
-|------------------|-------------|---------|
-| "g" | General quantity pattern. Equivalent to parameterless `ToString()`. Rounds to 2 significant digits after the radix. | `Length.FromFeet(Math.PI).ToString("g")` -> 3.14 ft |
-| `f`, `f2`, ... `e`, `e3`, ... `r` `#.0` `00000.0` | [Standard numeric formatting](https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers) of value, with unit appended. | `Length.FromFeet(Math.PI).ToString("f")` -> 3.140 ft, `Length.FromFeet(Math.PI).ToString("f1")` -> 3.1 ft, `Length.FromFeet(Math.PI).ToString("r")` -> 3.141592653589793 ft, `Length.FromFeet(Math.PI).ToString("e2")` -> 3.14e+000 ft, `Length.FromFeet(Math.PI).ToString("#.0")` -> 3.1 ft, `Length.FromFeet(Math.PI).ToString("00.0")` -> 003.1 ft |
-| "aXX" | Unit abbreviation pattern. If more than one abbreviation is defined for the unit, then XX specifies the zero-indexed position in the array of abbreviations. XX defaults to 0. If the position is not found, `System.FormatException` is thrown. | `Length.FromFeet(Math.PI).ToString("a")` -> ft, `Length.FromFeet(Math.PI).ToString("a0")` -> ft, `Length.FromFeet(Math.PI).ToString("a1")` -> ', `Length.FromFeet(Math.PI).ToString("a2")` -> prime symbol, `Length.FromFeet(Math.PI).ToString("a3")` -> System.FormatException |
-| "q" | Quantity name pattern. Outputs the corresponding QuantityType enum name. | `Length.FromFeet(Math.PI).ToString("q")` -> Length, `Mass.FromTonnes(Math.PI).ToString("u")` -> Mass |
-| "u" | Unit name pattern. Each quantity type has a corresponding unit enum, such as `Length` quantity having `LengthUnit` unit enum with values `Meter`, `Centimeter` etc. This pattern outputs the unit enum name. | `Length.FromFeet(Math.PI).ToString("u")` -> Foot, `Mass.FromTonnes(Math.PI).ToString("u")` -> Tonne |
+```csharp
+length.ToString(CultureInfo.GetCultureInfo("nb-NO")); // 3,141592653589793 cm
+length.ToString(CultureInfo.GetCultureInfo("ru-RU")); // 3,141592653589793 см
+```
 
-There are three different overloads of the ToString() method to provide a string representation of a value and its units.
+Convert the quantity before formatting when a different unit is required:
 
-## Number Formatting
+```csharp
+Length meters = length.ToUnit(LengthUnit.Meter);
+string text = meters.ToString("G3", CultureInfo.InvariantCulture); // 0.0314 m
+```
 
-For "g" pattern (or if no pattern is specified), the number will be formatted with scientific notation for very small or very large values to increase readability. We did not find .NET's default behavior to work well for this so we created our own rules.
+## Numeric formats
 
-| Interval | Format | Examples |
-|-----------|-----------|-------------|
-| `(-inf <= x < 1e-03]` | scientific notation | 1e-04; 2.13e-05 |
-| `[1e-03 <= x < 1e+03]` | fixed point notation | 0.001; 0.01; 100 |
-| `[1e+03 <= x < 1e+06]` | fixed point notation with digit grouping | 1,000; 10,000; 100,000 |
-| `[1e+06 <= x <= +inf)` | scientific notation | 1.1e+06; 3.14e+07 |
+UnitsNet accepts standard and custom .NET numeric formats, including:
 
-The symbols used for digit grouping and radix point are culture-sensitive. The above examples use `CultureInfo.InvariantCulture`.
+| Intent | Format | Example |
+|---|---|---|
+| General notation with a precision | `G3` | `3.14 cm` |
+| Fixed decimal places | `F2` | `3.14 cm` |
+| Grouped number with fixed decimals | `N2` | `1,234.50 cm` |
+| Scientific notation | `E2` | `3.14E+000 cm` |
+| Up to two decimal places | `0.##` | `3.14 cm` |
+| Grouped with up to two decimal places | `#,##0.##` | `1,234.5 cm` |
 
-For more examples, refer to the unit tests in [UnitsNet/UnitFormatter.cs](https://github.com/angularsen/UnitsNet/blob/master/UnitsNet/UnitFormatter.cs).
+Currency (`C`) and percent (`P`) formats are rejected because adding currency or percent symbols to
+a physical quantity is misleading.
+
+See [.NET standard numeric format strings](https://learn.microsoft.com/dotnet/standard/base-types/standard-numeric-format-strings)
+and [.NET custom numeric format strings](https://learn.microsoft.com/dotnet/standard/base-types/custom-numeric-format-strings)
+for the complete syntax.
+
+## Unit abbreviations
+
+Use the generated quantity API to get the primary localized abbreviation explicitly:
+
+```csharp
+string abbreviation = Length.GetAbbreviation(LengthUnit.Foot);
+string localized = Length.GetAbbreviation(LengthUnit.Meter, CultureInfo.GetCultureInfo("ru-RU"));
+```
+
+Use the configured abbreviation cache when every accepted abbreviation is needed. This includes
+runtime customizations made through `UnitsNetSetup`:
+
+```csharp
+IReadOnlyList<string> abbreviations = UnitsNetSetup.Default.UnitAbbreviations
+    .GetUnitAbbreviations(LengthUnit.Foot, CultureInfo.InvariantCulture);
+// "ft", "'", "′"
+```
+
+## v6 quantity-format cleanup
+
+UnitsNet v6 accepts numeric format strings only. The remaining proprietary quantity formats were
+removed together with the formats already retired during the v6 redesign:
+
+| Removed format | Replacement |
+|---|---|
+| `A`, `A0`, `A1`, ... | `Length.GetAbbreviation(unit)` or `UnitAbbreviationsCache.GetUnitAbbreviations(unit)` |
+| `S`, `S2`, ... | An explicit numeric format such as `G3`, `F2`, `N2`, `E2`, or `0.##` |
+| `U` | The quantity's `Unit` property |
+| `V` | The quantity's `Value` property, optionally formatted separately |
+| `Q` | Static quantity metadata such as `Length.Info.Name` |
+
+This keeps formatting compatible with standard .NET tooling and enables IDE assistance through
+`StringSyntaxAttribute.NumericFormat`.

--- a/Docs/upgrading-from-5.x-to-6.x.md
+++ b/Docs/upgrading-from-5.x-to-6.x.md
@@ -68,10 +68,9 @@ as binary floating point lose precision.
   strings only; see [String formatting](string-formatting.md).
     - Replace `A`, `A0`, `A1`, ... with a generated `GetAbbreviation()` method or
       `UnitAbbreviationsCache.GetUnitAbbreviations()`.
-    - The `S` format, which was removed in v5 but briefly returned in a v6 prerelease through `QuantityValue`, remains
-      removed. Use an explicit numeric format such as `G3`, `F2`, `N2`, `E2`, or `0.##`.
-    - Continue replacing the v6-removed `U`, `V`, and `Q` formats with the `Unit` property, the `Value` property, and
-      static quantity metadata such as `Length.Info.Name`, respectively.
+    - Replace `S`, `S2`, ... with an explicit numeric format such as `G3`, `F2`, `N2`, `E2`, or `0.##`.
+    - Replace `U`, `V`, and `Q` with the `Unit` property, the `Value` property, and static quantity metadata such as
+      `Length.Info.Name`, respectively.
 - Exact rational conversions and arithmetic may produce results that differ from the previous `double` implementation in the least significant digits. Precision can be lost when a `QuantityValue` is converted to `double`; perform that conversion only at boundaries where floating-point behavior is required. #1544
 - Calls to `.As()` and `.ToUnit()` through an `IQuantity` or `IQuantity<TUnitType>` reference now use the `QuantityExtensions` methods and `UnitConverter.Default`. They no longer dispatch to type-specific methods defined by a custom quantity. Custom quantities that need these calls to support conversion must register their conversion functions with `UnitConverter.Default`. #1696
 - Calling these extension methods with an incompatible unit type now throws `UnitNotFoundException` instead of `ArgumentException`. Code that catches `ArgumentException` around interface-based conversions may need to be updated. #1696

--- a/Docs/upgrading-from-5.x-to-6.x.md
+++ b/Docs/upgrading-from-5.x-to-6.x.md
@@ -19,6 +19,8 @@ as binary floating point lose precision.
 - Allow `NaN` and infinity values in quantities #1289
 - Exact fractional values, arithmetic and generated unit conversions with `QuantityValue` #1544
 - `UnitsNet.Serialization.SystemTextJson`, with configurable quantity, unit and value converters #1544
+- Annotate numeric format-string parameters with `StringSyntaxAttribute.NumericFormat` so supported IDEs can provide
+  syntax assistance
 
 ## Breaking changes
 
@@ -62,6 +64,14 @@ as binary floating point lose precision.
 
 ### Behavioral change
 
+- Complete the removal of proprietary quantity format strings. Quantity formatting now accepts .NET numeric format
+  strings only; see [String formatting](string-formatting.md).
+    - Replace `A`, `A0`, `A1`, ... with a generated `GetAbbreviation()` method or
+      `UnitAbbreviationsCache.GetUnitAbbreviations()`.
+    - The `S` format, which was removed in v5 but briefly returned in a v6 prerelease through `QuantityValue`, remains
+      removed. Use an explicit numeric format such as `G3`, `F2`, `N2`, `E2`, or `0.##`.
+    - Continue replacing the v6-removed `U`, `V`, and `Q` formats with the `Unit` property, the `Value` property, and
+      static quantity metadata such as `Length.Info.Name`, respectively.
 - Exact rational conversions and arithmetic may produce results that differ from the previous `double` implementation in the least significant digits. Precision can be lost when a `QuantityValue` is converted to `double`; perform that conversion only at boundaries where floating-point behavior is required. #1544
 - Calls to `.As()` and `.ToUnit()` through an `IQuantity` or `IQuantity<TUnitType>` reference now use the `QuantityExtensions` methods and `UnitConverter.Default`. They no longer dispatch to type-specific methods defined by a custom quantity. Custom quantities that need these calls to support conversion must register their conversion functions with `UnitConverter.Default`. #1696
 - Calling these extension methods with an incompatible unit type now throws `UnitNotFoundException` instead of `ArgumentException`. Code that catches `ArgumentException` around interface-based conversions may need to be updated. #1696

--- a/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.ConvertToString.cs
+++ b/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.ConvertToString.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Linq;
 using System.Numerics;
 using Xunit.Abstractions;
@@ -1171,208 +1171,30 @@ public partial class QuantityValueTests
         }
 
 
-        /// <summary>
-        ///     The significant digits after radix ("S") format specifier converts a number to a string that preserves the
-        ///     precision of the Fraction object with a variable number of digits after the radix point.
-        /// </summary>
-        public class SignificantDigitsAfterTheRadixFormatTests
+        public class RemovedQuantitySpecificFormatTests
         {
             [Theory]
-            [ClassData(typeof(NormalValueCases))]
-            public void ToString_WithNormalValues(ValueFormatPair testCase, string expected)
+            [InlineData("S")]
+            [InlineData("s2")]
+            [InlineData("S+4")]
+            public void ToString_ThrowsWithMigrationGuidance(string format)
             {
-                var (value, format) = testCase;
-                var result = value.ToString(format, CultureInfo.InvariantCulture);
-                Assert.Equal(expected, result);
+                FormatException exception = Assert.Throws<FormatException>(
+                    () => QuantityValue.One.ToString(format, CultureInfo.InvariantCulture));
+
+                Assert.Contains("no longer supported", exception.Message, StringComparison.Ordinal);
             }
 
-            [Theory]
-            [ClassData(typeof(SmallAbsoluteValueCases))]
-            public void ToString_WithSmallAbsoluteValue(ValueFormatPair testCase, string expected)
-            {
-                var (value, format) = testCase;
-                var result = value.ToString(format, CultureInfo.InvariantCulture);
-                Assert.Equal(expected, result);
-            }
-
-            [Theory]
-            [ClassData(typeof(LargePositiveValueCases))]
-            public void ToString_WithLargePositiveValue(ValueFormatPair testCase, string expected)
-            {
-                var (value, format) = testCase;
-                var result = value.ToString(format, CultureInfo.InvariantCulture);
-                Assert.Equal(expected, result);
-            }
-
-            [Theory]
-            [ClassData(typeof(LargeNegativeValueCases))]
-            public void ToString_LargeNegativeValue(ValueFormatPair testCase, string expected)
-            {
-                var (value, format) = testCase;
-                var result = value.ToString(format, CultureInfo.InvariantCulture);
-                Assert.Equal(expected, result);
-            }
-
-            [Fact]
-            public void ToString_WithVeryLargePositiveNumber()
-            {
-                var value = new QuantityValue(1234 * BigInteger.Pow(10, 1000));
-
-                var actualValue = value.ToString("s", CultureInfo.InvariantCulture);
-
-                Assert.Equal("1.23e+1003", actualValue);
-            }
-
-            [Fact]
-            public void ToString_WithVerySmallPositiveNumber()
-            {
-                var value = new QuantityValue(1234, BigInteger.Pow(10, 1004));
-
-                var actualValue = value.ToString("s", CultureInfo.InvariantCulture);
-
-                Assert.Equal("1.23e-1001", actualValue);
-            }
-            
 #if NET
             [Fact]
-            public void TryFormat_Zero_WithValidSpanLength_ReturnsTrue()
+            public void TryFormat_ThrowsWithMigrationGuidance()
             {
-                QuantityValue value = 0;
-                var destination = new Span<char>(new char[1]);
-                var result = value.TryFormat(destination, out var charsWritten, "S", CultureInfo.InvariantCulture);
-                Assert.True(result);
-                Assert.Equal(1, charsWritten);
-                Assert.Equal("0", destination[Range.EndAt(charsWritten)]);
-            }
-            
-            [Fact]
-            public void TryFormat_NegativeNumber_WithValidSpanLength_ReturnsTrue()
-            {
-                QuantityValue value = -4.2;
-                var destination = new Span<char>(new char[4]);
-                var result = value.TryFormat(destination, out var charsWritten, "S", CultureInfo.InvariantCulture);
-                Assert.True(result);
-                Assert.Equal(4, charsWritten);
-                Assert.Equal("-4.2", destination[Range.EndAt(charsWritten)]);
-            }
+                FormatException exception = Assert.Throws<FormatException>(
+                    () => QuantityValue.One.TryFormat(new char[16], out _, "S2", CultureInfo.InvariantCulture));
 
-            [Theory]
-            [InlineData(-1, "S0", 0)]
-            [InlineData(1, "S0", 0)]
-            [InlineData(0.1, "S1", 2)]
-            [InlineData(0.0001, "S4", 0)] // "1E-04"
-            [InlineData(0.0001, "S4", 4)] // "1E-04"
-            [InlineData(1e6, "S4", 0)] // "1E+06"
-            [InlineData(1e6, "S4", 4)] // "1E+06"
-            public void TryFormat_WithInvalidSpanLength_ReturnsFalse(decimal decimalValue, string format, int testLength)
-            {
-                QuantityValue value= decimalValue;
-                var destination = new Span<char>(new char[testLength]);
-                var result = value.TryFormat(destination, out var charsWritten, format, CultureInfo.InvariantCulture);
-                Assert.False(result);
-                // Assert.Equal(0, charsWritten); // TODO should we make sure that nothing was written?
+                Assert.Contains("no longer supported", exception.Message, StringComparison.Ordinal);
             }
 #endif
-
-            /// <summary>
-            ///     Values with exponent in the interval [-3 ≤ e ≤ 5] are formatted using the decimal point notation (no extra digits).
-            /// </summary>
-            public sealed class NormalValueCases : TheoryData<ValueFormatPair, string>
-            {
-                public NormalValueCases()
-                {
-                    foreach (var format in new[] { "S2", "s2" })
-                    {
-                        // from -1000000 to -1
-                        Add(new ValueFormatPair(-999999.99m, format), "-999,999.99");
-                        Add(new ValueFormatPair(-111000, format), "-111,000");
-                        Add(new ValueFormatPair(-11000, format), "-11,000");
-                        Add(new ValueFormatPair(-1000, format), "-1,000");
-                        Add(new ValueFormatPair(-999.99m, format), "-999.99");
-                        Add(new ValueFormatPair(-2.001234m, format), "-2"); 
-                        Add(new ValueFormatPair(-1.1m, format), "-1.1");
-                        Add(new ValueFormatPair(-1, format), "-1");
-                        // from -1 to 0
-                        Add(new ValueFormatPair(-0.1m, format), "-0.1");
-                        Add(new ValueFormatPair(-0.01m, format), "-0.01");
-                        Add(new ValueFormatPair(-0.001m, format), "-0.001");
-                        // from 0 to 1
-                        Add(new ValueFormatPair(0, format), "0");
-                        Add(new ValueFormatPair(0.001m, format), "0.001");
-                        Add(new ValueFormatPair(0.01m, format), "0.01");
-                        Add(new ValueFormatPair(0.1m, format), "0.1");
-                        // from 1 to 1000000
-                        Add(new ValueFormatPair(1, format), "1");
-                        Add(new ValueFormatPair(1.1m, format), "1.1");
-                        Add(new ValueFormatPair(2.001234m, format), "2"); 
-                        Add(new ValueFormatPair(999.99m, format), "999.99");
-                        Add(new ValueFormatPair(1000, format), "1,000");
-                        Add(new ValueFormatPair(11000, format), "11,000");
-                        Add(new ValueFormatPair(111000, format), "111,000");
-                        Add(new ValueFormatPair(999999.99m, format), "999,999.99");
-                    }
-                }
-            }
-
-            /// <summary>
-            ///     Values with exponent in the interval [-inf ≤ e ≤ -4] are formatted in scientific notation.
-            /// </summary>
-            public sealed class SmallAbsoluteValueCases : TheoryData<ValueFormatPair, string>
-            {
-                public SmallAbsoluteValueCases()
-                {
-                    // uppercase letter
-                    Add(new ValueFormatPair(1.99e-4m, "S2"), "1.99E-04");
-                    Add(new ValueFormatPair(-1.99e-4m, "S2"), "-1.99E-04");
-                    Add(new ValueFormatPair(0.0000111m, "S2"), "1.11E-05");
-                    Add(new ValueFormatPair(-0.0000111m, "S2"), "-1.11E-05");
-                    Add(new ValueFormatPair(1.23e-120, "S2"), "1.23E-120");
-                    Add(new ValueFormatPair(-1.23e-120, "S2"), "-1.23E-120");
-                    // lowercase letter
-                    Add(new ValueFormatPair(1.99e-4m, "s2"), "1.99e-04");
-                    Add(new ValueFormatPair(-1.99e-4m, "s2"), "-1.99e-04");
-                    Add(new ValueFormatPair(0.0000111m, "s2"), "1.11e-05");
-                    Add(new ValueFormatPair(-0.0000111m, "s2"), "-1.11e-05");
-                    Add(new ValueFormatPair(1.23e-120, "s2"), "1.23e-120");
-                    Add(new ValueFormatPair(-1.23e-120, "s2"), "-1.23e-120");
-                }
-            }
-
-            /// <summary>
-            ///     Any value in the interval [1e+06 ≤ x ≤ +inf] is formatted in scientific notation.
-            /// </summary>
-            public sealed class LargePositiveValueCases : TheoryData<ValueFormatPair, string>
-            {
-                public LargePositiveValueCases()
-                {
-                    // from 1E+6 to +inf (uppercase)
-                    Add(new ValueFormatPair(1000000, "S2"), "1E+06");
-                    Add(new ValueFormatPair(11100000, "S2"), "1.11E+07");
-                    Add(new ValueFormatPair(double.MaxValue, "S2"), "1.8E+308");
-                    // from 1e+6 to +inf (lowercase)
-                    Add(new ValueFormatPair(1000000, "s2"), "1e+06");
-                    Add(new ValueFormatPair(11100000, "s2"), "1.11e+07");
-                    Add(new ValueFormatPair(double.MaxValue, "s2"), "1.8e+308");
-                }
-            }
-
-            /// <summary>
-            ///     Any value in the interval [-inf ≤ x ≤ 1e-04] is formatted in scientific notation.
-            /// </summary>
-            public sealed class LargeNegativeValueCases : TheoryData<ValueFormatPair, string>
-            {
-                public LargeNegativeValueCases()
-                {
-                    // from -inf up to -1E+6 (uppercase)
-                    Add(new ValueFormatPair(double.MinValue, "S2"), "-1.8E+308");
-                    Add(new ValueFormatPair(-11100000, "S2"), "-1.11E+07");
-                    Add(new ValueFormatPair(-1000000, "S2"), "-1E+06");
-                    // from -inf up to -1e+6 (lowercase)
-                    Add(new ValueFormatPair(double.MinValue, "s2"), "-1.8e+308");
-                    Add(new ValueFormatPair(-11100000, "s2"), "-1.11e+07");
-                    Add(new ValueFormatPair(-1000000, "s2"), "-1e+06");
-                }
-            }
         }
 
         public class CustomFormatTests

--- a/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.DebugView.cs
+++ b/UnitsNet.Tests/CustomCode/ValueTests/QuantityValueTests.DebugView.cs
@@ -64,7 +64,7 @@ public partial class QuantityValueTests
             QuantityValue value = decimalValue;
             var debugView = new QuantityValue.QuantityValueDebugView(value);
 
-            Assert.Equal(value.ToString("S"), debugView.StringFormats.ShortFormat);
+            Assert.Equal(value.ToString("G6"), debugView.StringFormats.ShortFormat);
         }
 
         [Theory]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AbsorbedDoseOfIonizingRadiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AbsorbedDoseOfIonizingRadiationTestsBase.g.cs
@@ -1089,26 +1089,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TGy", new AbsorbedDoseOfIonizingRadiation(1, AbsorbedDoseOfIonizingRadiationUnit.Teragray).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s1"));
-            Assert.Equal("0.12 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s2"));
-            Assert.Equal("0.123 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s3"));
-            Assert.Equal("0.1235 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s1", culture));
-            Assert.Equal("0.12 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s2", culture));
-            Assert.Equal("0.123 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s3", culture));
-            Assert.Equal("0.1235 Gy", new AbsorbedDoseOfIonizingRadiation(0.123456, AbsorbedDoseOfIonizingRadiationUnit.Gray).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AccelerationTestsBase.g.cs
@@ -1008,26 +1008,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 g", new Acceleration(1, AccelerationUnit.StandardGravity).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s1"));
-            Assert.Equal("0.12 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s2"));
-            Assert.Equal("0.123 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s3"));
-            Assert.Equal("0.1235 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s1", culture));
-            Assert.Equal("0.12 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s2", culture));
-            Assert.Equal("0.123 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s3", culture));
-            Assert.Equal("0.1235 m/s²", new Acceleration(0.123456, AccelerationUnit.MeterPerSecondSquared).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AmountOfSubstanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AmountOfSubstanceTestsBase.g.cs
@@ -970,26 +970,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lbmol", new AmountOfSubstance(1, AmountOfSubstanceUnit.PoundMole).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s1"));
-            Assert.Equal("0.12 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s2"));
-            Assert.Equal("0.123 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s3"));
-            Assert.Equal("0.1235 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s1", culture));
-            Assert.Equal("0.12 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s2", culture));
-            Assert.Equal("0.123 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s3", culture));
-            Assert.Equal("0.1235 mol", new AmountOfSubstance(0.123456, AmountOfSubstanceUnit.Mole).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AmplitudeRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AmplitudeRatioTestsBase.g.cs
@@ -656,26 +656,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 dBV", new AmplitudeRatio(1, AmplitudeRatioUnit.DecibelVolt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s1"));
-            Assert.Equal("0.12 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s2"));
-            Assert.Equal("0.123 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s3"));
-            Assert.Equal("0.1235 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s1", culture));
-            Assert.Equal("0.12 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s2", culture));
-            Assert.Equal("0.123 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s3", culture));
-            Assert.Equal("0.1235 dBV", new AmplitudeRatio(0.123456, AmplitudeRatioUnit.DecibelVolt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AngleTestsBase.g.cs
@@ -1054,26 +1054,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 r", new Angle(1, AngleUnit.Revolution).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s1"));
-            Assert.Equal("0.12 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s2"));
-            Assert.Equal("0.123 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s3"));
-            Assert.Equal("0.1235 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s1", culture));
-            Assert.Equal("0.12 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s2", culture));
-            Assert.Equal("0.123 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s3", culture));
-            Assert.Equal("0.1235 rad", new Angle(0.123456, AngleUnit.Radian).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaDensityTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lb/MSF", new AreaDensity(1, AreaDensityUnit.PoundPerThousandSquareFeet).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 kg/m²", new AreaDensity(0.123456, AreaDensityUnit.KilogramPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaMomentOfInertiaTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mm⁴", new AreaMomentOfInertia(1, AreaMomentOfInertiaUnit.MillimeterToTheFourth).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s1"));
-            Assert.Equal("0.12 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s2"));
-            Assert.Equal("0.123 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s3"));
-            Assert.Equal("0.1235 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s1", culture));
-            Assert.Equal("0.12 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s2", culture));
-            Assert.Equal("0.123 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s3", culture));
-            Assert.Equal("0.1235 m⁴", new AreaMomentOfInertia(0.123456, AreaMomentOfInertiaUnit.MeterToTheFourth).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaPerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaPerLengthTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mm²/m", new AreaPerLength(1, AreaPerLengthUnit.SquareMillimeterPerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s1"));
-            Assert.Equal("0.12 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s2"));
-            Assert.Equal("0.123 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m²/m", new AreaPerLength(0.123456, AreaPerLengthUnit.SquareMeterPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/AreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/AreaTestsBase.g.cs
@@ -1115,26 +1115,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 ft² (US)", new Area(1, AreaUnit.UsSurveySquareFoot).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s1"));
-            Assert.Equal("0.12 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s2"));
-            Assert.Equal("0.123 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m²", new Area(0.123456, AreaUnit.SquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/BitRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/BitRateTestsBase.g.cs
@@ -1540,26 +1540,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 To/s", new BitRate(1, BitRateUnit.TeraoctetPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s1"));
-            Assert.Equal("0.12 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s2"));
-            Assert.Equal("0.123 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 bit/s", new BitRate(0.123456, BitRateUnit.BitPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/BrakeSpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/BrakeSpecificFuelConsumptionTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lb/hph", new BrakeSpecificFuelConsumption(1, BrakeSpecificFuelConsumptionUnit.PoundPerMechanicalHorsepowerHour).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s1"));
-            Assert.Equal("0.12 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s2"));
-            Assert.Equal("0.123 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s3"));
-            Assert.Equal("0.1235 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s1", culture));
-            Assert.Equal("0.12 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s2", culture));
-            Assert.Equal("0.123 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s3", culture));
-            Assert.Equal("0.1235 kg/J", new BrakeSpecificFuelConsumption(0.123456, BrakeSpecificFuelConsumptionUnit.KilogramPerJoule).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CoefficientOfThermalExpansionTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 ppm/K", new CoefficientOfThermalExpansion(1, CoefficientOfThermalExpansionUnit.PpmPerKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s1"));
-            Assert.Equal("0.12 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s2"));
-            Assert.Equal("0.123 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s3"));
-            Assert.Equal("0.1235 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 K⁻¹", new CoefficientOfThermalExpansion(0.123456, CoefficientOfThermalExpansionUnit.PerKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/CompressibilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/CompressibilityTestsBase.g.cs
@@ -840,26 +840,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 psi⁻¹", new Compressibility(1, CompressibilityUnit.InversePoundForcePerSquareInch).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s1"));
-            Assert.Equal("0.12 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s2"));
-            Assert.Equal("0.123 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s3"));
-            Assert.Equal("0.1235 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s1", culture));
-            Assert.Equal("0.12 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s2", culture));
-            Assert.Equal("0.123 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s3", culture));
-            Assert.Equal("0.1235 Pa⁻¹", new Compressibility(0.123456, CompressibilityUnit.InversePascal).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DensityTestsBase.g.cs
@@ -1838,26 +1838,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 t/mm³", new Density(1, DensityUnit.TonnePerCubicMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 kg/m³", new Density(0.123456, DensityUnit.KilogramPerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DoseAreaProductTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DoseAreaProductTestsBase.g.cs
@@ -1305,26 +1305,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mGy·mm²", new DoseAreaProduct(1, DoseAreaProductUnit.MilligraySquareMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s1"));
-            Assert.Equal("0.12 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s2"));
-            Assert.Equal("0.123 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 Gy·m²", new DoseAreaProduct(0.123456, DoseAreaProductUnit.GraySquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DurationTestsBase.g.cs
@@ -1379,26 +1379,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 yr", new Duration(1, DurationUnit.Year365).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 s", new Duration(0.123456, DurationUnit.Second).ToString("s1"));
-            Assert.Equal("0.12 s", new Duration(0.123456, DurationUnit.Second).ToString("s2"));
-            Assert.Equal("0.123 s", new Duration(0.123456, DurationUnit.Second).ToString("s3"));
-            Assert.Equal("0.1235 s", new Duration(0.123456, DurationUnit.Second).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 s", new Duration(0.123456, DurationUnit.Second).ToString("s1", culture));
-            Assert.Equal("0.12 s", new Duration(0.123456, DurationUnit.Second).ToString("s2", culture));
-            Assert.Equal("0.123 s", new Duration(0.123456, DurationUnit.Second).ToString("s3", culture));
-            Assert.Equal("0.1235 s", new Duration(0.123456, DurationUnit.Second).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/DynamicViscosityTestsBase.g.cs
@@ -860,26 +860,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 reyn", new DynamicViscosity(1, DynamicViscosityUnit.Reyn).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s1"));
-            Assert.Equal("0.12 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s2"));
-            Assert.Equal("0.123 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s3"));
-            Assert.Equal("0.1235 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s1", culture));
-            Assert.Equal("0.12 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s2", culture));
-            Assert.Equal("0.123 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s3", culture));
-            Assert.Equal("0.1235 Ns/m²", new DynamicViscosity(0.123456, DynamicViscosityUnit.NewtonSecondPerMeterSquared).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricAdmittanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricAdmittanceTestsBase.g.cs
@@ -950,26 +950,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TS", new ElectricAdmittance(1, ElectricAdmittanceUnit.Terasiemens).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s1"));
-            Assert.Equal("0.12 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s2"));
-            Assert.Equal("0.123 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s3"));
-            Assert.Equal("0.1235 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s1", culture));
-            Assert.Equal("0.12 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s2", culture));
-            Assert.Equal("0.123 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s3", culture));
-            Assert.Equal("0.1235 S", new ElectricAdmittance(0.123456, ElectricAdmittanceUnit.Siemens).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentEnergyTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 VAh", new ElectricApparentEnergy(1, ElectricApparentEnergyUnit.VoltampereHour).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s1"));
-            Assert.Equal("0.12 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s2"));
-            Assert.Equal("0.123 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s3"));
-            Assert.Equal("0.1235 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s1", culture));
-            Assert.Equal("0.12 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s2", culture));
-            Assert.Equal("0.123 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s3", culture));
-            Assert.Equal("0.1235 VAh", new ElectricApparentEnergy(0.123456, ElectricApparentEnergyUnit.VoltampereHour).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentPowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricApparentPowerTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 VA", new ElectricApparentPower(1, ElectricApparentPowerUnit.Voltampere).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s1"));
-            Assert.Equal("0.12 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s2"));
-            Assert.Equal("0.123 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s3"));
-            Assert.Equal("0.1235 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s1", culture));
-            Assert.Equal("0.12 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s2", culture));
-            Assert.Equal("0.123 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s3", culture));
-            Assert.Equal("0.1235 VA", new ElectricApparentPower(0.123456, ElectricApparentPowerUnit.Voltampere).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCapacitanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCapacitanceTestsBase.g.cs
@@ -770,26 +770,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 pF", new ElectricCapacitance(1, ElectricCapacitanceUnit.Picofarad).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s1"));
-            Assert.Equal("0.12 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s2"));
-            Assert.Equal("0.123 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s3"));
-            Assert.Equal("0.1235 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s1", culture));
-            Assert.Equal("0.12 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s2", culture));
-            Assert.Equal("0.123 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s3", culture));
-            Assert.Equal("0.1235 F", new ElectricCapacitance(0.123456, ElectricCapacitanceUnit.Farad).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeDensityTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 C/m³", new ElectricChargeDensity(1, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 C/m³", new ElectricChargeDensity(0.123456, ElectricChargeDensityUnit.CoulombPerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricChargeTestsBase.g.cs
@@ -890,26 +890,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 pC", new ElectricCharge(1, ElectricChargeUnit.Picocoulomb).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s1"));
-            Assert.Equal("0.12 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s2"));
-            Assert.Equal("0.123 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s3"));
-            Assert.Equal("0.1235 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s1", culture));
-            Assert.Equal("0.12 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s2", culture));
-            Assert.Equal("0.123 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s3", culture));
-            Assert.Equal("0.1235 C", new ElectricCharge(0.123456, ElectricChargeUnit.Coulomb).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductanceTestsBase.g.cs
@@ -950,26 +950,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TS", new ElectricConductance(1, ElectricConductanceUnit.Terasiemens).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s1"));
-            Assert.Equal("0.12 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s2"));
-            Assert.Equal("0.123 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s3"));
-            Assert.Equal("0.1235 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s1", culture));
-            Assert.Equal("0.12 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s2", culture));
-            Assert.Equal("0.123 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s3", culture));
-            Assert.Equal("0.1235 S", new ElectricConductance(0.123456, ElectricConductanceUnit.Siemens).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricConductivityTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 S/m", new ElectricConductivity(1, ElectricConductivityUnit.SiemensPerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s1"));
-            Assert.Equal("0.12 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s2"));
-            Assert.Equal("0.123 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 S/m", new ElectricConductivity(0.123456, ElectricConductivityUnit.SiemensPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentDensityTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 A/m²", new ElectricCurrentDensity(1, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 A/m²", new ElectricCurrentDensity(0.123456, ElectricCurrentDensityUnit.AmperePerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentGradientTestsBase.g.cs
@@ -770,26 +770,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mA/s", new ElectricCurrentGradient(1, ElectricCurrentGradientUnit.MilliamperePerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s1"));
-            Assert.Equal("0.12 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s2"));
-            Assert.Equal("0.123 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s3"));
-            Assert.Equal("0.1235 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 A/s", new ElectricCurrentGradient(0.123456, ElectricCurrentGradientUnit.AmperePerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricCurrentTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 pA", new ElectricCurrent(1, ElectricCurrentUnit.Picoampere).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s1"));
-            Assert.Equal("0.12 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s2"));
-            Assert.Equal("0.123 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s3"));
-            Assert.Equal("0.1235 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s1", culture));
-            Assert.Equal("0.12 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s2", culture));
-            Assert.Equal("0.123 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s3", culture));
-            Assert.Equal("0.1235 A", new ElectricCurrent(0.123456, ElectricCurrentUnit.Ampere).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricFieldTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 V/m", new ElectricField(1, ElectricFieldUnit.VoltPerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s1"));
-            Assert.Equal("0.12 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s2"));
-            Assert.Equal("0.123 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 V/m", new ElectricField(0.123456, ElectricFieldUnit.VoltPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricImpedanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricImpedanceTestsBase.g.cs
@@ -790,26 +790,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TΩ", new ElectricImpedance(1, ElectricImpedanceUnit.Teraohm).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s1"));
-            Assert.Equal("0.12 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s2"));
-            Assert.Equal("0.123 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s3"));
-            Assert.Equal("0.1235 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s1", culture));
-            Assert.Equal("0.12 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s2", culture));
-            Assert.Equal("0.123 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s3", culture));
-            Assert.Equal("0.1235 Ω", new ElectricImpedance(0.123456, ElectricImpedanceUnit.Ohm).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricInductanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricInductanceTestsBase.g.cs
@@ -730,26 +730,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 pH", new ElectricInductance(1, ElectricInductanceUnit.Picohenry).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s1"));
-            Assert.Equal("0.12 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s2"));
-            Assert.Equal("0.123 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s3"));
-            Assert.Equal("0.1235 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s1", culture));
-            Assert.Equal("0.12 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s2", culture));
-            Assert.Equal("0.123 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s3", culture));
-            Assert.Equal("0.1235 H", new ElectricInductance(0.123456, ElectricInductanceUnit.Henry).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialChangeRateTestsBase.g.cs
@@ -1030,26 +1030,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 V/s", new ElectricPotentialChangeRate(1, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s1"));
-            Assert.Equal("0.12 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s2"));
-            Assert.Equal("0.123 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 V/s", new ElectricPotentialChangeRate(0.123456, ElectricPotentialChangeRateUnit.VoltPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricPotentialTestsBase.g.cs
@@ -792,26 +792,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 V", new ElectricPotential(1, ElectricPotentialUnit.Volt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s1"));
-            Assert.Equal("0.12 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s2"));
-            Assert.Equal("0.123 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s3"));
-            Assert.Equal("0.1235 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s1", culture));
-            Assert.Equal("0.12 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s2", culture));
-            Assert.Equal("0.123 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s3", culture));
-            Assert.Equal("0.1235 V", new ElectricPotential(0.123456, ElectricPotentialUnit.Volt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactanceTestsBase.g.cs
@@ -790,26 +790,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TΩ", new ElectricReactance(1, ElectricReactanceUnit.Teraohm).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s1"));
-            Assert.Equal("0.12 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s2"));
-            Assert.Equal("0.123 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s3"));
-            Assert.Equal("0.1235 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s1", culture));
-            Assert.Equal("0.12 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s2", culture));
-            Assert.Equal("0.123 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s3", culture));
-            Assert.Equal("0.1235 Ω", new ElectricReactance(0.123456, ElectricReactanceUnit.Ohm).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactiveEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactiveEnergyTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 varh", new ElectricReactiveEnergy(1, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s1"));
-            Assert.Equal("0.12 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s2"));
-            Assert.Equal("0.123 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s3"));
-            Assert.Equal("0.1235 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s1", culture));
-            Assert.Equal("0.12 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s2", culture));
-            Assert.Equal("0.123 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s3", culture));
-            Assert.Equal("0.1235 varh", new ElectricReactiveEnergy(0.123456, ElectricReactiveEnergyUnit.VoltampereReactiveHour).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactivePowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricReactivePowerTestsBase.g.cs
@@ -710,26 +710,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 var", new ElectricReactivePower(1, ElectricReactivePowerUnit.VoltampereReactive).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s1"));
-            Assert.Equal("0.12 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s2"));
-            Assert.Equal("0.123 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s3"));
-            Assert.Equal("0.1235 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s1", culture));
-            Assert.Equal("0.12 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s2", culture));
-            Assert.Equal("0.123 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s3", culture));
-            Assert.Equal("0.1235 var", new ElectricReactivePower(0.123456, ElectricReactivePowerUnit.VoltampereReactive).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistanceTestsBase.g.cs
@@ -790,26 +790,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TΩ", new ElectricResistance(1, ElectricResistanceUnit.Teraohm).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s1"));
-            Assert.Equal("0.12 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s2"));
-            Assert.Equal("0.123 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s3"));
-            Assert.Equal("0.1235 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s1", culture));
-            Assert.Equal("0.12 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s2", culture));
-            Assert.Equal("0.123 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s3", culture));
-            Assert.Equal("0.1235 Ω", new ElectricResistance(0.123456, ElectricResistanceUnit.Ohm).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricResistivityTestsBase.g.cs
@@ -910,26 +910,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 pΩ·m", new ElectricResistivity(1, ElectricResistivityUnit.PicoohmMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s1"));
-            Assert.Equal("0.12 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s2"));
-            Assert.Equal("0.123 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s3"));
-            Assert.Equal("0.1235 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s1", culture));
-            Assert.Equal("0.12 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s2", culture));
-            Assert.Equal("0.123 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 Ω·m", new ElectricResistivity(0.123456, ElectricResistivityUnit.OhmMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSurfaceChargeDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSurfaceChargeDensityTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 C/m²", new ElectricSurfaceChargeDensity(1, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 C/m²", new ElectricSurfaceChargeDensity(0.123456, ElectricSurfaceChargeDensityUnit.CoulombPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSusceptanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ElectricSusceptanceTestsBase.g.cs
@@ -950,26 +950,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TS", new ElectricSusceptance(1, ElectricSusceptanceUnit.Terasiemens).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s1"));
-            Assert.Equal("0.12 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s2"));
-            Assert.Equal("0.123 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s3"));
-            Assert.Equal("0.1235 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s1", culture));
-            Assert.Equal("0.12 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s2", culture));
-            Assert.Equal("0.123 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s3", culture));
-            Assert.Equal("0.1235 S", new ElectricSusceptance(0.123456, ElectricSusceptanceUnit.Siemens).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyDensityTestsBase.g.cs
@@ -870,26 +870,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Wh/m³", new EnergyDensity(1, EnergyDensityUnit.WattHourPerCubicMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 J/m³", new EnergyDensity(0.123456, EnergyDensityUnit.JoulePerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EnergyTestsBase.g.cs
@@ -1577,26 +1577,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Wh", new Energy(1, EnergyUnit.WattHour).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s1"));
-            Assert.Equal("0.12 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s2"));
-            Assert.Equal("0.123 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s3"));
-            Assert.Equal("0.1235 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s1", culture));
-            Assert.Equal("0.12 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s2", culture));
-            Assert.Equal("0.123 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s3", culture));
-            Assert.Equal("0.1235 J", new Energy(0.123456, EnergyUnit.Joule).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/EntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/EntropyTestsBase.g.cs
@@ -770,26 +770,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 MJ/K", new Entropy(1, EntropyUnit.MegajoulePerKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s1"));
-            Assert.Equal("0.12 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s2"));
-            Assert.Equal("0.123 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s3"));
-            Assert.Equal("0.1235 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 J/K", new Entropy(0.123456, EntropyUnit.JoulePerKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FluidResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FluidResistanceTestsBase.g.cs
@@ -1175,26 +1175,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 WU", new FluidResistance(1, FluidResistanceUnit.WoodUnit).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 Pa·s/m³", new FluidResistance(0.123456, FluidResistanceUnit.PascalSecondPerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceChangeRateTestsBase.g.cs
@@ -970,26 +970,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lbf/s", new ForceChangeRate(1, ForceChangeRateUnit.PoundForcePerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s1"));
-            Assert.Equal("0.12 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s2"));
-            Assert.Equal("0.123 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 N/s", new ForceChangeRate(0.123456, ForceChangeRateUnit.NewtonPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForcePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForcePerLengthTestsBase.g.cs
@@ -1472,26 +1472,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 tf/mm", new ForcePerLength(1, ForcePerLengthUnit.TonneForcePerMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s1"));
-            Assert.Equal("0.12 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s2"));
-            Assert.Equal("0.123 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 N/m", new ForcePerLength(0.123456, ForcePerLengthUnit.NewtonPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ForceTestsBase.g.cs
@@ -1126,26 +1126,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 tf", new Force(1, ForceUnit.TonneForce).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N", new Force(0.123456, ForceUnit.Newton).ToString("s1"));
-            Assert.Equal("0.12 N", new Force(0.123456, ForceUnit.Newton).ToString("s2"));
-            Assert.Equal("0.123 N", new Force(0.123456, ForceUnit.Newton).ToString("s3"));
-            Assert.Equal("0.1235 N", new Force(0.123456, ForceUnit.Newton).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N", new Force(0.123456, ForceUnit.Newton).ToString("s1", culture));
-            Assert.Equal("0.12 N", new Force(0.123456, ForceUnit.Newton).ToString("s2", culture));
-            Assert.Equal("0.123 N", new Force(0.123456, ForceUnit.Newton).ToString("s3", culture));
-            Assert.Equal("0.1235 N", new Force(0.123456, ForceUnit.Newton).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FrequencyTestsBase.g.cs
@@ -933,26 +933,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 THz", new Frequency(1, FrequencyUnit.Terahertz).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s1"));
-            Assert.Equal("0.12 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s2"));
-            Assert.Equal("0.123 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s3"));
-            Assert.Equal("0.1235 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s1", culture));
-            Assert.Equal("0.12 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s2", culture));
-            Assert.Equal("0.123 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s3", culture));
-            Assert.Equal("0.1235 Hz", new Frequency(0.123456, FrequencyUnit.Hertz).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/FuelEfficiencyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/FuelEfficiencyTestsBase.g.cs
@@ -710,26 +710,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mpg (U.S.)", new FuelEfficiency(1, FuelEfficiencyUnit.MilePerUsGallon).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s1"));
-            Assert.Equal("0.12 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s2"));
-            Assert.Equal("0.123 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s3"));
-            Assert.Equal("0.1235 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s1", culture));
-            Assert.Equal("0.12 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s2", culture));
-            Assert.Equal("0.123 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s3", culture));
-            Assert.Equal("0.1235 km/l", new FuelEfficiency(0.123456, FuelEfficiencyUnit.KilometerPerLiter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/HeatFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/HeatFluxTestsBase.g.cs
@@ -1140,26 +1140,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W/mm²", new HeatFlux(1, HeatFluxUnit.WattPerSquareMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 W/m²", new HeatFlux(0.123456, HeatFluxUnit.WattPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/HeatTransferCoefficientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/HeatTransferCoefficientTestsBase.g.cs
@@ -870,26 +870,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W/(m²·K)", new HeatTransferCoefficient(1, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s1"));
-            Assert.Equal("0.12 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s2"));
-            Assert.Equal("0.123 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s3"));
-            Assert.Equal("0.1235 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 W/(m²·K)", new HeatTransferCoefficient(0.123456, HeatTransferCoefficientUnit.WattPerSquareMeterKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IlluminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IlluminanceTestsBase.g.cs
@@ -710,26 +710,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mlx", new Illuminance(1, IlluminanceUnit.Millilux).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s1"));
-            Assert.Equal("0.12 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s2"));
-            Assert.Equal("0.123 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s3"));
-            Assert.Equal("0.1235 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s1", culture));
-            Assert.Equal("0.12 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s2", culture));
-            Assert.Equal("0.123 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s3", culture));
-            Assert.Equal("0.1235 lx", new Illuminance(0.123456, IlluminanceUnit.Lux).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ImpulseTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ImpulseTestsBase.g.cs
@@ -890,26 +890,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 slug·ft/s", new Impulse(1, ImpulseUnit.SlugFootPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s1"));
-            Assert.Equal("0.12 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s2"));
-            Assert.Equal("0.123 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s3"));
-            Assert.Equal("0.1235 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s1", culture));
-            Assert.Equal("0.12 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s2", culture));
-            Assert.Equal("0.123 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 N·s", new Impulse(0.123456, ImpulseUnit.NewtonSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/InformationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/InformationTestsBase.g.cs
@@ -1350,26 +1350,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 To", new Information(1, InformationUnit.Teraoctet).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 b", new Information(0.123456, InformationUnit.Bit).ToString("s1"));
-            Assert.Equal("0.12 b", new Information(0.123456, InformationUnit.Bit).ToString("s2"));
-            Assert.Equal("0.123 b", new Information(0.123456, InformationUnit.Bit).ToString("s3"));
-            Assert.Equal("0.1235 b", new Information(0.123456, InformationUnit.Bit).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 b", new Information(0.123456, InformationUnit.Bit).ToString("s1", culture));
-            Assert.Equal("0.12 b", new Information(0.123456, InformationUnit.Bit).ToString("s2", culture));
-            Assert.Equal("0.123 b", new Information(0.123456, InformationUnit.Bit).ToString("s3", culture));
-            Assert.Equal("0.1235 b", new Information(0.123456, InformationUnit.Bit).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IrradianceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IrradianceTestsBase.g.cs
@@ -910,26 +910,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W/m²", new Irradiance(1, IrradianceUnit.WattPerSquareMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 W/m²", new Irradiance(0.123456, IrradianceUnit.WattPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/IrradiationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/IrradiationTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Wh/m²", new Irradiation(1, IrradiationUnit.WattHourPerSquareMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 J/m²", new Irradiation(0.123456, IrradiationUnit.JoulePerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/JerkTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/JerkTestsBase.g.cs
@@ -927,26 +927,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 g/s", new Jerk(1, JerkUnit.StandardGravitiesPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s1"));
-            Assert.Equal("0.12 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s2"));
-            Assert.Equal("0.123 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s3"));
-            Assert.Equal("0.1235 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s1", culture));
-            Assert.Equal("0.12 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s2", culture));
-            Assert.Equal("0.123 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s3", culture));
-            Assert.Equal("0.1235 m/s³", new Jerk(0.123456, JerkUnit.MeterPerSecondCubed).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/KinematicViscosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/KinematicViscosityTestsBase.g.cs
@@ -866,26 +866,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 St", new KinematicViscosity(1, KinematicViscosityUnit.Stokes).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s1"));
-            Assert.Equal("0.12 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s2"));
-            Assert.Equal("0.123 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 m²/s", new KinematicViscosity(0.123456, KinematicViscosityUnit.SquareMeterPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LeakRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LeakRateTestsBase.g.cs
@@ -710,26 +710,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Torr·l/s", new LeakRate(1, LeakRateUnit.TorrLiterPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s1"));
-            Assert.Equal("0.12 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s2"));
-            Assert.Equal("0.123 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 Pa·m³/s", new LeakRate(0.123456, LeakRateUnit.PascalCubicMeterPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LengthTestsBase.g.cs
@@ -1854,26 +1854,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 yd", new Length(1, LengthUnit.Yard).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m", new Length(0.123456, LengthUnit.Meter).ToString("s1"));
-            Assert.Equal("0.12 m", new Length(0.123456, LengthUnit.Meter).ToString("s2"));
-            Assert.Equal("0.123 m", new Length(0.123456, LengthUnit.Meter).ToString("s3"));
-            Assert.Equal("0.1235 m", new Length(0.123456, LengthUnit.Meter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m", new Length(0.123456, LengthUnit.Meter).ToString("s1", culture));
-            Assert.Equal("0.12 m", new Length(0.123456, LengthUnit.Meter).ToString("s2", culture));
-            Assert.Equal("0.123 m", new Length(0.123456, LengthUnit.Meter).ToString("s3", culture));
-            Assert.Equal("0.1235 m", new Length(0.123456, LengthUnit.Meter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LevelTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LevelTestsBase.g.cs
@@ -616,26 +616,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Np", new Level(1, LevelUnit.Neper).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s1"));
-            Assert.Equal("0.12 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s2"));
-            Assert.Equal("0.123 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s3"));
-            Assert.Equal("0.1235 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s1", culture));
-            Assert.Equal("0.12 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s2", culture));
-            Assert.Equal("0.123 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s3", culture));
-            Assert.Equal("0.1235 dB", new Level(0.123456, LevelUnit.Decibel).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LinearDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LinearDensityTestsBase.g.cs
@@ -990,26 +990,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lb/in", new LinearDensity(1, LinearDensityUnit.PoundPerInch).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s1"));
-            Assert.Equal("0.12 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s2"));
-            Assert.Equal("0.123 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 kg/m", new LinearDensity(0.123456, LinearDensityUnit.KilogramPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LinearPowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LinearPowerDensityTestsBase.g.cs
@@ -1130,26 +1130,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W/mm", new LinearPowerDensity(1, LinearPowerDensityUnit.WattPerMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s1"));
-            Assert.Equal("0.12 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s2"));
-            Assert.Equal("0.123 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 W/m", new LinearPowerDensity(0.123456, LinearPowerDensityUnit.WattPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminanceTestsBase.g.cs
@@ -830,26 +830,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 nt", new Luminance(1, LuminanceUnit.Nit).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 Cd/m²", new Luminance(0.123456, LuminanceUnit.CandelaPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminosityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminosityTestsBase.g.cs
@@ -910,26 +910,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W", new Luminosity(1, LuminosityUnit.Watt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s1"));
-            Assert.Equal("0.12 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s2"));
-            Assert.Equal("0.123 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s3"));
-            Assert.Equal("0.1235 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s1", culture));
-            Assert.Equal("0.12 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s2", culture));
-            Assert.Equal("0.123 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s3", culture));
-            Assert.Equal("0.1235 W", new Luminosity(0.123456, LuminosityUnit.Watt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousFluxTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lm", new LuminousFlux(1, LuminousFluxUnit.Lumen).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s1"));
-            Assert.Equal("0.12 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s2"));
-            Assert.Equal("0.123 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s3"));
-            Assert.Equal("0.1235 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s1", culture));
-            Assert.Equal("0.12 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s2", culture));
-            Assert.Equal("0.123 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s3", culture));
-            Assert.Equal("0.1235 lm", new LuminousFlux(0.123456, LuminousFluxUnit.Lumen).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousIntensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/LuminousIntensityTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 cd", new LuminousIntensity(1, LuminousIntensityUnit.Candela).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s1"));
-            Assert.Equal("0.12 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s2"));
-            Assert.Equal("0.123 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s3"));
-            Assert.Equal("0.1235 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s1", culture));
-            Assert.Equal("0.12 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s2", culture));
-            Assert.Equal("0.123 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s3", culture));
-            Assert.Equal("0.1235 cd", new LuminousIntensity(0.123456, LuminousIntensityUnit.Candela).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFieldTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFieldTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 T", new MagneticField(1, MagneticFieldUnit.Tesla).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s1"));
-            Assert.Equal("0.12 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s2"));
-            Assert.Equal("0.123 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s3"));
-            Assert.Equal("0.1235 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s1", culture));
-            Assert.Equal("0.12 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s2", culture));
-            Assert.Equal("0.123 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s3", culture));
-            Assert.Equal("0.1235 T", new MagneticField(0.123456, MagneticFieldUnit.Tesla).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagneticFluxTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Wb", new MagneticFlux(1, MagneticFluxUnit.Weber).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s1"));
-            Assert.Equal("0.12 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s2"));
-            Assert.Equal("0.123 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s3"));
-            Assert.Equal("0.1235 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s1", culture));
-            Assert.Equal("0.12 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s2", culture));
-            Assert.Equal("0.123 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s3", culture));
-            Assert.Equal("0.1235 Wb", new MagneticFlux(0.123456, MagneticFluxUnit.Weber).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MagnetizationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MagnetizationTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 A/m", new Magnetization(1, MagnetizationUnit.AmperePerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s1"));
-            Assert.Equal("0.12 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s2"));
-            Assert.Equal("0.123 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s3"));
-            Assert.Equal("0.1235 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 A/m", new Magnetization(0.123456, MagnetizationUnit.AmperePerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassConcentrationTestsBase.g.cs
@@ -1638,26 +1638,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 t/mm³", new MassConcentration(1, MassConcentrationUnit.TonnePerCubicMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 kg/m³", new MassConcentration(0.123456, MassConcentrationUnit.KilogramPerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFlowTestsBase.g.cs
@@ -1394,26 +1394,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 t/h", new MassFlow(1, MassFlowUnit.TonnePerHour).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s1"));
-            Assert.Equal("0.12 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s2"));
-            Assert.Equal("0.123 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 g/s", new MassFlow(0.123456, MassFlowUnit.GramPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFluxTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFluxTestsBase.g.cs
@@ -870,26 +870,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 kg·s⁻¹·mm⁻²", new MassFlux(1, MassFluxUnit.KilogramPerSecondPerSquareMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 kg·s⁻¹·m⁻²", new MassFlux(0.123456, MassFluxUnit.KilogramPerSecondPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassFractionTestsBase.g.cs
@@ -1060,26 +1060,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 %", new MassFraction(1, MassFractionUnit.Percent).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s1"));
-            Assert.Equal("0.12", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s2"));
-            Assert.Equal("0.123", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s3"));
-            Assert.Equal("0.1235", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s1", culture));
-            Assert.Equal("0.12", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s2", culture));
-            Assert.Equal("0.123", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s3", culture));
-            Assert.Equal("0.1235", new MassFraction(0.123456, MassFractionUnit.DecimalFraction).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassMomentOfInertiaTestsBase.g.cs
@@ -1190,26 +1190,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 t·mm²", new MassMomentOfInertia(1, MassMomentOfInertiaUnit.TonneSquareMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 kg·m²", new MassMomentOfInertia(0.123456, MassMomentOfInertiaUnit.KilogramSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MassTestsBase.g.cs
@@ -1661,26 +1661,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 t", new Mass(1, MassUnit.Tonne).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s1"));
-            Assert.Equal("0.12 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s2"));
-            Assert.Equal("0.123 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s3"));
-            Assert.Equal("0.1235 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s1", culture));
-            Assert.Equal("0.12 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s2", culture));
-            Assert.Equal("0.123 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s3", culture));
-            Assert.Equal("0.1235 kg", new Mass(0.123456, MassUnit.Kilogram).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolalityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolalityTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mol/kg", new Molality(1, MolalityUnit.MolePerKilogram).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s1"));
-            Assert.Equal("0.12 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s2"));
-            Assert.Equal("0.123 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s3"));
-            Assert.Equal("0.1235 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s1", culture));
-            Assert.Equal("0.12 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s2", culture));
-            Assert.Equal("0.123 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s3", culture));
-            Assert.Equal("0.1235 mol/kg", new Molality(0.123456, MolalityUnit.MolePerKilogram).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEnergyTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 MJ/mol", new MolarEnergy(1, MolarEnergyUnit.MegajoulePerMole).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s1"));
-            Assert.Equal("0.12 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s2"));
-            Assert.Equal("0.123 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s3"));
-            Assert.Equal("0.1235 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s1", culture));
-            Assert.Equal("0.12 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s2", culture));
-            Assert.Equal("0.123 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s3", culture));
-            Assert.Equal("0.1235 J/mol", new MolarEnergy(0.123456, MolarEnergyUnit.JoulePerMole).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarEntropyTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 MJ/(mol·K)", new MolarEntropy(1, MolarEntropyUnit.MegajoulePerMoleKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s1"));
-            Assert.Equal("0.12 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s2"));
-            Assert.Equal("0.123 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s3"));
-            Assert.Equal("0.1235 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 J/(mol·K)", new MolarEntropy(0.123456, MolarEntropyUnit.JoulePerMoleKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarFlowTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lbmol/s", new MolarFlow(1, MolarFlowUnit.PoundMolePerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s1"));
-            Assert.Equal("0.12 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s2"));
-            Assert.Equal("0.123 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s3"));
-            Assert.Equal("0.1235 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 mol/s", new MolarFlow(0.123456, MolarFlowUnit.MolePerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarMassTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarMassTestsBase.g.cs
@@ -1004,26 +1004,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lb/lbmol", new MolarMass(1, MolarMassUnit.PoundPerPoundMole).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s1"));
-            Assert.Equal("0.12 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s2"));
-            Assert.Equal("0.123 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s3"));
-            Assert.Equal("0.1235 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s1", culture));
-            Assert.Equal("0.12 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s2", culture));
-            Assert.Equal("0.123 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s3", culture));
-            Assert.Equal("0.1235 kg/mol", new MolarMass(0.123456, MolarMassUnit.KilogramPerMole).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/MolarityTestsBase.g.cs
@@ -930,26 +930,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lbmol/ft³", new Molarity(1, MolarityUnit.PoundMolePerCubicFoot).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 mol/m³", new Molarity(0.123456, MolarityUnit.MolePerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PermeabilityTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 H/m", new Permeability(1, PermeabilityUnit.HenryPerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s1"));
-            Assert.Equal("0.12 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s2"));
-            Assert.Equal("0.123 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 H/m", new Permeability(0.123456, PermeabilityUnit.HenryPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PermittivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PermittivityTestsBase.g.cs
@@ -650,26 +650,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 F/m", new Permittivity(1, PermittivityUnit.FaradPerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s1"));
-            Assert.Equal("0.12 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s2"));
-            Assert.Equal("0.123 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 F/m", new Permittivity(0.123456, PermittivityUnit.FaradPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PorousMediumPermeabilityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PorousMediumPermeabilityTestsBase.g.cs
@@ -730,26 +730,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 m²", new PorousMediumPermeability(1, PorousMediumPermeabilityUnit.SquareMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s1"));
-            Assert.Equal("0.12 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s2"));
-            Assert.Equal("0.123 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m²", new PorousMediumPermeability(0.123456, PorousMediumPermeabilityUnit.SquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerDensityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerDensityTestsBase.g.cs
@@ -1550,26 +1550,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W/l", new PowerDensity(1, PowerDensityUnit.WattPerLiter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 W/m³", new PowerDensity(0.123456, PowerDensityUnit.WattPerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerRatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerRatioTestsBase.g.cs
@@ -626,26 +626,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 dBW", new PowerRatio(1, PowerRatioUnit.DecibelWatt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s1"));
-            Assert.Equal("0.12 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s2"));
-            Assert.Equal("0.123 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s3"));
-            Assert.Equal("0.1235 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s1", culture));
-            Assert.Equal("0.12 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s2", culture));
-            Assert.Equal("0.123 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s3", culture));
-            Assert.Equal("0.1235 dBW", new PowerRatio(0.123456, PowerRatioUnit.DecibelWatt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PowerTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PowerTestsBase.g.cs
@@ -1200,26 +1200,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W", new Power(1, PowerUnit.Watt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W", new Power(0.123456, PowerUnit.Watt).ToString("s1"));
-            Assert.Equal("0.12 W", new Power(0.123456, PowerUnit.Watt).ToString("s2"));
-            Assert.Equal("0.123 W", new Power(0.123456, PowerUnit.Watt).ToString("s3"));
-            Assert.Equal("0.1235 W", new Power(0.123456, PowerUnit.Watt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W", new Power(0.123456, PowerUnit.Watt).ToString("s1", culture));
-            Assert.Equal("0.12 W", new Power(0.123456, PowerUnit.Watt).ToString("s2", culture));
-            Assert.Equal("0.123 W", new Power(0.123456, PowerUnit.Watt).ToString("s3", culture));
-            Assert.Equal("0.1235 W", new Power(0.123456, PowerUnit.Watt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureChangeRateTestsBase.g.cs
@@ -1212,26 +1212,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 psi/s", new PressureChangeRate(1, PressureChangeRateUnit.PoundForcePerSquareInchPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s1"));
-            Assert.Equal("0.12 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s2"));
-            Assert.Equal("0.123 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 Pa/s", new PressureChangeRate(0.123456, PressureChangeRateUnit.PascalPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/PressureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/PressureTestsBase.g.cs
@@ -2023,26 +2023,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 torr", new Pressure(1, PressureUnit.Torr).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s1"));
-            Assert.Equal("0.12 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s2"));
-            Assert.Equal("0.123 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s3"));
-            Assert.Equal("0.1235 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s1", culture));
-            Assert.Equal("0.12 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s2", culture));
-            Assert.Equal("0.123 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s3", culture));
-            Assert.Equal("0.1235 Pa", new Pressure(0.123456, PressureUnit.Pascal).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseRateTestsBase.g.cs
@@ -886,26 +886,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Sv/s", new RadiationEquivalentDoseRate(1, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s1"));
-            Assert.Equal("0.12 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s2"));
-            Assert.Equal("0.123 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 Sv/s", new RadiationEquivalentDoseRate(0.123456, RadiationEquivalentDoseRateUnit.SievertPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationEquivalentDoseTestsBase.g.cs
@@ -778,26 +778,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Sv", new RadiationEquivalentDose(1, RadiationEquivalentDoseUnit.Sievert).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s1"));
-            Assert.Equal("0.12 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s2"));
-            Assert.Equal("0.123 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s3"));
-            Assert.Equal("0.1235 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s1", culture));
-            Assert.Equal("0.12 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s2", culture));
-            Assert.Equal("0.123 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s3", culture));
-            Assert.Equal("0.1235 Sv", new RadiationEquivalentDose(0.123456, RadiationEquivalentDoseUnit.Sievert).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationExposureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadiationExposureTestsBase.g.cs
@@ -790,26 +790,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 R", new RadiationExposure(1, RadiationExposureUnit.Roentgen).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s1"));
-            Assert.Equal("0.12 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s2"));
-            Assert.Equal("0.123 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s3"));
-            Assert.Equal("0.1235 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s1", culture));
-            Assert.Equal("0.12 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s2", culture));
-            Assert.Equal("0.123 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s3", culture));
-            Assert.Equal("0.1235 C/kg", new RadiationExposure(0.123456, RadiationExposureUnit.CoulombPerKilogram).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RadioactivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RadioactivityTestsBase.g.cs
@@ -1413,26 +1413,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 TRd", new Radioactivity(1, RadioactivityUnit.Terarutherford).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s1"));
-            Assert.Equal("0.12 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s2"));
-            Assert.Equal("0.123 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s3"));
-            Assert.Equal("0.1235 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s1", culture));
-            Assert.Equal("0.12 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s2", culture));
-            Assert.Equal("0.123 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s3", culture));
-            Assert.Equal("0.1235 Bq", new Radioactivity(0.123456, RadioactivityUnit.Becquerel).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioChangeRateTestsBase.g.cs
@@ -670,26 +670,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 %/s", new RatioChangeRate(1, RatioChangeRateUnit.PercentPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s1"));
-            Assert.Equal("0.12 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s2"));
-            Assert.Equal("0.123 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 /s", new RatioChangeRate(0.123456, RatioChangeRateUnit.DecimalFractionPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RatioTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 %", new Ratio(1, RatioUnit.Percent).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s1"));
-            Assert.Equal("0.12", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s2"));
-            Assert.Equal("0.123", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s3"));
-            Assert.Equal("0.1235", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s1", culture));
-            Assert.Equal("0.12", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s2", culture));
-            Assert.Equal("0.123", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s3", culture));
-            Assert.Equal("0.1235", new Ratio(0.123456, RatioUnit.DecimalFraction).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalAreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalAreaTestsBase.g.cs
@@ -850,26 +850,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 ft⁻² (US)", new ReciprocalArea(1, ReciprocalAreaUnit.InverseUsSurveySquareFoot).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m⁻²", new ReciprocalArea(0.123456, ReciprocalAreaUnit.InverseSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ReciprocalLengthTestsBase.g.cs
@@ -930,26 +930,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 yd⁻¹", new ReciprocalLength(1, ReciprocalLengthUnit.InverseYard).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s1"));
-            Assert.Equal("0.12 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s2"));
-            Assert.Equal("0.123 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s3"));
-            Assert.Equal("0.1235 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m⁻¹", new ReciprocalLength(0.123456, ReciprocalLengthUnit.InverseMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RelativeHumidityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RelativeHumidityTestsBase.g.cs
@@ -590,26 +590,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 %RH", new RelativeHumidity(1, RelativeHumidityUnit.Percent).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s1"));
-            Assert.Equal("0.12 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s2"));
-            Assert.Equal("0.123 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s3"));
-            Assert.Equal("0.1235 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s1", culture));
-            Assert.Equal("0.12 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s2", culture));
-            Assert.Equal("0.123 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s3", culture));
-            Assert.Equal("0.1235 %RH", new RelativeHumidity(0.123456, RelativeHumidityUnit.Percent).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalAccelerationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalAccelerationTestsBase.g.cs
@@ -720,26 +720,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 r/s²", new RotationalAcceleration(1, RotationalAccelerationUnit.RevolutionPerSecondSquared).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s1"));
-            Assert.Equal("0.12 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s2"));
-            Assert.Equal("0.123 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s3"));
-            Assert.Equal("0.1235 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s1", culture));
-            Assert.Equal("0.12 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s2", culture));
-            Assert.Equal("0.123 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s3", culture));
-            Assert.Equal("0.1235 rad/s²", new RotationalAcceleration(0.123456, RotationalAccelerationUnit.RadianPerSecondSquared).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalSpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalSpeedTestsBase.g.cs
@@ -1034,26 +1034,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 r/s", new RotationalSpeed(1, RotationalSpeedUnit.RevolutionPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s1"));
-            Assert.Equal("0.12 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s2"));
-            Assert.Equal("0.123 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 rad/s", new RotationalSpeed(0.123456, RotationalSpeedUnit.RadianPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessPerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessPerLengthTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lbf·ft/deg/ft", new RotationalStiffnessPerLength(1, RotationalStiffnessPerLengthUnit.PoundForceFootPerDegreesPerFoot).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s1"));
-            Assert.Equal("0.12 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s2"));
-            Assert.Equal("0.123 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 N·m/rad/m", new RotationalStiffnessPerLength(0.123456, RotationalStiffnessPerLengthUnit.NewtonMeterPerRadianPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/RotationalStiffnessTestsBase.g.cs
@@ -2040,26 +2040,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lbf·ft/deg", new RotationalStiffness(1, RotationalStiffnessUnit.PoundForceFootPerDegrees).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s1"));
-            Assert.Equal("0.12 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s2"));
-            Assert.Equal("0.123 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s3"));
-            Assert.Equal("0.1235 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s1", culture));
-            Assert.Equal("0.12 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s2", culture));
-            Assert.Equal("0.123 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s3", culture));
-            Assert.Equal("0.1235 N·m/rad", new RotationalStiffness(0.123456, RotationalStiffnessUnit.NewtonMeterPerRadian).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ScalarTestsBase.g.cs
@@ -590,26 +590,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1", new Scalar(1, ScalarUnit.Amount).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1", new Scalar(0.123456, ScalarUnit.Amount).ToString("s1"));
-            Assert.Equal("0.12", new Scalar(0.123456, ScalarUnit.Amount).ToString("s2"));
-            Assert.Equal("0.123", new Scalar(0.123456, ScalarUnit.Amount).ToString("s3"));
-            Assert.Equal("0.1235", new Scalar(0.123456, ScalarUnit.Amount).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1", new Scalar(0.123456, ScalarUnit.Amount).ToString("s1", culture));
-            Assert.Equal("0.12", new Scalar(0.123456, ScalarUnit.Amount).ToString("s2", culture));
-            Assert.Equal("0.123", new Scalar(0.123456, ScalarUnit.Amount).ToString("s3", culture));
-            Assert.Equal("0.1235", new Scalar(0.123456, ScalarUnit.Amount).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SolidAngleTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SolidAngleTestsBase.g.cs
@@ -590,26 +590,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 sr", new SolidAngle(1, SolidAngleUnit.Steradian).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s1"));
-            Assert.Equal("0.12 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s2"));
-            Assert.Equal("0.123 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s3"));
-            Assert.Equal("0.1235 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s1", culture));
-            Assert.Equal("0.12 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s2", culture));
-            Assert.Equal("0.123 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s3", culture));
-            Assert.Equal("0.1235 sr", new SolidAngle(0.123456, SolidAngleUnit.Steradian).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEnergyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEnergyTestsBase.g.cs
@@ -1230,26 +1230,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 Wh/lbs", new SpecificEnergy(1, SpecificEnergyUnit.WattHourPerPound).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s1"));
-            Assert.Equal("0.12 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s2"));
-            Assert.Equal("0.123 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s3"));
-            Assert.Equal("0.1235 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s1", culture));
-            Assert.Equal("0.12 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s2", culture));
-            Assert.Equal("0.123 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s3", culture));
-            Assert.Equal("0.1235 J/kg", new SpecificEnergy(0.123456, SpecificEnergyUnit.JoulePerKilogram).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEntropyTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificEntropyTestsBase.g.cs
@@ -820,26 +820,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 MJ/kg·K", new SpecificEntropy(1, SpecificEntropyUnit.MegajoulePerKilogramKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s1"));
-            Assert.Equal("0.12 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s2"));
-            Assert.Equal("0.123 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s3"));
-            Assert.Equal("0.1235 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 J/kg·K", new SpecificEntropy(0.123456, SpecificEntropyUnit.JoulePerKilogramKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificFuelConsumptionTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificFuelConsumptionTestsBase.g.cs
@@ -710,26 +710,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 lb/(lbf·h)", new SpecificFuelConsumption(1, SpecificFuelConsumptionUnit.PoundMassPerPoundForceHour).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s1"));
-            Assert.Equal("0.12 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s2"));
-            Assert.Equal("0.123 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s3"));
-            Assert.Equal("0.1235 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s1", culture));
-            Assert.Equal("0.12 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s2", culture));
-            Assert.Equal("0.123 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 g/(kN·s)", new SpecificFuelConsumption(0.123456, SpecificFuelConsumptionUnit.GramPerKilonewtonSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificVolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificVolumeTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mm³/kg", new SpecificVolume(1, SpecificVolumeUnit.CubicMillimeterPerKilogram).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s1"));
-            Assert.Equal("0.12 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s2"));
-            Assert.Equal("0.123 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s3"));
-            Assert.Equal("0.1235 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s1", culture));
-            Assert.Equal("0.12 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s2", culture));
-            Assert.Equal("0.123 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s3", culture));
-            Assert.Equal("0.1235 m³/kg", new SpecificVolume(0.123456, SpecificVolumeUnit.CubicMeterPerKilogram).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificWeightTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpecificWeightTestsBase.g.cs
@@ -970,26 +970,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 tf/mm³", new SpecificWeight(1, SpecificWeightUnit.TonneForcePerCubicMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s1"));
-            Assert.Equal("0.12 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s2"));
-            Assert.Equal("0.123 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 N/m³", new SpecificWeight(0.123456, SpecificWeightUnit.NewtonPerCubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/SpeedTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/SpeedTestsBase.g.cs
@@ -1518,26 +1518,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 yd/s", new Speed(1, SpeedUnit.YardPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s1"));
-            Assert.Equal("0.12 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s2"));
-            Assert.Equal("0.123 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 m/s", new Speed(0.123456, SpeedUnit.MeterPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/StandardVolumeFlowTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 slm", new StandardVolumeFlow(1, StandardVolumeFlowUnit.StandardLiterPerMinute).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s1"));
-            Assert.Equal("0.12 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s2"));
-            Assert.Equal("0.123 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 Sm³/s", new StandardVolumeFlow(0.123456, StandardVolumeFlowUnit.StandardCubicMeterPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureChangeRateTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureChangeRateTestsBase.g.cs
@@ -970,26 +970,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 n°C/s", new TemperatureChangeRate(1, TemperatureChangeRateUnit.NanodegreeCelsiusPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s1"));
-            Assert.Equal("0.12 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s2"));
-            Assert.Equal("0.123 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 °C/s", new TemperatureChangeRate(0.123456, TemperatureChangeRateUnit.DegreeCelsiusPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureDeltaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureDeltaTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 ∆m°C", new TemperatureDelta(1, TemperatureDeltaUnit.MillidegreeCelsius).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s1"));
-            Assert.Equal("0.12 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s2"));
-            Assert.Equal("0.123 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s3"));
-            Assert.Equal("0.1235 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s1", culture));
-            Assert.Equal("0.12 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s2", culture));
-            Assert.Equal("0.123 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 ∆K", new TemperatureDelta(0.123456, TemperatureDeltaUnit.Kelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureGradientTestsBase.g.cs
@@ -710,26 +710,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 ∆°K/m", new TemperatureGradient(1, TemperatureGradientUnit.KelvinPerMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s1"));
-            Assert.Equal("0.12 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s2"));
-            Assert.Equal("0.123 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 ∆°K/m", new TemperatureGradient(0.123456, TemperatureGradientUnit.KelvinPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TemperatureTestsBase.g.cs
@@ -818,26 +818,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 T⊙", new Temperature(1, TemperatureUnit.SolarTemperature).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s1"));
-            Assert.Equal("0.12 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s2"));
-            Assert.Equal("0.123 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s3"));
-            Assert.Equal("0.1235 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s1", culture));
-            Assert.Equal("0.12 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s2", culture));
-            Assert.Equal("0.123 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 K", new Temperature(0.123456, TemperatureUnit.Kelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalConductivityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalConductivityTestsBase.g.cs
@@ -690,26 +690,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 W/(m·K)", new ThermalConductivity(1, ThermalConductivityUnit.WattPerMeterKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s1"));
-            Assert.Equal("0.12 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s2"));
-            Assert.Equal("0.123 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s3"));
-            Assert.Equal("0.1235 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 W/(m·K)", new ThermalConductivity(0.123456, ThermalConductivityUnit.WattPerMeterKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalInsulanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalInsulanceTestsBase.g.cs
@@ -770,26 +770,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mm²K/W", new ThermalInsulance(1, ThermalInsulanceUnit.SquareMillimeterKelvinPerWatt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s1"));
-            Assert.Equal("0.12 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s2"));
-            Assert.Equal("0.123 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s3"));
-            Assert.Equal("0.1235 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s1", culture));
-            Assert.Equal("0.12 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s2", culture));
-            Assert.Equal("0.123 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s3", culture));
-            Assert.Equal("0.1235 m²K/kW", new ThermalInsulance(0.123456, ThermalInsulanceUnit.SquareMeterKelvinPerKilowatt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/ThermalResistanceTestsBase.g.cs
@@ -670,26 +670,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 K/W", new ThermalResistance(1, ThermalResistanceUnit.KelvinPerWatt).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s1"));
-            Assert.Equal("0.12 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s2"));
-            Assert.Equal("0.123 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s3"));
-            Assert.Equal("0.1235 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s1", culture));
-            Assert.Equal("0.12 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s2", culture));
-            Assert.Equal("0.123 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s3", culture));
-            Assert.Equal("0.1235 K/W", new ThermalResistance(0.123456, ThermalResistanceUnit.KelvinPerWatt).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TorqueTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TorqueTestsBase.g.cs
@@ -1421,26 +1421,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 tf·mm", new Torque(1, TorqueUnit.TonneForceMillimeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s1"));
-            Assert.Equal("0.12 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s2"));
-            Assert.Equal("0.123 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s3"));
-            Assert.Equal("0.1235 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s1", culture));
-            Assert.Equal("0.12 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s2", culture));
-            Assert.Equal("0.123 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 N·m", new Torque(0.123456, TorqueUnit.NewtonMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/TurbidityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/TurbidityTestsBase.g.cs
@@ -590,26 +590,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 NTU", new Turbidity(1, TurbidityUnit.NTU).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s1"));
-            Assert.Equal("0.12 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s2"));
-            Assert.Equal("0.123 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s3"));
-            Assert.Equal("0.1235 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s1", culture));
-            Assert.Equal("0.12 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s2", culture));
-            Assert.Equal("0.123 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s3", culture));
-            Assert.Equal("0.1235 NTU", new Turbidity(0.123456, TurbidityUnit.NTU).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VitaminATestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VitaminATestsBase.g.cs
@@ -590,26 +590,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 IU", new VitaminA(1, VitaminAUnit.InternationalUnit).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s1"));
-            Assert.Equal("0.12 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s2"));
-            Assert.Equal("0.123 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s3"));
-            Assert.Equal("0.1235 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s1", culture));
-            Assert.Equal("0.12 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s2", culture));
-            Assert.Equal("0.123 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s3", culture));
-            Assert.Equal("0.1235 IU", new VitaminA(0.123456, VitaminAUnit.InternationalUnit).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeConcentrationTestsBase.g.cs
@@ -980,26 +980,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 pl/ml", new VolumeConcentration(1, VolumeConcentrationUnit.PicoliterPerMilliliter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s1"));
-            Assert.Equal("0.12", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s2"));
-            Assert.Equal("0.123", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s3"));
-            Assert.Equal("0.1235", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s1", culture));
-            Assert.Equal("0.12", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s2", culture));
-            Assert.Equal("0.123", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s3", culture));
-            Assert.Equal("0.1235", new VolumeConcentration(0.123456, VolumeConcentrationUnit.DecimalFraction).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowPerAreaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowPerAreaTestsBase.g.cs
@@ -670,26 +670,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 m³/(s·m²)", new VolumeFlowPerArea(1, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s1"));
-            Assert.Equal("0.12 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s2"));
-            Assert.Equal("0.123 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s3"));
-            Assert.Equal("0.1235 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m³/(s·m²)", new VolumeFlowPerArea(0.123456, VolumeFlowPerAreaUnit.CubicMeterPerSecondPerSquareMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeFlowTestsBase.g.cs
@@ -2972,26 +2972,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 gal (U.S.)/s", new VolumeFlow(1, VolumeFlowUnit.UsGallonPerSecond).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s1"));
-            Assert.Equal("0.12 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s2"));
-            Assert.Equal("0.123 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s3"));
-            Assert.Equal("0.1235 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s1", culture));
-            Assert.Equal("0.12 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s2", culture));
-            Assert.Equal("0.123 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s3", culture));
-            Assert.Equal("0.1235 m³/s", new VolumeFlow(0.123456, VolumeFlowUnit.CubicMeterPerSecond).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumePerLengthTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumePerLengthTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 gal (U.S.)/mi", new VolumePerLength(1, VolumePerLengthUnit.UsGallonPerMile).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s1"));
-            Assert.Equal("0.12 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s2"));
-            Assert.Equal("0.123 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s3"));
-            Assert.Equal("0.1235 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m³/m", new VolumePerLength(0.123456, VolumePerLengthUnit.CubicMeterPerMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumeTestsBase.g.cs
@@ -2203,26 +2203,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 teaspoon (U.S.)", new Volume(1, VolumeUnit.UsTeaspoon).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s1"));
-            Assert.Equal("0.12 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s2"));
-            Assert.Equal("0.123 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s3"));
-            Assert.Equal("0.1235 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s1", culture));
-            Assert.Equal("0.12 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s2", culture));
-            Assert.Equal("0.123 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s3", culture));
-            Assert.Equal("0.1235 m³", new Volume(0.123456, VolumeUnit.CubicMeter).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/VolumetricHeatCapacityTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/VolumetricHeatCapacityTestsBase.g.cs
@@ -810,26 +810,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 MJ/(m³·K)", new VolumetricHeatCapacity(1, VolumetricHeatCapacityUnit.MegajoulePerCubicMeterKelvin).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s1"));
-            Assert.Equal("0.12 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s2"));
-            Assert.Equal("0.123 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s3"));
-            Assert.Equal("0.1235 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s1", culture));
-            Assert.Equal("0.12 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s2", culture));
-            Assert.Equal("0.123 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s3", culture));
-            Assert.Equal("0.1235 J/(m³·K)", new VolumetricHeatCapacity(0.123456, VolumetricHeatCapacityUnit.JoulePerCubicMeterKelvin).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/GeneratedCode/TestsBase/WarpingMomentOfInertiaTestsBase.g.cs
+++ b/UnitsNet.Tests/GeneratedCode/TestsBase/WarpingMomentOfInertiaTestsBase.g.cs
@@ -750,26 +750,6 @@ namespace UnitsNet.Tests
             Assert.Equal("1 mm⁶", new WarpingMomentOfInertia(1, WarpingMomentOfInertiaUnit.MillimeterToTheSixth).ToString(swedishCulture));
         }
 
-        [Fact]
-        public void ToString_SFormat_FormatsNumberWithGivenDigitsAfterRadixForCurrentCulture()
-        {
-            var _ = new CultureScope(CultureInfo.InvariantCulture);
-            Assert.Equal("0.1 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s1"));
-            Assert.Equal("0.12 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s2"));
-            Assert.Equal("0.123 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s3"));
-            Assert.Equal("0.1235 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s4"));
-        }
-
-        [Fact]
-        public void ToString_SFormatAndCulture_FormatsNumberWithGivenDigitsAfterRadixForGivenCulture()
-        {
-            var culture = CultureInfo.InvariantCulture;
-            Assert.Equal("0.1 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s1", culture));
-            Assert.Equal("0.12 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s2", culture));
-            Assert.Equal("0.123 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s3", culture));
-            Assert.Equal("0.1235 m⁶", new WarpingMomentOfInertia(0.123456, WarpingMomentOfInertiaUnit.MeterToTheSixth).ToString("s4", culture));
-        }
-
         [Theory]
         [InlineData(null)]
         [InlineData("en-US")]

--- a/UnitsNet.Tests/QuantityFormatterTests.cs
+++ b/UnitsNet.Tests/QuantityFormatterTests.cs
@@ -95,7 +95,7 @@ namespace UnitsNet.Tests
         {
             var length = Length.FromMeters(123456789.987654321);
 
-            var expected = string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}} {{1:a}}", length.Value, length);
+            var expected = $"{length.Value.ToString(format, CultureInfo.CurrentCulture)} {Length.GetAbbreviation(length.Unit)}";
             Assert.Equal(expected, QuantityFormatter.Default.Format(length, format));
         }
 
@@ -106,6 +106,10 @@ namespace UnitsNet.Tests
         [InlineData("v")]
         [InlineData("Q")]
         [InlineData("q")]
+        [InlineData("A")]
+        [InlineData("a0")]
+        [InlineData("S")]
+        [InlineData("s2")]
         [InlineData("C")]
         [InlineData("C0")]
         [InlineData("C1")]
@@ -173,7 +177,7 @@ namespace UnitsNet.Tests
         {
             var length = Length.FromMeters(123456789.987654321);
 
-            var expected = string.Format(CultureInfo.CurrentCulture, $"{{0:{format}}} {{1:a}}", length.Value, length);
+            var expected = $"{length.Value.ToString(format, CultureInfo.CurrentCulture)} {Length.GetAbbreviation(length.Unit)}";
             Assert.Equal(expected, QuantityFormatter.Default.Format(length, format));
         }
 
@@ -197,18 +201,5 @@ namespace UnitsNet.Tests
             Assert.Equal(expected, actual);
         }
 
-        [Theory]
-        [InlineData("A+0", "m")]
-        [InlineData("S+1", "123.3 m")]
-        public void Format_CustomSpecifierSuffix_ParsesUsingInvariantCulture(string format, string expected)
-        {
-            var culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-            culture.NumberFormat.PositiveSign = "!";
-            using var cultureScope = new CultureScope(culture);
-
-            var length = Length.FromMeters(123.321);
-
-            Assert.Equal(expected, QuantityFormatter.Default.Format(length, format));
-        }
     }
 }

--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -1,8 +1,11 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Linq;
+using System.Reflection;
 using UnitsNet.Units;
 using Xunit;
 
@@ -15,6 +18,34 @@ namespace UnitsNet.Tests
         private static readonly CultureInfo AmericanCulture = CultureInfo.GetCultureInfo("en-US");
         private static readonly CultureInfo NorwegianCulture = CultureInfo.GetCultureInfo("nb-NO");
         private static readonly CultureInfo RussianCulture = CultureInfo.GetCultureInfo("ru-RU");
+
+        [Fact]
+        public void FormattingApisIdentifyNumericFormatSyntax()
+        {
+            MethodInfo quantityToString = typeof(Length).GetMethod(
+                nameof(Length.ToString),
+                [typeof(string), typeof(IFormatProvider)])!;
+            MethodInfo quantityValueToString = typeof(QuantityValue).GetMethod(
+                nameof(QuantityValue.ToString),
+                [typeof(string), typeof(IFormatProvider)])!;
+            MethodInfo formatter = typeof(QuantityFormatter)
+                .GetMethods()
+                .Single(method => method.Name == nameof(QuantityFormatter.Format) && method is { IsStatic: false, IsGenericMethod: true });
+
+            AssertNumericFormat(quantityToString.GetParameters()[0]);
+            AssertNumericFormat(quantityValueToString.GetParameters()[0]);
+            AssertNumericFormat(formatter.GetParameters()[1]);
+            Assert.Equal(
+                StringSyntaxAttribute.NumericFormat,
+                typeof(DisplayAsUnitAttribute).GetProperty(nameof(DisplayAsUnitAttribute.Format))!
+                    .GetCustomAttribute<StringSyntaxAttribute>()?.Syntax);
+        }
+
+        private static void AssertNumericFormat(ParameterInfo parameter)
+        {
+            StringSyntaxAttribute? syntax = parameter.GetCustomAttribute<StringSyntaxAttribute>();
+            Assert.Equal(StringSyntaxAttribute.NumericFormat, syntax?.Syntax);
+        }
 
         [Fact]
         public void GFormatStringEqualsToString()
@@ -30,20 +61,28 @@ namespace UnitsNet.Tests
         }
 
         [Fact]
-        public void AFormatGetsAbbreviations()
+        public void ExplicitAbbreviationApisReplaceAFormat()
         {
-            UnitAbbreviationsCache cache = UnitsNetSetup.Default.UnitAbbreviations;
-            Assert.Equal(cache.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a", CultureInfo.InvariantCulture));
-            Assert.Equal(cache.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture), MyLength.ToString("a0", CultureInfo.InvariantCulture));
+            UnitAbbreviationsCache abbreviations = UnitsNetSetup.Default.UnitAbbreviations;
 
-            Assert.Equal(cache.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[1], MyLength.ToString("a1", CultureInfo.InvariantCulture));
-            Assert.Equal(cache.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture)[2], MyLength.ToString("a2", CultureInfo.InvariantCulture));
+            Assert.Equal("ft", Length.GetAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture));
+            Assert.Equal("ft", abbreviations.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture));
+            Assert.Equal(
+                ["ft", "'", "′"],
+                abbreviations.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture));
         }
 
-        [Fact]
-        public void AFormatWithInvalidIndexThrowsFormatException()
+        [Theory]
+        [InlineData("a")]
+        [InlineData("A0")]
+        [InlineData("s")]
+        [InlineData("S2")]
+        public void RemovedQuantitySpecificFormatThrowsWithMigrationGuidance(string format)
         {
-            Assert.Throws<FormatException>(() => MyLength.ToString("a100"));
+            FormatException exception = Assert.Throws<FormatException>(
+                () => MyLength.ToString(format, CultureInfo.InvariantCulture));
+
+            Assert.Contains("no longer supported", exception.Message, StringComparison.Ordinal);
         }
 
         [Fact]
@@ -100,24 +139,6 @@ namespace UnitsNet.Tests
         }
 
         [Theory]
-        [InlineData("de-DE")]
-        [InlineData("da-DK")]
-        [InlineData("es-AR")]
-        [InlineData("es-ES")]
-        [InlineData("it-IT")]
-        [InlineData("en-CA")]
-        [InlineData("en-US")]
-        [InlineData("ar-EG")]
-        [InlineData("en-GB")]
-        [InlineData("es-MX")]
-        public void ToString_SFormat_DecimalSeparator_ForCulture(string cultureName)
-        {
-            CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
-            string ds = culture.NumberFormat.NumberDecimalSeparator;
-            Assert.Equal($"0{ds}12 m", Length.FromMeters(0.12).ToString("s2", culture));
-        }
-
-        [Theory]
         [InlineData("en-CA")]
         [InlineData("en-GB")]
         [InlineData("en-US")]
@@ -134,27 +155,6 @@ namespace UnitsNet.Tests
         {
             CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
             Assert.Equal("1111 m", Length.FromMeters(1111).ToString(culture));
-        }
-
-        [Theory]
-        [InlineData("en-CA")]
-        [InlineData("en-GB")]
-        [InlineData("en-US")]
-        [InlineData("ar-EG")]
-        [InlineData("es-MX")]
-        [InlineData("nn-NO")]
-        [InlineData("fr-FR")]
-        [InlineData("de-DE")]
-        [InlineData("da-DK")]
-        [InlineData("es-AR")]
-        [InlineData("es-ES")]
-        [InlineData("it-IT")]
-        public void ToString_SFormat_UsesGroupingSeparator_ForCulture(string cultureName)
-        {
-            CultureInfo culture = CultureInfo.GetCultureInfo(cultureName);
-            string gs = culture.NumberFormat.NumberGroupSeparator;
-
-            Assert.Equal($"1{gs}111 m", Length.FromMeters(1111).ToString("S", culture));
         }
 
         [Theory]
@@ -203,75 +203,6 @@ namespace UnitsNet.Tests
             Assert.Equal($"3{gs}333 st 7 lb", Mass.FromStonePounds(3333, 7).StonePounds.ToString(culture));
         }
         
-        // Due to rounding, the values will result in the same string representation regardless of the number of significant digits (up to a certain point)
-        [Theory]
-        [InlineData(-0.819999999999, "S", "-0.819999999999 m")]
-        [InlineData(-0.819999999999, "s2", "-0.82 m")]
-        [InlineData(-0.819999999999, "s4", "-0.82 m")]
-        [InlineData(-0.8, "s4", "-0.8 m")]
-        [InlineData(0.819999999999, "S", "0.819999999999 m")]
-        [InlineData(0.819999999999, "s", "0.819999999999 m")]
-        [InlineData(0.819999999999, "s2", "0.82 m")]
-        [InlineData(0.819999999999, "s4", "0.82 m")]
-        [InlineData(0.8, "s4", "0.8 m")]
-        [InlineData(0.00299999999, "s2", "0.003 m")]
-        [InlineData(0.00299999999, "s4", "0.003 m")]
-        [InlineData(0.0003000001, "s2", "3e-04 m")]
-        [InlineData(0.0003000001, "s4", "3e-04 m")]
-        [InlineData(0.0003000001, "S4", "3E-04 m")]
-        public void ToString_SFormat_RoundsToSignificantDigitsAfterRadix(double value,
-            string significantDigitsAfterRadixFormatString, string expected)
-        {
-            string actual = Length.FromMeters(value).ToString(significantDigitsAfterRadixFormatString, AmericanCulture);
-            Assert.Equal(expected, actual);
-        }
-
-        // Any value in the interval (-inf ≤ x < 1e-03] is formatted in scientific notation
-        [Theory]
-        [InlineData(double.MinValue, "-1.8e+308 m")]
-        [InlineData(1.23e-120, "1.23e-120 m")]
-        [InlineData(0.0000111, "1.11e-05 m")]
-        [InlineData(1.99e-4, "1.99e-04 m")]
-        public void ToString_SFormat_BelowMilli_UsesScientificNotation(double value, string expected)
-        {
-            string actual = Length.FromMeters(value).ToString("s2", AmericanCulture);
-            Assert.Equal(expected, actual);
-        }
-
-        // Any value in the interval [1e-03 ≤ x < 1e+03] is formatted in fixed point notation.
-        [Theory]
-        [InlineData(1e-3, "0.001 m")]
-        [InlineData(1.1, "1.1 m")]
-        [InlineData(999.99, "999.99 m")]
-        public void ToString_SFormat_BetweenMilliAndKilo_UsesFixedPointFormat(double value, string expected)
-        {
-            string actual = Length.FromMeters(value).ToString("s2",AmericanCulture);
-            Assert.Equal(expected, actual);
-        }
-
-        // Any value in the interval [1e+03 ≤ x < 1e+06] is formatted in fixed point notation with digit grouping.
-        [Theory]
-        [InlineData(1000, "1,000 m")]
-        [InlineData(11000, "11,000 m")]
-        [InlineData(111000, "111,000 m")]
-        [InlineData(999999.99, "999,999.99 m")]
-        public void ToString_SFormat_From1e3To1e5_UsesFixedPointFormatWithDigitGrouping(double value, string expected)
-        {
-            string actual = Length.FromMeters(value).ToString("s2",AmericanCulture);
-            Assert.Equal(expected, actual);
-        }
-
-        // Any value in the interval [1e+06 ≤ x ≤ +inf) is formatted in scientific notation.
-        [Theory]
-        [InlineData(1e6, "1e+06 m")]
-        [InlineData(11100000, "1.11e+07 m")]
-        [InlineData(double.MaxValue, "1.8e+308 m")]
-        public void ToString_SFormat_Above1e6_UsesScientificNotation(double value, string expected)
-        {
-            string actual = Length.FromMeters(value).ToString("s2",AmericanCulture);
-            Assert.Equal(expected, actual);
-        }
-
         [Fact]
         public void AllUnitsImplementToStringForInvariantCulture()
         {

--- a/UnitsNet.Tests/QuantityIFormattableTests.cs
+++ b/UnitsNet.Tests/QuantityIFormattableTests.cs
@@ -60,18 +60,6 @@ namespace UnitsNet.Tests
             Assert.Equal(MyLength.ToString("G"), MyLength.ToString(format: null!));
         }
 
-        [Fact]
-        public void ExplicitAbbreviationApisReplaceAFormat()
-        {
-            UnitAbbreviationsCache abbreviations = UnitsNetSetup.Default.UnitAbbreviations;
-
-            Assert.Equal("ft", Length.GetAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture));
-            Assert.Equal("ft", abbreviations.GetDefaultAbbreviation(MyLength.Unit, CultureInfo.InvariantCulture));
-            Assert.Equal(
-                ["ft", "'", "′"],
-                abbreviations.GetUnitAbbreviations(MyLength.Unit, CultureInfo.InvariantCulture));
-        }
-
         [Theory]
         [InlineData("a")]
         [InlineData("A0")]

--- a/UnitsNet/CustomCode/Compatibility/StringSyntaxAttribute.cs
+++ b/UnitsNet/CustomCode/Compatibility/StringSyntaxAttribute.cs
@@ -1,0 +1,36 @@
+// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
+
+#if NETSTANDARD2_0
+
+namespace System.Diagnostics.CodeAnalysis;
+
+/// <summary>Describes the syntax used by a string.</summary>
+[AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, AllowMultiple = false, Inherited = false)]
+internal sealed class StringSyntaxAttribute : Attribute
+{
+    /// <summary>The syntax identifier for numeric format strings.</summary>
+    public const string NumericFormat = nameof(NumericFormat);
+
+    /// <summary>Creates an attribute describing <paramref name="syntax" />.</summary>
+    public StringSyntaxAttribute(string syntax)
+    {
+        Syntax = syntax;
+        Arguments = [];
+    }
+
+    /// <summary>Creates an attribute describing <paramref name="syntax" /> with additional arguments.</summary>
+    public StringSyntaxAttribute(string syntax, params object?[] arguments)
+    {
+        Syntax = syntax;
+        Arguments = arguments;
+    }
+
+    /// <summary>Gets the syntax identifier.</summary>
+    public string Syntax { get; }
+
+    /// <summary>Gets optional syntax-specific arguments.</summary>
+    public object?[] Arguments { get; }
+}
+
+#endif

--- a/UnitsNet/CustomCode/Value/QuantityValue.ConvertToString.cs
+++ b/UnitsNet/CustomCode/Value/QuantityValue.ConvertToString.cs
@@ -1,4 +1,4 @@
-﻿// Licensed under MIT No Attribution, see LICENSE file at the root.
+// Licensed under MIT No Attribution, see LICENSE file at the root.
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System.Globalization;
@@ -26,7 +26,7 @@ public partial struct QuantityValue
     ///     base type)
     /// </param>
     /// <returns>The string representation</returns>
-    public string ToString(string format)
+    public string ToString([StringSyntax(StringSyntaxAttribute.NumericFormat)] string format)
     {
         return ToString(format, NumberFormatInfo.CurrentInfo);
     }
@@ -123,17 +123,6 @@ public partial struct QuantityValue
     ///                 : Round-trip format. Example: 1234567/1000 formatted with 'R' gives "1234.567".
     ///             </description>
     ///         </item>
-    ///         <item>
-    ///             <description>
-    ///                 <see
-    ///                     href="https://github.com/danm-de/Fractions?tab=readme-ov-file#significant-digits-after-radix-format">
-    ///                     'S'
-    ///                     or 's'
-    ///                 </see>
-    ///                 : Significant Digits After Radix format. Example: 400/3 formatted with 'S2' gives
-    ///                 "133.33".
-    ///             </description>
-    ///         </item>
     ///     </list>
     ///     Note: The 'R' format and custom formats do not support precision specifiers and are handed over to the `double`
     ///     type for formatting, which may result in a loss of precision.
@@ -144,7 +133,9 @@ public partial struct QuantityValue
     ///     </see>
     ///     in the GitHub README.
     /// </remarks>
-    public string ToString(string? format, IFormatProvider? formatProvider)
+    public string ToString(
+        [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+        IFormatProvider? formatProvider)
     {
         return DecimalNotationFormatter.Format(this, format, formatProvider);
     }
@@ -279,17 +270,6 @@ public partial struct QuantityValue
         ///                 : Round-trip format. Example: 1234567/1000 formatted with 'R' gives "1234.567".
         ///             </description>
         ///         </item>
-        ///         <item>
-        ///             <description>
-        ///                 <see
-        ///                     href="https://github.com/danm-de/Fractions?tab=readme-ov-file#significant-digits-after-radix-format">
-        ///                     'S'
-        ///                     or 's'
-        ///                 </see>
-        ///                 : Significant Digits After Radix format. Example: 400/3 formatted with 'S2' gives
-        ///                 "133.33".
-        ///             </description>
-        ///         </item>
         ///     </list>
         ///     Note: The 'R' format and custom formats do not support precision specifiers and are handed over to the `double`
         ///     type for formatting, which may result in a loss of precision.
@@ -320,6 +300,13 @@ public partial struct QuantityValue
                 return FormatGeneral(numerator, denominator, "G", numberFormatInfo);
             }
 
+            if (format[0] is 'S' or 's' &&
+                (format.Length == 1 || int.TryParse(format.AsSpan(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _)))
+            {
+                throw new FormatException(
+                    $"The \"{format}\" significant-digits format is no longer supported; use a standard or custom numeric format string.");
+            }
+
             var formatCharacter = format[0];
             return formatCharacter switch
             {
@@ -329,7 +316,6 @@ public partial struct QuantityValue
                 'E' or 'e' => FormatWithScientificFormat(numerator, denominator, format, numberFormatInfo),
                 'P' or 'p' => FormatWithPercentFormat(numerator, denominator, format, numberFormatInfo),
                 'C' or 'c' => FormatWithCurrencyFormat(numerator, denominator, format, numberFormatInfo),
-                'S' or 's' => FormatWithSignificantDigitsAfterRadix(numerator, denominator, format, numberFormatInfo),
                 _ => // 'R', 'r' and the custom formats are handed over to the double (possible loss of precision)
                     fraction.ToDouble().ToString(format, numberFormatInfo)
             };
@@ -377,6 +363,13 @@ public partial struct QuantityValue
                 return TryFormatGeneral(destination, out charsWritten, numerator, denominator, "G", numberFormatInfo);
             }
 
+            if (format[0] is 'S' or 's' &&
+                (format.Length == 1 || int.TryParse(format[1..], NumberStyles.Integer, CultureInfo.InvariantCulture, out _)))
+            {
+                throw new FormatException(
+                    $"The \"{format.ToString()}\" significant-digits format is no longer supported; use a standard or custom numeric format string.");
+            }
+
             var formatCharacter = format[0];
             return formatCharacter switch
             {
@@ -386,7 +379,6 @@ public partial struct QuantityValue
                 'E' or 'e' => TryFormatWithScientificFormat(destination, out charsWritten, numerator, denominator, format, numberFormatInfo),
                 'P' or 'p' => TryFormatWithPercentFormat(destination, out charsWritten, numerator, denominator, format, numberFormatInfo),
                 'C' or 'c' => TryFormatWithCurrencyFormat(destination, out charsWritten, numerator, denominator, format, numberFormatInfo),
-                'S' or 's' => TryFormatWithSignificantDigitsAfterRadix(destination, out charsWritten, numerator, denominator, format, numberFormatInfo),
                 _ => // 'R', 'r' and the custom formats are handed over to the double (possible loss of precision)
                     fraction.ToDouble().TryFormat(destination, out charsWritten, format, numberFormatInfo)
             };
@@ -1959,166 +1951,6 @@ public partial struct QuantityValue
             return true;
         }
 
-        /// <summary>
-        ///     Formats a fraction as a string with a specified number of significant digits after the radix point.
-        /// </summary>
-        /// <param name="numerator">The numerator of the fraction.</param>
-        /// <param name="denominator">The denominator of the fraction.</param>
-        /// <param name="format">
-        ///     The format string to use, which specifies the maximum number of digits after the radix point.
-        /// </param>
-        /// <param name="formatProvider">An object that provides culture-specific formatting information.</param>
-        /// <returns>
-        ///     A string representation of the fraction, formatted with the specified number of significant digits after the
-        ///     radix point.
-        /// </returns>
-        /// <remarks>
-        ///     The method determines the formatting style based on the magnitude of the fraction:
-        ///     <list type="bullet">
-        ///         <item>
-        ///             For values greater than 1e5, the fraction is formatted in scientific notation (e.g., 1.23e6 for 1230000).
-        ///         </item>
-        ///         <item>
-        ///             For values less than or equal to 1e-4, the fraction is formatted in scientific notation (e.g., 1.23e-4 for
-        ///             0.000123).
-        ///         </item>
-        ///         <item>
-        ///             For values between 1e-3 and 1e5, the fraction is formatted as a decimal number.
-        ///         </item>
-        ///     </list>
-        /// </remarks>
-        private static string FormatWithSignificantDigitsAfterRadix(BigInteger numerator, BigInteger denominator, string format, NumberFormatInfo formatProvider)
-        {
-            if (numerator.IsZero)
-            {
-                return 0.ToString(formatProvider);
-            }
-
-            if (!TryGetPrecisionDigits(format, 2, out var maxDigitsAfterRadix))
-            {
-                // not a valid "S" format: assuming a custom format
-                return FormatWithCustomFormat(numerator, denominator, format, formatProvider);
-            }
-
-            // typical worst case: -1.23E+123456
-            var significantDigitsLength = maxDigitsAfterRadix;
-            // assuming a maximum exponent equal to 10^999999
-            var exponentDigitsLength = 1 + int.Max(formatProvider.NegativeSign.Length, formatProvider.PositiveSign.Length) + 6;
-            // worst case for grouping is "1_2_3_0_0_0" with every '_' representing a group separator (up to 9 characters)
-            var maxGroupsLength = 5 * formatProvider.NumberGroupSeparator.Length;
-            var maxLength = formatProvider.NegativeSign.Length + formatProvider.NumberDecimalSeparator.Length + significantDigitsLength +
-                            int.Max(maxGroupsLength, exponentDigitsLength); // we can either have groups or an exponent
-
-            var buffer = maxLength <= StackLimit
-                ? stackalloc char[maxLength] // Use stack memory
-                : new char[maxLength]; // Use heap if needed
-
-            TryFormatWithSignificantDigitsAfterRadix(buffer, out var charsWritten, numerator, denominator, formatProvider, maxDigitsAfterRadix, format[0] is 's');
-            return new string(buffer[..charsWritten]);
-        }
-
-        private static bool TryFormatWithSignificantDigitsAfterRadix(Span<char> destination, out int charsWritten, BigInteger numerator, BigInteger denominator,
-            ReadOnlySpan<char> format, NumberFormatInfo formatProvider)
-        {
-            if (numerator.IsZero)
-            {
-                return 0.TryFormat(destination, out charsWritten, default, formatProvider);
-            }
-
-            if (!TryGetPrecisionDigits(format, 2, out var maxDigitsAfterRadix))
-            {
-                // not a valid "S" format: assuming a custom format
-                return TryFormatWithCustomFormat(destination, out charsWritten, numerator, denominator, format, formatProvider);
-            }
-
-            return TryFormatWithSignificantDigitsAfterRadix(destination, out charsWritten, numerator, denominator, formatProvider, maxDigitsAfterRadix, format[0] is 's');
-        }
-
-        private static bool TryFormatWithSignificantDigitsAfterRadix(Span<char> destination, out int charsWritten, BigInteger numerator, BigInteger denominator,
-            NumberFormatInfo formatProvider, int maxDigitsAfterRadix, bool lowerCase)
-        {
-            charsWritten = 0;
-            if (numerator.Sign < 0)
-            {
-                if (!formatProvider.NegativeSign.TryCopyTo(destination))
-                {
-                    return false;
-                }
-
-                charsWritten += formatProvider.NegativeSign.Length;
-                numerator = -numerator;
-            }
-
-            const string quotientFormat = "N0";
-            var exponent = GetExponentPower(numerator, denominator, out var exponentTerm);
-            QuantityValue mantissa;
-            switch (exponent)
-            {
-                case > 5:
-                {
-                    // the smallest value would have the form: 1.23e6 (1230000)
-                    mantissa = Round(numerator, denominator * exponentTerm, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    if (!TryAppendSignificantDecimals(destination[charsWritten..], out var written, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat))
-                    {
-                        return false;
-                    }
-
-                    charsWritten += written;
-                    if (!TryAppendExponentWithSignificantDigits(destination[charsWritten..], out written, exponent, formatProvider, lowerCase ? 'e' : 'E'))
-                    {
-                        return false;
-                    }
-
-                    charsWritten += written;
-                    return true;
-                }
-                case <= -4:
-                {
-                    // the largest value would have the form: 1.23e-4 (0.000123)
-                    mantissa = Round(numerator * exponentTerm, denominator, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    if (!TryAppendSignificantDecimals(destination[charsWritten..], out var written, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat))
-                    {
-                        return false;
-                    }
-
-                    charsWritten += written;
-                    if (!TryAppendExponentWithSignificantDigits(destination[charsWritten..], out written, exponent, formatProvider, lowerCase ? 'e' : 'E'))
-                    {
-                        return false;
-                    }
-
-                    charsWritten += written;
-                    return true;
-                }
-                case < 0:
-                {
-                    // the smallest value would have the form: 1.23e-3 (0.00123)
-                    var leadingZeroes = -exponent;
-                    maxDigitsAfterRadix += leadingZeroes - 1;
-                    mantissa = Round(numerator, denominator, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    if (!TryAppendSignificantDecimals(destination[charsWritten..], out var written, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat))
-                    {
-                        return false;
-                    }
-
-                    charsWritten += written;
-                    return true;
-                }
-                default:
-                {
-                    // the largest value would have the form: 1.23e5 (123000)
-                    mantissa = Round(numerator, denominator, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    if (!TryAppendSignificantDecimals(destination[charsWritten..], out var written, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat))
-                    {
-                        return false;
-                    }
-
-                    charsWritten += written;
-                    return true;
-                }
-            }
-        }
-
         private static string FormatWithCustomFormat(BigInteger numerator, BigInteger denominator, string format, NumberFormatInfo formatProvider)
         {
             return new QuantityValue(numerator, denominator).ToDouble().ToString(format, formatProvider);
@@ -2667,17 +2499,6 @@ public partial struct QuantityValue
         ///                 : Round-trip format. Example: 1234567/1000 formatted with 'R' gives "1234.567".
         ///             </description>
         ///         </item>
-        ///         <item>
-        ///             <description>
-        ///                 <see
-        ///                     href="https://github.com/danm-de/Fractions?tab=readme-ov-file#significant-digits-after-radix-format">
-        ///                     'S'
-        ///                     or 's'
-        ///                 </see>
-        ///                 : Significant Digits After Radix format. Example: 400/3 formatted with 'S2' gives
-        ///                 "133.33".
-        ///             </description>
-        ///         </item>
         ///     </list>
         ///     Note: The 'R' format and custom formats do not support precision specifiers and are handed over to the `double`
         ///     type for formatting, which may result in a loss of precision.
@@ -2710,7 +2531,14 @@ public partial struct QuantityValue
                 return FormatGeneral(numerator, denominator, "G", numberFormatInfo);
             }
 
-            var formatCharacter = format![0];
+            if (format![0] is 'S' or 's' &&
+                (format.Length == 1 || int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _)))
+            {
+                throw new FormatException(
+                    $"The \"{format}\" significant-digits format is no longer supported; use a standard or custom numeric format string.");
+            }
+
+            var formatCharacter = format[0];
             return formatCharacter switch
             {
                 'G' or 'g' => FormatGeneral(numerator, denominator, format, numberFormatInfo),
@@ -2719,7 +2547,6 @@ public partial struct QuantityValue
                 'E' or 'e' => FormatWithScientificFormat(numerator, denominator, format, numberFormatInfo),
                 'P' or 'p' => FormatWithPercentFormat(numerator, denominator, format, numberFormatInfo),
                 'C' or 'c' => FormatWithCurrencyFormat(numerator, denominator, format, numberFormatInfo),
-                'S' or 's' => FormatWithSignificantDigitsAfterRadix(numerator, denominator, format, numberFormatInfo),
                 _ => // 'R', 'r' and the custom formats are handed over to the double (possible loss of precision)
                     fraction.ToDouble().ToString(format, formatProvider)
             };
@@ -3285,88 +3112,6 @@ public partial struct QuantityValue
         private static string FormatWithCustomFormat(BigInteger numerator, BigInteger denominator, string format, NumberFormatInfo formatProvider)
         {
             return new QuantityValue(numerator, denominator).ToDouble().ToString(format, formatProvider);
-        }
-
-        /// <summary>
-        ///     Formats a fraction as a string with a specified number of significant digits after the radix point.
-        /// </summary>
-        /// <param name="numerator">The numerator of the fraction.</param>
-        /// <param name="denominator">The denominator of the fraction.</param>
-        /// <param name="format">
-        ///     The format string to use, which specifies the maximum number of digits after the radix point.
-        /// </param>
-        /// <param name="formatProvider">An object that provides culture-specific formatting information.</param>
-        /// <returns>
-        ///     A string representation of the fraction, formatted with the specified number of significant digits after the
-        ///     radix point.
-        /// </returns>
-        /// <remarks>
-        ///     The method determines the formatting style based on the magnitude of the fraction:
-        ///     <list type="bullet">
-        ///         <item>
-        ///             For values greater than 1e5, the fraction is formatted in scientific notation (e.g., 1.23e6 for 1230000).
-        ///         </item>
-        ///         <item>
-        ///             For values less than or equal to 1e-4, the fraction is formatted in scientific notation (e.g., 1.23e-4 for
-        ///             0.000123).
-        ///         </item>
-        ///         <item>
-        ///             For values between 1e-3 and 1e5, the fraction is formatted as a decimal number.
-        ///         </item>
-        ///     </list>
-        /// </remarks>
-        private static string FormatWithSignificantDigitsAfterRadix(BigInteger numerator, BigInteger denominator, string format, NumberFormatInfo formatProvider)
-        {
-            if (numerator.IsZero)
-            {
-                return 0.ToString(formatProvider);
-            }
-
-            const string quotientFormat = "N0";
-
-            if (!TryGetPrecisionDigits(format, 2, out var maxDigitsAfterRadix))
-            {
-                // not a valid "S" format: assuming a custom format
-                return FormatWithCustomFormat(numerator, denominator, format, formatProvider);
-            }
-
-            var sb = new StringBuilder(3 + maxDigitsAfterRadix);
-
-            if (numerator.Sign < 0)
-            {
-                sb.Append(formatProvider.NegativeSign);
-                numerator = -numerator;
-            }
-
-            var exponent = GetExponentPower(numerator, denominator, out var exponentTerm);
-            QuantityValue mantissa;
-            switch (exponent)
-            {
-                case > 5:
-                    // the smallest value would have the form: 1.23e6 (1230000)
-                    mantissa = Round(numerator, denominator * exponentTerm, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    AppendSignificantDecimals(sb, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat);
-                    return AppendExponentWithSignificantDigits(sb, exponent, formatProvider, format[0] is 's' ? 'e' : 'E')
-                        .ToString();
-                case <= -4:
-                    // the largest value would have the form: 1.23e-4 (0.000123)
-                    mantissa = Round(numerator * exponentTerm, denominator, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    AppendSignificantDecimals(sb, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat);
-                    return AppendExponentWithSignificantDigits(sb, exponent, formatProvider, format[0] is 's' ? 'e' : 'E')
-                        .ToString();
-                case < 0:
-                    // the smallest value would have the form: 1.23e-3 (0.00123)
-                    var leadingZeroes = -exponent;
-                    maxDigitsAfterRadix += leadingZeroes - 1;
-                    mantissa = Round(numerator, denominator, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    return AppendSignificantDecimals(sb, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat)
-                        .ToString();
-                default:
-                    // the largest value would have the form: 1.23e5 (123000)
-                    mantissa = Round(numerator, denominator, maxDigitsAfterRadix, DefaultMidpointRoundingMode);
-                    return AppendSignificantDecimals(sb, mantissa, formatProvider, maxDigitsAfterRadix, quotientFormat)
-                        .ToString();
-            }
         }
 
         /// <summary>

--- a/UnitsNet/CustomCode/Value/QuantityValue.DebugView.cs
+++ b/UnitsNet/CustomCode/Value/QuantityValue.DebugView.cs
@@ -29,7 +29,7 @@ public partial struct QuantityValue
 
             public string GeneralFormat => _value.ToString("G", _currentCulture);
 
-            public string ShortFormat => _value.ToString("S", _currentCulture);
+            public string ShortFormat => _value.ToString("G6", _currentCulture);
 
             public string SimplifiedFraction
             {

--- a/UnitsNet/Extensions/QuantityExtensions.cs
+++ b/UnitsNet/Extensions/QuantityExtensions.cs
@@ -288,7 +288,9 @@ public static class QuantityExtensions
     ///     If <c>null</c> or empty, the default format is used.
     /// </param>
     /// <returns>A string representation of the quantity.</returns>
-    public static string ToString<TQuantity>(this TQuantity quantity, string? format)
+    public static string ToString<TQuantity>(
+        this TQuantity quantity,
+        [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format)
         where TQuantity : IQuantity, IFormattable
     {
         return quantity.ToString(format, null);

--- a/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AbsorbedDoseOfIonizingRadiation.g.cs
@@ -868,7 +868,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Acceleration.g.cs
@@ -859,7 +859,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmountOfSubstance.g.cs
@@ -900,7 +900,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AmplitudeRatio.g.cs
@@ -648,7 +648,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Angle.g.cs
@@ -833,7 +833,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Area.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Area.g.cs
@@ -971,7 +971,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaDensity.g.cs
@@ -701,7 +701,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaMomentOfInertia.g.cs
@@ -703,7 +703,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/AreaPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/AreaPerLength.g.cs
@@ -689,7 +689,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BitRate.g.cs
@@ -1234,7 +1234,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/BrakeSpecificFuelConsumption.g.cs
@@ -654,7 +654,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/CoefficientOfThermalExpansion.g.cs
@@ -689,7 +689,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Compressibility.g.cs
@@ -705,7 +705,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Density.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Density.g.cs
@@ -1548,7 +1548,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DoseAreaProduct.g.cs
@@ -1003,7 +1003,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Duration.g.cs
@@ -962,7 +962,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/DynamicViscosity.g.cs
@@ -763,7 +763,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricAdmittance.g.cs
@@ -842,7 +842,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentEnergy.g.cs
@@ -648,7 +648,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricApparentPower.g.cs
@@ -692,7 +692,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCapacitance.g.cs
@@ -708,7 +708,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCharge.g.cs
@@ -828,7 +828,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricChargeDensity.g.cs
@@ -612,7 +612,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductance.g.cs
@@ -852,7 +852,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricConductivity.g.cs
@@ -692,7 +692,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrent.g.cs
@@ -796,7 +796,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentDensity.g.cs
@@ -644,7 +644,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricCurrentGradient.g.cs
@@ -705,7 +705,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricField.g.cs
@@ -612,7 +612,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricImpedance.g.cs
@@ -714,7 +714,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricInductance.g.cs
@@ -665,7 +665,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotential.g.cs
@@ -755,7 +755,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricPotentialChangeRate.g.cs
@@ -913,7 +913,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactance.g.cs
@@ -713,7 +713,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactiveEnergy.g.cs
@@ -648,7 +648,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricReactivePower.g.cs
@@ -660,7 +660,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistance.g.cs
@@ -724,7 +724,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricResistivity.g.cs
@@ -820,7 +820,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSurfaceChargeDensity.g.cs
@@ -644,7 +644,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ElectricSusceptance.g.cs
@@ -841,7 +841,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Energy.g.cs
@@ -1317,7 +1317,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/EnergyDensity.g.cs
@@ -799,7 +799,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Entropy.g.cs
@@ -719,7 +719,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FluidResistance.g.cs
@@ -900,7 +900,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Force.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Force.g.cs
@@ -947,7 +947,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForceChangeRate.g.cs
@@ -833,7 +833,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ForcePerLength.g.cs
@@ -1271,7 +1271,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Frequency.g.cs
@@ -799,7 +799,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/FuelEfficiency.g.cs
@@ -650,7 +650,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatFlux.g.cs
@@ -1014,7 +1014,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/HeatTransferCoefficient.g.cs
@@ -689,7 +689,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Illuminance.g.cs
@@ -660,7 +660,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Impulse.g.cs
@@ -808,7 +808,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Information.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Information.g.cs
@@ -1217,7 +1217,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiance.g.cs
@@ -817,7 +817,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Irradiation.g.cs
@@ -747,7 +747,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Jerk.g.cs
@@ -769,7 +769,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/KinematicViscosity.g.cs
@@ -761,7 +761,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LeakRate.g.cs
@@ -667,7 +667,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Length.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Length.g.cs
@@ -1433,7 +1433,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Level.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Level.g.cs
@@ -613,7 +613,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearDensity.g.cs
@@ -919,7 +919,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LinearPowerDensity.g.cs
@@ -996,7 +996,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminance.g.cs
@@ -756,7 +756,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Luminosity.g.cs
@@ -809,7 +809,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousFlux.g.cs
@@ -633,7 +633,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/LuminousIntensity.g.cs
@@ -626,7 +626,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticField.g.cs
@@ -692,7 +692,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MagneticFlux.g.cs
@@ -619,7 +619,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Magnetization.g.cs
@@ -601,7 +601,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Mass.g.cs
@@ -1194,7 +1194,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassConcentration.g.cs
@@ -1408,7 +1408,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlow.g.cs
@@ -1184,7 +1184,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFlux.g.cs
@@ -799,7 +799,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassFraction.g.cs
@@ -966,7 +966,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MassMomentOfInertia.g.cs
@@ -1030,7 +1030,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molality.g.cs
@@ -633,7 +633,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEnergy.g.cs
@@ -641,7 +641,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarEntropy.g.cs
@@ -630,7 +630,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarFlow.g.cs
@@ -758,7 +758,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/MolarMass.g.cs
@@ -831,7 +831,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Molarity.g.cs
@@ -800,7 +800,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permeability.g.cs
@@ -601,7 +601,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Permittivity.g.cs
@@ -601,7 +601,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PorousMediumPermeability.g.cs
@@ -665,7 +665,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Power.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Power.g.cs
@@ -1151,7 +1151,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerDensity.g.cs
@@ -1329,7 +1329,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PowerRatio.g.cs
@@ -614,7 +614,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Pressure.g.cs
@@ -1498,7 +1498,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/PressureChangeRate.g.cs
@@ -881,7 +881,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDose.g.cs
@@ -696,7 +696,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationEquivalentDoseRate.g.cs
@@ -753,7 +753,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RadiationExposure.g.cs
@@ -710,7 +710,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Radioactivity.g.cs
@@ -1046,7 +1046,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Ratio.g.cs
@@ -696,7 +696,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RatioChangeRate.g.cs
@@ -625,7 +625,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalArea.g.cs
@@ -807,7 +807,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ReciprocalLength.g.cs
@@ -805,7 +805,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RelativeHumidity.g.cs
@@ -584,7 +584,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalAcceleration.g.cs
@@ -657,7 +657,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalSpeed.g.cs
@@ -822,7 +822,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffness.g.cs
@@ -1151,7 +1151,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/RotationalStiffnessPerLength.g.cs
@@ -673,7 +673,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Scalar.g.cs
@@ -584,7 +584,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SolidAngle.g.cs
@@ -598,7 +598,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEnergy.g.cs
@@ -1117,7 +1117,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificEntropy.g.cs
@@ -744,7 +744,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificFuelConsumption.g.cs
@@ -649,7 +649,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificVolume.g.cs
@@ -648,7 +648,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/SpecificWeight.g.cs
@@ -896,7 +896,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Speed.g.cs
@@ -1170,7 +1170,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/StandardVolumeFlow.g.cs
@@ -726,7 +726,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Temperature.g.cs
@@ -702,7 +702,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureChangeRate.g.cs
@@ -865,7 +865,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureDelta.g.cs
@@ -821,7 +821,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/TemperatureGradient.g.cs
@@ -657,7 +657,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalConductivity.g.cs
@@ -633,7 +633,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ThermalInsulance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalInsulance.g.cs
@@ -705,7 +705,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/ThermalResistance.g.cs
@@ -625,7 +625,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Torque.g.cs
@@ -1067,7 +1067,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Turbidity.g.cs
@@ -587,7 +587,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VitaminA.g.cs
@@ -584,7 +584,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/Volume.g.cs
@@ -1562,7 +1562,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeConcentration.g.cs
@@ -909,7 +909,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlow.g.cs
@@ -1835,7 +1835,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumeFlowPerArea.g.cs
@@ -625,7 +625,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumePerLength.g.cs
@@ -737,7 +737,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/VolumetricHeatCapacity.g.cs
@@ -740,7 +740,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
+++ b/UnitsNet/GeneratedCode/Quantities/WarpingMomentOfInertia.g.cs
@@ -678,7 +678,9 @@ namespace UnitsNet
         /// <summary>
         /// Gets the string representation of this instance in the specified format string using the specified format provider, or <see cref="CultureInfo.CurrentCulture" /> if null.
         /// </summary>
-        public string ToString(string? format, IFormatProvider? provider)
+        public string ToString(
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+            IFormatProvider? provider)
         {
             return QuantityFormatter.Default.Format(this, format, provider);
         }

--- a/UnitsNet/QuantityFormatter.cs
+++ b/UnitsNet/QuantityFormatter.cs
@@ -2,7 +2,6 @@
 // Copyright 2013 Andreas Gullberg Larsen (andreas.larsen84@gmail.com). Maintained at https://github.com/angularsen/UnitsNet.
 
 using System;
-using System.Collections.Generic;
 using System.Globalization;
 
 namespace UnitsNet;
@@ -34,7 +33,9 @@ public class QuantityFormatter
 
     /// <inheritdoc cref="Format{TUnitType}(UnitsNet.IQuantity{TUnitType},string,IFormatProvider)" />
     [Obsolete("Consider switching to one of the more performant instance methods available on QuantityFormatter.Default.")]
-    public static string Format<TUnitType>(IQuantity<TUnitType> quantity, string format)
+    public static string Format<TUnitType>(
+        IQuantity<TUnitType> quantity,
+        [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format)
         where TUnitType : struct, Enum
     {
         return Format(quantity, format, CultureInfo.CurrentCulture);
@@ -42,7 +43,10 @@ public class QuantityFormatter
 
     /// <inheritdoc cref="Format{TQuantity}(TQuantity,string,IFormatProvider)" />
     [Obsolete("Consider switching to one of the more performant instance methods available on QuantityFormatter.Default.")]
-    public static string Format<TUnitType>(IQuantity<TUnitType> quantity, string? format, IFormatProvider? formatProvider)
+    public static string Format<TUnitType>(
+        IQuantity<TUnitType> quantity,
+        [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format,
+        IFormatProvider? formatProvider)
         where TUnitType : struct, Enum
     {
         return Default.Format(quantity, format, formatProvider);
@@ -58,48 +62,14 @@ public class QuantityFormatter
     ///     <see cref="CultureInfo.CurrentCulture" /> if null.
     /// </param>
     /// <remarks>
-    ///     The valid format strings are as follows:
-    ///     <list type="bullet">
-    ///         <item>
-    ///             <term>A standard numeric format string.</term>
-    ///             <description>
-    ///                 Any of the
-    ///                 <see
-    ///                     href="https://docs.microsoft.com/en-us/dotnet/standard/base-types/standard-numeric-format-strings#standard-format-specifiers">
-    ///                     Standard format specifiers
-    ///                 </see>
-    ///                 .
-    ///             </description>
-    ///         </item>
-    ///         <item>
-    ///             <term>"A" or "a".</term>
-    ///             <description>The default unit abbreviation for <see cref="IQuantity{TUnitType}.Unit" />, such as "m".</description>
-    ///         </item>
-    ///         <item>
-    ///             <term>"A0", "A1", ..., "An" or "a0", "a1", ..., "an".</term>
-    ///             <description>
-    ///                 The n-th unit abbreviation for the <see cref="IQuantity{TUnitType}.Unit" />. "a0" is the same as "a".
-    ///                 <para>
-    ///                     A <see cref="FormatException" /> will be thrown if the requested abbreviation index does not
-    ///                     exist.
-    ///                 </para>
-    ///             </description>
-    ///         </item>
-    ///         <item>
-    ///             <term>"S" or "s".</term>
-    ///             <description>
-    ///                 The value with 2 significant digits after the radix followed by the unit abbreviation, such as
-    ///                 "1.23 m".
-    ///             </description>
-    ///         </item>
-    ///         <item>
-    ///             <term>"S0", "S1", ..., "Sn" or "s0", "s1", ..., "sn".</term>
-    ///             <description>
-    ///                 The value with n significant digits after the radix followed by the unit abbreviation. "S2"
-    ///                 and "s2" is the same as "s".
-    ///             </description>
-    ///         </item>
-    ///     </list>
+    ///     The format is applied to the numeric value and the localized unit abbreviation is appended. Use a
+    ///     <see href="https://learn.microsoft.com/dotnet/standard/base-types/standard-numeric-format-strings">
+    ///         standard numeric format string
+    ///     </see>
+    ///     or a
+    ///     <see href="https://learn.microsoft.com/dotnet/standard/base-types/custom-numeric-format-strings">
+    ///         custom numeric format string
+    ///     </see>.
     ///     For more information about the formatter, see the
     ///     <see href="https://github.com/angularsen/UnitsNet?tab=readme-ov-file#culture-and-localization">
     ///         QuantityFormatter
@@ -109,7 +79,10 @@ public class QuantityFormatter
     /// </remarks>
     /// <returns>The string representation.</returns>
     /// <exception cref="FormatException">Thrown when the format specifier is invalid.</exception>
-    public string Format<TQuantity>(TQuantity quantity, string? format = null, IFormatProvider? formatProvider = null)
+    public string Format<TQuantity>(
+        TQuantity quantity,
+        [StringSyntax(StringSyntaxAttribute.NumericFormat)] string? format = null,
+        IFormatProvider? formatProvider = null)
         where TQuantity : IQuantity
     {
         formatProvider ??= CultureInfo.CurrentCulture;
@@ -121,18 +94,12 @@ public class QuantityFormatter
         {
             switch (format[0])
             {
-                case 'S':
-                {
-                    format = "S15";
-                    break;
-                }
-                case 's':
-                {
-                    format = "s15";
-                    break;
-                }
                 case 'A' or 'a':
-                    return _unitAbbreviations.GetDefaultAbbreviation(quantity.UnitKey, formatProvider);
+                    throw new FormatException(
+                        $"The \"{format}\" abbreviation format is no longer supported; use the generated quantity's GetAbbreviation method or UnitAbbreviationsCache.");
+                case 'S' or 's':
+                    throw new FormatException(
+                        $"The \"{format}\" significant-digits format is no longer supported; use a standard or custom numeric format string.");
                 case 'U' or 'u':
                     throw new FormatException($"The \"{format}\" format is no longer supported: consider using the Unit property.");
                 case 'V' or 'v':
@@ -150,33 +117,23 @@ public class QuantityFormatter
             switch (format[0])
             {
 #if NET
-                case 'A' or 'a' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out var abbreviationIndex):
-                {
-                    IReadOnlyList<string> abbreviations = _unitAbbreviations.GetUnitAbbreviations(quantity.UnitKey, formatProvider);
-
-                    if (abbreviationIndex >= abbreviations.Count)
-                    {
-                        throw new FormatException($"The \"{format}\" format string is invalid because the index is out of range.");
-                    }
-
-                    return abbreviations[abbreviationIndex];
-                }
+                case 'A' or 'a' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out _):
+                    throw new FormatException(
+                        $"The \"{format}\" abbreviation format is no longer supported; use UnitAbbreviationsCache.GetUnitAbbreviations.");
+                case 'S' or 's' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out _):
+                    throw new FormatException(
+                        $"The \"{format}\" significant-digits format is no longer supported; use a standard or custom numeric format string.");
                 case 'C' or 'c' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (currency) format is not supported.");
                 case 'P' or 'p' when int.TryParse(format.AsSpan(1), CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (percent) format is not supported.");
 #else
-                case 'A' or 'a' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out var abbreviationIndex):
-                {
-                    IReadOnlyList<string> abbreviations = _unitAbbreviations.GetUnitAbbreviations(quantity.UnitKey, formatProvider);
-
-                    if (abbreviationIndex >= abbreviations.Count)
-                    {
-                        throw new FormatException($"The \"{format}\" format string is invalid because the index is out of range.");
-                    }
-
-                    return abbreviations[abbreviationIndex];
-                }
+                case 'A' or 'a' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _):
+                    throw new FormatException(
+                        $"The \"{format}\" abbreviation format is no longer supported; use UnitAbbreviationsCache.GetUnitAbbreviations.");
+                case 'S' or 's' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _):
+                    throw new FormatException(
+                        $"The \"{format}\" significant-digits format is no longer supported; use a standard or custom numeric format string.");
                 case 'C' or 'c' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _):
                     throw new FormatException($"The \"{format}\" (currency) format is not supported.");
                 case 'P' or 'p' when int.TryParse(format.Substring(1), NumberStyles.Integer, CultureInfo.InvariantCulture, out _):

--- a/UnitsNet/QuantityTypeConverter.cs
+++ b/UnitsNet/QuantityTypeConverter.cs
@@ -61,6 +61,7 @@ namespace UnitsNet
         /// <summary>
         /// The formatting used when the quantity is converted to string. See <see cref="QuantityFormatter"/> for more information about the supported formats.
         /// </summary>
+        [StringSyntax(StringSyntaxAttribute.NumericFormat)]
         public string Format { get; set; }
 
         /// <summary>
@@ -68,7 +69,9 @@ namespace UnitsNet
         /// </summary>
         /// <param name="unitType">The unit the quantity should be displayed in</param>
         /// <param name="format">Formatting string passed to the <see cref="IFormattable.ToString(string?,System.IFormatProvider?)"/> </param>
-        public DisplayAsUnitAttribute(object? unitType, string format = "G") : base(unitType)
+        public DisplayAsUnitAttribute(
+            object? unitType,
+            [StringSyntax(StringSyntaxAttribute.NumericFormat)] string format = "G") : base(unitType)
         {
             Format = format;
         }


### PR DESCRIPTION
## Motivation

UnitsNet v6 has already removed the proprietary `U`, `V`, and `Q` quantity format strings. This completes that cleanup by removing the remaining `A` and `S` formats, so quantity format parameters consistently accept .NET numeric format strings and can be described accurately with `StringSyntaxAttribute.NumericFormat`.

The historical rationale supports the cleanup:

- `A` only returns unit abbreviations, which are already available explicitly through generated `GetAbbreviation()` APIs and the configurable `UnitAbbreviationsCache`.
- #797 intended to remove `S`, and commit 721287d removed its documentation and tests, but the formatter implementation remained in v5. This PR completes that cleanup. The discussion in #1450 also noted that `S` can hide precision and that callers should choose an explicit numeric format.

## Changes

- Remove `A`/`An` and `S`/`Sn` formatting from `QuantityFormatter` and `QuantityValue`.
- Throw focused `FormatException` messages for those formerly recognized formats with migration guidance.
- Keep standard and custom .NET numeric formats, such as `G3`, `F2`, `N2`, `E2`, and `0.##`.
- Annotate generated quantity formatting, `QuantityFormatter`, `QuantityValue`, quantity extensions, and type-converter formatting with `StringSyntaxAttribute.NumericFormat`.
- Add an internal `StringSyntaxAttribute` compatibility definition for the `netstandard2.0` target.
- Regenerate quantities and tests, and update the string-formatting guide and v6 upgrade guide.

## Migration

| Removed | Replacement |
|---|---|
| `A`, `A0`, `A1`, ... | `Length.GetAbbreviation(unit)` or `UnitAbbreviationsCache.GetUnitAbbreviations(unit)` |
| `S`, `S2`, ... | An explicit standard/custom numeric format such as `G3`, `F2`, `N2`, `E2`, or `0.##` |
| `U` | `quantity.Unit` |
| `V` | `quantity.Value` |
| `Q` | Static metadata such as `Length.Info.Name` |

Currency (`C`) and percent (`P`) formats remain intentionally unsupported for physical quantities.

Refs #1200.

## Validation

- `generate-code.bat`
- `dotnet build UnitsNet/UnitsNet.csproj --no-restore` (`netstandard2.0`, `net8.0`, `net9.0`, `net10.0`)
- `dotnet test UnitsNet.Tests --no-restore -f net10.0` (52,506 passed, 16 skipped)
- `dotnet test UnitsNet.Tests --no-restore -f net48` (45,321 passed, 16 skipped)