### PR TITLE
Splat build.ps1 arguments as a hashtable so the CI dispatch inputs work

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,11 +81,14 @@ jobs:
         PACK_NUGETS: ${{ github.event_name != 'workflow_dispatch' || inputs.pack_nugets || inputs.publish_nuget }}
         CREATE_ARCHIVE: ${{ github.event_name != 'workflow_dispatch' || inputs.upload_artifacts }}
       run: |
-        $buildArguments = @()
-        if ($env:RUN_TESTS -ne 'true') { $buildArguments += '-SkipTests' }
-        if ($env:COLLECT_COVERAGE -ne 'true') { $buildArguments += '-SkipCoverage' }
-        if ($env:PACK_NUGETS -ne 'true') { $buildArguments += '-SkipPack' }
-        if ($env:CREATE_ARCHIVE -ne 'true') { $buildArguments += '-SkipArchive' }
+        # Splat a hashtable, not an array. Array splatting binds positionally, and
+        # build.ps1 declares only switches, so any non-empty array fails with
+        # "A positional parameter cannot be found that accepts argument '-SkipTests'".
+        $buildArguments = @{}
+        if ($env:RUN_TESTS -ne 'true') { $buildArguments['SkipTests'] = $true }
+        if ($env:COLLECT_COVERAGE -ne 'true') { $buildArguments['SkipCoverage'] = $true }
+        if ($env:PACK_NUGETS -ne 'true') { $buildArguments['SkipPack'] = $true }
+        if ($env:CREATE_ARCHIVE -ne 'true') { $buildArguments['SkipArchive'] = $true }
         ./Build/build.ps1 @buildArguments
 
     # Codecov intermittently fails while importing its verification key from Keybase.


### PR DESCRIPTION
## The problem

`CI Build`'s `workflow_dispatch` inputs cannot be used. Setting any of them to `false` fails the
run immediately:

```
build.ps1: A positional parameter cannot be found that accepts argument '-SkipCoverage'.
```

`$buildArguments` is an **array**, and PowerShell array splatting binds **positionally**.
`Build/build.ps1` declares only switches (`SkipTests`, `SkipCoverage`, `SkipPack`,
`SkipArchive`) and no positional parameters, so the first element has nowhere to bind.

Only the all-defaults path works, because that leaves the array empty and splats nothing. That
is why `push` and `pull_request` have never hit this — neither populates the inputs, so every
value resolves `true` and every branch of the `if` is skipped.

## The fix

Splat a hashtable instead, which binds by parameter name.

## Why it is worth fixing

Beyond the inputs doing what they say: dispatching this workflow by hand is the only way to get
a full matrix run on a branch that has no pull request open, and it is the practical way for a
first-time contributor to produce CI evidence while `pull_request` runs are gated behind
approval. Right now that path only works if you want the slowest possible run — full coverage,
pack and archive — because asking to skip any of it is what breaks it.

## Validation

Same workflow, same inputs, before and after. Both runs on my fork.

**Before** — `ci.yml` exactly as it is on `master`, dispatched with
`run_tests=true, collect_coverage=false, pack_nugets=false, upload_artifacts=false`:

https://github.com/Rafael-SOWNet/UnitsNet/actions/runs/31124240783 — **failure**, at
`Build selected components`, with the message quoted above.

**After** — this branch, identical inputs:

https://github.com/Rafael-SOWNet/UnitsNet/actions/runs/31136388644 — **success**.

```
Passed! - Failed: 0, Passed: 52560, Skipped: 16, Total: 52576
Passed! - Failed: 0, Passed:  1731, Skipped:  0, Total:  1731
Passed! - Failed: 0, Passed:  1731, Skipped:  0, Total:  1731
Passed! - Failed: 0, Passed:   213, Skipped:  0, Total:   213
Passed! - Failed: 0, Passed:   241, Skipped:  0, Total:   241
Passed! - Failed: 0, Passed:     1, Skipped:  0, Total:     1
Passed! - Failed: 0, Passed:     1, Skipped:  0, Total:     1
```

`Upload coverage to Codecov`, `Upload artifacts` and `Upload NuGet packages` were all skipped,
which is what the inputs asked for and what previously could not be expressed.

## What this does not do

No change to `Build/build.ps1`, to the default behaviour of `push` or `pull_request`, or to any
other workflow. `.github/workflows/unitsnet-modular-ci.yml` uses a plain `run:` and is
unaffected.
