### PR TITLE
Collect and report coverage for UnitsNet.Modular

### DIFF
--- a/.github/workflows/unitsnet-modular-ci.yml
+++ b/.github/workflows/unitsnet-modular-ci.yml
@@ -49,6 +49,9 @@ on:
 
 permissions:
   contents: read
+  # Codecov uploads with use_oidc, which needs a token. This workflow declares its
+  # permissions explicitly, so id-token stays none unless it is named here.
+  id-token: write
 
 concurrency:
   group: unitsnet-modular-ci-${{ github.ref }}
@@ -80,11 +83,29 @@ jobs:
       - name: Restore
         run: dotnet restore UnitsNet.Modular.slnx -p:Platform=ProjectReferences
 
+      - name: Restore local tools
+        run: dotnet tool restore
+
       - name: Build
         run: dotnet build UnitsNet.Modular.slnx --configuration Release --no-restore --no-incremental -p:Platform=ProjectReferences
 
-      - name: Test
-        run: dotnet test UnitsNet.Modular.slnx --configuration Release --no-build -p:Platform=ProjectReferences
+      - name: Test with coverage
+        run: |
+          mkdir -p Artifacts/Coverage
+          dotnet tool run dotCover -- cover-dotnet \
+            --Output "Artifacts/Coverage/UnitsNet.Modular.coverage.xml" \
+            --ReportType DetailedXML \
+            --Filters '+:module=UnitsNet.Modular;+:module=UnitsNet.Modular.Generator;-:module=*Tests;-:module=*Fixture' \
+            --ReturnTargetExitCode \
+            -- test UnitsNet.Modular.slnx --configuration Release --no-build -p:Platform=ProjectReferences
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          directory: Artifacts/Coverage
+          fail_ci_if_error: false
+          plugins: noop
+          use_oidc: true
 
       - name: Native AOT smoke test
         run: |


### PR DESCRIPTION
## Motivation

Nothing in the repository measures UnitsNet.Modular's coverage. `Build/test-projects.psm1`
lists seven test projects and none of the three Modular ones are among them, and this workflow
ran plain `dotnet test`. `codecov.yml` sets the target range to 80–100, but that target has only
ever seen the legacy projects.

The Modular projects cannot simply be added to `test-projects.psm1`, for two reasons.

`Start-Tests` runs `dotnet test --no-build` against projects that `build.ps1` has already built
from `UnitsNet.slnx`, whereas Modular is a separate solution needing `-p:Platform=ProjectReferences`.

More to the point, #1693 introduced that list specifically so the **net48 compatibility
workflow** could share it without importing the full build-functions module. So it means "the
main test projects that also run on .NET Framework". The Modular test projects target `net10.0`
only, so adding them there would pull them into a net48 run where they cannot build.

Collecting here, where the solution is already built correctly and the platform is already set,
avoids both.

## Changes

- restore the local tools, so the `dotCover` the repository already depends on is available
- wrap the existing test run in `dotCover cover-dotnet`, writing DetailedXML to `Artifacts/Coverage`
- upload with the same `codecov/codecov-action@v6` step and options `pr.yml` uses
- grant `id-token: write`

Two of those deserve a reason.

**`id-token`.** `pr.yml` declares no `permissions` block and inherits the repository default.
This workflow declares `contents: read` explicitly, which sets everything else to `none`, so
Codecov's `use_oidc: true` would have no token to request.

**The filter is narrower than the legacy one.** `Start-Tests` uses
`+:module=UnitsNet*;-:module=*Tests`. Applied here that reports assemblies this workflow does
not own, because the compatibility suite compiles the current UnitsNet project and generates a
large fixture:

| filter | reported |
|---|---|
| `+:module=UnitsNet*;-:module=*Tests` | **31%** — legacy `UnitsNet` at 24% (35 557 statements) and `UnitsNet.Modular.Compatibility.GeneratedFixture`, a generated *test* fixture, at 37% (19 435 statements) |
| this PR's filter | **90%** — `UnitsNet.Modular` 81%, `UnitsNet.Modular.Generator` 93% |

Legacy `UnitsNet` is already measured by `pr.yml`, so including it here would double-count it
against a number this workflow cannot move.

## Result

Modular's coverage turns out to be healthy — 2 498 / 2 764 statements, inside the repository's
80–100 target. This PR does not improve coverage; it makes an existing good number visible and
guards it against regressing unnoticed. The thinnest areas, for anyone interested later, are
`UnitDescriptor` at 21%, `BaseDimensions` at 31% and `LogarithmicQuantityMath` at 55%.

## What this does not do

No test is added or changed, and no product code is touched. The AOT smoke test, the NuGet
consumer checks and packing are untouched and still run in the same order.

## Validation

I cannot run this workflow against upstream, so I ran it on my fork, from this branch, with the
workflow file as it stands in this PR:

https://github.com/Rafael-SOWNet/UnitsNet/actions/runs/31126042733 — **all steps green**,
including the two new ones.

```
Passed! - Failed: 0, Passed: 40, Skipped: 0, Total: 40   UnitsNet.Modular.Tests
Passed! - Failed: 0, Passed: 43, Skipped: 0, Total: 43   UnitsNet.Modular.Compatibility.Tests
Passed! - Failed: 0, Passed: 33, Skipped: 0, Total: 33   UnitsNet.Modular.Generator.Tests

Found 1 coverage files to report
 > Artifacts/Coverage/UnitsNet.Modular.coverage.xml
Sending upload (186600 bytes) to storage
Upload queued for processing complete
```

So the upload path works, not just the collection. It landed in my fork's Codecov project
rather than yours, which is the one part of this that can only be confirmed once it runs here.

