### PR TITLE
Pin the logarithmic subtraction edge cases for Level

### DIFF
--- a/UnitsNet.Tests/CustomCode/LevelTests.cs
+++ b/UnitsNet.Tests/CustomCode/LevelTests.cs
@@ -41,5 +41,41 @@ namespace UnitsNet.Tests
             // reference can't be zero or less than zero if quantity is postive.
             Assert.Throws<ArgumentOutOfRangeException>(() => new Level(quantity, reference));
         }
+
+        [Fact]
+        public void LogarithmicAddition_OfTwoLevels_CombinesThemInLinearSpace()
+        {
+            // The values from https://github.com/angularsen/UnitsNet/issues/1569, which read
+            // 4.18 dB as wrong on the assumption that adding levels adds their decibel numbers.
+            // Adding two levels combines them in linear power space, so the result is
+            // 10 * log10(10^0.16 + 10^0.07).
+            Level sum = Level.FromDecibels(1.6) + Level.FromDecibels(0.7);
+
+            var expected = 10 * Math.Log10(Math.Pow(10, 0.16) + Math.Pow(10, 0.07));
+            AssertEx.EqualTolerance(expected, sum.Decibels, DecibelsTolerance);
+            AssertEx.EqualTolerance(4.18357203248652, sum.Decibels, DecibelsTolerance);
+        }
+
+        [Fact]
+        public void LogarithmicSubtraction_OfEqualLevels_ReturnsNegativeInfinity()
+        {
+            // Removing a level from itself leaves no power at all, and log10(0) is -infinity.
+            // Pinned because it is returned silently rather than signalled.
+            Level v = Level.FromDecibels(40);
+
+            Assert.Equal(double.NegativeInfinity, (double)(v - v).Decibels);
+        }
+
+        [Fact]
+        public void LogarithmicSubtraction_WhenSubtrahendIsLarger_ReturnsNaN()
+        {
+            // The linear difference is negative here, and log10 of a negative number is undefined.
+            // The constructor rejects that case with ArgumentOutOfRangeException; this operator
+            // returns NaN silently instead. Pinned as current behaviour, not endorsed as correct.
+            Level smaller = Level.FromDecibels(0.7);
+            Level larger = Level.FromDecibels(1.6);
+
+            Assert.Equal(double.NaN, (double)(smaller - larger).Decibels);
+        }
     }
 }


### PR DESCRIPTION
## Motivation

While reproducing #1569 I found that `Level`'s logarithmic operators are exercised by
`LevelTestsBase.ArithmeticOperators` for the ordinary case, but not where the linear result
stops being positive. Two such cases return silently today:

```
Level.FromDecibels(40) - Level.FromDecibels(40)    ->  -Infinity dB
Level.FromDecibels(0.7) - Level.FromDecibels(1.6)  ->  NaN dB
```

The second is inconsistent with the rest of the quantity. `Level(double quantity, double
reference)` rejects a non-positive ratio with `ArgumentOutOfRangeException` and the message
*"The base-10 logarithm of a number ≤ 0 is undefined"*, while `operator-` performs that same
logarithm and yields `NaN` without signalling anything.

## Changes

Three tests in `UnitsNet.Tests/CustomCode/LevelTests.cs`:

- `LogarithmicSubtraction_OfEqualLevels_ReturnsNegativeInfinity`
- `LogarithmicSubtraction_WhenSubtrahendIsLarger_ReturnsNaN`
- `LogarithmicAddition_OfTwoLevels_CombinesThemInLinearSpace`, using the values from #1569 and
  asserting against `10 * log10(10^0.16 + 10^0.07)` rather than a bare literal, so the test
  states why the answer is what it is.

## What this does not do

**It changes no behaviour, and none of these tests fail without a source change.** They are
characterisation tests: they pin what the operators do today so that any later change to it is
a visible decision rather than a silent one. I have deliberately not made `operator-` throw —
that is a breaking change and your call, not something to slip in under a test PR. If you would
like it to throw, say so and I will open that separately with these tests updated.

Nothing is asserted about `AmplitudeRatio` or `PowerRatio`, which have the same logarithmic
machinery with a scaling factor of 20 and 10 respectively. I stopped at `Level` because that is
what #1569 is about; happy to extend if useful.

## Relationship to the v6 plan for logarithmic operators

I missed this when opening the PR. In https://github.com/angularsen/UnitsNet/issues/1569#issuecomment-3140306604
the plan for v6 is to **remove `+`/`-` on logarithmic quantities** in favour of named
`Linear*` and `LogValue*` methods. That splits these three tests in two:

- `LogarithmicSubtraction_OfEqualLevels_ReturnsNegativeInfinity` and
  `LogarithmicSubtraction_WhenSubtrahendIsLarger_ReturnsNaN` are **not** affected by the
  spelling. A linear-space subtraction has to answer for a non-positive linear result however
  it is named, and today it answers silently while the constructor rejects the same logarithm
  with `ArgumentOutOfRangeException`. These carry over to `LinearSubtract` unchanged.
- `LogarithmicAddition_OfTwoLevels_CombinesThemInLinearSpace` **does** pin operator behaviour
  that is slated for removal. It is a record of today rather than something to preserve. Say
  the word and I will drop it, or rewrite it against whichever named API lands.

## On #1569 itself

The arithmetic is not wrong, though "not a bug" was too strong of me — the maintainer had
already identified a real design problem there before I commented. `Level` is
logarithmic, so `+` combines two levels in linear power space; `1.6 dB + 0.7 dB` is
`4.18357203248652 dB`, which matches `10·log10(10^0.16 + 10^0.07)` exactly. The reporter wanted
plain arithmetic on the decibel numbers, which is the right operation for a gain rather than a
level, and already works via `Level.FromDecibels(a.Decibels + b.Decibels)`.

## Validation

```
dotnet test UnitsNet.Tests/UnitsNet.Tests.csproj -f net10.0 --filter "FullyQualifiedName~LevelTests"
Passed!  - Failed: 0, Passed: 82, Skipped: 0, Total: 82
```

Local run on .NET 10 only; I have not run the full multi-target matrix.

